### PR TITLE
Add /place/stat-vars API (replacement for /place/stats-var)

### DIFF
--- a/deployment/minikube/README.md
+++ b/deployment/minikube/README.md
@@ -36,6 +36,9 @@ minikube start --memory=4g
 
 Use local docker image with Minikube.
 
+**NOTE** Must run `docker build` below in the same terminal as this one,
+so the docker image can be found.
+
 ```bash
 eval $(minikube docker-env)
 ```
@@ -84,7 +87,7 @@ cd deployment/minikube
 
 ```bash
 cd ../..
-docker build --tag mixer:local .
+DOCKER_BUILDKIT=1 docker build --tag mixer:local .
 cd deployment/minikube
 ```
 

--- a/e2etest/get_place_statsvar_test.go
+++ b/e2etest/get_place_statsvar_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/datacommonsorg/mixer/server"
 )
 
-func TestGetPlaceStatVar(t *testing.T) {
+func TestGetPlaceStatsVar(t *testing.T) {
 	ctx := context.Background()
 	client, err := setup(server.NewMemcache(map[string][]byte{}))
 	if err != nil {
@@ -61,10 +61,10 @@ func TestGetPlaceStatVar(t *testing.T) {
 		},
 	} {
 
-		req := &pb.GetPlaceStatVarsRequest{
+		req := &pb.GetPlaceStatsVarRequest{
 			Dcids: c.dcids,
 		}
-		resp, err := client.GetPlaceStatVars(ctx, req)
+		resp, err := client.GetPlaceStatsVar(ctx, req)
 		if c.wanterr {
 			if err == nil {
 				t.Errorf("Expect to get error for GetPlaceStatsVar() but succeed")
@@ -76,11 +76,11 @@ func TestGetPlaceStatVar(t *testing.T) {
 			continue
 		}
 		for dcid, place := range resp.Places {
-			if len(place.StatVars) < c.minCount {
+			if len(place.StatsVars) < c.minCount {
 				t.Errorf("%s has less than %d stats vars", dcid, c.minCount)
 			}
 			statsVarSet := map[string]bool{}
-			for _, statsVar := range place.StatVars {
+			for _, statsVar := range place.StatsVars {
 				statsVarSet[statsVar] = true
 			}
 			for _, statsVar := range c.want {

--- a/e2etest/get_place_statvars_test.go
+++ b/e2etest/get_place_statvars_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/datacommonsorg/mixer/server"
 )
 
-func TestGetPlaceStatVar(t *testing.T) {
+func TestGetPlaceStatsVar(t *testing.T) {
 	ctx := context.Background()
 	client, err := setup(server.NewMemcache(map[string][]byte{}))
 	if err != nil {
@@ -61,10 +61,10 @@ func TestGetPlaceStatVar(t *testing.T) {
 		},
 	} {
 
-		req := &pb.GetPlaceStatVarsRequest{
+		req := &pb.GetPlaceStatsVarRequest{
 			Dcids: c.dcids,
 		}
-		resp, err := client.GetPlaceStatVars(ctx, req)
+		resp, err := client.GetPlaceStatsVar(ctx, req)
 		if c.wanterr {
 			if err == nil {
 				t.Errorf("Expect to get error for GetPlaceStatsVar() but succeed")
@@ -76,11 +76,11 @@ func TestGetPlaceStatVar(t *testing.T) {
 			continue
 		}
 		for dcid, place := range resp.Places {
-			if len(place.StatVars) < c.minCount {
+			if len(place.StatsVars) < c.minCount {
 				t.Errorf("%s has less than %d stats vars", dcid, c.minCount)
 			}
 			statsVarSet := map[string]bool{}
-			for _, statsVar := range place.StatVars {
+			for _, statsVar := range place.StatsVars {
 				statsVarSet[statsVar] = true
 			}
 			for _, statsVar := range c.want {

--- a/e2etest/get_place_statvars_test.go
+++ b/e2etest/get_place_statvars_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/datacommonsorg/mixer/server"
 )
 
-func TestGetPlaceStatsVar(t *testing.T) {
+func TestGetPlaceStatVars(t *testing.T) {
 	ctx := context.Background()
 	client, err := setup(server.NewMemcache(map[string][]byte{}))
 	if err != nil {
@@ -61,10 +61,10 @@ func TestGetPlaceStatsVar(t *testing.T) {
 		},
 	} {
 
-		req := &pb.GetPlaceStatsVarRequest{
+		req := &pb.GetPlaceStatVarsRequest{
 			Dcids: c.dcids,
 		}
-		resp, err := client.GetPlaceStatsVar(ctx, req)
+		resp, err := client.GetPlaceStatVars(ctx, req)
 		if c.wanterr {
 			if err == nil {
 				t.Errorf("Expect to get error for GetPlaceStatsVar() but succeed")
@@ -76,11 +76,11 @@ func TestGetPlaceStatsVar(t *testing.T) {
 			continue
 		}
 		for dcid, place := range resp.Places {
-			if len(place.StatsVars) < c.minCount {
+			if len(place.StatVars) < c.minCount {
 				t.Errorf("%s has less than %d stats vars", dcid, c.minCount)
 			}
 			statsVarSet := map[string]bool{}
-			for _, statsVar := range place.StatsVars {
+			for _, statsVar := range place.StatVars {
 				statsVarSet[statsVar] = true
 			}
 			for _, statsVar := range c.want {

--- a/proto/mixer.proto
+++ b/proto/mixer.proto
@@ -449,6 +449,24 @@ message GetPlaceStatsVarResponse {
   map<string, StatsVars> places = 1;
 }
 
+
+// StatVars represent a list of statistical variable dcids.
+message StatVars {
+  repeated string statVars = 1;
+}
+
+// Request message for GetPlaceStatVars API.
+message GetPlaceStatVarsRequest {
+  // DCIDs of the places.
+  repeated string dcids = 1;
+}
+
+// Response message for GetPlaceStatVars API.
+message GetPlaceStatVarsResponse {
+  // A map from place dcid to a list of statistical variable dcids.
+  map<string, StatVars> places = 1;
+}
+
 // TODO(wsws): Refactor all these "won't persist to cache" fields across caches
 // into a single TemporaryFields message, and clear just that "tmp_data" field
 // before persistence.
@@ -967,6 +985,16 @@ service Mixer {
       returns (GetPlaceStatsVarResponse) {
     option (google.api.http) = {
       get: "/place/stats-var"
+    };
+  }
+
+  // Give a list of place dcids, return all the statistical variables for each
+  // place.
+  // TODO(shifucun): Deprecate GetPlaceStatsVar when all internal clients are migrated.
+  rpc GetPlaceStatVars(GetPlaceStatVarsRequest)
+      returns (GetPlaceStatVarsResponse) {
+    option (google.api.http) = {
+      get: "/place/stat-vars"
     };
   }
 }

--- a/proto/mixer.proto
+++ b/proto/mixer.proto
@@ -452,7 +452,7 @@ message GetPlaceStatsVarResponse {
 
 // StatVars represent a list of statistical variable dcids.
 message StatVars {
-  repeated string statVars = 1;
+  repeated string stat_vars = 1;
 }
 
 // Request message for GetPlaceStatVars API.


### PR DESCRIPTION
Once all clients are migrated over, can remove "/place/stats-var".

Tested in Minikube and looking fine