### PR TITLE
Use a new bucket to hold mixer grpc descriptor files

### DIFF
--- a/build/ci/cloudbuild.push.yaml
+++ b/build/ci/cloudbuild.push.yaml
@@ -60,10 +60,10 @@ steps:
       - -c
       - |
         set -e
-        gsutil cp mixer-grpc.$SHORT_SHA.pb gs://artifacts.datcom-ci.appspot.com/mixer-grpc/mixer-grpc.$SHORT_SHA.pb
-        gsutil cp mixer-grpc.$SHORT_SHA.pb gs://artifacts.datcom-ci.appspot.com/mixer-grpc/mixer-grpc.latest.pb
-        gsutil acl ch -u AllUsers:R gs://artifacts.datcom-ci.appspot.com/mixer-grpc/mixer-grpc.$SHORT_SHA.pb
-        gsutil acl ch -u AllUsers:R gs://artifacts.datcom-ci.appspot.com/mixer-grpc/mixer-grpc.latest.pb
+        gsutil cp mixer-grpc.$SHORT_SHA.pb gs://datcom-mixer-grpc/mixer-grpc/mixer-grpc.$SHORT_SHA.pb
+        gsutil cp mixer-grpc.$SHORT_SHA.pb gs://datcom-mixer-grpc/mixer-grpc/mixer-grpc.latest.pb
+        gsutil acl ch -u AllUsers:R gs://datcom-mixer-grpc/mixer-grpc/mixer-grpc.$SHORT_SHA.pb
+        gsutil acl ch -u AllUsers:R gs://datcom-mixer-grpc/mixer-grpc/mixer-grpc.latest.pb
   # Update all the versions.
   - id: update-version
     name: "gcr.io/cloud-builders/git"

--- a/gke/setup_esp.sh
+++ b/gke/setup_esp.sh
@@ -31,6 +31,6 @@ yq w -i endpoints.yaml endpoints[0].target "$IP"
 yq w -i endpoints.yaml endpoints[0].name "$DOMAIN"
 
 ## Deploy ESP configuration
-gsutil cp gs://artifacts.datcom-ci.appspot.com/mixer-grpc/mixer-grpc.latest.pb .
+gsutil cp gs://datcom-mixer-grpc/mixer-grpc/mixer-grpc.latest.pb .
 gcloud endpoints services deploy mixer-grpc.latest.pb endpoints.yaml --project $PROJECT_ID
 gcloud services enable $DOMAIN

--- a/script/deploy_gke.sh
+++ b/script/deploy_gke.sh
@@ -68,5 +68,5 @@ yq w --style=double $ROOT/esp/endpoints.yaml.tmpl name $DOMAIN > endpoints.yaml
 yq w -i endpoints.yaml title "$API_TITLE"
 yq w -i endpoints.yaml endpoints[0].target "$IP"
 yq w -i endpoints.yaml endpoints[0].name "$DOMAIN"
-gsutil cp gs://artifacts.datcom-ci.appspot.com/mixer-grpc/mixer-grpc.$TAG.pb .
+gsutil cp gs://datcom-mixer-grpc/mixer-grpc/mixer-grpc.$TAG.pb .
 gcloud endpoints services deploy mixer-grpc.$TAG.pb endpoints.yaml --project $PROJECT_ID


### PR DESCRIPTION
artifacts.datcom-ci.appspot.com holds the docker images. Separate out these files to make it safer to manage.