### PR TITLE
Add health check for mixer container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,4 +45,9 @@ RUN protoc \
 # Install the Go app.
 RUN go install .
 
+# Adding the grpc_health_probe
+RUN GRPC_HEALTH_PROBE_VERSION=v0.3.5 && \
+    wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
+    chmod +x /bin/grpc_health_probe
+
 ENTRYPOINT ["/go/bin/mixer"]

--- a/cloudbuild.binarydatapush.yaml
+++ b/cloudbuild.binarydatapush.yaml
@@ -50,6 +50,7 @@ steps:
     args: ["go", "test", "./..."]
 
   # Push the mixer docker image to container registry
+  # TODO(shifucun): use the Dockerfile for this step
   - id: push-docker-image
     name: gcr.io/cloud-builders/docker
     entrypoint: "bash"

--- a/cloudbuild.binarydatapush.yaml
+++ b/cloudbuild.binarydatapush.yaml
@@ -62,6 +62,11 @@ steps:
         WORKDIR /mixer
         COPY . .
         RUN go install .
+
+        RUN GRPC_HEALTH_PROBE_VERSION=v0.3.5
+        wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
+        chmod +x /bin/grpc_health_probe
+
         ENTRYPOINT ["/go/bin/mixer"]
         EOT
         docker build \

--- a/deployment/template/mixer.yaml.tmpl
+++ b/deployment/template/mixer.yaml.tmpl
@@ -21,6 +21,13 @@ metadata:
   namespace: mixer
 spec:
   replicas: <REPLICAS>
+  strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        # maximum number of Pods that can be created over the desired number of Pods
+        maxSurge: 1
+        # maximum number of Pods that can be unavailable during the update process
+        maxUnavailable: 25%
   selector:
       matchLabels:
         app: mixer-grpc
@@ -55,6 +62,21 @@ spec:
             ]
           ports:
             - containerPort: 12345
+          # Mixer startup loading branch cache, can taking minutes
+          # Use a large failureThreshold to prevent infinit loop of restart
+          startupProbe:
+            exec:
+              command: ["/bin/grpc_health_probe", "-addr=:12345"]
+            failureThreshold: 50
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command: ["/bin/grpc_health_probe", "-addr=:12345"]
+            periodSeconds: 5
+          livenessProbe:
+            exec:
+              command: ["/bin/grpc_health_probe", "-addr=:12345"]
+            periodSeconds: 5
           volumeMounts:
             - name: mixer-robot-key
               mountPath: /var/secrets/google

--- a/healthcheck/healthchecker.go
+++ b/healthcheck/healthchecker.go
@@ -1,0 +1,39 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package healthcheck
+
+import (
+	"context"
+
+	"google.golang.org/grpc/health/grpc_health_v1"
+)
+
+type HealthChecker struct{}
+
+func (s *HealthChecker) Check(ctx context.Context, req *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
+	return &grpc_health_v1.HealthCheckResponse{
+		Status: grpc_health_v1.HealthCheckResponse_SERVING,
+	}, nil
+}
+
+func (s *HealthChecker) Watch(req *grpc_health_v1.HealthCheckRequest, server grpc_health_v1.Health_WatchServer) error {
+	return server.Send(&grpc_health_v1.HealthCheckResponse{
+		Status: grpc_health_v1.HealthCheckResponse_SERVING,
+	})
+}
+
+func NewHealthChecker() *HealthChecker {
+	return &HealthChecker{}
+}

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	"log"
 	"net"
 
+	"github.com/datacommonsorg/mixer/healthcheck"
 	pb "github.com/datacommonsorg/mixer/proto"
 	"github.com/datacommonsorg/mixer/server"
 	"golang.org/x/oauth2/google"
@@ -30,6 +31,7 @@ import (
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/alts"
+	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/reflection"
 )
 
@@ -126,6 +128,10 @@ func main() {
 	pb.RegisterMixerServer(srv, s)
 	// Register reflection service on gRPC server.
 	reflection.Register(srv)
+
+	healthService := healthcheck.NewHealthChecker()
+	grpc_health_v1.RegisterHealthServer(srv, healthService)
+
 	// Listen on network
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", *port))
 	if err != nil {


### PR DESCRIPTION
- Mixer is  unavailable during rolling out due to the lack of health check, branch cache loading taking minutes and need to use startup probe to guard it.

- I suspect some of of the long latency we have seen is due to the lack of liveness check, adding liveness check to overcome that.