### PR TITLE
Bump mixer version to 0.3.5

### DIFF
--- a/deployment/docker_image.txt
+++ b/deployment/docker_image.txt
@@ -1,1 +1,1 @@
-gcr.io/datcom-mixer/go-grpc-mixer:0.3.3
+gcr.io/datcom-mixer/go-grpc-mixer:0.3.5


### PR DESCRIPTION
This includes the branch cache for GetPropertyValue and new api /bulk/stats