### PR TITLE
Update cache version used by the mixer to dc4

### DIFF
--- a/deployment/template_deployment.yaml
+++ b/deployment/template_deployment.yaml
@@ -64,7 +64,7 @@ spec:
           imagePullPolicy: Always
           args: [
             "--bq_dataset", "google.com:datcom-store-dev.dc_v3_clustered",
-            "--bt_table", "dc2",
+            "--bt_table", "dc4",
             "--bt_project", "google.com:datcom-store-dev",
             "--bt_instance", "prophet-cache",
             "--project_id", "PROJECT_ID",


### PR DESCRIPTION
dc4 was generated today based on yesterday's snapshot of ingested data.