### PR TITLE
Fix bug in BQ table path starting from PR 169

### DIFF
--- a/deployment/prod_bq_dataset.txt
+++ b/deployment/prod_bq_dataset.txt
@@ -1,1 +1,1 @@
-google.com:datcom-store-dev:dc_kg_2020_04_25_16_18_24
+google.com:datcom-store-dev.dc_kg_2020_04_25_16_18_24


### PR DESCRIPTION
Found by error "Project name needs to be separated by dot from dataset name, not by colon in table name"