### PR TITLE
Remove hard coded cluster version number

### DIFF
--- a/deployment/gke.sh
+++ b/deployment/gke.sh
@@ -79,8 +79,7 @@ gcloud services enable container.googleapis.com
 if [[ $(gcloud container clusters list --filter='mixer-cluster' --format=yaml) ]]; then
   echo "mixer-cluster already exists, continue..."
 else
-  # Use version > 1.13 to make sure only provision one certificate object per ssl-certificate
-  gcloud container clusters create mixer-cluster --zone=us-central1-c --cluster-version 1.13.7-gke.8
+  gcloud container clusters create mixer-cluster --zone=us-central1-c
 fi
 
 gcloud container clusters get-credentials mixer-cluster


### PR DESCRIPTION
The default cluster version number is 1.13.11-gke.14 which is sufficiently new for us