### PR TITLE
Only return place dcids in landing page data

### DIFF
--- a/golden_response/staging/get_landing_page_data/city.json
+++ b/golden_response/staging/get_landing_page_data/city.json
@@ -44667,82 +44667,28 @@
     ]
   },
   "childPlaces": [
-    {
-      "dcid": "zip/94611",
-      "name": "94611",
-      "pop": 39384
-    },
-    {
-      "dcid": "zip/94610",
-      "name": "94610",
-      "pop": 31496
-    },
-    {
-      "dcid": "zip/94618",
-      "name": "94618",
-      "pop": 17041
-    }
+    "zip/94611",
+    "zip/94610",
+    "zip/94618"
   ],
   "parentPlaces": [
-    {
-      "dcid": "geoId/06001",
-      "name": "Alameda County"
-    },
-    {
-      "dcid": "geoId/06",
-      "name": "California"
-    },
-    {
-      "dcid": "country/USA",
-      "name": "United States"
-    },
-    {
-      "dcid": "northamerica",
-      "name": "North America"
-    }
+    "geoId/06001",
+    "geoId/06",
+    "country/USA",
+    "northamerica"
   ],
   "similarPlaces": [
-    {
-      "dcid": "geoId/06001",
-      "name": "Alameda County"
-    },
-    {
-      "dcid": "geoId/12031",
-      "name": "Duval County"
-    },
-    {
-      "dcid": "geoId/53033",
-      "name": "King County"
-    },
-    {
-      "dcid": "geoId/36005",
-      "name": "Bronx County"
-    },
-    {
-      "dcid": "geoId/04013",
-      "name": "Maricopa County"
-    }
+    "geoId/06001",
+    "geoId/12031",
+    "geoId/53033",
+    "geoId/36005",
+    "geoId/04013"
   ],
   "nearbyPlaces": [
-    {
-      "dcid": "geoId/0653000",
-      "pop": 429082
-    },
-    {
-      "dcid": "geoId/0606000",
-      "pop": 121643
-    },
-    {
-      "dcid": "geoId/0600562",
-      "pop": 78338
-    },
-    {
-      "dcid": "geoId/0654232",
-      "pop": 19806
-    },
-    {
-      "dcid": "geoId/0622594",
-      "pop": 12104
-    }
+    "geoId/0653000",
+    "geoId/0606000",
+    "geoId/0600562",
+    "geoId/0654232",
+    "geoId/0622594"
   ]
 }

--- a/golden_response/staging/get_landing_page_data/county.json
+++ b/golden_response/staging/get_landing_page_data/county.json
@@ -58386,88 +58386,29 @@
     ]
   },
   "childPlaces": [
-    {
-      "dcid": "geoId/0668000",
-      "name": "San Jose",
-      "pop": 1030119
-    },
-    {
-      "dcid": "geoId/0677000",
-      "name": "Sunnyvale",
-      "pop": 153185
-    },
-    {
-      "dcid": "geoId/0669084",
-      "name": "Santa Clara",
-      "pop": 129488
-    },
-    {
-      "dcid": "geoId/0649670",
-      "name": "Mountain View",
-      "pop": 83377
-    },
-    {
-      "dcid": "geoId/0647766",
-      "name": "Milpitas",
-      "pop": 80430
-    }
+    "geoId/0668000",
+    "geoId/0677000",
+    "geoId/0669084",
+    "geoId/0649670",
+    "geoId/0647766"
   ],
   "parentPlaces": [
-    {
-      "dcid": "geoId/06",
-      "name": "California"
-    },
-    {
-      "dcid": "country/USA",
-      "name": "United States"
-    },
-    {
-      "dcid": "northamerica",
-      "name": "North America"
-    }
+    "geoId/06",
+    "country/USA",
+    "northamerica"
   ],
   "similarPlaces": [
-    {
-      "dcid": "geoId/0667000",
-      "name": "San Francisco"
-    },
-    {
-      "dcid": "geoId/0937000",
-      "name": "Hartford"
-    },
-    {
-      "dcid": "geoId/4513330",
-      "name": "Charleston"
-    },
-    {
-      "dcid": "geoId/2603000",
-      "name": "Ann Arbor"
-    },
-    {
-      "dcid": "geoId/1245000",
-      "name": "Miami"
-    }
+    "geoId/0667000",
+    "geoId/0937000",
+    "geoId/4513330",
+    "geoId/2603000",
+    "geoId/1245000"
   ],
   "nearbyPlaces": [
-    {
-      "dcid": "geoId/06001",
-      "pop": 1671329
-    },
-    {
-      "dcid": "geoId/06013",
-      "pop": 1153526
-    },
-    {
-      "dcid": "geoId/06081",
-      "pop": 765935
-    },
-    {
-      "dcid": "geoId/06099",
-      "pop": 550660
-    },
-    {
-      "dcid": "geoId/06087",
-      "pop": 273213
-    }
+    "geoId/06001",
+    "geoId/06013",
+    "geoId/06081",
+    "geoId/06099",
+    "geoId/06087"
   ]
 }

--- a/server/model.go
+++ b/server/model.go
@@ -152,8 +152,8 @@ type place struct {
 type LandingPageResponse struct {
 	Data           map[string]map[string]*ObsTimeSeries `json:"data,omitempty"`
 	AllChildPlaces map[string][]*place                  `json:"allChildPlaces,omitempty"`
-	ChildPlaces    []*place                             `json:"childPlaces,omitempty"`
-	ParentPlaces   []*place                             `json:"parentPlaces,omitempty"`
-	SimilarPlaces  []*place                             `json:"similarPlaces,omitempty"`
-	NearbyPlaces   []*place                             `json:"nearbyPlaces,omitempty"`
+	ChildPlaces    []string                             `json:"childPlaces,omitempty"`
+	ParentPlaces   []string                             `json:"parentPlaces,omitempty"`
+	SimilarPlaces  []string                             `json:"similarPlaces,omitempty"`
+	NearbyPlaces   []string                             `json:"nearbyPlaces,omitempty"`
 }


### PR DESCRIPTION
The client needs to get display name like "San Jose, CA" from separate API call, so the name returned here is redundant. 

Remove to make it easier to use in client side.