### PR TITLE
check type conversion errors

### DIFF
--- a/internal/server/landing_page.go
+++ b/internal/server/landing_page.go
@@ -248,7 +248,10 @@ func fetchBtData(
 	// Populate result from landing page cache
 	result := map[string]map[string]*ObsTimeSeries{}
 	for dcid, data := range dataMap {
-		landingPageData := data.(*LandingPageData)
+		landingPageData, ok := data.(*LandingPageData)
+		if !ok {
+			continue
+		}
 		finalData := map[string]*ObsTimeSeries{}
 		for statVarDcid, obsTimeSeries := range landingPageData.Data {
 			obsTimeSeries.filterAndRank(&ObsProp{})

--- a/internal/server/place_stat_date.go
+++ b/internal/server/place_stat_date.go
@@ -82,16 +82,19 @@ func (s *Server) GetPlaceStatDateWithinPlace(
 		},
 	)
 	for token, data := range cacheData {
-		if data != nil {
-			cohorts := data.(*pb.ObsCollection).SourceCohorts
-			sort.Sort(SeriesByRank(cohorts))
-			dates := []string{}
-			for date := range cohorts[0].Val {
-				dates = append(dates, date)
-			}
-			sort.Strings(dates)
-			result.Data[token] = &pb.DateList{Dates: dates}
+		collection, ok := data.(*pb.ObsCollection)
+		if !ok {
+			continue
 		}
+		cohorts := collection.SourceCohorts
+		sort.Sort(SeriesByRank(cohorts))
+		dates := []string{}
+		for date := range cohorts[0].Val {
+			dates = append(dates, date)
+		}
+		sort.Strings(dates)
+		result.Data[token] = &pb.DateList{Dates: dates}
+
 	}
 	// Get row keys that are not in mem-cache.
 	extraRowList := bigtable.RowList{}

--- a/internal/server/place_stat_vars.go
+++ b/internal/server/place_stat_vars.go
@@ -67,8 +67,9 @@ func (s *Server) GetPlaceStatVars(
 	resp := pb.GetPlaceStatVarsResponse{Places: map[string]*pb.StatVars{}}
 	for _, dcid := range dcids {
 		resp.Places[dcid] = &pb.StatVars{StatVars: []string{}}
-		if dataMap[dcid] != nil {
-			resp.Places[dcid].StatVars = dataMap[dcid].([]string)
+		v, ok := dataMap[dcid].([]string)
+		if ok {
+			resp.Places[dcid].StatVars = v
 		}
 	}
 	return &resp, nil

--- a/internal/server/places.go
+++ b/internal/server/places.go
@@ -129,10 +129,11 @@ func (s *Server) GetRelatedLocations(ctx context.Context,
 	}
 	results := map[string]*RelatedPlacesInfo{}
 	for statVarDcid, data := range dataMap {
-		if data == nil {
-			results[statVarDcid] = nil
+		info, ok := data.(*RelatedPlacesInfo)
+		if ok {
+			results[statVarDcid] = info
 		} else {
-			results[statVarDcid] = data.(*RelatedPlacesInfo)
+			results[statVarDcid] = nil
 		}
 	}
 	jsonRaw, err := json.Marshal(results)
@@ -182,10 +183,11 @@ func (s *Server) GetLocationsRankings(ctx context.Context,
 
 	results := map[string]*pb.RelatedPlacesInfo{}
 	for statVarDcid, data := range dataMap {
-		if data == nil {
-			results[statVarDcid] = nil
+		info, ok := data.(*pb.RelatedPlacesInfo)
+		if ok {
+			results[statVarDcid] = info
 		} else {
-			results[statVarDcid] = data.(*pb.RelatedPlacesInfo)
+			results[statVarDcid] = nil
 		}
 	}
 	return &pb.GetLocationsRankingsResponse{Payload: results}, nil

--- a/internal/server/places.go
+++ b/internal/server/places.go
@@ -53,11 +53,10 @@ func (s *Server) GetPlacesIn(ctx context.Context, in *pb.GetPlacesInRequest) (
 	}
 	results := []map[string]string{}
 	for _, dcid := range dcids {
-			v, ok := dataMap[dcid].([]string)
-			if ok {
-				for _, place := range v {
-					results = append(results, map[string]string{"dcid": dcid, "place": place})
-				}
+		v, ok := dataMap[dcid].([]string)
+		if ok {
+			for _, place := range v {
+				results = append(results, map[string]string{"dcid": dcid, "place": place})
 			}
 		}
 	}

--- a/internal/server/places.go
+++ b/internal/server/places.go
@@ -53,13 +53,14 @@ func (s *Server) GetPlacesIn(ctx context.Context, in *pb.GetPlacesInRequest) (
 	}
 	results := []map[string]string{}
 	for _, dcid := range dcids {
-		if dataMap[dcid] != nil {
-			for _, place := range dataMap[dcid].([]string) {
-				results = append(results, map[string]string{"dcid": dcid, "place": place})
+			v, ok := dataMap[dcid].([]string)
+			if ok {
+				for _, place := range v {
+					results = append(results, map[string]string{"dcid": dcid, "place": place})
+				}
 			}
 		}
 	}
-
 	jsonRaw, err := json.Marshal(results)
 	if err != nil {
 		return nil, err

--- a/internal/server/property_label.go
+++ b/internal/server/property_label.go
@@ -52,7 +52,13 @@ func (s *Server) GetPropertyLabels(ctx context.Context,
 	}
 	result := map[string]*PropLabelCache{}
 	for dcid, data := range dataMap {
-		result[dcid] = data.(*PropLabelCache)
+		pc, ok := data.(*PropLabelCache)
+		if !ok {
+			result[dcid].InLabels = []string{}
+			result[dcid].OutLabels = []string{}
+			continue
+		}
+		result[dcid] = pc
 		// Fill in InLabels / OutLabels with an empty list if not present.
 		if result[dcid].InLabels == nil {
 			result[dcid].InLabels = []string{}

--- a/internal/server/property_value.go
+++ b/internal/server/property_value.go
@@ -17,6 +17,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	mapset "github.com/deckarep/golang-set"
 	"google.golang.org/grpc/codes"
@@ -125,7 +126,10 @@ func getPropertyValuesHelper(
 			return propVals.Nodes, nil
 		}, nil)
 	for dcid := range branchNodeMap {
-		branchNodes := branchNodeMap[dcid].([]*Node)
+		branchNodes, ok := branchNodeMap[dcid].([]*Node)
+		if !ok {
+			return nil, fmt.Errorf("branch nodes invalid for %s", dcid)
+		}
 		baseNodes, exist := nodeMap[dcid]
 		if !exist {
 			nodeMap[dcid] = branchNodes
@@ -188,7 +192,12 @@ func readPropertyValues(
 	}
 	result := map[string][]*Node{}
 	for dcid, data := range tmp {
-		result[dcid] = data.([]*Node)
+		n, ok := data.([]*Node)
+		if ok {
+			result[dcid] = n
+		} else {
+			result[dcid] = nil
+		}
 	}
 	return result, nil
 }

--- a/internal/server/stat_bt_reader.go
+++ b/internal/server/stat_bt_reader.go
@@ -45,10 +45,11 @@ func readStats(
 		if result[place] == nil {
 			result[place] = map[string]*ObsTimeSeries{}
 		}
-		if data == nil {
-			result[place][statVar] = nil
+		s, ok := data.(*ObsTimeSeries)
+		if ok {
+			result[place][statVar] = s
 		} else {
-			result[place][statVar] = data.(*ObsTimeSeries)
+			result[place][statVar] = nil
 		}
 	}
 	return result, nil
@@ -77,10 +78,11 @@ func readStatsPb(
 		if result[place] == nil {
 			result[place] = map[string]*pb.ObsTimeSeries{}
 		}
-		if data == nil {
-			result[place][statVar] = nil
+		s, ok := data.(*pb.ObsTimeSeries)
+		if ok {
+			result[place][statVar] = s
 		} else {
-			result[place][statVar] = data.(*pb.ObsTimeSeries)
+			result[place][statVar] = nil
 		}
 	}
 	return result, nil
@@ -106,7 +108,12 @@ func readStatCollection(
 	}
 	result := map[string]*pb.ObsCollection{}
 	for token, data := range dataMap {
-		result[token] = data.(*pb.ObsCollection)
+		collection, ok := data.(*pb.ObsCollection)
+		if ok {
+			result[token] = collection
+		} else {
+			result[token] = nil
+		}
 	}
 	return result, nil
 }

--- a/internal/server/stat_point.go
+++ b/internal/server/stat_point.go
@@ -74,10 +74,9 @@ func (s *Server) GetStatValue(ctx context.Context, in *pb.GetStatValueRequest) (
 		convertToObsSeries,
 		tokenFn(keyTokens))
 	if data, ok := cacheData[place]; ok {
-		if data == nil {
+		obsTimeSeries, ok = data.(*ObsTimeSeries)
+		if !ok {
 			obsTimeSeries = nil
-		} else {
-			obsTimeSeries = data.(*ObsTimeSeries)
 		}
 	} else {
 		// If the data is missing in branch cache, fetch it from the base cache in
@@ -158,8 +157,9 @@ func (s *Server) GetStatSet(ctx context.Context, in *pb.GetStatSetRequest) (
 		parts := strings.Split(token, "^")
 		place := parts[0]
 		statVar := parts[1]
-		if data != nil {
-			result.Data[statVar].Stat[place] = data.(*pb.PointStat)
+		ps, ok := data.(*pb.PointStat)
+		if ok {
+			result.Data[statVar].Stat[place] = ps
 		}
 	}
 
@@ -251,8 +251,9 @@ func (s *Server) GetStatCollection(
 		},
 	)
 	for token, data := range cacheData {
-		if data != nil {
-			cohorts := data.(*pb.ObsCollection).SourceCohorts
+		collection, ok := data.(*pb.ObsCollection)
+		if ok {
+			cohorts := collection.SourceCohorts
 			sort.Sort(SeriesByRank(cohorts))
 			result.Data[token] = cohorts[0]
 		}

--- a/internal/server/stat_series.go
+++ b/internal/server/stat_series.go
@@ -77,10 +77,9 @@ func (s *Server) GetStatSeries(
 		tokenFn(keyTokens),
 	)
 	if data, ok := cacheData[place]; ok {
-		if data == nil {
+		obsTimeSeries, ok = data.(*ObsTimeSeries)
+		if !ok {
 			obsTimeSeries = nil
-		} else {
-			obsTimeSeries = data.(*ObsTimeSeries)
 		}
 	} else {
 		// If the data is missing in branch cache, fetch it from the base cache in
@@ -164,10 +163,11 @@ func (s *Server) GetStatAll(ctx context.Context, in *pb.GetStatAllRequest) (
 		parts := strings.Split(token, "^")
 		place := parts[0]
 		statVar := parts[1]
-		if data == nil {
+		ts, ok := data.(*pb.ObsTimeSeries)
+		if ok {
 			result.PlaceData[place].StatVarData[statVar] = &pb.ObsTimeSeries{}
 		} else {
-			result.PlaceData[place].StatVarData[statVar] = data.(*pb.ObsTimeSeries)
+			result.PlaceData[place].StatVarData[statVar] = ts
 		}
 	}
 
@@ -245,10 +245,11 @@ func (s *Server) GetStats(ctx context.Context, in *pb.GetStatsRequest) (
 	)
 	for token, data := range cacheData {
 		place := strings.Split(token, "^")[0]
-		if data == nil {
-			result[place] = nil
+		ts, ok := data.(*ObsTimeSeries)
+		if ok {
+			result[place] = ts
 		} else {
-			result[place] = data.(*ObsTimeSeries)
+			result[place] = nil
 		}
 	}
 	// For each place, if the data is missing in branch cache, fetch it from the
@@ -346,10 +347,11 @@ func (s *Server) GetStatSetSeries(ctx context.Context, in *pb.GetStatSetSeriesRe
 		parts := strings.Split(token, "^")
 		place := parts[0]
 		statVar := parts[1]
-		if data == nil {
-			result.Data[place].Data[statVar] = nil
+		ts, ok := data.(*pb.ObsTimeSeries)
+		if ok {
+			result.Data[place].Data[statVar] = getBestSeries(ts)
 		} else {
-			result.Data[place].Data[statVar] = getBestSeries(data.(*pb.ObsTimeSeries))
+			result.Data[place].Data[statVar] = nil
 		}
 	}
 

--- a/internal/server/triple.go
+++ b/internal/server/triple.go
@@ -75,10 +75,11 @@ func (s *Server) GetTriples(ctx context.Context, in *pb.GetTriplesRequest) (
 		dataMap := s.memcache.ReadParallel(
 			buildTriplesKey(popDcids), convertTriplesCache, nil)
 		for dcid, data := range dataMap {
-			if data == nil {
-				resultsMap[dcid] = nil
+			tc, ok := data.(*TriplesCache)
+			if ok {
+				resultsMap[dcid] = tc.Triples
 			} else {
-				resultsMap[dcid] = data.(*TriplesCache).Triples
+				resultsMap[dcid] = nil
 			}
 		}
 	}
@@ -252,10 +253,11 @@ func readTriples(
 	}
 	result := make(map[string]*TriplesCache)
 	for dcid, data := range dataMap {
-		if data == nil {
-			result[dcid] = nil
+		tc, ok := data.(*TriplesCache)
+		if ok {
+			result[dcid] = tc
 		} else {
-			result[dcid] = data.(*TriplesCache)
+			result[dcid] = nil
 		}
 	}
 	return result, nil


### PR DESCRIPTION
There are quite some instances of un-checked type conversion. These can potentially lead to server crash.

Use s, ok: = data(.DataType) can deal with a nil "data", so no need for a precedent data == nil check

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datacommonsorg/mixer/440)
<!-- Reviewable:end -->
