### PR TITLE
Update bigtable prefix in check_bt tool

### DIFF
--- a/examples/check_bt.sh
+++ b/examples/check_bt.sh
@@ -16,8 +16,8 @@
 
 # Useful BT prefix:
 
-# "d/f/country/AUT^count^measured^^^^Person^gender^Male"
-# "d/f/country/AUT^count^measured^Count_Person_25To64Years^^^Person^age^Years25To64^educationalAttainment^LessThanPrimaryEducation&PrimaryEducation&LowerSecondaryEducation"
+# "d/f/country/AUT^count^measured^^^Person^gender^Male"
+# "d/f/country/AUT^count^measured^Count_Person_25To64Years^^Person^age^Years25To64^educationalAttainment^LessThanPrimaryEducation&PrimaryEducation&LowerSecondaryEducation"
 
 export BT=$(head -1 ../deployment/bigtable.txt)
 export PROJECT=google.com:datcom-store-dev


### PR DESCRIPTION
The measurement method is moved out of the prefix.