### PR TITLE
Only use readiness probe since GKE does not support it until k8s 1.20 (currently stable version is 1.17)

### DIFF
--- a/cloudbuild.binarydatapush.yaml
+++ b/cloudbuild.binarydatapush.yaml
@@ -64,8 +64,7 @@ steps:
         COPY . .
         RUN go install .
 
-        RUN GRPC_HEALTH_PROBE_VERSION=v0.3.5 && \
-        wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
+        RUN wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.3.5/grpc_health_probe-linux-amd64 && \
         chmod +x /bin/grpc_health_probe
 
         ENTRYPOINT ["/go/bin/mixer"]

--- a/deployment/template/mixer.yaml.tmpl
+++ b/deployment/template/mixer.yaml.tmpl
@@ -62,18 +62,7 @@ spec:
             ]
           ports:
             - containerPort: 12345
-          # Mixer startup loading branch cache, can taking minutes
-          # Use a large failureThreshold to prevent infinit loop of restart
-          startupProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:12345"]
-            failureThreshold: 50
-            periodSeconds: 10
           readinessProbe:
-            exec:
-              command: ["/bin/grpc_health_probe", "-addr=:12345"]
-            periodSeconds: 5
-          livenessProbe:
             exec:
               command: ["/bin/grpc_health_probe", "-addr=:12345"]
             periodSeconds: 5


### PR DESCRIPTION
See discussion: https://stackoverflow.com/a/61936155.

Basically without startupProbe, the liveness probe can timeout if server starts slow and restart it, making it an infinite loop.