### PR TITLE
Staging

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -8,11 +8,13 @@ Create a Google Cloud Platform (GCP) project and run the following command where
 
 `{IMAGE}` is Data Commons mixer Docker image registry url. It is in the form of `gcr.io/datcom-mixer/go-grpc-mixer:{TAG}`. Ask Data Commons team to obtain the TAG number.
 
+`{BT_TABLE}` is the Bigtable table in use now, eg: dc22. If updated, please also update template_deployment.yaml.
+
 `{DOMAIN}` is optional, and only need to be set if you want to expose the endpoints from your custom domain.
 
 ```shell
 ./gcp.sh {PROJECT_ID}
-./gke.sh {PROJECT_ID} {IMAGE} {DOMAIN}
+./gke.sh {PROJECT_ID} {IMAGE} {BT_TABLE} {DOMAIN}
 ```
 
 ## (Optional) Use custom domain

--- a/deployment/gcp.sh
+++ b/deployment/gcp.sh
@@ -26,7 +26,11 @@ else
 fi
 gcloud auth login
 gcloud config set project $PROJECT_ID
-gcloud config set compute/zone us-central1
+if [ "$PROJECT_ID" == "datcom-mixer" ]; then
+  gcloud config set compute/zone us-central1
+else 
+  gcloud config set compute/zone us-central1-c
+fi
 
 
 # Create service account

--- a/deployment/gke.sh
+++ b/deployment/gke.sh
@@ -50,6 +50,14 @@ else
   perl -i -pe's/#_d\|//g' deployment.yaml
 fi
 
+# Set BT instance & BQ dataset
+if [ "$PROJECT_ID" == "datcom-mixer-staging" ]; then
+  perl -i -pe's/BT_INSTANCE/prophet-cache-staging/g' deployment.yaml
+  perl -i -pe's/BQ_DATASET/google.com:datcom-store-dev.dc_v3_staging_clustered/g' deployment.yaml
+else 
+  perl -i -pe's/BT_INSTANCE/prophet-cache/g' deployment.yaml
+  perl -i -pe's/BQ_DATASET/google.com:datcom-store-dev.dc_v3_clustered/g' deployment.yaml
+fi
 
 # Get a static ip address
 if ! [[ $(gcloud compute addresses list --global --filter='name:mixer-ip' --format=yaml) ]]; then

--- a/deployment/gke.sh
+++ b/deployment/gke.sh
@@ -17,7 +17,8 @@
 
 export PROJECT_ID=$1
 export IMAGE=$2
-export DOMAIN=$3
+export BT_TABLE=$3
+export DOMAIN=$4
 
 SERVICE_ACCOUNT=mixer-robot@$PROJECT_ID.iam.gserviceaccount.com
 if [ "$PROJECT_ID" == "datcom-mixer" ]; then
@@ -42,14 +43,6 @@ fi
 # Set docker image
 perl -i -pe's/IMAGE/$ENV{IMAGE}/g' deployment.yaml
 
-# Set endpints domain
-if [[ $DOMAIN ]]; then
-  perl -i -pe's/#_c\|//g' deployment.yaml
-  perl -i -pe's/DOMAIN/$ENV{DOMAIN}/g' deployment.yaml
-else
-  perl -i -pe's/#_d\|//g' deployment.yaml
-fi
-
 # Set BT instance & BQ dataset
 if [ "$PROJECT_ID" == "datcom-mixer-staging" ]; then
   perl -i -pe's/BT_INSTANCE/prophet-cache-staging/g' deployment.yaml
@@ -58,6 +51,18 @@ else
   perl -i -pe's/BT_INSTANCE/prophet-cache/g' deployment.yaml
   perl -i -pe's/BQ_DATASET/google.com:datcom-store-dev.dc_v3_clustered/g' deployment.yaml
 fi
+
+# Set BT table, please refer to template_deployment for current table choice.
+perl -i -pe's/BT_TABLE/$ENV{BT_TABLE}/g' deployment.yaml
+
+# Set endpints domain
+if [[ $DOMAIN ]]; then
+  perl -i -pe's/#_c\|//g' deployment.yaml
+  perl -i -pe's/DOMAIN/$ENV{DOMAIN}/g' deployment.yaml
+else
+  perl -i -pe's/#_d\|//g' deployment.yaml
+fi
+
 
 # Get a static ip address
 if ! [[ $(gcloud compute addresses list --global --filter='name:mixer-ip' --format=yaml) ]]; then

--- a/deployment/template_deployment.yaml
+++ b/deployment/template_deployment.yaml
@@ -63,10 +63,10 @@ spec:
           image: IMAGE
           imagePullPolicy: Always
           args: [
-            "--bq_dataset", "google.com:datcom-store-dev.dc_v3_clustered",
+            "--bq_dataset", "BQ_DATASET",
             "--bt_table", "dc22",
             "--bt_project", "google.com:datcom-store-dev",
-            "--bt_instance", "prophet-cache",
+            "--bt_instance", "BT_INSTANCE",
             "--project_id", "PROJECT_ID",
           ]
           ports:

--- a/deployment/template_deployment.yaml
+++ b/deployment/template_deployment.yaml
@@ -64,7 +64,8 @@ spec:
           imagePullPolicy: Always
           args: [
             "--bq_dataset", "BQ_DATASET",
-            "--bt_table", "dc22",
+            # Prod using dc22 and staging using dc1. Update this when bt_table change.
+            "--bt_table", "BT_TABLE",
             "--bt_project", "google.com:datcom-store-dev",
             "--bt_instance", "BT_INSTANCE",
             "--project_id", "PROJECT_ID",


### PR DESCRIPTION
Add support to deploy to staging cloud mixer
1) make bq_dataset, bt_table & bt_instance configurable from template_deployment
2) update gke.sh which would replace deployment with the right value for above arguments
2) depending on project_id, set different compute/zone
4) update readme 

Question, people may forget to update bt_table, which cause we lose track the current in-use bt_table. Is there a better way to achieve that?
