### PR TITLE
Parallel integration tests to speed up from ~2min to 10s

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/golang/mock v1.4.4 // indirect
 	github.com/golang/protobuf v1.4.3
 	github.com/google/go-cmp v0.5.2
-	github.com/google/martian/v3 v3.0.0 // indirect
 	go.opencensus.io v0.22.5 // indirect
 	golang.org/x/net v0.0.0-20201026091529-146b70c837a4 // indirect
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,6 @@ require (
 	google.golang.org/api v0.24.0
 	google.golang.org/genproto v0.0.0-20200515170657-fc4c6c6a6587
 	google.golang.org/grpc v1.33.1
-	google.golang.org/grpc/cmd/protoc-gen-go-grpc v0.0.0-20200824180931-410880dd7d91 // indirect
 	google.golang.org/protobuf v1.23.0
 	honnef.co/go/tools v0.0.1-2020.1.5 // indirect
 

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	google.golang.org/api v0.24.0
 	google.golang.org/genproto v0.0.0-20200515170657-fc4c6c6a6587
 	google.golang.org/grpc v1.33.1
+	google.golang.org/grpc/cmd/protoc-gen-go-grpc v0.0.0-20200824180931-410880dd7d91 // indirect
 	google.golang.org/protobuf v1.23.0
 	honnef.co/go/tools v0.0.1-2020.1.5 // indirect
 

--- a/go.sum
+++ b/go.sum
@@ -614,6 +614,7 @@ google.golang.org/genproto v0.0.0-20201019141844-1ed22bb0c154/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20201021134325-0d71844de594/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201026171402-d4b8fe4fd877 h1:d4k3uIU763E31Rk4UZPA47oOoBymMsDImV3U4mGhX9E=
 google.golang.org/genproto v0.0.0-20201026171402-d4b8fe4fd877/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
+google.golang.org/grpc v0.0.0-20200824180931-410880dd7d91 h1:wUuCXZ+cuPPafvpgTcL2n47sIq4f1vSh0EJPOFGLEX8=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=

--- a/script/update-golden-staging.sh
+++ b/script/update-golden-staging.sh
@@ -14,7 +14,7 @@
 
 #!/bin/bash
 
-cd test/integration/e2etest
+cd test/integration
 if [ "$#" -eq 1 ]; then
     go test -generate_golden=true -run "$1"
 else

--- a/test/integration/get_landing_page_data_test.go
+++ b/test/integration/get_landing_page_data_test.go
@@ -29,6 +29,7 @@ import (
 
 // TestGetLandingPageData tests GetLandingPageData.
 func TestGetLandingPageData(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	client, err := setup(server.NewMemcache(map[string][]byte{}))
 	if err != nil {

--- a/test/integration/get_observations_test.go
+++ b/test/integration/get_observations_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func TestGetObservations(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	client, err := setup(server.NewMemcache(map[string][]byte{}))
 	if err != nil {

--- a/test/integration/get_place_statsvar_test.go
+++ b/test/integration/get_place_statsvar_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestGetPlaceStatsVar(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	client, err := setup(server.NewMemcache(map[string][]byte{}))
 	if err != nil {

--- a/test/integration/get_place_statvars_test.go
+++ b/test/integration/get_place_statvars_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestGetPlaceStatVars(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	client, err := setup(server.NewMemcache(map[string][]byte{}))
 	if err != nil {

--- a/test/integration/get_places_in_test.go
+++ b/test/integration/get_places_in_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func TestGetPlacesIn(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	client, err := setup(server.NewMemcache(map[string][]byte{}))
 	if err != nil {

--- a/test/integration/get_pop_obs_test.go
+++ b/test/integration/get_pop_obs_test.go
@@ -37,6 +37,7 @@ func (a byID) Less(i, j int) bool { return a[i].GetId() < a[j].GetId() }
 func (a byID) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 
 func TestGetPopObs(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	_, filename, _, _ := runtime.Caller(0)
 

--- a/test/integration/get_populations_test.go
+++ b/test/integration/get_populations_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 func TestGetPopulations(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	client, err := setup(server.NewMemcache(map[string][]byte{}))
 	if err != nil {

--- a/test/integration/get_property_labels_test.go
+++ b/test/integration/get_property_labels_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func TestGetPropertyLabels(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	client, err := setup(server.NewMemcache(map[string][]byte{}))
 	if err != nil {

--- a/test/integration/get_property_values_test.go
+++ b/test/integration/get_property_values_test.go
@@ -37,6 +37,7 @@ func TestGetPropertyValues(t *testing.T) {
 	goldenPath := path.Join(
 		path.Dir(filename), "golden_response/staging/get_property_values")
 
+	t.Parallel()
 	for _, c := range []struct {
 		goldenFile string
 		dcids      []string

--- a/test/integration/get_related_locations_test.go
+++ b/test/integration/get_related_locations_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func TestGetRelatedLocations(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	client, err := setup(server.NewMemcache(map[string][]byte{}))
 	if err != nil {

--- a/test/integration/get_stat_all_test.go
+++ b/test/integration/get_stat_all_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func TestGetStatAll(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	memcacheData, err := loadMemcache()

--- a/test/integration/get_stat_collection_test.go
+++ b/test/integration/get_stat_collection_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func TestGetStatCollection(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	memcacheData, err := loadMemcache()

--- a/test/integration/get_stat_ranking_test.go
+++ b/test/integration/get_stat_ranking_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func TestGetLocationsRankings(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	client, err := setup(server.NewMemcache(map[string][]byte{}))
 	if err != nil {

--- a/test/integration/get_stat_series_test.go
+++ b/test/integration/get_stat_series_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func TestGetStatSeries(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	memcacheData, err := loadMemcache()

--- a/test/integration/get_stat_set_test.go
+++ b/test/integration/get_stat_set_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func TestGetStatSet(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	memcacheData, err := loadMemcache()

--- a/test/integration/get_stat_test.go
+++ b/test/integration/get_stat_test.go
@@ -30,6 +30,7 @@ import (
 )
 
 func TestGetStat(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	memcacheData, err := loadMemcache()

--- a/test/integration/get_stat_value_test.go
+++ b/test/integration/get_stat_value_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func TestGetStatValue(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	memcacheData, err := loadMemcache()

--- a/test/integration/get_stats_test.go
+++ b/test/integration/get_stats_test.go
@@ -30,6 +30,7 @@ import (
 )
 
 func TestGetStats(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	memcacheData, err := loadMemcache()

--- a/test/integration/get_triples_test.go
+++ b/test/integration/get_triples_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func TestGetTriples(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	memcacheData, err := loadMemcache()

--- a/test/integration/golden_response/staging/statvar_ranking/missing_Earth_country_rankings.json
+++ b/test/integration/golden_response/staging/statvar_ranking/missing_Earth_country_rankings.json
@@ -1,72 +1,93 @@
 [
   {
-    "title": "Number of people employed",
+    "title": "Arson",
     "statsVars": [
-      "Count_Person_Employed"
+      "Count_CriminalActivities_Arson"
     ],
     "relatedChart": {
       "scale": true,
       "statsVars": [
-        "Count_Person_Employed"
+        "Count_CriminalActivities_Arson"
       ]
     }
   },
   {
-    "title": "Poverty rate",
+    "title": "COVID-19 cumulative cases",
     "statsVars": [
-      "Count_Person_BelowPovertyLevelInThePast12Months"
+      "CumulativeCount_MedicalConditionIncident_COVID_19_ConfirmedOrProbableCase"
+    ],
+    "relatedChart": {
+      "scale": true,
+      "statsVars": [
+        "CumulativeCount_MedicalConditionIncident_COVID_19_ConfirmedOrProbableCase"
+      ]
+    }
+  },
+  {
+    "title": "Citizenship status",
+    "statsVars": [
+      "Count_Person_USCitizenBornInTheUnitedStates",
+      "Count_Person_USCitizenByNaturalization",
+      "Count_Person_NotAUSCitizen",
+      "Count_Person_USCitizenBornAbroadOfAmericanParents"
+    ],
+    "relatedChart": {
+      "scale": true,
+      "statsVars": [
+        "Count_Person_USCitizenBornInTheUnitedStates",
+        "Count_Person_USCitizenByNaturalization",
+        "Count_Person_NotAUSCitizen",
+        "Count_Person_USCitizenBornAbroadOfAmericanParents"
+      ]
+    }
+  },
+  {
+    "title": "Disasters",
+    "statsVars": [
+      "Count_DroughtEvent",
+      "Count_StormSurgeTideEvent"
     ],
     "relatedChart": {}
   },
   {
-    "title": "State unemployment insurance claims",
+    "title": "Education attainment",
     "statsVars": [
-      "Count_UnemploymentInsuranceClaim_StateUnemploymentInsurance"
+      "Count_Person_EducationalAttainmentNoSchoolingCompleted",
+      "Count_Person_EducationalAttainmentRegularHighSchoolDiploma",
+      "Count_Person_EducationalAttainmentBachelorsDegree",
+      "Count_Person_EducationalAttainmentMastersDegree",
+      "Count_Person_EducationalAttainmentDoctorateDegree"
     ],
     "relatedChart": {
       "scale": true,
       "statsVars": [
-        "Count_UnemploymentInsuranceClaim_StateUnemploymentInsurance"
+        "Count_Person_EducationalAttainmentNoSchoolingCompleted",
+        "Count_Person_EducationalAttainmentRegularHighSchoolDiploma",
+        "Count_Person_EducationalAttainmentBachelorsDegree",
+        "Count_Person_EducationalAttainmentMastersDegree",
+        "Count_Person_EducationalAttainmentDoctorateDegree"
       ]
     }
   },
   {
-    "title": "Median individual income",
+    "title": "Health behaviors",
     "statsVars": [
-      "Median_Income_Person"
+      "Percent_Person_SleepLessThan7Hours",
+      "Percent_Person_Obesity",
+      "Percent_Person_BingeDrinking",
+      "Percent_Person_PhysicalInactivity",
+      "Percent_Person_Smoking"
     ],
     "relatedChart": {}
   },
   {
-    "title": "Individual income",
+    "title": "Health outcomes",
     "statsVars": [
-      "Count_Person_IncomeOfUpto9999USDollar",
-      "Count_Person_IncomeOf10000To14999USDollar",
-      "Count_Person_IncomeOf15000To24999USDollar",
-      "Count_Person_IncomeOf25000To34999USDollar",
-      "Count_Person_IncomeOf35000To49999USDollar",
-      "Count_Person_IncomeOf50000To64999USDollar",
-      "Count_Person_IncomeOf65000To74999USDollar",
-      "Count_Person_IncomeOf75000OrMoreUSDollar"
-    ],
-    "relatedChart": {
-      "scale": true,
-      "statsVars": [
-        "Count_Person_IncomeOfUpto9999USDollar",
-        "Count_Person_IncomeOf10000To14999USDollar",
-        "Count_Person_IncomeOf15000To24999USDollar",
-        "Count_Person_IncomeOf25000To34999USDollar",
-        "Count_Person_IncomeOf35000To49999USDollar",
-        "Count_Person_IncomeOf50000To64999USDollar",
-        "Count_Person_IncomeOf65000To74999USDollar",
-        "Count_Person_IncomeOf75000OrMoreUSDollar"
-      ]
-    }
-  },
-  {
-    "title": "Median household income",
-    "statsVars": [
-      "Median_Income_Household"
+      "Percent_Person_WithHighCholesterol",
+      "Percent_Person_WithHighBloodPressure",
+      "Percent_Person_WithArthritis",
+      "Percent_Person_WithMentalHealthNotGood",
+      "Percent_Person_WithPhysicalHealthNotGood"
     ],
     "relatedChart": {}
   },
@@ -103,362 +124,6 @@
     }
   },
   {
-    "title": "COVID-19 cumulative cases",
-    "statsVars": [
-      "CumulativeCount_MedicalConditionIncident_COVID_19_ConfirmedOrProbableCase"
-    ],
-    "relatedChart": {
-      "scale": true,
-      "statsVars": [
-        "CumulativeCount_MedicalConditionIncident_COVID_19_ConfirmedOrProbableCase"
-      ]
-    }
-  },
-  {
-    "title": "Mortality events",
-    "statsVars": [
-      "Count_Death_DiseasesOfTheCirculatorySystem",
-      "Count_Death_Neoplasms",
-      "Count_Death_DiseasesOfTheRespiratorySystem",
-      "Count_Death_ExternalCauses",
-      "Count_Death_DiseasesOfTheNervousSystem"
-    ],
-    "relatedChart": {
-      "scale": true,
-      "statsVars": [
-        "Count_Death_DiseasesOfTheCirculatorySystem",
-        "Count_Death_Neoplasms",
-        "Count_Death_DiseasesOfTheRespiratorySystem",
-        "Count_Death_ExternalCauses",
-        "Count_Death_DiseasesOfTheNervousSystem"
-      ]
-    }
-  },
-  {
-    "title": "Health outcomes",
-    "statsVars": [
-      "Percent_Person_WithHighCholesterol",
-      "Percent_Person_WithHighBloodPressure",
-      "Percent_Person_WithArthritis",
-      "Percent_Person_WithMentalHealthNotGood",
-      "Percent_Person_WithPhysicalHealthNotGood"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Health behaviors",
-    "statsVars": [
-      "Percent_Person_SleepLessThan7Hours",
-      "Percent_Person_Obesity",
-      "Percent_Person_BingeDrinking",
-      "Percent_Person_PhysicalInactivity",
-      "Percent_Person_Smoking"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Prescribed drugs (quarterly)",
-    "statsVars": [
-      "RetailDrugDistribution_DrugDistribution_Oxycodone",
-      "RetailDrugDistribution_DrugDistribution_Hydrocodone",
-      "RetailDrugDistribution_DrugDistribution_Codeine",
-      "RetailDrugDistribution_DrugDistribution_Amphetamine",
-      "RetailDrugDistribution_DrugDistribution_Morphine"
-    ],
-    "relatedChart": {
-      "scale": true,
-      "statsVars": [
-        "RetailDrugDistribution_DrugDistribution_Oxycodone",
-        "RetailDrugDistribution_DrugDistribution_Hydrocodone",
-        "RetailDrugDistribution_DrugDistribution_Codeine",
-        "RetailDrugDistribution_DrugDistribution_Amphetamine",
-        "RetailDrugDistribution_DrugDistribution_Morphine"
-      ]
-    }
-  },
-  {
-    "title": "Median household income by race",
-    "statsVars": [
-      "Median_Income_Household_HouseholderRaceAmericanIndianOrAlaskaNativeAlone",
-      "Median_Income_Household_HouseholderRaceAsianAlone",
-      "Median_Income_Household_HouseholderRaceBlackOrAfricanAmericanAlone",
-      "Median_Income_Household_HouseholderRaceHispanicOrLatino",
-      "Median_Income_Household_HouseholderRaceNativeHawaiianOrOtherPacificIslanderAlone",
-      "Median_Income_Household_HouseholderRaceWhiteAlone"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Median income by gender",
-    "statsVars": [
-      "Median_Income_Person_15OrMoreYears_Female_WithIncome",
-      "Median_Income_Person_15OrMoreYears_Male_WithIncome"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Poverty rate by race",
-    "statsVars": [
-      "Count_Person_BelowPovertyLevelInThePast12Months_AmericanIndianOrAlaskaNativeAlone",
-      "Count_Person_BelowPovertyLevelInThePast12Months_AsianAlone",
-      "Count_Person_BelowPovertyLevelInThePast12Months_BlackOrAfricanAmericanAlone",
-      "Count_Person_BelowPovertyLevelInThePast12Months_HispanicOrLatino",
-      "Count_Person_BelowPovertyLevelInThePast12Months_NativeHawaiianOrOtherPacificIslanderAlone",
-      "Count_Person_BelowPovertyLevelInThePast12Months_WhiteAlone"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Poverty rate by gender",
-    "statsVars": [
-      "Count_Person_Female_BelowPovertyLevelInThePast12Months",
-      "Count_Person_Male_BelowPovertyLevelInThePast12Months"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Percentage of people without health insurance by race",
-    "statsVars": [
-      "Percent_Person_18To64Years_NoHealthInsurance_BlackOrAfricanAmericanAlone",
-      "Percent_Person_18To64Years_NoHealthInsurance_HispanicOrLatino",
-      "Percent_Person_18To64Years_NoHealthInsurance_WhiteAlone"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Percentage of people without health insurance by gender",
-    "statsVars": [
-      "Percent_Person_18To64Years_Female_NoHealthInsurance",
-      "Percent_Person_18To64Years_Male_NoHealthInsurance"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Rate of associate degree attainment by gender",
-    "statsVars": [
-      "Count_Person_25To34Years_EducationalAttainmentAssociatesDegree_Female",
-      "Count_Person_25To34Years_EducationalAttainmentAssociatesDegree_Male"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Rate of bachelor's degree attainment by gender",
-    "statsVars": [
-      "Count_Person_25To34Years_EducationalAttainmentBachelorsDegree_Female",
-      "Count_Person_25To34Years_EducationalAttainmentBachelorsDegree_Male"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Rate of graduate or professional degree attainment by gender",
-    "statsVars": [
-      "Count_Person_25To34Years_EducationalAttainmentGraduateOrProfessionalDegree_Female",
-      "Count_Person_25To34Years_EducationalAttainmentGraduateOrProfessionalDegree_Male"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Total crime",
-    "statsVars": [
-      "Count_CriminalActivities_CombinedCrime"
-    ],
-    "relatedChart": {
-      "scale": true,
-      "statsVars": [
-        "Count_CriminalActivities_CombinedCrime"
-      ]
-    }
-  },
-  {
-    "title": "Violent crime",
-    "statsVars": [
-      "Count_CriminalActivities_ViolentCrime"
-    ],
-    "relatedChart": {
-      "scale": true,
-      "statsVars": [
-        "Count_CriminalActivities_ViolentCrime"
-      ]
-    }
-  },
-  {
-    "title": "Property crime",
-    "statsVars": [
-      "Count_CriminalActivities_PropertyCrime"
-    ],
-    "relatedChart": {
-      "scale": true,
-      "statsVars": [
-        "Count_CriminalActivities_PropertyCrime"
-      ]
-    }
-  },
-  {
-    "title": "Arson",
-    "statsVars": [
-      "Count_CriminalActivities_Arson"
-    ],
-    "relatedChart": {
-      "scale": true,
-      "statsVars": [
-        "Count_CriminalActivities_Arson"
-      ]
-    }
-  },
-  {
-    "title": "Education attainment",
-    "statsVars": [
-      "Count_Person_EducationalAttainmentNoSchoolingCompleted",
-      "Count_Person_EducationalAttainmentRegularHighSchoolDiploma",
-      "Count_Person_EducationalAttainmentBachelorsDegree",
-      "Count_Person_EducationalAttainmentMastersDegree",
-      "Count_Person_EducationalAttainmentDoctorateDegree"
-    ],
-    "relatedChart": {
-      "scale": true,
-      "statsVars": [
-        "Count_Person_EducationalAttainmentNoSchoolingCompleted",
-        "Count_Person_EducationalAttainmentRegularHighSchoolDiploma",
-        "Count_Person_EducationalAttainmentBachelorsDegree",
-        "Count_Person_EducationalAttainmentMastersDegree",
-        "Count_Person_EducationalAttainmentDoctorateDegree"
-      ]
-    }
-  },
-  {
-    "title": "School enrollment",
-    "statsVars": [
-      "Count_Person_EnrolledInSchool",
-      "Count_Person_NotEnrolledInSchool"
-    ],
-    "relatedChart": {
-      "scale": true,
-      "statsVars": [
-        "Count_Person_EnrolledInSchool",
-        "Count_Person_NotEnrolledInSchool"
-      ]
-    }
-  },
-  {
-    "title": "Population by age",
-    "statsVars": [
-      "Count_Person_5To17Years",
-      "Count_Person_18To24Years",
-      "Count_Person_25To34Years",
-      "Count_Person_35To44Years",
-      "Count_Person_45To54Years",
-      "Count_Person_60To61Years",
-      "Count_Person_62To64Years",
-      "Count_Person_65To74Years"
-    ],
-    "relatedChart": {
-      "scale": true,
-      "statsVars": [
-        "Count_Person_5To17Years",
-        "Count_Person_18To24Years",
-        "Count_Person_25To34Years",
-        "Count_Person_35To44Years",
-        "Count_Person_45To54Years",
-        "Count_Person_60To61Years",
-        "Count_Person_62To64Years",
-        "Count_Person_65To74Years"
-      ]
-    }
-  },
-  {
-    "title": "Population by race",
-    "statsVars": [
-      "Count_Person_AmericanIndianOrAlaskaNativeAlone",
-      "Count_Person_AsianAlone",
-      "Count_Person_BlackOrAfricanAmericanAlone",
-      "Count_Person_HispanicOrLatino",
-      "Count_Person_NativeHawaiianOrOtherPacificIslanderAlone",
-      "Count_Person_SomeOtherRaceAlone",
-      "Count_Person_TwoOrMoreRaces",
-      "Count_Person_WhiteAlone"
-    ],
-    "relatedChart": {
-      "scale": true,
-      "statsVars": [
-        "Count_Person_AmericanIndianOrAlaskaNativeAlone",
-        "Count_Person_AsianAlone",
-        "Count_Person_BlackOrAfricanAmericanAlone",
-        "Count_Person_HispanicOrLatino",
-        "Count_Person_NativeHawaiianOrOtherPacificIslanderAlone",
-        "Count_Person_SomeOtherRaceAlone",
-        "Count_Person_TwoOrMoreRaces",
-        "Count_Person_WhiteAlone"
-      ]
-    }
-  },
-  {
-    "title": "Median Age",
-    "statsVars": [
-      "Median_Age_Person"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Median age by gender",
-    "statsVars": [
-      "Median_Age_Person_Female",
-      "Median_Age_Person_Male"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Median age by race",
-    "statsVars": [
-      "Median_Age_Person_AmericanIndianOrAlaskaNativeAlone",
-      "Median_Age_Person_AsianAlone",
-      "Median_Age_Person_BlackOrAfricanAmericanAlone",
-      "Median_Age_Person_HispanicOrLatino",
-      "Median_Age_Person_NativeHawaiianOrOtherPacificIslanderAlone",
-      "Median_Age_Person_SomeOtherRaceAlone",
-      "Median_Age_Person_TwoOrMoreRaces",
-      "Median_Age_Person_WhiteAlone"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Citizenship status",
-    "statsVars": [
-      "Count_Person_USCitizenBornInTheUnitedStates",
-      "Count_Person_USCitizenByNaturalization",
-      "Count_Person_NotAUSCitizen",
-      "Count_Person_USCitizenBornAbroadOfAmericanParents"
-    ],
-    "relatedChart": {
-      "scale": true,
-      "statsVars": [
-        "Count_Person_USCitizenBornInTheUnitedStates",
-        "Count_Person_USCitizenByNaturalization",
-        "Count_Person_NotAUSCitizen",
-        "Count_Person_USCitizenBornAbroadOfAmericanParents"
-      ]
-    }
-  },
-  {
-    "title": "Marital status",
-    "statsVars": [
-      "Count_Person_MarriedAndNotSeparated",
-      "Count_Person_Divorced",
-      "Count_Person_NeverMarried",
-      "Count_Person_Widowed",
-      "Count_Person_Separated"
-    ],
-    "relatedChart": {
-      "scale": true,
-      "statsVars": [
-        "Count_Person_MarriedAndNotSeparated",
-        "Count_Person_Divorced",
-        "Count_Person_NeverMarried",
-        "Count_Person_Widowed",
-        "Count_Person_Separated"
-      ]
-    }
-  },
-  {
     "title": "Housing units",
     "statsVars": [
       "Count_HousingUnit"
@@ -467,6 +132,34 @@
       "scale": true,
       "statsVars": [
         "Count_HousingUnit"
+      ]
+    }
+  },
+  {
+    "title": "Housing units by date built",
+    "statsVars": [
+      "Count_HousingUnit_Before1939DateBuilt",
+      "Count_HousingUnit_1940To1949DateBuilt",
+      "Count_HousingUnit_1950To1959DateBuilt",
+      "Count_HousingUnit_1960To1969DateBuilt",
+      "Count_HousingUnit_1970To1979DateBuilt",
+      "Count_HousingUnit_1980To1989DateBuilt",
+      "Count_HousingUnit_1990To1999DateBuilt",
+      "Count_HousingUnit_2000To2009DateBuilt",
+      "Count_HousingUnit_2010OrLaterDateBuilt"
+    ],
+    "relatedChart": {
+      "scale": true,
+      "statsVars": [
+        "Count_HousingUnit_Before1939DateBuilt",
+        "Count_HousingUnit_1940To1949DateBuilt",
+        "Count_HousingUnit_1950To1959DateBuilt",
+        "Count_HousingUnit_1960To1969DateBuilt",
+        "Count_HousingUnit_1970To1979DateBuilt",
+        "Count_HousingUnit_1980To1989DateBuilt",
+        "Count_HousingUnit_1990To1999DateBuilt",
+        "Count_HousingUnit_2000To2009DateBuilt",
+        "Count_HousingUnit_2010OrLaterDateBuilt"
       ]
     }
   },
@@ -559,34 +252,6 @@
     }
   },
   {
-    "title": "Housing units by date built",
-    "statsVars": [
-      "Count_HousingUnit_Before1939DateBuilt",
-      "Count_HousingUnit_1940To1949DateBuilt",
-      "Count_HousingUnit_1950To1959DateBuilt",
-      "Count_HousingUnit_1960To1969DateBuilt",
-      "Count_HousingUnit_1970To1979DateBuilt",
-      "Count_HousingUnit_1980To1989DateBuilt",
-      "Count_HousingUnit_1990To1999DateBuilt",
-      "Count_HousingUnit_2000To2009DateBuilt",
-      "Count_HousingUnit_2010OrLaterDateBuilt"
-    ],
-    "relatedChart": {
-      "scale": true,
-      "statsVars": [
-        "Count_HousingUnit_Before1939DateBuilt",
-        "Count_HousingUnit_1940To1949DateBuilt",
-        "Count_HousingUnit_1950To1959DateBuilt",
-        "Count_HousingUnit_1960To1969DateBuilt",
-        "Count_HousingUnit_1970To1979DateBuilt",
-        "Count_HousingUnit_1980To1989DateBuilt",
-        "Count_HousingUnit_1990To1999DateBuilt",
-        "Count_HousingUnit_2000To2009DateBuilt",
-        "Count_HousingUnit_2010OrLaterDateBuilt"
-      ]
-    }
-  },
-  {
     "title": "Housing units by rental status",
     "statsVars": [
       "Count_HousingUnit_OwnerOccupied",
@@ -601,11 +266,346 @@
     }
   },
   {
-    "title": "Disasters",
+    "title": "Individual income",
     "statsVars": [
-      "Count_DroughtEvent",
-      "Count_StormSurgeTideEvent"
+      "Count_Person_IncomeOfUpto9999USDollar",
+      "Count_Person_IncomeOf10000To14999USDollar",
+      "Count_Person_IncomeOf15000To24999USDollar",
+      "Count_Person_IncomeOf25000To34999USDollar",
+      "Count_Person_IncomeOf35000To49999USDollar",
+      "Count_Person_IncomeOf50000To64999USDollar",
+      "Count_Person_IncomeOf65000To74999USDollar",
+      "Count_Person_IncomeOf75000OrMoreUSDollar"
+    ],
+    "relatedChart": {
+      "scale": true,
+      "statsVars": [
+        "Count_Person_IncomeOfUpto9999USDollar",
+        "Count_Person_IncomeOf10000To14999USDollar",
+        "Count_Person_IncomeOf15000To24999USDollar",
+        "Count_Person_IncomeOf25000To34999USDollar",
+        "Count_Person_IncomeOf35000To49999USDollar",
+        "Count_Person_IncomeOf50000To64999USDollar",
+        "Count_Person_IncomeOf65000To74999USDollar",
+        "Count_Person_IncomeOf75000OrMoreUSDollar"
+      ]
+    }
+  },
+  {
+    "title": "Marital status",
+    "statsVars": [
+      "Count_Person_MarriedAndNotSeparated",
+      "Count_Person_Divorced",
+      "Count_Person_NeverMarried",
+      "Count_Person_Widowed",
+      "Count_Person_Separated"
+    ],
+    "relatedChart": {
+      "scale": true,
+      "statsVars": [
+        "Count_Person_MarriedAndNotSeparated",
+        "Count_Person_Divorced",
+        "Count_Person_NeverMarried",
+        "Count_Person_Widowed",
+        "Count_Person_Separated"
+      ]
+    }
+  },
+  {
+    "title": "Median Age",
+    "statsVars": [
+      "Median_Age_Person"
     ],
     "relatedChart": {}
+  },
+  {
+    "title": "Median age by gender",
+    "statsVars": [
+      "Median_Age_Person_Female",
+      "Median_Age_Person_Male"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Median age by race",
+    "statsVars": [
+      "Median_Age_Person_AmericanIndianOrAlaskaNativeAlone",
+      "Median_Age_Person_AsianAlone",
+      "Median_Age_Person_BlackOrAfricanAmericanAlone",
+      "Median_Age_Person_HispanicOrLatino",
+      "Median_Age_Person_NativeHawaiianOrOtherPacificIslanderAlone",
+      "Median_Age_Person_SomeOtherRaceAlone",
+      "Median_Age_Person_TwoOrMoreRaces",
+      "Median_Age_Person_WhiteAlone"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Median household income",
+    "statsVars": [
+      "Median_Income_Household"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Median household income by race",
+    "statsVars": [
+      "Median_Income_Household_HouseholderRaceAmericanIndianOrAlaskaNativeAlone",
+      "Median_Income_Household_HouseholderRaceAsianAlone",
+      "Median_Income_Household_HouseholderRaceBlackOrAfricanAmericanAlone",
+      "Median_Income_Household_HouseholderRaceHispanicOrLatino",
+      "Median_Income_Household_HouseholderRaceNativeHawaiianOrOtherPacificIslanderAlone",
+      "Median_Income_Household_HouseholderRaceWhiteAlone"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Median income by gender",
+    "statsVars": [
+      "Median_Income_Person_15OrMoreYears_Female_WithIncome",
+      "Median_Income_Person_15OrMoreYears_Male_WithIncome"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Median individual income",
+    "statsVars": [
+      "Median_Income_Person"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Mortality events",
+    "statsVars": [
+      "Count_Death_DiseasesOfTheCirculatorySystem",
+      "Count_Death_Neoplasms",
+      "Count_Death_DiseasesOfTheRespiratorySystem",
+      "Count_Death_ExternalCauses",
+      "Count_Death_DiseasesOfTheNervousSystem"
+    ],
+    "relatedChart": {
+      "scale": true,
+      "statsVars": [
+        "Count_Death_DiseasesOfTheCirculatorySystem",
+        "Count_Death_Neoplasms",
+        "Count_Death_DiseasesOfTheRespiratorySystem",
+        "Count_Death_ExternalCauses",
+        "Count_Death_DiseasesOfTheNervousSystem"
+      ]
+    }
+  },
+  {
+    "title": "Number of people employed",
+    "statsVars": [
+      "Count_Person_Employed"
+    ],
+    "relatedChart": {
+      "scale": true,
+      "statsVars": [
+        "Count_Person_Employed"
+      ]
+    }
+  },
+  {
+    "title": "Percentage of people without health insurance by gender",
+    "statsVars": [
+      "Percent_Person_18To64Years_Female_NoHealthInsurance",
+      "Percent_Person_18To64Years_Male_NoHealthInsurance"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Percentage of people without health insurance by race",
+    "statsVars": [
+      "Percent_Person_18To64Years_NoHealthInsurance_BlackOrAfricanAmericanAlone",
+      "Percent_Person_18To64Years_NoHealthInsurance_HispanicOrLatino",
+      "Percent_Person_18To64Years_NoHealthInsurance_WhiteAlone"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Population by age",
+    "statsVars": [
+      "Count_Person_5To17Years",
+      "Count_Person_18To24Years",
+      "Count_Person_25To34Years",
+      "Count_Person_35To44Years",
+      "Count_Person_45To54Years",
+      "Count_Person_60To61Years",
+      "Count_Person_62To64Years",
+      "Count_Person_65To74Years"
+    ],
+    "relatedChart": {
+      "scale": true,
+      "statsVars": [
+        "Count_Person_5To17Years",
+        "Count_Person_18To24Years",
+        "Count_Person_25To34Years",
+        "Count_Person_35To44Years",
+        "Count_Person_45To54Years",
+        "Count_Person_60To61Years",
+        "Count_Person_62To64Years",
+        "Count_Person_65To74Years"
+      ]
+    }
+  },
+  {
+    "title": "Population by race",
+    "statsVars": [
+      "Count_Person_AmericanIndianOrAlaskaNativeAlone",
+      "Count_Person_AsianAlone",
+      "Count_Person_BlackOrAfricanAmericanAlone",
+      "Count_Person_HispanicOrLatino",
+      "Count_Person_NativeHawaiianOrOtherPacificIslanderAlone",
+      "Count_Person_SomeOtherRaceAlone",
+      "Count_Person_TwoOrMoreRaces",
+      "Count_Person_WhiteAlone"
+    ],
+    "relatedChart": {
+      "scale": true,
+      "statsVars": [
+        "Count_Person_AmericanIndianOrAlaskaNativeAlone",
+        "Count_Person_AsianAlone",
+        "Count_Person_BlackOrAfricanAmericanAlone",
+        "Count_Person_HispanicOrLatino",
+        "Count_Person_NativeHawaiianOrOtherPacificIslanderAlone",
+        "Count_Person_SomeOtherRaceAlone",
+        "Count_Person_TwoOrMoreRaces",
+        "Count_Person_WhiteAlone"
+      ]
+    }
+  },
+  {
+    "title": "Poverty rate",
+    "statsVars": [
+      "Count_Person_BelowPovertyLevelInThePast12Months"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Poverty rate by gender",
+    "statsVars": [
+      "Count_Person_Female_BelowPovertyLevelInThePast12Months",
+      "Count_Person_Male_BelowPovertyLevelInThePast12Months"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Poverty rate by race",
+    "statsVars": [
+      "Count_Person_BelowPovertyLevelInThePast12Months_AmericanIndianOrAlaskaNativeAlone",
+      "Count_Person_BelowPovertyLevelInThePast12Months_AsianAlone",
+      "Count_Person_BelowPovertyLevelInThePast12Months_BlackOrAfricanAmericanAlone",
+      "Count_Person_BelowPovertyLevelInThePast12Months_HispanicOrLatino",
+      "Count_Person_BelowPovertyLevelInThePast12Months_NativeHawaiianOrOtherPacificIslanderAlone",
+      "Count_Person_BelowPovertyLevelInThePast12Months_WhiteAlone"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Prescribed drugs (quarterly)",
+    "statsVars": [
+      "RetailDrugDistribution_DrugDistribution_Oxycodone",
+      "RetailDrugDistribution_DrugDistribution_Hydrocodone",
+      "RetailDrugDistribution_DrugDistribution_Codeine",
+      "RetailDrugDistribution_DrugDistribution_Amphetamine",
+      "RetailDrugDistribution_DrugDistribution_Morphine"
+    ],
+    "relatedChart": {
+      "scale": true,
+      "statsVars": [
+        "RetailDrugDistribution_DrugDistribution_Oxycodone",
+        "RetailDrugDistribution_DrugDistribution_Hydrocodone",
+        "RetailDrugDistribution_DrugDistribution_Codeine",
+        "RetailDrugDistribution_DrugDistribution_Amphetamine",
+        "RetailDrugDistribution_DrugDistribution_Morphine"
+      ]
+    }
+  },
+  {
+    "title": "Property crime",
+    "statsVars": [
+      "Count_CriminalActivities_PropertyCrime"
+    ],
+    "relatedChart": {
+      "scale": true,
+      "statsVars": [
+        "Count_CriminalActivities_PropertyCrime"
+      ]
+    }
+  },
+  {
+    "title": "Rate of associate degree attainment by gender",
+    "statsVars": [
+      "Count_Person_25To34Years_EducationalAttainmentAssociatesDegree_Female",
+      "Count_Person_25To34Years_EducationalAttainmentAssociatesDegree_Male"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Rate of bachelor's degree attainment by gender",
+    "statsVars": [
+      "Count_Person_25To34Years_EducationalAttainmentBachelorsDegree_Female",
+      "Count_Person_25To34Years_EducationalAttainmentBachelorsDegree_Male"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Rate of graduate or professional degree attainment by gender",
+    "statsVars": [
+      "Count_Person_25To34Years_EducationalAttainmentGraduateOrProfessionalDegree_Female",
+      "Count_Person_25To34Years_EducationalAttainmentGraduateOrProfessionalDegree_Male"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "School enrollment",
+    "statsVars": [
+      "Count_Person_EnrolledInSchool",
+      "Count_Person_NotEnrolledInSchool"
+    ],
+    "relatedChart": {
+      "scale": true,
+      "statsVars": [
+        "Count_Person_EnrolledInSchool",
+        "Count_Person_NotEnrolledInSchool"
+      ]
+    }
+  },
+  {
+    "title": "State unemployment insurance claims",
+    "statsVars": [
+      "Count_UnemploymentInsuranceClaim_StateUnemploymentInsurance"
+    ],
+    "relatedChart": {
+      "scale": true,
+      "statsVars": [
+        "Count_UnemploymentInsuranceClaim_StateUnemploymentInsurance"
+      ]
+    }
+  },
+  {
+    "title": "Total crime",
+    "statsVars": [
+      "Count_CriminalActivities_CombinedCrime"
+    ],
+    "relatedChart": {
+      "scale": true,
+      "statsVars": [
+        "Count_CriminalActivities_CombinedCrime"
+      ]
+    }
+  },
+  {
+    "title": "Violent crime",
+    "statsVars": [
+      "Count_CriminalActivities_ViolentCrime"
+    ],
+    "relatedChart": {
+      "scale": true,
+      "statsVars": [
+        "Count_CriminalActivities_ViolentCrime"
+      ]
+    }
   }
 ]

--- a/test/integration/golden_response/staging/statvar_ranking/missing_Earth_country_rankings.json
+++ b/test/integration/golden_response/staging/statvar_ranking/missing_Earth_country_rankings.json
@@ -124,18 +124,6 @@
     }
   },
   {
-    "title": "Housing units",
-    "statsVars": [
-      "Count_HousingUnit"
-    ],
-    "relatedChart": {
-      "scale": true,
-      "statsVars": [
-        "Count_HousingUnit"
-      ]
-    }
-  },
-  {
     "title": "Housing units by date built",
     "statsVars": [
       "Count_HousingUnit_Before1939DateBuilt",
@@ -266,6 +254,18 @@
     }
   },
   {
+    "title": "Housing units",
+    "statsVars": [
+      "Count_HousingUnit"
+    ],
+    "relatedChart": {
+      "scale": true,
+      "statsVars": [
+        "Count_HousingUnit"
+      ]
+    }
+  },
+  {
     "title": "Individual income",
     "statsVars": [
       "Count_Person_IncomeOfUpto9999USDollar",
@@ -341,13 +341,6 @@
     "relatedChart": {}
   },
   {
-    "title": "Median household income",
-    "statsVars": [
-      "Median_Income_Household"
-    ],
-    "relatedChart": {}
-  },
-  {
     "title": "Median household income by race",
     "statsVars": [
       "Median_Income_Household_HouseholderRaceAmericanIndianOrAlaskaNativeAlone",
@@ -356,6 +349,13 @@
       "Median_Income_Household_HouseholderRaceHispanicOrLatino",
       "Median_Income_Household_HouseholderRaceNativeHawaiianOrOtherPacificIslanderAlone",
       "Median_Income_Household_HouseholderRaceWhiteAlone"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Median household income",
+    "statsVars": [
+      "Median_Income_Household"
     ],
     "relatedChart": {}
   },
@@ -476,13 +476,6 @@
     }
   },
   {
-    "title": "Poverty rate",
-    "statsVars": [
-      "Count_Person_BelowPovertyLevelInThePast12Months"
-    ],
-    "relatedChart": {}
-  },
-  {
     "title": "Poverty rate by gender",
     "statsVars": [
       "Count_Person_Female_BelowPovertyLevelInThePast12Months",
@@ -499,6 +492,13 @@
       "Count_Person_BelowPovertyLevelInThePast12Months_HispanicOrLatino",
       "Count_Person_BelowPovertyLevelInThePast12Months_NativeHawaiianOrOtherPacificIslanderAlone",
       "Count_Person_BelowPovertyLevelInThePast12Months_WhiteAlone"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Poverty rate",
+    "statsVars": [
+      "Count_Person_BelowPovertyLevelInThePast12Months"
     ],
     "relatedChart": {}
   },

--- a/test/integration/golden_response/staging/statvar_ranking/missing_USA_city_rankings.json
+++ b/test/integration/golden_response/staging/statvar_ranking/missing_USA_city_rankings.json
@@ -38,17 +38,17 @@
     }
   },
   {
-    "title": "Children in employment",
-    "statsVars": [
-      "Count_Person_7To14Years_Employed_AsFractionOf_Count_Person_7To14Years"
-    ],
-    "relatedChart": {}
-  },
-  {
     "title": "Children in employment by gender",
     "statsVars": [
       "Count_Person_7To14Years_Female_Employed_AsFractionOf_Count_Person_7To14Years_Female",
       "Count_Person_7To14Years_Male_Employed_AsFractionOf_Count_Person_7To14Years_Male"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Children in employment",
+    "statsVars": [
+      "Count_Person_7To14Years_Employed_AsFractionOf_Count_Person_7To14Years"
     ],
     "relatedChart": {}
   },
@@ -135,16 +135,16 @@
     "relatedChart": {}
   },
   {
-    "title": "Government expenditures on military",
+    "title": "Government expenditures on military (% of GDP)",
     "statsVars": [
-      "Amount_EconomicActivity_ExpenditureActivity_MilitaryExpenditure_Government"
+      "Amount_EconomicActivity_ExpenditureActivity_MilitaryExpenditure_Government_AsFractionOf_Amount_EconomicActivity_GrossDomesticProduction_Nominal"
     ],
     "relatedChart": {}
   },
   {
-    "title": "Government expenditures on military (% of GDP)",
+    "title": "Government expenditures on military",
     "statsVars": [
-      "Amount_EconomicActivity_ExpenditureActivity_MilitaryExpenditure_Government_AsFractionOf_Amount_EconomicActivity_GrossDomesticProduction_Nominal"
+      "Amount_EconomicActivity_ExpenditureActivity_MilitaryExpenditure_Government"
     ],
     "relatedChart": {}
   },
@@ -189,13 +189,6 @@
     }
   },
   {
-    "title": "Infant mortality rate",
-    "statsVars": [
-      "Count_Death_0Years_AsFractionOf_Count_BirthEvent_LiveBirth"
-    ],
-    "relatedChart": {}
-  },
-  {
     "title": "Infant mortality rate by gender",
     "statsVars": [
       "Count_Death_0Years_Male_AsFractionOf_Count_BirthEvent_LiveBirth_Male",
@@ -204,9 +197,9 @@
     "relatedChart": {}
   },
   {
-    "title": "Inward remittance",
+    "title": "Infant mortality rate",
     "statsVars": [
-      "Amount_Remittance_InwardRemittance"
+      "Count_Death_0Years_AsFractionOf_Count_BirthEvent_LiveBirth"
     ],
     "relatedChart": {}
   },
@@ -214,6 +207,13 @@
     "title": "Inward remittance (% of GDP)",
     "statsVars": [
       "Amount_Remittance_InwardRemittance_AsFractionOf_Amount_EconomicActivity_GrossDomesticProduction_Nominal"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Inward remittance",
+    "statsVars": [
+      "Amount_Remittance_InwardRemittance"
     ],
     "relatedChart": {}
   },
@@ -232,16 +232,16 @@
     "relatedChart": {}
   },
   {
-    "title": "Market capitalization of domestic companies",
+    "title": "Market capitalization of domestic companies (% of GDP)",
     "statsVars": [
-      "Amount_Stock"
+      "Amount_Stock_AsFractionOf_Amount_EconomicActivity_GrossDomesticProduction_Nominal"
     ],
     "relatedChart": {}
   },
   {
-    "title": "Market capitalization of domestic companies (% of GDP)",
+    "title": "Market capitalization of domestic companies",
     "statsVars": [
-      "Amount_Stock_AsFractionOf_Amount_EconomicActivity_GrossDomesticProduction_Nominal"
+      "Amount_Stock"
     ],
     "relatedChart": {}
   },
@@ -373,17 +373,17 @@
     }
   },
   {
-    "title": "Severe wasting among children under 5",
-    "statsVars": [
-      "Count_Person_Upto4Years_SevereWasting_AsFractionOf_Count_Person_Upto4Years"
-    ],
-    "relatedChart": {}
-  },
-  {
     "title": "Severe wasting among children under 5 by gender",
     "statsVars": [
       "Count_Person_Upto4Years_Male_SevereWasting_AsFractionOf_Count_Person_Upto4Years_Male",
       "Count_Person_Upto4Years_Female_SevereWasting_AsFractionOf_Count_Person_Upto4Years_Female"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Severe wasting among children under 5",
+    "statsVars": [
+      "Count_Person_Upto4Years_SevereWasting_AsFractionOf_Count_Person_Upto4Years"
     ],
     "relatedChart": {}
   },
@@ -402,16 +402,16 @@
   {
     "title": "Unemployment rate by gender",
     "statsVars": [
-      "UnemploymentRate_Person_Male",
-      "UnemploymentRate_Person_Female"
+      "UnemploymentRate_Person_Female",
+      "UnemploymentRate_Person_Male"
     ],
     "relatedChart": {}
   },
   {
     "title": "Unemployment rate by gender",
     "statsVars": [
-      "UnemploymentRate_Person_Female",
-      "UnemploymentRate_Person_Male"
+      "UnemploymentRate_Person_Male",
+      "UnemploymentRate_Person_Female"
     ],
     "relatedChart": {}
   },
@@ -424,17 +424,17 @@
     "relatedChart": {}
   },
   {
-    "title": "Wasting among children under 5",
-    "statsVars": [
-      "Count_Person_Upto4Years_Wasting_AsFractionOf_Count_Person_Upto4Years"
-    ],
-    "relatedChart": {}
-  },
-  {
     "title": "Wasting among children under 5 by gender",
     "statsVars": [
       "Count_Person_Upto4Years_Male_Wasting_AsFractionOf_Count_Person_Upto4Years_Male",
       "Count_Person_Upto4Years_Female_Wasting_AsFractionOf_Count_Person_Upto4Years_Female"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Wasting among children under 5",
+    "statsVars": [
+      "Count_Person_Upto4Years_Wasting_AsFractionOf_Count_Person_Upto4Years"
     ],
     "relatedChart": {}
   }

--- a/test/integration/golden_response/staging/statvar_ranking/missing_USA_city_rankings.json
+++ b/test/integration/golden_response/staging/statvar_ranking/missing_USA_city_rankings.json
@@ -1,160 +1,15 @@
 [
   {
-    "title": "Labor force participation rate",
+    "title": "Alcohol consumption per capita (annual)",
     "statsVars": [
-      "Count_Person_15To64Years_InLaborForce_AsFractionOf_Count_Person_15To64Years"
+      "Amount_Consumption_Alcohol_15OrMoreYears_AsFractionOf_Count_Person_15OrMoreYears"
     ],
     "relatedChart": {}
   },
   {
-    "title": "Poverty rate",
+    "title": "CO2 emissions per capita",
     "statsVars": [
-      "Count_Person_BelowPovertyLevelInThePast12Months"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "State unemployment insurance claims",
-    "statsVars": [
-      "Count_UnemploymentInsuranceClaim_StateUnemploymentInsurance"
-    ],
-    "relatedChart": {
-      "scale": true,
-      "statsVars": [
-        "Count_UnemploymentInsuranceClaim_StateUnemploymentInsurance"
-      ]
-    }
-  },
-  {
-    "title": "Children in employment",
-    "statsVars": [
-      "Count_Person_7To14Years_Employed_AsFractionOf_Count_Person_7To14Years"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Children in employment by gender",
-    "statsVars": [
-      "Count_Person_7To14Years_Female_Employed_AsFractionOf_Count_Person_7To14Years_Female",
-      "Count_Person_7To14Years_Male_Employed_AsFractionOf_Count_Person_7To14Years_Male"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Unemployment rate by gender",
-    "statsVars": [
-      "UnemploymentRate_Person_Male",
-      "UnemploymentRate_Person_Female"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Gross domestic product per capita",
-    "statsVars": [
-      "Amount_EconomicActivity_GrossDomesticProduction_Nominal_PerCapita"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Gross domestic product growth rate",
-    "statsVars": [
-      "GrowthRate_Amount_EconomicActivity_GrossDomesticProduction"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Gross national income per capita (purchasing power parity)",
-    "statsVars": [
-      "Amount_EconomicActivity_GrossNationalIncome_PurchasingPowerParity_PerCapita"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Gross national income (purchasing power parity)",
-    "statsVars": [
-      "Amount_EconomicActivity_GrossNationalIncome_PurchasingPowerParity"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Government debt",
-    "statsVars": [
-      "Amount_Debt_Government"
-    ],
-    "relatedChart": {
-      "scale": true,
-      "statsVars": [
-        "Amount_Debt_Government"
-      ]
-    }
-  },
-  {
-    "title": "Government expenditures on education (% of government expenditure)",
-    "statsVars": [
-      "Amount_EconomicActivity_ExpenditureActivity_EducationExpenditure_Government_AsFractionOf_Amount_EconomicActivity_ExpenditureActivity_Government"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Government expenditures on education (% of GDP)",
-    "statsVars": [
-      "Amount_EconomicActivity_ExpenditureActivity_EducationExpenditure_Government_AsFractionOf_Amount_EconomicActivity_GrossDomesticProduction_Nominal"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Government expenditures on military",
-    "statsVars": [
-      "Amount_EconomicActivity_ExpenditureActivity_MilitaryExpenditure_Government"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Government expenditures on military (% of GDP)",
-    "statsVars": [
-      "Amount_EconomicActivity_ExpenditureActivity_MilitaryExpenditure_Government_AsFractionOf_Amount_EconomicActivity_GrossDomesticProduction_Nominal"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Market capitalization of domestic companies",
-    "statsVars": [
-      "Amount_Stock"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Market capitalization of domestic companies (% of GDP)",
-    "statsVars": [
-      "Amount_Stock_AsFractionOf_Amount_EconomicActivity_GrossDomesticProduction_Nominal"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Inward remittance",
-    "statsVars": [
-      "Amount_Remittance_InwardRemittance"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Inward remittance (% of GDP)",
-    "statsVars": [
-      "Amount_Remittance_InwardRemittance_AsFractionOf_Amount_EconomicActivity_GrossDomesticProduction_Nominal"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Outward remittance",
-    "statsVars": [
-      "Amount_Remittance_OutwardRemittance"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Life expectancy (years)",
-    "statsVars": [
-      "LifeExpectancy_Person"
+      "Amount_Emissions_CarbonDioxide_PerCapita"
     ],
     "relatedChart": {}
   },
@@ -183,6 +38,214 @@
     }
   },
   {
+    "title": "Children in employment",
+    "statsVars": [
+      "Count_Person_7To14Years_Employed_AsFractionOf_Count_Person_7To14Years"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Children in employment by gender",
+    "statsVars": [
+      "Count_Person_7To14Years_Female_Employed_AsFractionOf_Count_Person_7To14Years_Female",
+      "Count_Person_7To14Years_Male_Employed_AsFractionOf_Count_Person_7To14Years_Male"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Cyclones",
+    "statsVars": [
+      "Count_CycloneEvent"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Disasters",
+    "statsVars": [
+      "Count_CycloneEvent",
+      "Count_DroughtEvent",
+      "Count_EarthquakeEvent",
+      "Count_FloodEvent",
+      "Count_StormSurgeTideEvent",
+      "Count_ThunderstormWindEvent",
+      "Count_TornadoEvent",
+      "Count_WildlandFireEvent"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Earthquakes",
+    "statsVars": [
+      "Count_EarthquakeEvent"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Electricity consumption per capita",
+    "statsVars": [
+      "Amount_Consumption_Electricity_PerCapita"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Energy use (kg of oil equivalent per capita)",
+    "statsVars": [
+      "Amount_Consumption_Energy_PerCapita"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Fertility rate",
+    "statsVars": [
+      "FertilityRate_Person_Female"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Gini index",
+    "statsVars": [
+      "GiniIndex_EconomicActivity"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Government debt",
+    "statsVars": [
+      "Amount_Debt_Government"
+    ],
+    "relatedChart": {
+      "scale": true,
+      "statsVars": [
+        "Amount_Debt_Government"
+      ]
+    }
+  },
+  {
+    "title": "Government expenditures on education (% of GDP)",
+    "statsVars": [
+      "Amount_EconomicActivity_ExpenditureActivity_EducationExpenditure_Government_AsFractionOf_Amount_EconomicActivity_GrossDomesticProduction_Nominal"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Government expenditures on education (% of government expenditure)",
+    "statsVars": [
+      "Amount_EconomicActivity_ExpenditureActivity_EducationExpenditure_Government_AsFractionOf_Amount_EconomicActivity_ExpenditureActivity_Government"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Government expenditures on military",
+    "statsVars": [
+      "Amount_EconomicActivity_ExpenditureActivity_MilitaryExpenditure_Government"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Government expenditures on military (% of GDP)",
+    "statsVars": [
+      "Amount_EconomicActivity_ExpenditureActivity_MilitaryExpenditure_Government_AsFractionOf_Amount_EconomicActivity_GrossDomesticProduction_Nominal"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Gross domestic product growth rate",
+    "statsVars": [
+      "GrowthRate_Amount_EconomicActivity_GrossDomesticProduction"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Gross domestic product per capita",
+    "statsVars": [
+      "Amount_EconomicActivity_GrossDomesticProduction_Nominal_PerCapita"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Gross national income (purchasing power parity)",
+    "statsVars": [
+      "Amount_EconomicActivity_GrossNationalIncome_PurchasingPowerParity"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Gross national income per capita (purchasing power parity)",
+    "statsVars": [
+      "Amount_EconomicActivity_GrossNationalIncome_PurchasingPowerParity_PerCapita"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Housing units by householder race",
+    "statsVars": [
+      "Count_HousingUnit_HouseholderRaceNativeHawaiianOrOtherPacificIslanderAlone"
+    ],
+    "relatedChart": {
+      "scale": true,
+      "statsVars": [
+        "Count_HousingUnit_HouseholderRaceNativeHawaiianOrOtherPacificIslanderAlone"
+      ]
+    }
+  },
+  {
+    "title": "Infant mortality rate",
+    "statsVars": [
+      "Count_Death_0Years_AsFractionOf_Count_BirthEvent_LiveBirth"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Infant mortality rate by gender",
+    "statsVars": [
+      "Count_Death_0Years_Male_AsFractionOf_Count_BirthEvent_LiveBirth_Male",
+      "Count_Death_0Years_Female_AsFractionOf_Count_BirthEvent_LiveBirth_Female"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Inward remittance",
+    "statsVars": [
+      "Amount_Remittance_InwardRemittance"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Inward remittance (% of GDP)",
+    "statsVars": [
+      "Amount_Remittance_InwardRemittance_AsFractionOf_Amount_EconomicActivity_GrossDomesticProduction_Nominal"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Labor force participation rate",
+    "statsVars": [
+      "Count_Person_15To64Years_InLaborForce_AsFractionOf_Count_Person_15To64Years"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Life expectancy (years)",
+    "statsVars": [
+      "LifeExpectancy_Person"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Market capitalization of domestic companies",
+    "statsVars": [
+      "Amount_Stock"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Market capitalization of domestic companies (% of GDP)",
+    "statsVars": [
+      "Amount_Stock_AsFractionOf_Amount_EconomicActivity_GrossDomesticProduction_Nominal"
+    ],
+    "relatedChart": {}
+  },
+  {
     "title": "Mortality events",
     "statsVars": [
       "Count_Death_DiseasesOfTheCirculatorySystem",
@@ -203,98 +266,9 @@
     }
   },
   {
-    "title": "Infant mortality rate",
+    "title": "Outward remittance",
     "statsVars": [
-      "Count_Death_0Years_AsFractionOf_Count_BirthEvent_LiveBirth"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Infant mortality rate by gender",
-    "statsVars": [
-      "Count_Death_0Years_Male_AsFractionOf_Count_BirthEvent_LiveBirth_Male",
-      "Count_Death_0Years_Female_AsFractionOf_Count_BirthEvent_LiveBirth_Female"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Wasting among children under 5",
-    "statsVars": [
-      "Count_Person_Upto4Years_Wasting_AsFractionOf_Count_Person_Upto4Years"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Wasting among children under 5 by gender",
-    "statsVars": [
-      "Count_Person_Upto4Years_Male_Wasting_AsFractionOf_Count_Person_Upto4Years_Male",
-      "Count_Person_Upto4Years_Female_Wasting_AsFractionOf_Count_Person_Upto4Years_Female"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Severe wasting among children under 5",
-    "statsVars": [
-      "Count_Person_Upto4Years_SevereWasting_AsFractionOf_Count_Person_Upto4Years"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Severe wasting among children under 5 by gender",
-    "statsVars": [
-      "Count_Person_Upto4Years_Male_SevereWasting_AsFractionOf_Count_Person_Upto4Years_Male",
-      "Count_Person_Upto4Years_Female_SevereWasting_AsFractionOf_Count_Person_Upto4Years_Female"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Prescribed drugs (quarterly)",
-    "statsVars": [
-      "RetailDrugDistribution_DrugDistribution_Oxycodone",
-      "RetailDrugDistribution_DrugDistribution_Hydrocodone",
-      "RetailDrugDistribution_DrugDistribution_Codeine",
-      "RetailDrugDistribution_DrugDistribution_Amphetamine",
-      "RetailDrugDistribution_DrugDistribution_Morphine"
-    ],
-    "relatedChart": {
-      "scale": true,
-      "statsVars": [
-        "RetailDrugDistribution_DrugDistribution_Oxycodone",
-        "RetailDrugDistribution_DrugDistribution_Hydrocodone",
-        "RetailDrugDistribution_DrugDistribution_Codeine",
-        "RetailDrugDistribution_DrugDistribution_Amphetamine",
-        "RetailDrugDistribution_DrugDistribution_Morphine"
-      ]
-    }
-  },
-  {
-    "title": "Alcohol consumption per capita (annual)",
-    "statsVars": [
-      "Amount_Consumption_Alcohol_15OrMoreYears_AsFractionOf_Count_Person_15OrMoreYears"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Gini index",
-    "statsVars": [
-      "GiniIndex_EconomicActivity"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Unemployment rate by gender",
-    "statsVars": [
-      "UnemploymentRate_Person_Female",
-      "UnemploymentRate_Person_Male"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Percentage of people without health insurance by race",
-    "statsVars": [
-      "Percent_Person_18To64Years_NoHealthInsurance_BlackOrAfricanAmericanAlone",
-      "Percent_Person_18To64Years_NoHealthInsurance_HispanicOrLatino",
-      "Percent_Person_18To64Years_NoHealthInsurance_WhiteAlone"
+      "Amount_Remittance_OutwardRemittance"
     ],
     "relatedChart": {}
   },
@@ -307,24 +281,11 @@
     "relatedChart": {}
   },
   {
-    "title": "Population growth rate",
+    "title": "Percentage of people without health insurance by race",
     "statsVars": [
-      "GrowthRate_Count_Person"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Population density (people per km²)",
-    "statsVars": [
-      "Count_Person_PerArea"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Urban and rural population",
-    "statsVars": [
-      "Count_Person_Urban",
-      "Count_Person_Rural"
+      "Percent_Person_18To64Years_NoHealthInsurance_BlackOrAfricanAmericanAlone",
+      "Percent_Person_18To64Years_NoHealthInsurance_HispanicOrLatino",
+      "Percent_Person_18To64Years_NoHealthInsurance_WhiteAlone"
     ],
     "relatedChart": {}
   },
@@ -371,70 +332,109 @@
     }
   },
   {
-    "title": "Fertility rate",
+    "title": "Population density (people per km²)",
     "statsVars": [
-      "FertilityRate_Person_Female"
+      "Count_Person_PerArea"
     ],
     "relatedChart": {}
   },
   {
-    "title": "Housing units by householder race",
+    "title": "Population growth rate",
     "statsVars": [
-      "Count_HousingUnit_HouseholderRaceNativeHawaiianOrOtherPacificIslanderAlone"
+      "GrowthRate_Count_Person"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Poverty rate",
+    "statsVars": [
+      "Count_Person_BelowPovertyLevelInThePast12Months"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Prescribed drugs (quarterly)",
+    "statsVars": [
+      "RetailDrugDistribution_DrugDistribution_Oxycodone",
+      "RetailDrugDistribution_DrugDistribution_Hydrocodone",
+      "RetailDrugDistribution_DrugDistribution_Codeine",
+      "RetailDrugDistribution_DrugDistribution_Amphetamine",
+      "RetailDrugDistribution_DrugDistribution_Morphine"
     ],
     "relatedChart": {
       "scale": true,
       "statsVars": [
-        "Count_HousingUnit_HouseholderRaceNativeHawaiianOrOtherPacificIslanderAlone"
+        "RetailDrugDistribution_DrugDistribution_Oxycodone",
+        "RetailDrugDistribution_DrugDistribution_Hydrocodone",
+        "RetailDrugDistribution_DrugDistribution_Codeine",
+        "RetailDrugDistribution_DrugDistribution_Amphetamine",
+        "RetailDrugDistribution_DrugDistribution_Morphine"
       ]
     }
   },
   {
-    "title": "Energy use (kg of oil equivalent per capita)",
+    "title": "Severe wasting among children under 5",
     "statsVars": [
-      "Amount_Consumption_Energy_PerCapita"
+      "Count_Person_Upto4Years_SevereWasting_AsFractionOf_Count_Person_Upto4Years"
     ],
     "relatedChart": {}
   },
   {
-    "title": "CO2 emissions per capita",
+    "title": "Severe wasting among children under 5 by gender",
     "statsVars": [
-      "Amount_Emissions_CarbonDioxide_PerCapita"
+      "Count_Person_Upto4Years_Male_SevereWasting_AsFractionOf_Count_Person_Upto4Years_Male",
+      "Count_Person_Upto4Years_Female_SevereWasting_AsFractionOf_Count_Person_Upto4Years_Female"
     ],
     "relatedChart": {}
   },
   {
-    "title": "Electricity consumption per capita",
+    "title": "State unemployment insurance claims",
     "statsVars": [
-      "Amount_Consumption_Electricity_PerCapita"
+      "Count_UnemploymentInsuranceClaim_StateUnemploymentInsurance"
+    ],
+    "relatedChart": {
+      "scale": true,
+      "statsVars": [
+        "Count_UnemploymentInsuranceClaim_StateUnemploymentInsurance"
+      ]
+    }
+  },
+  {
+    "title": "Unemployment rate by gender",
+    "statsVars": [
+      "UnemploymentRate_Person_Male",
+      "UnemploymentRate_Person_Female"
     ],
     "relatedChart": {}
   },
   {
-    "title": "Disasters",
+    "title": "Unemployment rate by gender",
     "statsVars": [
-      "Count_CycloneEvent",
-      "Count_DroughtEvent",
-      "Count_EarthquakeEvent",
-      "Count_FloodEvent",
-      "Count_StormSurgeTideEvent",
-      "Count_ThunderstormWindEvent",
-      "Count_TornadoEvent",
-      "Count_WildlandFireEvent"
+      "UnemploymentRate_Person_Female",
+      "UnemploymentRate_Person_Male"
     ],
     "relatedChart": {}
   },
   {
-    "title": "Earthquakes",
+    "title": "Urban and rural population",
     "statsVars": [
-      "Count_EarthquakeEvent"
+      "Count_Person_Urban",
+      "Count_Person_Rural"
     ],
     "relatedChart": {}
   },
   {
-    "title": "Cyclones",
+    "title": "Wasting among children under 5",
     "statsVars": [
-      "Count_CycloneEvent"
+      "Count_Person_Upto4Years_Wasting_AsFractionOf_Count_Person_Upto4Years"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Wasting among children under 5 by gender",
+    "statsVars": [
+      "Count_Person_Upto4Years_Male_Wasting_AsFractionOf_Count_Person_Upto4Years_Male",
+      "Count_Person_Upto4Years_Female_Wasting_AsFractionOf_Count_Person_Upto4Years_Female"
     ],
     "relatedChart": {}
   }

--- a/test/integration/golden_response/staging/statvar_ranking/missing_USA_county_rankings.json
+++ b/test/integration/golden_response/staging/statvar_ranking/missing_USA_county_rankings.json
@@ -1,29 +1,29 @@
 [
   {
-    "title": "Labor force participation rate",
+    "title": "Alcohol consumption per capita (annual)",
     "statsVars": [
-      "Count_Person_15To64Years_InLaborForce_AsFractionOf_Count_Person_15To64Years"
+      "Amount_Consumption_Alcohol_15OrMoreYears_AsFractionOf_Count_Person_15OrMoreYears"
     ],
     "relatedChart": {}
   },
   {
-    "title": "Poverty rate",
+    "title": "Arson",
     "statsVars": [
-      "Count_Person_BelowPovertyLevelInThePast12Months"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "State unemployment insurance claims",
-    "statsVars": [
-      "Count_UnemploymentInsuranceClaim_StateUnemploymentInsurance"
+      "Count_CriminalActivities_Arson"
     ],
     "relatedChart": {
       "scale": true,
       "statsVars": [
-        "Count_UnemploymentInsuranceClaim_StateUnemploymentInsurance"
+        "Count_CriminalActivities_Arson"
       ]
     }
+  },
+  {
+    "title": "CO2 emissions per capita",
+    "statsVars": [
+      "Amount_Emissions_CarbonDioxide_PerCapita"
+    ],
+    "relatedChart": {}
   },
   {
     "title": "Children in employment",
@@ -41,38 +41,44 @@
     "relatedChart": {}
   },
   {
-    "title": "Unemployment rate by gender",
+    "title": "Cyclones",
     "statsVars": [
-      "UnemploymentRate_Person_Male",
-      "UnemploymentRate_Person_Female"
+      "Count_CycloneEvent"
     ],
     "relatedChart": {}
   },
   {
-    "title": "Gross domestic product per capita",
+    "title": "Disasters",
     "statsVars": [
-      "Amount_EconomicActivity_GrossDomesticProduction_Nominal_PerCapita"
+      "Count_CycloneEvent"
     ],
     "relatedChart": {}
   },
   {
-    "title": "Gross domestic product growth rate",
+    "title": "Electricity consumption per capita",
     "statsVars": [
-      "GrowthRate_Amount_EconomicActivity_GrossDomesticProduction"
+      "Amount_Consumption_Electricity_PerCapita"
     ],
     "relatedChart": {}
   },
   {
-    "title": "Gross national income per capita (purchasing power parity)",
+    "title": "Energy use (kg of oil equivalent per capita)",
     "statsVars": [
-      "Amount_EconomicActivity_GrossNationalIncome_PurchasingPowerParity_PerCapita"
+      "Amount_Consumption_Energy_PerCapita"
     ],
     "relatedChart": {}
   },
   {
-    "title": "Gross national income (purchasing power parity)",
+    "title": "Fertility rate",
     "statsVars": [
-      "Amount_EconomicActivity_GrossNationalIncome_PurchasingPowerParity"
+      "FertilityRate_Person_Female"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Gini index",
+    "statsVars": [
+      "GiniIndex_EconomicActivity"
     ],
     "relatedChart": {}
   },
@@ -89,16 +95,16 @@
     }
   },
   {
-    "title": "Government expenditures on education (% of government expenditure)",
+    "title": "Government expenditures on education (% of GDP)",
     "statsVars": [
-      "Amount_EconomicActivity_ExpenditureActivity_EducationExpenditure_Government_AsFractionOf_Amount_EconomicActivity_ExpenditureActivity_Government"
+      "Amount_EconomicActivity_ExpenditureActivity_EducationExpenditure_Government_AsFractionOf_Amount_EconomicActivity_GrossDomesticProduction_Nominal"
     ],
     "relatedChart": {}
   },
   {
-    "title": "Government expenditures on education (% of GDP)",
+    "title": "Government expenditures on education (% of government expenditure)",
     "statsVars": [
-      "Amount_EconomicActivity_ExpenditureActivity_EducationExpenditure_Government_AsFractionOf_Amount_EconomicActivity_GrossDomesticProduction_Nominal"
+      "Amount_EconomicActivity_ExpenditureActivity_EducationExpenditure_Government_AsFractionOf_Amount_EconomicActivity_ExpenditureActivity_Government"
     ],
     "relatedChart": {}
   },
@@ -117,16 +123,79 @@
     "relatedChart": {}
   },
   {
-    "title": "Market capitalization of domestic companies",
+    "title": "Gross domestic product growth rate",
     "statsVars": [
-      "Amount_Stock"
+      "GrowthRate_Amount_EconomicActivity_GrossDomesticProduction"
     ],
     "relatedChart": {}
   },
   {
-    "title": "Market capitalization of domestic companies (% of GDP)",
+    "title": "Gross domestic product per capita",
     "statsVars": [
-      "Amount_Stock_AsFractionOf_Amount_EconomicActivity_GrossDomesticProduction_Nominal"
+      "Amount_EconomicActivity_GrossDomesticProduction_Nominal_PerCapita"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Gross national income (purchasing power parity)",
+    "statsVars": [
+      "Amount_EconomicActivity_GrossNationalIncome_PurchasingPowerParity"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Gross national income per capita (purchasing power parity)",
+    "statsVars": [
+      "Amount_EconomicActivity_GrossNationalIncome_PurchasingPowerParity_PerCapita"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Health behaviors",
+    "statsVars": [
+      "Percent_Person_SleepLessThan7Hours",
+      "Percent_Person_Obesity",
+      "Percent_Person_BingeDrinking",
+      "Percent_Person_PhysicalInactivity",
+      "Percent_Person_Smoking"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Health outcomes",
+    "statsVars": [
+      "Percent_Person_WithHighCholesterol",
+      "Percent_Person_WithHighBloodPressure",
+      "Percent_Person_WithArthritis",
+      "Percent_Person_WithMentalHealthNotGood",
+      "Percent_Person_WithPhysicalHealthNotGood"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Housing units by householder race",
+    "statsVars": [
+      "Count_HousingUnit_HouseholderRaceNativeHawaiianOrOtherPacificIslanderAlone"
+    ],
+    "relatedChart": {
+      "scale": true,
+      "statsVars": [
+        "Count_HousingUnit_HouseholderRaceNativeHawaiianOrOtherPacificIslanderAlone"
+      ]
+    }
+  },
+  {
+    "title": "Infant mortality rate",
+    "statsVars": [
+      "Count_Death_0Years_AsFractionOf_Count_BirthEvent_LiveBirth"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Infant mortality rate by gender",
+    "statsVars": [
+      "Count_Death_0Years_Male_AsFractionOf_Count_BirthEvent_LiveBirth_Male",
+      "Count_Death_0Years_Female_AsFractionOf_Count_BirthEvent_LiveBirth_Female"
     ],
     "relatedChart": {}
   },
@@ -145,9 +214,9 @@
     "relatedChart": {}
   },
   {
-    "title": "Outward remittance",
+    "title": "Labor force participation rate",
     "statsVars": [
-      "Amount_Remittance_OutwardRemittance"
+      "Count_Person_15To64Years_InLaborForce_AsFractionOf_Count_Person_15To64Years"
     ],
     "relatedChart": {}
   },
@@ -159,91 +228,23 @@
     "relatedChart": {}
   },
   {
-    "title": "Infant mortality rate",
+    "title": "Market capitalization of domestic companies",
     "statsVars": [
-      "Count_Death_0Years_AsFractionOf_Count_BirthEvent_LiveBirth"
+      "Amount_Stock"
     ],
     "relatedChart": {}
   },
   {
-    "title": "Infant mortality rate by gender",
+    "title": "Market capitalization of domestic companies (% of GDP)",
     "statsVars": [
-      "Count_Death_0Years_Male_AsFractionOf_Count_BirthEvent_LiveBirth_Male",
-      "Count_Death_0Years_Female_AsFractionOf_Count_BirthEvent_LiveBirth_Female"
+      "Amount_Stock_AsFractionOf_Amount_EconomicActivity_GrossDomesticProduction_Nominal"
     ],
     "relatedChart": {}
   },
   {
-    "title": "Wasting among children under 5",
+    "title": "Outward remittance",
     "statsVars": [
-      "Count_Person_Upto4Years_Wasting_AsFractionOf_Count_Person_Upto4Years"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Wasting among children under 5 by gender",
-    "statsVars": [
-      "Count_Person_Upto4Years_Male_Wasting_AsFractionOf_Count_Person_Upto4Years_Male",
-      "Count_Person_Upto4Years_Female_Wasting_AsFractionOf_Count_Person_Upto4Years_Female"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Severe wasting among children under 5",
-    "statsVars": [
-      "Count_Person_Upto4Years_SevereWasting_AsFractionOf_Count_Person_Upto4Years"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Severe wasting among children under 5 by gender",
-    "statsVars": [
-      "Count_Person_Upto4Years_Male_SevereWasting_AsFractionOf_Count_Person_Upto4Years_Male",
-      "Count_Person_Upto4Years_Female_SevereWasting_AsFractionOf_Count_Person_Upto4Years_Female"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Health outcomes",
-    "statsVars": [
-      "Percent_Person_WithHighCholesterol",
-      "Percent_Person_WithHighBloodPressure",
-      "Percent_Person_WithArthritis",
-      "Percent_Person_WithMentalHealthNotGood",
-      "Percent_Person_WithPhysicalHealthNotGood"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Health behaviors",
-    "statsVars": [
-      "Percent_Person_SleepLessThan7Hours",
-      "Percent_Person_Obesity",
-      "Percent_Person_BingeDrinking",
-      "Percent_Person_PhysicalInactivity",
-      "Percent_Person_Smoking"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Alcohol consumption per capita (annual)",
-    "statsVars": [
-      "Amount_Consumption_Alcohol_15OrMoreYears_AsFractionOf_Count_Person_15OrMoreYears"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Gini index",
-    "statsVars": [
-      "GiniIndex_EconomicActivity"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Unemployment rate by gender",
-    "statsVars": [
-      "UnemploymentRate_Person_Female",
-      "UnemploymentRate_Person_Male"
+      "Amount_Remittance_OutwardRemittance"
     ],
     "relatedChart": {}
   },
@@ -253,76 +254,6 @@
       "Percent_Person_18To64Years_NoHealthInsurance_BlackOrAfricanAmericanAlone",
       "Percent_Person_18To64Years_NoHealthInsurance_HispanicOrLatino",
       "Percent_Person_18To64Years_NoHealthInsurance_WhiteAlone"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Total crime",
-    "statsVars": [
-      "Count_CriminalActivities_CombinedCrime"
-    ],
-    "relatedChart": {
-      "scale": true,
-      "statsVars": [
-        "Count_CriminalActivities_CombinedCrime"
-      ]
-    }
-  },
-  {
-    "title": "Violent crime",
-    "statsVars": [
-      "Count_CriminalActivities_ViolentCrime"
-    ],
-    "relatedChart": {
-      "scale": true,
-      "statsVars": [
-        "Count_CriminalActivities_ViolentCrime"
-      ]
-    }
-  },
-  {
-    "title": "Property crime",
-    "statsVars": [
-      "Count_CriminalActivities_PropertyCrime"
-    ],
-    "relatedChart": {
-      "scale": true,
-      "statsVars": [
-        "Count_CriminalActivities_PropertyCrime"
-      ]
-    }
-  },
-  {
-    "title": "Arson",
-    "statsVars": [
-      "Count_CriminalActivities_Arson"
-    ],
-    "relatedChart": {
-      "scale": true,
-      "statsVars": [
-        "Count_CriminalActivities_Arson"
-      ]
-    }
-  },
-  {
-    "title": "Population growth rate",
-    "statsVars": [
-      "GrowthRate_Count_Person"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Population density (people per km²)",
-    "statsVars": [
-      "Count_Person_PerArea"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Urban and rural population",
-    "statsVars": [
-      "Count_Person_Urban",
-      "Count_Person_Rural"
     ],
     "relatedChart": {}
   },
@@ -369,56 +300,125 @@
     }
   },
   {
-    "title": "Fertility rate",
+    "title": "Population density (people per km²)",
     "statsVars": [
-      "FertilityRate_Person_Female"
+      "Count_Person_PerArea"
     ],
     "relatedChart": {}
   },
   {
-    "title": "Housing units by householder race",
+    "title": "Population growth rate",
     "statsVars": [
-      "Count_HousingUnit_HouseholderRaceNativeHawaiianOrOtherPacificIslanderAlone"
+      "GrowthRate_Count_Person"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Poverty rate",
+    "statsVars": [
+      "Count_Person_BelowPovertyLevelInThePast12Months"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Property crime",
+    "statsVars": [
+      "Count_CriminalActivities_PropertyCrime"
     ],
     "relatedChart": {
       "scale": true,
       "statsVars": [
-        "Count_HousingUnit_HouseholderRaceNativeHawaiianOrOtherPacificIslanderAlone"
+        "Count_CriminalActivities_PropertyCrime"
       ]
     }
   },
   {
-    "title": "Energy use (kg of oil equivalent per capita)",
+    "title": "Severe wasting among children under 5",
     "statsVars": [
-      "Amount_Consumption_Energy_PerCapita"
+      "Count_Person_Upto4Years_SevereWasting_AsFractionOf_Count_Person_Upto4Years"
     ],
     "relatedChart": {}
   },
   {
-    "title": "CO2 emissions per capita",
+    "title": "Severe wasting among children under 5 by gender",
     "statsVars": [
-      "Amount_Emissions_CarbonDioxide_PerCapita"
+      "Count_Person_Upto4Years_Male_SevereWasting_AsFractionOf_Count_Person_Upto4Years_Male",
+      "Count_Person_Upto4Years_Female_SevereWasting_AsFractionOf_Count_Person_Upto4Years_Female"
     ],
     "relatedChart": {}
   },
   {
-    "title": "Electricity consumption per capita",
+    "title": "State unemployment insurance claims",
     "statsVars": [
-      "Amount_Consumption_Electricity_PerCapita"
+      "Count_UnemploymentInsuranceClaim_StateUnemploymentInsurance"
+    ],
+    "relatedChart": {
+      "scale": true,
+      "statsVars": [
+        "Count_UnemploymentInsuranceClaim_StateUnemploymentInsurance"
+      ]
+    }
+  },
+  {
+    "title": "Total crime",
+    "statsVars": [
+      "Count_CriminalActivities_CombinedCrime"
+    ],
+    "relatedChart": {
+      "scale": true,
+      "statsVars": [
+        "Count_CriminalActivities_CombinedCrime"
+      ]
+    }
+  },
+  {
+    "title": "Unemployment rate by gender",
+    "statsVars": [
+      "UnemploymentRate_Person_Male",
+      "UnemploymentRate_Person_Female"
     ],
     "relatedChart": {}
   },
   {
-    "title": "Disasters",
+    "title": "Unemployment rate by gender",
     "statsVars": [
-      "Count_CycloneEvent"
+      "UnemploymentRate_Person_Female",
+      "UnemploymentRate_Person_Male"
     ],
     "relatedChart": {}
   },
   {
-    "title": "Cyclones",
+    "title": "Urban and rural population",
     "statsVars": [
-      "Count_CycloneEvent"
+      "Count_Person_Urban",
+      "Count_Person_Rural"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Violent crime",
+    "statsVars": [
+      "Count_CriminalActivities_ViolentCrime"
+    ],
+    "relatedChart": {
+      "scale": true,
+      "statsVars": [
+        "Count_CriminalActivities_ViolentCrime"
+      ]
+    }
+  },
+  {
+    "title": "Wasting among children under 5",
+    "statsVars": [
+      "Count_Person_Upto4Years_Wasting_AsFractionOf_Count_Person_Upto4Years"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Wasting among children under 5 by gender",
+    "statsVars": [
+      "Count_Person_Upto4Years_Male_Wasting_AsFractionOf_Count_Person_Upto4Years_Male",
+      "Count_Person_Upto4Years_Female_Wasting_AsFractionOf_Count_Person_Upto4Years_Female"
     ],
     "relatedChart": {}
   }

--- a/test/integration/golden_response/staging/statvar_ranking/missing_USA_county_rankings.json
+++ b/test/integration/golden_response/staging/statvar_ranking/missing_USA_county_rankings.json
@@ -26,17 +26,17 @@
     "relatedChart": {}
   },
   {
-    "title": "Children in employment",
-    "statsVars": [
-      "Count_Person_7To14Years_Employed_AsFractionOf_Count_Person_7To14Years"
-    ],
-    "relatedChart": {}
-  },
-  {
     "title": "Children in employment by gender",
     "statsVars": [
       "Count_Person_7To14Years_Female_Employed_AsFractionOf_Count_Person_7To14Years_Female",
       "Count_Person_7To14Years_Male_Employed_AsFractionOf_Count_Person_7To14Years_Male"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Children in employment",
+    "statsVars": [
+      "Count_Person_7To14Years_Employed_AsFractionOf_Count_Person_7To14Years"
     ],
     "relatedChart": {}
   },
@@ -109,16 +109,16 @@
     "relatedChart": {}
   },
   {
-    "title": "Government expenditures on military",
+    "title": "Government expenditures on military (% of GDP)",
     "statsVars": [
-      "Amount_EconomicActivity_ExpenditureActivity_MilitaryExpenditure_Government"
+      "Amount_EconomicActivity_ExpenditureActivity_MilitaryExpenditure_Government_AsFractionOf_Amount_EconomicActivity_GrossDomesticProduction_Nominal"
     ],
     "relatedChart": {}
   },
   {
-    "title": "Government expenditures on military (% of GDP)",
+    "title": "Government expenditures on military",
     "statsVars": [
-      "Amount_EconomicActivity_ExpenditureActivity_MilitaryExpenditure_Government_AsFractionOf_Amount_EconomicActivity_GrossDomesticProduction_Nominal"
+      "Amount_EconomicActivity_ExpenditureActivity_MilitaryExpenditure_Government"
     ],
     "relatedChart": {}
   },
@@ -185,13 +185,6 @@
     }
   },
   {
-    "title": "Infant mortality rate",
-    "statsVars": [
-      "Count_Death_0Years_AsFractionOf_Count_BirthEvent_LiveBirth"
-    ],
-    "relatedChart": {}
-  },
-  {
     "title": "Infant mortality rate by gender",
     "statsVars": [
       "Count_Death_0Years_Male_AsFractionOf_Count_BirthEvent_LiveBirth_Male",
@@ -200,9 +193,9 @@
     "relatedChart": {}
   },
   {
-    "title": "Inward remittance",
+    "title": "Infant mortality rate",
     "statsVars": [
-      "Amount_Remittance_InwardRemittance"
+      "Count_Death_0Years_AsFractionOf_Count_BirthEvent_LiveBirth"
     ],
     "relatedChart": {}
   },
@@ -210,6 +203,13 @@
     "title": "Inward remittance (% of GDP)",
     "statsVars": [
       "Amount_Remittance_InwardRemittance_AsFractionOf_Amount_EconomicActivity_GrossDomesticProduction_Nominal"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Inward remittance",
+    "statsVars": [
+      "Amount_Remittance_InwardRemittance"
     ],
     "relatedChart": {}
   },
@@ -228,16 +228,16 @@
     "relatedChart": {}
   },
   {
-    "title": "Market capitalization of domestic companies",
+    "title": "Market capitalization of domestic companies (% of GDP)",
     "statsVars": [
-      "Amount_Stock"
+      "Amount_Stock_AsFractionOf_Amount_EconomicActivity_GrossDomesticProduction_Nominal"
     ],
     "relatedChart": {}
   },
   {
-    "title": "Market capitalization of domestic companies (% of GDP)",
+    "title": "Market capitalization of domestic companies",
     "statsVars": [
-      "Amount_Stock_AsFractionOf_Amount_EconomicActivity_GrossDomesticProduction_Nominal"
+      "Amount_Stock"
     ],
     "relatedChart": {}
   },
@@ -333,17 +333,17 @@
     }
   },
   {
-    "title": "Severe wasting among children under 5",
-    "statsVars": [
-      "Count_Person_Upto4Years_SevereWasting_AsFractionOf_Count_Person_Upto4Years"
-    ],
-    "relatedChart": {}
-  },
-  {
     "title": "Severe wasting among children under 5 by gender",
     "statsVars": [
       "Count_Person_Upto4Years_Male_SevereWasting_AsFractionOf_Count_Person_Upto4Years_Male",
       "Count_Person_Upto4Years_Female_SevereWasting_AsFractionOf_Count_Person_Upto4Years_Female"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Severe wasting among children under 5",
+    "statsVars": [
+      "Count_Person_Upto4Years_SevereWasting_AsFractionOf_Count_Person_Upto4Years"
     ],
     "relatedChart": {}
   },
@@ -374,16 +374,16 @@
   {
     "title": "Unemployment rate by gender",
     "statsVars": [
-      "UnemploymentRate_Person_Male",
-      "UnemploymentRate_Person_Female"
+      "UnemploymentRate_Person_Female",
+      "UnemploymentRate_Person_Male"
     ],
     "relatedChart": {}
   },
   {
     "title": "Unemployment rate by gender",
     "statsVars": [
-      "UnemploymentRate_Person_Female",
-      "UnemploymentRate_Person_Male"
+      "UnemploymentRate_Person_Male",
+      "UnemploymentRate_Person_Female"
     ],
     "relatedChart": {}
   },
@@ -408,17 +408,17 @@
     }
   },
   {
-    "title": "Wasting among children under 5",
-    "statsVars": [
-      "Count_Person_Upto4Years_Wasting_AsFractionOf_Count_Person_Upto4Years"
-    ],
-    "relatedChart": {}
-  },
-  {
     "title": "Wasting among children under 5 by gender",
     "statsVars": [
       "Count_Person_Upto4Years_Male_Wasting_AsFractionOf_Count_Person_Upto4Years_Male",
       "Count_Person_Upto4Years_Female_Wasting_AsFractionOf_Count_Person_Upto4Years_Female"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Wasting among children under 5",
+    "statsVars": [
+      "Count_Person_Upto4Years_Wasting_AsFractionOf_Count_Person_Upto4Years"
     ],
     "relatedChart": {}
   }

--- a/test/integration/golden_response/staging/statvar_ranking/missing_USA_state_rankings.json
+++ b/test/integration/golden_response/staging/statvar_ranking/missing_USA_state_rankings.json
@@ -1,15 +1,27 @@
 [
   {
-    "title": "Labor force participation rate",
+    "title": "Alcohol consumption per capita (annual)",
     "statsVars": [
-      "Count_Person_15To64Years_InLaborForce_AsFractionOf_Count_Person_15To64Years"
+      "Amount_Consumption_Alcohol_15OrMoreYears_AsFractionOf_Count_Person_15OrMoreYears"
     ],
     "relatedChart": {}
   },
   {
-    "title": "Poverty rate",
+    "title": "Arson",
     "statsVars": [
-      "Count_Person_BelowPovertyLevelInThePast12Months"
+      "Count_CriminalActivities_Arson"
+    ],
+    "relatedChart": {
+      "scale": true,
+      "statsVars": [
+        "Count_CriminalActivities_Arson"
+      ]
+    }
+  },
+  {
+    "title": "CO2 emissions per capita",
+    "statsVars": [
+      "Amount_Emissions_CarbonDioxide_PerCapita"
     ],
     "relatedChart": {}
   },
@@ -29,38 +41,30 @@
     "relatedChart": {}
   },
   {
-    "title": "Unemployment rate by gender",
+    "title": "Electricity consumption per capita",
     "statsVars": [
-      "UnemploymentRate_Person_Male",
-      "UnemploymentRate_Person_Female"
+      "Amount_Consumption_Electricity_PerCapita"
     ],
     "relatedChart": {}
   },
   {
-    "title": "Gross domestic product per capita",
+    "title": "Energy use (kg of oil equivalent per capita)",
     "statsVars": [
-      "Amount_EconomicActivity_GrossDomesticProduction_Nominal_PerCapita"
+      "Amount_Consumption_Energy_PerCapita"
     ],
     "relatedChart": {}
   },
   {
-    "title": "Gross domestic product growth rate",
+    "title": "Fertility rate",
     "statsVars": [
-      "GrowthRate_Amount_EconomicActivity_GrossDomesticProduction"
+      "FertilityRate_Person_Female"
     ],
     "relatedChart": {}
   },
   {
-    "title": "Gross national income per capita (purchasing power parity)",
+    "title": "Gini index",
     "statsVars": [
-      "Amount_EconomicActivity_GrossNationalIncome_PurchasingPowerParity_PerCapita"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Gross national income (purchasing power parity)",
-    "statsVars": [
-      "Amount_EconomicActivity_GrossNationalIncome_PurchasingPowerParity"
+      "GiniIndex_EconomicActivity"
     ],
     "relatedChart": {}
   },
@@ -77,16 +81,16 @@
     }
   },
   {
-    "title": "Government expenditures on education (% of government expenditure)",
+    "title": "Government expenditures on education (% of GDP)",
     "statsVars": [
-      "Amount_EconomicActivity_ExpenditureActivity_EducationExpenditure_Government_AsFractionOf_Amount_EconomicActivity_ExpenditureActivity_Government"
+      "Amount_EconomicActivity_ExpenditureActivity_EducationExpenditure_Government_AsFractionOf_Amount_EconomicActivity_GrossDomesticProduction_Nominal"
     ],
     "relatedChart": {}
   },
   {
-    "title": "Government expenditures on education (% of GDP)",
+    "title": "Government expenditures on education (% of government expenditure)",
     "statsVars": [
-      "Amount_EconomicActivity_ExpenditureActivity_EducationExpenditure_Government_AsFractionOf_Amount_EconomicActivity_GrossDomesticProduction_Nominal"
+      "Amount_EconomicActivity_ExpenditureActivity_EducationExpenditure_Government_AsFractionOf_Amount_EconomicActivity_ExpenditureActivity_Government"
     ],
     "relatedChart": {}
   },
@@ -105,16 +109,79 @@
     "relatedChart": {}
   },
   {
-    "title": "Market capitalization of domestic companies",
+    "title": "Gross domestic product growth rate",
     "statsVars": [
-      "Amount_Stock"
+      "GrowthRate_Amount_EconomicActivity_GrossDomesticProduction"
     ],
     "relatedChart": {}
   },
   {
-    "title": "Market capitalization of domestic companies (% of GDP)",
+    "title": "Gross domestic product per capita",
     "statsVars": [
-      "Amount_Stock_AsFractionOf_Amount_EconomicActivity_GrossDomesticProduction_Nominal"
+      "Amount_EconomicActivity_GrossDomesticProduction_Nominal_PerCapita"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Gross national income (purchasing power parity)",
+    "statsVars": [
+      "Amount_EconomicActivity_GrossNationalIncome_PurchasingPowerParity"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Gross national income per capita (purchasing power parity)",
+    "statsVars": [
+      "Amount_EconomicActivity_GrossNationalIncome_PurchasingPowerParity_PerCapita"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Health behaviors",
+    "statsVars": [
+      "Percent_Person_SleepLessThan7Hours",
+      "Percent_Person_Obesity",
+      "Percent_Person_BingeDrinking",
+      "Percent_Person_PhysicalInactivity",
+      "Percent_Person_Smoking"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Health outcomes",
+    "statsVars": [
+      "Percent_Person_WithHighCholesterol",
+      "Percent_Person_WithHighBloodPressure",
+      "Percent_Person_WithArthritis",
+      "Percent_Person_WithMentalHealthNotGood",
+      "Percent_Person_WithPhysicalHealthNotGood"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Housing units by householder race",
+    "statsVars": [
+      "Count_HousingUnit_HouseholderRaceNativeHawaiianOrOtherPacificIslanderAlone"
+    ],
+    "relatedChart": {
+      "scale": true,
+      "statsVars": [
+        "Count_HousingUnit_HouseholderRaceNativeHawaiianOrOtherPacificIslanderAlone"
+      ]
+    }
+  },
+  {
+    "title": "Infant mortality rate",
+    "statsVars": [
+      "Count_Death_0Years_AsFractionOf_Count_BirthEvent_LiveBirth"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Infant mortality rate by gender",
+    "statsVars": [
+      "Count_Death_0Years_Male_AsFractionOf_Count_BirthEvent_LiveBirth_Male",
+      "Count_Death_0Years_Female_AsFractionOf_Count_BirthEvent_LiveBirth_Female"
     ],
     "relatedChart": {}
   },
@@ -133,6 +200,27 @@
     "relatedChart": {}
   },
   {
+    "title": "Labor force participation rate",
+    "statsVars": [
+      "Count_Person_15To64Years_InLaborForce_AsFractionOf_Count_Person_15To64Years"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Market capitalization of domestic companies",
+    "statsVars": [
+      "Amount_Stock"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Market capitalization of domestic companies (% of GDP)",
+    "statsVars": [
+      "Amount_Stock_AsFractionOf_Amount_EconomicActivity_GrossDomesticProduction_Nominal"
+    ],
+    "relatedChart": {}
+  },
+  {
     "title": "Outward remittance",
     "statsVars": [
       "Amount_Remittance_OutwardRemittance"
@@ -140,32 +228,16 @@
     "relatedChart": {}
   },
   {
-    "title": "Infant mortality rate",
+    "title": "Population growth rate",
     "statsVars": [
-      "Count_Death_0Years_AsFractionOf_Count_BirthEvent_LiveBirth"
+      "GrowthRate_Count_Person"
     ],
     "relatedChart": {}
   },
   {
-    "title": "Infant mortality rate by gender",
+    "title": "Poverty rate",
     "statsVars": [
-      "Count_Death_0Years_Male_AsFractionOf_Count_BirthEvent_LiveBirth_Male",
-      "Count_Death_0Years_Female_AsFractionOf_Count_BirthEvent_LiveBirth_Female"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Wasting among children under 5",
-    "statsVars": [
-      "Count_Person_Upto4Years_Wasting_AsFractionOf_Count_Person_Upto4Years"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Wasting among children under 5 by gender",
-    "statsVars": [
-      "Count_Person_Upto4Years_Male_Wasting_AsFractionOf_Count_Person_Upto4Years_Male",
-      "Count_Person_Upto4Years_Female_Wasting_AsFractionOf_Count_Person_Upto4Years_Female"
+      "Count_Person_BelowPovertyLevelInThePast12Months"
     ],
     "relatedChart": {}
   },
@@ -185,42 +257,6 @@
     "relatedChart": {}
   },
   {
-    "title": "Health outcomes",
-    "statsVars": [
-      "Percent_Person_WithHighCholesterol",
-      "Percent_Person_WithHighBloodPressure",
-      "Percent_Person_WithArthritis",
-      "Percent_Person_WithMentalHealthNotGood",
-      "Percent_Person_WithPhysicalHealthNotGood"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Health behaviors",
-    "statsVars": [
-      "Percent_Person_SleepLessThan7Hours",
-      "Percent_Person_Obesity",
-      "Percent_Person_BingeDrinking",
-      "Percent_Person_PhysicalInactivity",
-      "Percent_Person_Smoking"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Alcohol consumption per capita (annual)",
-    "statsVars": [
-      "Amount_Consumption_Alcohol_15OrMoreYears_AsFractionOf_Count_Person_15OrMoreYears"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Gini index",
-    "statsVars": [
-      "GiniIndex_EconomicActivity"
-    ],
-    "relatedChart": {}
-  },
-  {
     "title": "Unemployment rate by gender",
     "statsVars": [
       "UnemploymentRate_Person_Female",
@@ -229,21 +265,10 @@
     "relatedChart": {}
   },
   {
-    "title": "Arson",
+    "title": "Unemployment rate by gender",
     "statsVars": [
-      "Count_CriminalActivities_Arson"
-    ],
-    "relatedChart": {
-      "scale": true,
-      "statsVars": [
-        "Count_CriminalActivities_Arson"
-      ]
-    }
-  },
-  {
-    "title": "Population growth rate",
-    "statsVars": [
-      "GrowthRate_Count_Person"
+      "UnemploymentRate_Person_Male",
+      "UnemploymentRate_Person_Female"
     ],
     "relatedChart": {}
   },
@@ -256,42 +281,17 @@
     "relatedChart": {}
   },
   {
-    "title": "Fertility rate",
+    "title": "Wasting among children under 5",
     "statsVars": [
-      "FertilityRate_Person_Female"
+      "Count_Person_Upto4Years_Wasting_AsFractionOf_Count_Person_Upto4Years"
     ],
     "relatedChart": {}
   },
   {
-    "title": "Housing units by householder race",
+    "title": "Wasting among children under 5 by gender",
     "statsVars": [
-      "Count_HousingUnit_HouseholderRaceNativeHawaiianOrOtherPacificIslanderAlone"
-    ],
-    "relatedChart": {
-      "scale": true,
-      "statsVars": [
-        "Count_HousingUnit_HouseholderRaceNativeHawaiianOrOtherPacificIslanderAlone"
-      ]
-    }
-  },
-  {
-    "title": "Energy use (kg of oil equivalent per capita)",
-    "statsVars": [
-      "Amount_Consumption_Energy_PerCapita"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "CO2 emissions per capita",
-    "statsVars": [
-      "Amount_Emissions_CarbonDioxide_PerCapita"
-    ],
-    "relatedChart": {}
-  },
-  {
-    "title": "Electricity consumption per capita",
-    "statsVars": [
-      "Amount_Consumption_Electricity_PerCapita"
+      "Count_Person_Upto4Years_Male_Wasting_AsFractionOf_Count_Person_Upto4Years_Male",
+      "Count_Person_Upto4Years_Female_Wasting_AsFractionOf_Count_Person_Upto4Years_Female"
     ],
     "relatedChart": {}
   }

--- a/test/integration/golden_response/staging/statvar_ranking/missing_USA_state_rankings.json
+++ b/test/integration/golden_response/staging/statvar_ranking/missing_USA_state_rankings.json
@@ -26,17 +26,17 @@
     "relatedChart": {}
   },
   {
-    "title": "Children in employment",
-    "statsVars": [
-      "Count_Person_7To14Years_Employed_AsFractionOf_Count_Person_7To14Years"
-    ],
-    "relatedChart": {}
-  },
-  {
     "title": "Children in employment by gender",
     "statsVars": [
       "Count_Person_7To14Years_Female_Employed_AsFractionOf_Count_Person_7To14Years_Female",
       "Count_Person_7To14Years_Male_Employed_AsFractionOf_Count_Person_7To14Years_Male"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Children in employment",
+    "statsVars": [
+      "Count_Person_7To14Years_Employed_AsFractionOf_Count_Person_7To14Years"
     ],
     "relatedChart": {}
   },
@@ -95,16 +95,16 @@
     "relatedChart": {}
   },
   {
-    "title": "Government expenditures on military",
+    "title": "Government expenditures on military (% of GDP)",
     "statsVars": [
-      "Amount_EconomicActivity_ExpenditureActivity_MilitaryExpenditure_Government"
+      "Amount_EconomicActivity_ExpenditureActivity_MilitaryExpenditure_Government_AsFractionOf_Amount_EconomicActivity_GrossDomesticProduction_Nominal"
     ],
     "relatedChart": {}
   },
   {
-    "title": "Government expenditures on military (% of GDP)",
+    "title": "Government expenditures on military",
     "statsVars": [
-      "Amount_EconomicActivity_ExpenditureActivity_MilitaryExpenditure_Government_AsFractionOf_Amount_EconomicActivity_GrossDomesticProduction_Nominal"
+      "Amount_EconomicActivity_ExpenditureActivity_MilitaryExpenditure_Government"
     ],
     "relatedChart": {}
   },
@@ -171,13 +171,6 @@
     }
   },
   {
-    "title": "Infant mortality rate",
-    "statsVars": [
-      "Count_Death_0Years_AsFractionOf_Count_BirthEvent_LiveBirth"
-    ],
-    "relatedChart": {}
-  },
-  {
     "title": "Infant mortality rate by gender",
     "statsVars": [
       "Count_Death_0Years_Male_AsFractionOf_Count_BirthEvent_LiveBirth_Male",
@@ -186,9 +179,9 @@
     "relatedChart": {}
   },
   {
-    "title": "Inward remittance",
+    "title": "Infant mortality rate",
     "statsVars": [
-      "Amount_Remittance_InwardRemittance"
+      "Count_Death_0Years_AsFractionOf_Count_BirthEvent_LiveBirth"
     ],
     "relatedChart": {}
   },
@@ -200,6 +193,13 @@
     "relatedChart": {}
   },
   {
+    "title": "Inward remittance",
+    "statsVars": [
+      "Amount_Remittance_InwardRemittance"
+    ],
+    "relatedChart": {}
+  },
+  {
     "title": "Labor force participation rate",
     "statsVars": [
       "Count_Person_15To64Years_InLaborForce_AsFractionOf_Count_Person_15To64Years"
@@ -207,16 +207,16 @@
     "relatedChart": {}
   },
   {
-    "title": "Market capitalization of domestic companies",
+    "title": "Market capitalization of domestic companies (% of GDP)",
     "statsVars": [
-      "Amount_Stock"
+      "Amount_Stock_AsFractionOf_Amount_EconomicActivity_GrossDomesticProduction_Nominal"
     ],
     "relatedChart": {}
   },
   {
-    "title": "Market capitalization of domestic companies (% of GDP)",
+    "title": "Market capitalization of domestic companies",
     "statsVars": [
-      "Amount_Stock_AsFractionOf_Amount_EconomicActivity_GrossDomesticProduction_Nominal"
+      "Amount_Stock"
     ],
     "relatedChart": {}
   },
@@ -242,17 +242,17 @@
     "relatedChart": {}
   },
   {
-    "title": "Severe wasting among children under 5",
-    "statsVars": [
-      "Count_Person_Upto4Years_SevereWasting_AsFractionOf_Count_Person_Upto4Years"
-    ],
-    "relatedChart": {}
-  },
-  {
     "title": "Severe wasting among children under 5 by gender",
     "statsVars": [
       "Count_Person_Upto4Years_Male_SevereWasting_AsFractionOf_Count_Person_Upto4Years_Male",
       "Count_Person_Upto4Years_Female_SevereWasting_AsFractionOf_Count_Person_Upto4Years_Female"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Severe wasting among children under 5",
+    "statsVars": [
+      "Count_Person_Upto4Years_SevereWasting_AsFractionOf_Count_Person_Upto4Years"
     ],
     "relatedChart": {}
   },
@@ -281,17 +281,17 @@
     "relatedChart": {}
   },
   {
-    "title": "Wasting among children under 5",
-    "statsVars": [
-      "Count_Person_Upto4Years_Wasting_AsFractionOf_Count_Person_Upto4Years"
-    ],
-    "relatedChart": {}
-  },
-  {
     "title": "Wasting among children under 5 by gender",
     "statsVars": [
       "Count_Person_Upto4Years_Male_Wasting_AsFractionOf_Count_Person_Upto4Years_Male",
       "Count_Person_Upto4Years_Female_Wasting_AsFractionOf_Count_Person_Upto4Years_Female"
+    ],
+    "relatedChart": {}
+  },
+  {
+    "title": "Wasting among children under 5",
+    "statsVars": [
+      "Count_Person_Upto4Years_Wasting_AsFractionOf_Count_Person_Upto4Years"
     ],
     "relatedChart": {}
   }

--- a/test/integration/place_statvar_ranking_test.go
+++ b/test/integration/place_statvar_ranking_test.go
@@ -59,7 +59,9 @@ func readChartConfig() ([]Chart, error) {
 	return config, nil
 }
 
-func getMissingStatVarRanking(client pb.MixerClient, req *pb.GetLocationsRankingsRequest) ([]string, error) {
+func getMissingStatVarRanking(
+	client pb.MixerClient,
+	req *pb.GetLocationsRankingsRequest) ([]string, error) {
 	ctx := context.Background()
 	response, err := client.GetLocationsRankings(ctx, req)
 	if err != nil {
@@ -90,7 +92,10 @@ func TestChartConfigRankings(t *testing.T) {
 		return
 	}
 	_, filename, _, _ := runtime.Caller(0)
-	goldenPath := path.Join(path.Dir(filename), "golden_response/staging/statvar_ranking")
+	goldenPath := path.Join(
+		path.Dir(filename),
+		"golden_response/staging/statvar_ranking",
+	)
 	for _, c := range []struct {
 		placeType   string
 		parentPlace string
@@ -138,7 +143,11 @@ func TestChartConfigRankings(t *testing.T) {
 					}
 					missingStatVars, err := getMissingStatVarRanking(client, req)
 					if err != nil {
-						t.Errorf("Error fetching rankings for chart %s: %s", chart.Title, c.placeType)
+						t.Errorf(
+							"Error fetching rankings for chart %s: %s",
+							chart.Title,
+							c.placeType,
+						)
 						t.Errorf("%s", err.Error())
 					}
 					missingRanking.StatsVars = missingStatVars
@@ -148,7 +157,11 @@ func TestChartConfigRankings(t *testing.T) {
 						req.IsPerCapita = true
 						missingStatVars, err := getMissingStatVarRanking(client, req)
 						if err != nil {
-							t.Errorf("Error fetching rankings for chart %s: %s", chart.Title, c.placeType)
+							t.Errorf(
+								"Error fetching rankings for chart %s: %s",
+								chart.Title,
+								c.placeType,
+							)
 							t.Errorf("%s", err.Error())
 						}
 						missingRanking.RelatedChart.Scale = true
@@ -166,7 +179,9 @@ func TestChartConfigRankings(t *testing.T) {
 				missingRankings = append(missingRankings, elem)
 			}
 			sort.Slice(missingRankings, func(i, j int) bool {
-				return missingRankings[i].Title < missingRankings[j].Title
+				si := missingRankings[i].Title + missingRankings[i].StatsVars[0]
+				sj := missingRankings[j].Title + missingRankings[j].StatsVars[0]
+				return si < sj
 			})
 
 			goldenFile := path.Join(goldenPath, c.goldenFile)

--- a/test/integration/query_test.go
+++ b/test/integration/query_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func TestQuery(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	client, err := setup(server.NewMemcache(map[string][]byte{}))
 	if err != nil {


### PR DESCRIPTION
- Add t.Parallel() to all the integration tests.
- The TestChartConfigRankings ranking test have two for loops over place type (4) and chart config (>100) which takes about 60 seconds to run. Use goroutine to parallel at config level so the O(100) request can emit concurrently. Hence needs to sort the final result by chart title and updating the golden response.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datacommonsorg/mixer/421)
<!-- Reviewable:end -->
