### PR TITLE
Support concurrent read of multiple BigTables

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -114,7 +114,7 @@ func main() {
 	}
 
 	// Create server object
-	s := server.NewServer(bqClient, btTable, memcache, metadata)
+	s := server.NewServer(bqClient, []*bigtable.Table{btTable}, memcache, metadata)
 
 	// Subscribe to cache update
 	if !*bigqueryOnly && *enableBranchCache {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -81,15 +81,14 @@ func main() {
 		log.Fatalf("Failed to create Bigquery client: %v", err)
 	}
 
-	var btTable *bigtable.Table
-	if *bigqueryOnly {
-		btTable = nil
-	} else {
+	btTables := []*bigtable.Table{}
+	if !*bigqueryOnly {
 		// BigTable.
-		btTable, err = server.NewBtTable(ctx, *btProject, *btInstance, *btTableName)
+		btTable, err := server.NewBtTable(ctx, *btProject, *btInstance, *btTableName)
 		if err != nil {
 			log.Fatalf("Failed to create BigTable client: %v", err)
 		}
+		btTables = append(btTables, btTable)
 	}
 
 	// Metadata.
@@ -114,7 +113,7 @@ func main() {
 	}
 
 	// Create server object
-	s := server.NewServer(bqClient, []*bigtable.Table{btTable}, memcache, metadata)
+	s := server.NewServer(bqClient, btTables, memcache, metadata)
 
 	// Subscribe to cache update
 	if !*bigqueryOnly && *enableBranchCache {

--- a/internal/server/bigtable.go
+++ b/internal/server/bigtable.go
@@ -24,10 +24,9 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// A functional generator that return a function that is to be used as
-// callback function in Bigtable reads.
-// This utilize the Golang closure so the arguments can be scoped in the
-// returned function.
+// Generates a function to be used as the callback function in Bigtable Read.
+// This utilizes the Golang closure so the arguments can be scoped in the
+// generated function.
 func readRowFn(
 	errCtx context.Context,
 	btTable *bigtable.Table,

--- a/internal/server/bigtable.go
+++ b/internal/server/bigtable.go
@@ -59,7 +59,7 @@ func readRowFn(
 				if err != nil {
 					return false
 				}
-				elemChan <- chanData{token, elem, btTable}
+				elemChan <- chanData{token, elem}
 				return true
 			}); err != nil {
 			return err
@@ -151,7 +151,7 @@ func bigTableReadRowsParallel(
 		ch := elemChanMap[table]
 		for elem := range ch {
 			// If date does not exist for this token, added. Otherwise, it is already
-			// add ed from a prefered table.
+			// added from a prefered table.
 			if _, ok := result[elem.token]; !ok {
 				result[elem.token] = elem.data
 			}

--- a/internal/server/bigtable.go
+++ b/internal/server/bigtable.go
@@ -24,11 +24,58 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// bigTableReadRowsParallel reads BigTable rows in parallel,
-// considering the size limit for RowSet is 500KB.
+func readRowFn(
+	errCtx context.Context,
+	btTable *bigtable.Table,
+	rowSetPart bigtable.RowSet,
+	getToken func(string) (string, error),
+	action func(string, []byte) (interface{}, error),
+	elemChan chan chanData,
+) func() error {
+	return func() error {
+		if err := btTable.ReadRows(errCtx, rowSetPart,
+			func(btRow bigtable.Row) bool {
+				if len(btRow[util.BtFamily]) == 0 {
+					return true
+				}
+				raw := btRow[util.BtFamily][0].Value
+
+				if getToken == nil {
+					getToken = util.KeyToDcid
+				}
+				token, err := getToken(btRow.Key())
+				if err != nil {
+					return false
+				}
+
+				jsonRaw, err := util.UnzipAndDecode(string(raw))
+				if err != nil {
+					return false
+				}
+				elem, err := action(token, jsonRaw)
+				if err != nil {
+					return false
+				}
+				elemChan <- chanData{token, elem, btTable}
+				return true
+			}); err != nil {
+			return err
+		}
+		return nil
+	}
+}
+
+// bigTableReadRowsParallel reads BigTable rows from multiple Bigtable
+// in parallel.
+// As the  size limit for RowSet is 500KB, each table read is also chunked.
+//
+// IMPORTANT: the order of the input bigtable pointers matters. The most
+// important table should come first and the least important table last.
+// When data is present in multiple tables, that from the most important table
+// is selected.
 func bigTableReadRowsParallel(
 	ctx context.Context,
-	btTable *bigtable.Table,
+	btTables []*bigtable.Table,
 	rowSet bigtable.RowSet,
 	action func(string, []byte) (interface{}, error),
 	getToken func(string) (string, error)) (
@@ -42,7 +89,6 @@ func bigTableReadRowsParallel(
 	var rowSetSize int
 	var rowList bigtable.RowList
 	var rowRangeList bigtable.RowRangeList
-
 	switch v := rowSet.(type) {
 	case bigtable.RowList:
 		rowList = rowSet.(bigtable.RowList)
@@ -87,33 +133,9 @@ func bigTableReadRowsParallel(
 		} else {
 			rowSetPart = rowRangeList[left:right]
 		}
-		errs.Go(func() error {
-			if err := btTable.ReadRows(errCtx, rowSetPart,
-				func(btRow bigtable.Row) bool {
-					if len(btRow[util.BtFamily]) == 0 {
-						return true
-					}
-					raw := btRow[util.BtFamily][0].Value
-					token, err := getToken(btRow.Key())
-					if err != nil {
-						return false
-					}
-
-					jsonRaw, err := util.UnzipAndDecode(string(raw))
-					if err != nil {
-						return false
-					}
-					elem, err := action(token, jsonRaw)
-					if err != nil {
-						return false
-					}
-					elemChan <- chanData{token, elem}
-					return true
-				}); err != nil {
-				return err
-			}
-			return nil
-		})
+		for _, btTable := range btTables {
+			errs.Go(readRowFn(errCtx, btTable, rowSetPart, getToken, action, elemChan))
+		}
 	}
 
 	err := errs.Wait()
@@ -122,8 +144,22 @@ func bigTableReadRowsParallel(
 	}
 	close(elemChan)
 
+	// Result is keyed by the bigtable pointer, then by the token
+	tmp := map[string]map[*bigtable.Table]interface{}{}
 	for elem := range elemChan {
-		result[elem.token] = elem.data
+		if _, ok := tmp[elem.token]; !ok {
+			tmp[elem.token] = make(map[*bigtable.Table]interface{})
+		}
+		tmp[elem.token][elem.table] = elem.data
+	}
+	result := map[string]interface{}{}
+	for token, tableData := range tmp {
+		for _, t := range btTables {
+			if data, ok := tableData[t]; ok {
+				result[token] = data
+				break
+			}
+		}
 	}
 	return result, nil
 }

--- a/internal/server/bigtable_test.go
+++ b/internal/server/bigtable_test.go
@@ -28,12 +28,12 @@ func TestReadOneTable(t *testing.T) {
 		"key1": "data1",
 		"key2": "data2",
 	}
-	btTable, err := setupBigtable(ctx, data)
+	btTables, err := setupBigtable(ctx, data)
 	if err != nil {
 		t.Errorf("setupBigtable got error: %v", err)
 	}
 	rowList := bigtable.RowList{"key1", "key2"}
-	dataMap, err := bigTableReadRowsParallel(ctx, []*bigtable.Table{btTable}, rowList,
+	dataMap, err := bigTableReadRowsParallel(ctx, btTables, rowList,
 		func(dcid string, jsonRaw []byte) (interface{}, error) {
 			return string(jsonRaw), nil
 		}, nil)
@@ -77,7 +77,7 @@ func TestReadTwoTables(t *testing.T) {
 
 	rowList := bigtable.RowList{"key1", "key2"}
 	dataMap, err := bigTableReadRowsParallel(
-		ctx, []*bigtable.Table{btTable1, btTable2}, rowList,
+		ctx, append(btTable1, btTable2...), rowList,
 		func(dcid string, jsonRaw []byte) (interface{}, error) {
 			return string(jsonRaw), nil
 		}, nil)

--- a/internal/server/bigtable_test.go
+++ b/internal/server/bigtable_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestReadRowsParallel(t *testing.T) {
+func TestReadOneTable(t *testing.T) {
 	ctx := context.Background()
 	data := map[string]string{
 		"key1": "data1",
@@ -33,7 +33,7 @@ func TestReadRowsParallel(t *testing.T) {
 		t.Errorf("setupBigtable got error: %v", err)
 	}
 	rowList := bigtable.RowList{"key1", "key2"}
-	dataMap, err := bigTableReadRowsParallel(ctx, btTable, rowList,
+	dataMap, err := bigTableReadRowsParallel(ctx, []*bigtable.Table{btTable}, rowList,
 		func(dcid string, jsonRaw []byte) (interface{}, error) {
 			return string(jsonRaw), nil
 		}, nil)
@@ -42,6 +42,50 @@ func TestReadRowsParallel(t *testing.T) {
 	}
 	for dcid, result := range dataMap {
 		if diff := cmp.Diff(data[dcid], result.(string)); diff != "" {
+			t.Errorf("read rows got diff from table data %+v", diff)
+		}
+	}
+}
+
+func TestReadTwoTables(t *testing.T) {
+	ctx := context.Background()
+
+	data1 := map[string]string{
+		"key1": "foo1",
+		"key2": "foo2",
+	}
+	data2 := map[string]string{
+		"key1": "bar1",
+		"key2": "bar2",
+		"key3": "bar3",
+	}
+	expected := map[string]string{
+		"key1": "foo1",
+		"key2": "foo2",
+		"key3": "bar3",
+	}
+
+	btTable1, err := setupBigtable(ctx, data1)
+	if err != nil {
+		t.Errorf("setupBigtable1 got error: %v", err)
+	}
+
+	btTable2, err := setupBigtable(ctx, data2)
+	if err != nil {
+		t.Errorf("setupBigtable2 got error: %v", err)
+	}
+
+	rowList := bigtable.RowList{"key1", "key2"}
+	dataMap, err := bigTableReadRowsParallel(
+		ctx, []*bigtable.Table{btTable1, btTable2}, rowList,
+		func(dcid string, jsonRaw []byte) (interface{}, error) {
+			return string(jsonRaw), nil
+		}, nil)
+	if err != nil {
+		t.Errorf("btReadRowsParallel got error: %v", err)
+	}
+	for dcid, result := range dataMap {
+		if diff := cmp.Diff(expected[dcid], result.(string)); diff != "" {
 			t.Errorf("read rows got diff from table data %+v", diff)
 		}
 	}

--- a/internal/server/landing_page.go
+++ b/internal/server/landing_page.go
@@ -139,7 +139,7 @@ func getCohort(placeType string, placeDcid string) (string, error) {
 // get the type of a place.
 func getPlaceType(ctx context.Context, s *Server, dcid string) (string, error) {
 	resp, err := getPropertyValuesHelper(
-		ctx, s.btTable, s.memcache, []string{dcid}, "typeOf", true)
+		ctx, s.btTables, s.memcache, []string{dcid}, "typeOf", true)
 	if err != nil {
 		return "", err
 	}
@@ -232,7 +232,7 @@ func fetchBtData(
 	}
 
 	// Fetch landing page cache data in parallel.
-	dataMap, err := bigTableReadRowsParallel(ctx, []*bigtable.Table{s.btTable}, rowList,
+	dataMap, err := bigTableReadRowsParallel(ctx, s.btTables, rowList,
 		func(dcid string, jsonRaw []byte) (interface{}, error) {
 			var landingPageData LandingPageData
 
@@ -351,14 +351,14 @@ func getChildPlaces(ctx context.Context, s *Server, placedDcid, placeType string
 	children := []*Node{}
 	// ContainedIn places
 	containedInPlaces, err := getPropertyValuesHelper(
-		ctx, s.btTable, s.memcache, []string{placedDcid}, "containedInPlace", false)
+		ctx, s.btTables, s.memcache, []string{placedDcid}, "containedInPlace", false)
 	if err != nil {
 		return nil, err
 	}
 	children = append(children, containedInPlaces[placedDcid]...)
 	// GeoOverlaps places
 	overlapPlaces, err := getPropertyValuesHelper(
-		ctx, s.btTable, s.memcache, []string{placedDcid}, "geoOverlaps", false)
+		ctx, s.btTables, s.memcache, []string{placedDcid}, "geoOverlaps", false)
 	if err != nil {
 		return nil, err
 	}
@@ -419,7 +419,7 @@ func getParentPlaces(ctx context.Context, s *Server, dcid string) (
 	result := []*place{}
 	for {
 		containedInPlaces, err := getPropertyValuesHelper(
-			ctx, s.btTable, s.memcache, []string{dcid}, "containedInPlace", true)
+			ctx, s.btTables, s.memcache, []string{dcid}, "containedInPlace", true)
 		if err != nil {
 			return nil, err
 		}
@@ -463,7 +463,7 @@ func getSimilarPlaces(
 		return []string{}, nil
 	}
 	resp, err := getPropertyValuesHelper(
-		ctx, s.btTable, s.memcache, []string{cohort}, "member", true)
+		ctx, s.btTables, s.memcache, []string{cohort}, "member", true)
 	if err != nil {
 		return nil, err
 	}
@@ -505,7 +505,7 @@ func getNearbyPlaces(ctx context.Context, s *Server, dcid string) (
 	[]string, error) {
 
 	resp, err := getPropertyValuesHelper(
-		ctx, s.btTable, s.memcache, []string{dcid}, "nearbyPlaces", true)
+		ctx, s.btTables, s.memcache, []string{dcid}, "nearbyPlaces", true)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/landing_page.go
+++ b/internal/server/landing_page.go
@@ -232,7 +232,7 @@ func fetchBtData(
 	}
 
 	// Fetch landing page cache data in parallel.
-	dataMap, err := bigTableReadRowsParallel(ctx, s.btTable, rowList,
+	dataMap, err := bigTableReadRowsParallel(ctx, []*bigtable.Table{s.btTable}, rowList,
 		func(dcid string, jsonRaw []byte) (interface{}, error) {
 			var landingPageData LandingPageData
 

--- a/internal/server/memcache.go
+++ b/internal/server/memcache.go
@@ -146,7 +146,7 @@ func (m *Memcache) ReadParallel(
 				if err != nil {
 					log.Printf("Unable to process token %s, data %s", token, jsonRaw)
 				}
-				elemChan <- chanData{token, elem}
+				elemChan <- chanData{token, elem, nil}
 			}
 			<-rowKeyChan
 			wg.Done()

--- a/internal/server/memcache.go
+++ b/internal/server/memcache.go
@@ -146,7 +146,7 @@ func (m *Memcache) ReadParallel(
 				if err != nil {
 					log.Printf("Unable to process token %s, data %s", token, jsonRaw)
 				}
-				elemChan <- chanData{token, elem, nil}
+				elemChan <- chanData{token, elem}
 			}
 			<-rowKeyChan
 			wg.Done()

--- a/internal/server/model.go
+++ b/internal/server/model.go
@@ -15,7 +15,6 @@
 package server
 
 import (
-	"cloud.google.com/go/bigtable"
 	"github.com/datacommonsorg/mixer/internal/base"
 	"github.com/datacommonsorg/mixer/internal/translator"
 )
@@ -64,9 +63,6 @@ type chanData struct {
 	token string
 	// Data read from Cloud Bigtable
 	data interface{}
-	// The Cloud Bigtable object, used when reading multiple Bigtable concurrently
-	// to differentiate them from the channel data
-	table *bigtable.Table
 }
 
 // RelatedPlacesInfo represents the json structure returned by the RelatedPlaces cache.

--- a/internal/server/model.go
+++ b/internal/server/model.go
@@ -15,6 +15,7 @@
 package server
 
 import (
+	"cloud.google.com/go/bigtable"
 	"github.com/datacommonsorg/mixer/internal/base"
 	"github.com/datacommonsorg/mixer/internal/translator"
 )
@@ -58,10 +59,14 @@ type PropLabelCache struct {
 }
 
 type chanData struct {
-	// token is the identifier of the data when reading multiple BigTable rows
+	// Identifier of the data when reading multiple BigTable rows
 	// concurrently. It could be place dcid, statvar dcid or other "key".
 	token string
-	data  interface{}
+	// Data read from Cloud Bigtable
+	data interface{}
+	// The Cloud Bigtable object, used when reading multiple Bigtable concurrently
+	// to differentiate them from the channel data
+	table *bigtable.Table
 }
 
 // RelatedPlacesInfo represents the json structure returned by the RelatedPlaces cache.

--- a/internal/server/place_stat_date.go
+++ b/internal/server/place_stat_date.go
@@ -58,7 +58,7 @@ func (s *Server) GetPlaceStatDateWithinPlace(
 
 	// Read triples for statistical variable.
 	triplesRowList := buildTriplesKey(statVars)
-	triples, err := readTriples(ctx, s.btTable, triplesRowList)
+	triples, err := readTriples(ctx, s.btTables, triplesRowList)
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +102,7 @@ func (s *Server) GetPlaceStatDateWithinPlace(
 	}
 
 	if len(extraRowList) > 0 {
-		extraData, err := readStatCollection(ctx, s.btTable, extraRowList, keyTokens)
+		extraData, err := readStatCollection(ctx, s.btTables, extraRowList, keyTokens)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/server/place_stat_vars.go
+++ b/internal/server/place_stat_vars.go
@@ -20,7 +20,6 @@ import (
 
 	"encoding/json"
 
-	"cloud.google.com/go/bigtable"
 	pb "github.com/datacommonsorg/mixer/internal/proto"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -53,7 +52,7 @@ func (s *Server) GetPlaceStatVars(
 		return nil, status.Error(codes.InvalidArgument, "Missing required arguments: dcid")
 	}
 	rowList := buildPlaceStatsVarKey(dcids)
-	dataMap, err := bigTableReadRowsParallel(ctx, []*bigtable.Table{s.btTable}, rowList,
+	dataMap, err := bigTableReadRowsParallel(ctx, s.btTables, rowList,
 		func(dcid string, jsonRaw []byte) (interface{}, error) {
 			var data PlaceStatsVar
 			err := json.Unmarshal(jsonRaw, &data)

--- a/internal/server/place_stat_vars.go
+++ b/internal/server/place_stat_vars.go
@@ -20,6 +20,7 @@ import (
 
 	"encoding/json"
 
+	"cloud.google.com/go/bigtable"
 	pb "github.com/datacommonsorg/mixer/internal/proto"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -52,7 +53,7 @@ func (s *Server) GetPlaceStatVars(
 		return nil, status.Error(codes.InvalidArgument, "Missing required arguments: dcid")
 	}
 	rowList := buildPlaceStatsVarKey(dcids)
-	dataMap, err := bigTableReadRowsParallel(ctx, s.btTable, rowList,
+	dataMap, err := bigTableReadRowsParallel(ctx, []*bigtable.Table{s.btTable}, rowList,
 		func(dcid string, jsonRaw []byte) (interface{}, error) {
 			var data PlaceStatsVar
 			err := json.Unmarshal(jsonRaw, &data)

--- a/internal/server/places.go
+++ b/internal/server/places.go
@@ -44,7 +44,7 @@ func (s *Server) GetPlacesIn(ctx context.Context, in *pb.GetPlacesInRequest) (
 
 	rowList := buildPlaceInKey(dcids, placeType)
 
-	dataMap, err := bigTableReadRowsParallel(ctx, s.btTable, rowList,
+	dataMap, err := bigTableReadRowsParallel(ctx, []*bigtable.Table{s.btTable}, rowList,
 		func(dcid string, jsonRaw []byte) (interface{}, error) {
 			return strings.Split(string(jsonRaw), ","), nil
 		}, nil)
@@ -109,7 +109,7 @@ func (s *Server) GetRelatedLocations(ctx context.Context,
 				"%s%s^%s", prefix, in.GetDcid(), statVarDcid))
 		}
 	}
-	dataMap, err := bigTableReadRowsParallel(ctx, s.btTable, rowList,
+	dataMap, err := bigTableReadRowsParallel(ctx, []*bigtable.Table{s.btTable}, rowList,
 		func(dcid string, jsonRaw []byte) (interface{}, error) {
 			var btRelatedPlacesInfo RelatedPlacesInfo
 			err := json.Unmarshal(jsonRaw, &btRelatedPlacesInfo)
@@ -161,7 +161,7 @@ func (s *Server) GetLocationsRankings(ctx context.Context,
 			rowList = append(rowList, fmt.Sprintf("%s%s^%s^%s", prefix, "*", in.GetPlaceType(), statVarDcid))
 		}
 	}
-	dataMap, err := bigTableReadRowsParallel(ctx, s.btTable, rowList,
+	dataMap, err := bigTableReadRowsParallel(ctx, []*bigtable.Table{s.btTable}, rowList,
 		func(dcid string, jsonRaw []byte) (interface{}, error) {
 			var btRelatedPlacesInfo pb.RelatedPlacesInfo
 			err := protojson.Unmarshal(jsonRaw, &btRelatedPlacesInfo)

--- a/internal/server/places.go
+++ b/internal/server/places.go
@@ -44,7 +44,7 @@ func (s *Server) GetPlacesIn(ctx context.Context, in *pb.GetPlacesInRequest) (
 
 	rowList := buildPlaceInKey(dcids, placeType)
 
-	dataMap, err := bigTableReadRowsParallel(ctx, []*bigtable.Table{s.btTable}, rowList,
+	dataMap, err := bigTableReadRowsParallel(ctx, s.btTables, rowList,
 		func(dcid string, jsonRaw []byte) (interface{}, error) {
 			return strings.Split(string(jsonRaw), ","), nil
 		}, nil)
@@ -109,7 +109,7 @@ func (s *Server) GetRelatedLocations(ctx context.Context,
 				"%s%s^%s", prefix, in.GetDcid(), statVarDcid))
 		}
 	}
-	dataMap, err := bigTableReadRowsParallel(ctx, []*bigtable.Table{s.btTable}, rowList,
+	dataMap, err := bigTableReadRowsParallel(ctx, s.btTables, rowList,
 		func(dcid string, jsonRaw []byte) (interface{}, error) {
 			var btRelatedPlacesInfo RelatedPlacesInfo
 			err := json.Unmarshal(jsonRaw, &btRelatedPlacesInfo)
@@ -161,7 +161,7 @@ func (s *Server) GetLocationsRankings(ctx context.Context,
 			rowList = append(rowList, fmt.Sprintf("%s%s^%s^%s", prefix, "*", in.GetPlaceType(), statVarDcid))
 		}
 	}
-	dataMap, err := bigTableReadRowsParallel(ctx, []*bigtable.Table{s.btTable}, rowList,
+	dataMap, err := bigTableReadRowsParallel(ctx, s.btTables, rowList,
 		func(dcid string, jsonRaw []byte) (interface{}, error) {
 			var btRelatedPlacesInfo pb.RelatedPlacesInfo
 			err := protojson.Unmarshal(jsonRaw, &btRelatedPlacesInfo)

--- a/internal/server/populations.go
+++ b/internal/server/populations.go
@@ -38,6 +38,10 @@ type PopObs struct {
 // GetPopObs implements API for Mixer.GetPopObs.
 func (s *Server) GetPopObs(ctx context.Context, in *pb.GetPopObsRequest) (
 	*pb.GetPopObsResponse, error) {
+	if len(s.btTables) == 0 {
+		return nil, status.Errorf(
+			codes.NotFound, "Bigtable instance is not specified")
+	}
 	dcid := in.GetDcid()
 
 	if dcid == "" {
@@ -107,6 +111,10 @@ func (s *Server) GetPopObs(ctx context.Context, in *pb.GetPopObsRequest) (
 // GetPlaceObs implements API for Mixer.GetPlaceObs.
 func (s *Server) GetPlaceObs(ctx context.Context, in *pb.GetPlaceObsRequest) (
 	*pb.GetPlaceObsResponse, error) {
+	if len(s.btTables) == 0 {
+		return nil, status.Errorf(
+			codes.NotFound, "Bigtable instance is not specified")
+	}
 	if in.GetPlaceType() == "" || in.GetPopulationType() == "" ||
 		in.GetObservationDate() == "" {
 		return nil, status.Errorf(codes.InvalidArgument, "missing required arguments")

--- a/internal/server/populations.go
+++ b/internal/server/populations.go
@@ -213,7 +213,7 @@ func (s *Server) GetPopulations(
 
 	// Query the cache
 	collection := []*PlacePopInfo{}
-	dataMap, err := bigTableReadRowsParallel(ctx, s.btTable, rowList,
+	dataMap, err := bigTableReadRowsParallel(ctx, []*bigtable.Table{s.btTable}, rowList,
 		func(dcid string, jsonRaw []byte) (interface{}, error) {
 			return string(jsonRaw), nil
 		}, nil)
@@ -266,7 +266,7 @@ func (s *Server) GetObservations(
 	// Query the cache for all keys.
 	collection := []*PopObs{}
 	dataMap, err := bigTableReadRowsParallel(
-		ctx, s.btTable, rowList,
+		ctx, []*bigtable.Table{s.btTable}, rowList,
 		func(dcid string, jsonRaw []byte) (interface{}, error) {
 			return string(jsonRaw), nil
 		}, nil)

--- a/internal/server/populations.go
+++ b/internal/server/populations.go
@@ -56,7 +56,7 @@ func (s *Server) GetPopObs(ctx context.Context, in *pb.GetPopObsRequest) (
 	var hasBaseData, hasBranchData bool
 	out.Payload, _ = util.ZipAndEncode([]byte("{}"))
 
-	btRow, err := s.btTable.ReadRow(ctx, key)
+	btRow, err := s.btTables[0].ReadRow(ctx, key)
 	if err != nil {
 		log.Print(err)
 	}
@@ -129,7 +129,7 @@ func (s *Server) GetPlaceObs(ctx context.Context, in *pb.GetPlaceObsRequest) (
 	var hasBaseData, hasBranchData bool
 	out.Payload, _ = util.ZipAndEncode([]byte("{}"))
 
-	btRow, err := s.btTable.ReadRow(ctx, key)
+	btRow, err := s.btTables[0].ReadRow(ctx, key)
 	if err != nil {
 		log.Print(err)
 	}
@@ -213,7 +213,7 @@ func (s *Server) GetPopulations(
 
 	// Query the cache
 	collection := []*PlacePopInfo{}
-	dataMap, err := bigTableReadRowsParallel(ctx, []*bigtable.Table{s.btTable}, rowList,
+	dataMap, err := bigTableReadRowsParallel(ctx, s.btTables, rowList,
 		func(dcid string, jsonRaw []byte) (interface{}, error) {
 			return string(jsonRaw), nil
 		}, nil)
@@ -266,7 +266,7 @@ func (s *Server) GetObservations(
 	// Query the cache for all keys.
 	collection := []*PopObs{}
 	dataMap, err := bigTableReadRowsParallel(
-		ctx, []*bigtable.Table{s.btTable}, rowList,
+		ctx, s.btTables, rowList,
 		func(dcid string, jsonRaw []byte) (interface{}, error) {
 			return string(jsonRaw), nil
 		}, nil)

--- a/internal/server/property_label.go
+++ b/internal/server/property_label.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 
+	"cloud.google.com/go/bigtable"
 	pb "github.com/datacommonsorg/mixer/internal/proto"
 	"github.com/datacommonsorg/mixer/internal/util"
 	"google.golang.org/grpc/codes"
@@ -38,7 +39,7 @@ func (s *Server) GetPropertyLabels(ctx context.Context,
 	rowList := buildPropertyLabelKey(dcids)
 
 	dataMap, err := bigTableReadRowsParallel(
-		ctx, s.btTable, rowList,
+		ctx, []*bigtable.Table{s.btTable}, rowList,
 		func(dcid string, jsonRaw []byte) (interface{}, error) {
 			var propLabels PropLabelCache
 			err := json.Unmarshal(jsonRaw, &propLabels)

--- a/internal/server/property_label.go
+++ b/internal/server/property_label.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 
-	"cloud.google.com/go/bigtable"
 	pb "github.com/datacommonsorg/mixer/internal/proto"
 	"github.com/datacommonsorg/mixer/internal/util"
 	"google.golang.org/grpc/codes"
@@ -39,7 +38,7 @@ func (s *Server) GetPropertyLabels(ctx context.Context,
 	rowList := buildPropertyLabelKey(dcids)
 
 	dataMap, err := bigTableReadRowsParallel(
-		ctx, []*bigtable.Table{s.btTable}, rowList,
+		ctx, s.btTables, rowList,
 		func(dcid string, jsonRaw []byte) (interface{}, error) {
 			var propLabels PropLabelCache
 			err := json.Unmarshal(jsonRaw, &propLabels)

--- a/internal/server/property_label_test.go
+++ b/internal/server/property_label_test.go
@@ -75,12 +75,12 @@ func TestGetPropertyLabels(t *testing.T) {
 		Payload: string(wantPayloadRaw),
 	}
 
-	btTable, err := setupBigtable(ctx, data)
+	btTables, err := setupBigtable(ctx, data)
 	if err != nil {
 		t.Fatalf("NewTestBtStore() = %+v", err)
 	}
 
-	s := NewServer(nil, btTable, nil, nil)
+	s := NewServer(nil, btTables, nil, nil)
 
 	got, err := s.GetPropertyLabels(ctx,
 		&pb.GetPropertyLabelsRequest{

--- a/internal/server/property_value.go
+++ b/internal/server/property_value.go
@@ -174,7 +174,7 @@ func readPropertyValues(
 	btTable *bigtable.Table,
 	rowList bigtable.RowList,
 ) (map[string][]*Node, error) {
-	tmp, err := bigTableReadRowsParallel(ctx, btTable, rowList,
+	tmp, err := bigTableReadRowsParallel(ctx, []*bigtable.Table{btTable}, rowList,
 		func(dcid string, jsonRaw []byte) (interface{}, error) {
 			var propVals PropValueCache
 			err := json.Unmarshal(jsonRaw, &propVals)

--- a/internal/server/property_value.go
+++ b/internal/server/property_value.go
@@ -60,14 +60,14 @@ func (s *Server) GetPropertyValues(ctx context.Context,
 	}
 
 	if inArc {
-		inRes, err = getPropertyValuesHelper(ctx, s.btTable, s.memcache, dcids,
+		inRes, err = getPropertyValuesHelper(ctx, s.btTables, s.memcache, dcids,
 			prop, false)
 		if err != nil {
 			return nil, err
 		}
 	}
 	if outArc {
-		outRes, err = getPropertyValuesHelper(ctx, s.btTable, s.memcache, dcids,
+		outRes, err = getPropertyValuesHelper(ctx, s.btTables, s.memcache, dcids,
 			prop, true)
 		if err != nil {
 			return nil, err
@@ -101,14 +101,14 @@ func (s *Server) GetPropertyValues(ctx context.Context,
 
 func getPropertyValuesHelper(
 	ctx context.Context,
-	btTable *bigtable.Table,
+	btTables []*bigtable.Table,
 	memcache *Memcache,
 	dcids []string,
 	prop string,
 	arcOut bool,
 ) (map[string][]*Node, error) {
 	rowList := buildPropertyValuesKey(dcids, prop, arcOut)
-	nodeMap, err := readPropertyValues(ctx, btTable, rowList)
+	nodeMap, err := readPropertyValues(ctx, btTables, rowList)
 	if err != nil {
 		return nil, err
 	}
@@ -171,10 +171,10 @@ func trimNodes(nodes []*Node, typ string, limit int) []*Node {
 
 func readPropertyValues(
 	ctx context.Context,
-	btTable *bigtable.Table,
+	btTables []*bigtable.Table,
 	rowList bigtable.RowList,
 ) (map[string][]*Node, error) {
-	tmp, err := bigTableReadRowsParallel(ctx, []*bigtable.Table{btTable}, rowList,
+	tmp, err := bigTableReadRowsParallel(ctx, btTables, rowList,
 		func(dcid string, jsonRaw []byte) (interface{}, error) {
 			var propVals PropValueCache
 			err := json.Unmarshal(jsonRaw, &propVals)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -38,7 +38,7 @@ import (
 // Server holds resources for a mixer server
 type Server struct {
 	bqClient *bigquery.Client
-	btTable  *bigtable.Table
+	btTables []*bigtable.Table
 	memcache *Memcache
 	metadata *Metadata
 }
@@ -152,8 +152,8 @@ func (s *Server) SubscribeBranchCacheUpdate(
 // NewServer creates a new server instance.
 func NewServer(
 	bqClient *bigquery.Client,
-	btTable *bigtable.Table,
+	btTables []*bigtable.Table,
 	memcache *Memcache,
 	metadata *Metadata) *Server {
-	return &Server{bqClient, btTable, memcache, metadata}
+	return &Server{bqClient, btTables, memcache, metadata}
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -18,12 +18,13 @@ import (
 	"context"
 	"testing"
 
+	"cloud.google.com/go/bigtable"
 	pb "github.com/datacommonsorg/mixer/internal/proto"
 )
 
 func TestNoBigTable(t *testing.T) {
 	ctx := context.Background()
-	s := NewServer(nil, nil, nil, nil)
+	s := NewServer(nil, []*bigtable.Table{}, nil, nil)
 	_, err := s.GetLandingPageData(ctx, &pb.GetLandingPageDataRequest{
 		Place: "geoId/06",
 	})

--- a/internal/server/stat_bt_reader.go
+++ b/internal/server/stat_bt_reader.go
@@ -32,7 +32,7 @@ func readStats(
 	map[string]map[string]*ObsTimeSeries, error) {
 
 	dataMap, err := bigTableReadRowsParallel(
-		ctx, btTable, rowList, convertToObsSeries, tokenFn(keyTokens),
+		ctx, []*bigtable.Table{btTable}, rowList, convertToObsSeries, tokenFn(keyTokens),
 	)
 	if err != nil {
 		return nil, err
@@ -64,7 +64,7 @@ func readStatsPb(
 	map[string]map[string]*pb.ObsTimeSeries, error) {
 
 	dataMap, err := bigTableReadRowsParallel(
-		ctx, btTable, rowList, convertToObsSeriesPb, tokenFn(keyTokens),
+		ctx, []*bigtable.Table{btTable}, rowList, convertToObsSeriesPb, tokenFn(keyTokens),
 	)
 	if err != nil {
 		return nil, err
@@ -96,7 +96,7 @@ func readStatCollection(
 	map[string]*pb.ObsCollection, error) {
 
 	dataMap, err := bigTableReadRowsParallel(
-		ctx, btTable, rowList, convertToObsCollection,
+		ctx, []*bigtable.Table{btTable}, rowList, convertToObsCollection,
 		func(rowKey string) (string, error) {
 			return keyTokens[rowKey], nil
 		},

--- a/internal/server/stat_bt_reader.go
+++ b/internal/server/stat_bt_reader.go
@@ -26,13 +26,13 @@ import (
 // Consider consolidate this function and bigTableReadRowsParallel.
 func readStats(
 	ctx context.Context,
-	btTable *bigtable.Table,
+	btTables []*bigtable.Table,
 	rowList bigtable.RowList,
 	keyTokens map[string]*placeStatVar) (
 	map[string]map[string]*ObsTimeSeries, error) {
 
 	dataMap, err := bigTableReadRowsParallel(
-		ctx, []*bigtable.Table{btTable}, rowList, convertToObsSeries, tokenFn(keyTokens),
+		ctx, btTables, rowList, convertToObsSeries, tokenFn(keyTokens),
 	)
 	if err != nil {
 		return nil, err
@@ -58,13 +58,13 @@ func readStats(
 // Consider consolidate this function and bigTableReadRowsParallel.
 func readStatsPb(
 	ctx context.Context,
-	btTable *bigtable.Table,
+	btTables []*bigtable.Table,
 	rowList bigtable.RowList,
 	keyTokens map[string]*placeStatVar) (
 	map[string]map[string]*pb.ObsTimeSeries, error) {
 
 	dataMap, err := bigTableReadRowsParallel(
-		ctx, []*bigtable.Table{btTable}, rowList, convertToObsSeriesPb, tokenFn(keyTokens),
+		ctx, btTables, rowList, convertToObsSeriesPb, tokenFn(keyTokens),
 	)
 	if err != nil {
 		return nil, err
@@ -90,13 +90,13 @@ func readStatsPb(
 // in parallel.
 func readStatCollection(
 	ctx context.Context,
-	btTable *bigtable.Table,
+	btTables []*bigtable.Table,
 	rowList bigtable.RowList,
 	keyTokens map[string]string) (
 	map[string]*pb.ObsCollection, error) {
 
 	dataMap, err := bigTableReadRowsParallel(
-		ctx, []*bigtable.Table{btTable}, rowList, convertToObsCollection,
+		ctx, btTables, rowList, convertToObsCollection,
 		func(rowKey string) (string, error) {
 			return keyTokens[rowKey], nil
 		},

--- a/internal/server/stat_point.go
+++ b/internal/server/stat_point.go
@@ -49,7 +49,7 @@ func (s *Server) GetStatValue(ctx context.Context, in *pb.GetStatValueRequest) (
 
 	// Read triples for the statistical variable.
 	triplesRowList := buildTriplesKey([]string{statVar})
-	triples, err := readTriples(ctx, s.btTable, triplesRowList)
+	triples, err := readTriples(ctx, s.btTables, triplesRowList)
 	if err != nil {
 		return nil, err
 	}
@@ -82,7 +82,7 @@ func (s *Server) GetStatValue(ctx context.Context, in *pb.GetStatValueRequest) (
 	} else {
 		// If the data is missing in branch cache, fetch it from the base cache in
 		// Bigtable.
-		btData, err := readStats(ctx, s.btTable, rowList, keyTokens)
+		btData, err := readStats(ctx, s.btTables, rowList, keyTokens)
 		if err != nil {
 			return nil, err
 		}
@@ -131,7 +131,7 @@ func (s *Server) GetStatSet(ctx context.Context, in *pb.GetStatSetRequest) (
 	// TODO(shifucun): Merge this with the logic in GetStatAll()
 	// Read triples for statistical variable.
 	triplesRowList := buildTriplesKey(statVars)
-	triples, err := readTriples(ctx, s.btTable, triplesRowList)
+	triples, err := readTriples(ctx, s.btTables, triplesRowList)
 	if err != nil {
 		return nil, err
 	}
@@ -171,7 +171,7 @@ func (s *Server) GetStatSet(ctx context.Context, in *pb.GetStatSetRequest) (
 		}
 	}
 	if len(extraRowList) > 0 {
-		extraData, err := readStatsPb(ctx, s.btTable, extraRowList, keyTokens)
+		extraData, err := readStatsPb(ctx, s.btTables, extraRowList, keyTokens)
 		if err != nil {
 			return nil, err
 		}
@@ -226,7 +226,7 @@ func (s *Server) GetStatCollection(
 
 	// Read triples for statistical variable.
 	triplesRowList := buildTriplesKey(statVars)
-	triples, err := readTriples(ctx, s.btTable, triplesRowList)
+	triples, err := readTriples(ctx, s.btTables, triplesRowList)
 	if err != nil {
 		return nil, err
 	}
@@ -266,7 +266,7 @@ func (s *Server) GetStatCollection(
 	}
 
 	if len(extraRowList) > 0 {
-		extraData, err := readStatCollection(ctx, s.btTable, extraRowList, keyTokens)
+		extraData, err := readStatCollection(ctx, s.btTables, extraRowList, keyTokens)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/server/stat_series.go
+++ b/internal/server/stat_series.go
@@ -51,7 +51,7 @@ func (s *Server) GetStatSeries(
 
 	// Read triples for statistical variable.
 	triplesRowList := buildTriplesKey([]string{statVar})
-	triples, err := readTriples(ctx, s.btTable, triplesRowList)
+	triples, err := readTriples(ctx, s.btTables, triplesRowList)
 	if err != nil {
 		return nil, err
 	}
@@ -85,7 +85,7 @@ func (s *Server) GetStatSeries(
 	} else {
 		// If the data is missing in branch cache, fetch it from the base cache in
 		// Bigtable.
-		btData, err := readStats(ctx, s.btTable, rowList, keyTokens)
+		btData, err := readStats(ctx, s.btTables, rowList, keyTokens)
 		if err != nil {
 			return nil, err
 		}
@@ -137,7 +137,7 @@ func (s *Server) GetStatAll(ctx context.Context, in *pb.GetStatAllRequest) (
 
 	// Read triples for statistical variable.
 	triplesRowList := buildTriplesKey(statVars)
-	triples, err := readTriples(ctx, s.btTable, triplesRowList)
+	triples, err := readTriples(ctx, s.btTables, triplesRowList)
 	if err != nil {
 		return nil, err
 	}
@@ -179,7 +179,7 @@ func (s *Server) GetStatAll(ctx context.Context, in *pb.GetStatAllRequest) (
 		}
 	}
 	if len(extraRowList) > 0 {
-		extraData, err := readStatsPb(ctx, s.btTable, extraRowList, keyTokens)
+		extraData, err := readStatsPb(ctx, s.btTables, extraRowList, keyTokens)
 		if err != nil {
 			return nil, err
 		}
@@ -216,7 +216,7 @@ func (s *Server) GetStats(ctx context.Context, in *pb.GetStatsRequest) (
 
 	// Read triples for statistical variable.
 	triplesRowList := buildTriplesKey([]string{statsVarDcid})
-	triples, err := readTriples(ctx, s.btTable, triplesRowList)
+	triples, err := readTriples(ctx, s.btTables, triplesRowList)
 	if err != nil {
 		return nil, err
 	}
@@ -263,7 +263,7 @@ func (s *Server) GetStats(ctx context.Context, in *pb.GetStatsRequest) (
 		rowList, keyTokens := buildStatsKey(
 			extraDcids,
 			map[string]*StatisticalVariable{statsVarDcid: statsVarObject})
-		extraData, err := readStats(ctx, s.btTable, rowList, keyTokens)
+		extraData, err := readStats(ctx, s.btTables, rowList, keyTokens)
 		if err != nil {
 			return nil, err
 		}
@@ -305,7 +305,7 @@ func (s *Server) GetStatSetSeries(ctx context.Context, in *pb.GetStatSetSeriesRe
 
 	// Read triples for statistical variable.
 	triplesRowList := buildTriplesKey(statVars)
-	triples, err := readTriples(ctx, s.btTable, triplesRowList)
+	triples, err := readTriples(ctx, s.btTables, triplesRowList)
 	if err != nil {
 		return nil, err
 	}
@@ -361,7 +361,7 @@ func (s *Server) GetStatSetSeries(ctx context.Context, in *pb.GetStatSetSeriesRe
 		}
 	}
 	if len(extraRowList) > 0 {
-		extraData, err := readStatsPb(ctx, s.btTable, extraRowList, keyTokens)
+		extraData, err := readStatsPb(ctx, s.btTables, extraRowList, keyTokens)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/server/testing.go
+++ b/internal/server/testing.go
@@ -31,7 +31,7 @@ const (
 )
 
 func setupBigtable(
-	ctx context.Context, data map[string]string) (*bigtable.Table, error) {
+	ctx context.Context, data map[string]string) ([]*bigtable.Table, error) {
 	srv, err := bttest.NewServer("localhost:0")
 	if err != nil {
 		return nil, err
@@ -71,5 +71,5 @@ func setupBigtable(
 			return nil, err
 		}
 	}
-	return client.Open(testTable), err
+	return []*bigtable.Table{client.Open(testTable)}, err
 }

--- a/internal/server/triple.go
+++ b/internal/server/triple.go
@@ -93,7 +93,7 @@ func (s *Server) GetTriples(ctx context.Context, in *pb.GetTriplesRequest) (
 		} {
 			rowList := buildObservedNodeKey(obsDcids, param.predKey)
 			dataMap, err := bigTableReadRowsParallel(
-				ctx, s.btTable, rowList,
+				ctx, []*bigtable.Table{s.btTable}, rowList,
 				func(dcid string, raw []byte) (interface{}, error) {
 					return string(raw), nil
 				}, nil)
@@ -144,7 +144,7 @@ func (s *Server) GetTriples(ctx context.Context, in *pb.GetTriplesRequest) (
 	if len(popDcids) > 0 {
 		rowList := buildPopPVKey(popDcids)
 		dataMap, err := bigTableReadRowsParallel(
-			ctx, s.btTable, rowList, convertPopTriples, nil)
+			ctx, []*bigtable.Table{s.btTable}, rowList, convertPopTriples, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -246,7 +246,7 @@ func readTriples(
 	ctx context.Context, btTable *bigtable.Table, rowList bigtable.RowList) (
 	map[string]*TriplesCache, error) {
 	dataMap, err := bigTableReadRowsParallel(
-		ctx, btTable, rowList, convertTriplesCache, nil)
+		ctx, []*bigtable.Table{btTable}, rowList, convertTriplesCache, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/triple_test.go
+++ b/internal/server/triple_test.go
@@ -47,7 +47,7 @@ func TestReadTriple(t *testing.T) {
 	}
 	data[key] = tableValue
 	// Setup bigtable
-	btTable, err := setupBigtable(ctx, data)
+	btTables, err := setupBigtable(ctx, data)
 	if err != nil {
 		t.Errorf("SetupBigtable(...) = %v", err)
 	}
@@ -65,7 +65,7 @@ func TestReadTriple(t *testing.T) {
 			},
 		},
 	}
-	got, err := readTriples(ctx, btTable, buildTriplesKey([]string{"City"}))
+	got, err := readTriples(ctx, btTables, buildTriplesKey([]string{"City"}))
 	if err != nil {
 		t.Errorf("ReadTriple get err: %v", err)
 	}

--- a/test/integration/setup.go
+++ b/test/integration/setup.go
@@ -101,7 +101,7 @@ func newClient(
 	btTable *bigtable.Table,
 	memcache *server.Memcache,
 	metadata *server.Metadata) (pb.MixerClient, error) {
-	s := server.NewServer(bqClient, btTable, memcache, metadata)
+	s := server.NewServer(bqClient, []*bigtable.Table{btTable}, memcache, metadata)
 	srv := grpc.NewServer()
 	pb.RegisterMixerServer(srv, s)
 	reflection.Register(srv)

--- a/test/integration/setup.go
+++ b/test/integration/setup.go
@@ -75,7 +75,7 @@ func setup(memcache *server.Memcache) (pb.MixerClient, error) {
 	if err != nil {
 		return nil, err
 	}
-	return newClient(bqClient, btTable, memcache, metadata)
+	return newClient(bqClient, []*bigtable.Table{btTable}, memcache, metadata)
 }
 
 func setupBqOnly() (pb.MixerClient, error) {
@@ -93,15 +93,15 @@ func setupBqOnly() (pb.MixerClient, error) {
 	if err != nil {
 		return nil, err
 	}
-	return newClient(bqClient, nil, nil, metadata)
+	return newClient(bqClient, []*bigtable.Table{}, nil, metadata)
 }
 
 func newClient(
 	bqClient *bigquery.Client,
-	btTable *bigtable.Table,
+	btTables []*bigtable.Table,
 	memcache *server.Memcache,
 	metadata *server.Metadata) (pb.MixerClient, error) {
-	s := server.NewServer(bqClient, []*bigtable.Table{btTable}, memcache, metadata)
+	s := server.NewServer(bqClient, btTables, memcache, metadata)
 	srv := grpc.NewServer()
 	pb.RegisterMixerServer(srv, s)
 	reflection.Register(srv)


### PR DESCRIPTION
This is to prepare for reading from both base and branch BigTables.

bigTableReadRowsParallel now takes multiple tables. The first one should be the branch BT and second one the base BT. The result will rank the result by the table order and pick the data by that order when exists in both tables.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datacommonsorg/mixer/441)
<!-- Reviewable:end -->
