### PR TITLE
Add config for mixer autopush deployment

### DIFF
--- a/build/ci/cloudbuild.push.yaml
+++ b/build/ci/cloudbuild.push.yaml
@@ -71,7 +71,7 @@ steps:
     args:
       - -c
       - |
-        ./scripts/update_staging_version.sh $SHORT_SHA
+        ./scripts/update_autopush_version.sh $SHORT_SHA
 
   # This is a trigger to push website at website/mixer code HEAD and with the
   # latest base cache.

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Build docker image used in Cloud Build for staging/prod deployment.
+# Build docker image used in Cloud Build for deployment.
 # This image contains "gcloud", "kubectl", "yq", "kustomize"
 
 FROM google/cloud-sdk:slim

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -7,13 +7,14 @@ Mixer is deployed to Kubernetes cluster either locally on
 
 * `storage`: BigQuery and Bigtable version config
 * `base`: Base Kubernetes config yaml files.
-* `overlays`: Kubernetes deployment yaml files extending the base yaml files on dev/staging/prod environment.
+* `overlays`: Kubernetes deployment yaml files extending the base yaml files on dev/autopush/staging/prod environment.
 * `gke`: GKE cluster config.
 
 ## Overlays
 
 * `dev`: Yaml patches for local minikube cluster.
-* `staging`: Yaml patches for staging GKE cluster (staging Mixer)
+* `autopush`: Yaml patches for autopush GKE cluster (autopush.api.datacommons.org)
+* `staging`: Yaml patches for staging GKE cluster (staging.api.datacommons.org)
 * `prod`: Yaml patches for prod GKE cluster (prod mixer that serves api.datacommons.org)
 
 ## Generate kubetcl yaml file and deploy

--- a/deploy/base/deployment.yaml
+++ b/deploy/base/deployment.yaml
@@ -14,7 +14,7 @@
 
 
 # Mixer Kubernetes Deployment config. (https://kubernetes.io/docs/concepts/workloads/controllers/deployment/)
-# This is to be extended by the dev/staging/prod overlay.
+# This is to be extended by the dev/autopush/staging/prod overlay.
 # The deployment contains grpc mixer container and esp container that transcodes grpc to JSON.
 
 apiVersion: apps/v1

--- a/deploy/gke/autopush.yaml
+++ b/deploy/gke/autopush.yaml
@@ -14,10 +14,10 @@
 
 # Staging Mixer GKE params
 
-project: datcom-mixer-staging
+project: datcom-mixer-autopush
 region: us-central1
-ip: 34.107.161.252
-domain: staging.api.datacommons.org
-api_title: DataCommons API (Staging)
-nodes: 3
+ip: 34.117.145.125
+domain: autopush.api.datacommons.org
+api_title: DataCommons API (Autopush)
+nodes: 1
 store: google.com:datcom-store-dev

--- a/deploy/gke/autopush.yaml
+++ b/deploy/gke/autopush.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Staging Mixer GKE params
+# Autopush Mixer GKE params
 
 project: datcom-mixer-autopush
 region: us-central1

--- a/deploy/overlays/autopush/kustomization.yaml
+++ b/deploy/overlays/autopush/kustomization.yaml
@@ -12,12 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Staging Mixer GKE params
+# Kustomization for "autopush" mixer running on GCP `datcom-mixer-autopush` project.
+# - Adds "autopush" suffix to all the resources.
+# - Use replica of 15.
 
-project: datcom-mixer-staging
-region: us-central1
-ip: 34.107.161.252
-domain: staging.api.datacommons.org
-api_title: DataCommons API (Staging)
-nodes: 3
-store: google.com:datcom-store-dev
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+nameSuffix: -autopush
+
+resources:
+- ../../base
+
+configMapGenerator:
+- name: mixer-configmap
+  behavior: create
+  namespace: mixer
+  literals:
+  - projectId=datcom-mixer-autopush
+  - serviceName=autopush.api.datacommons.org
+
+patchesStrategicMerge:
+- |-
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: mixer-grpc
+  spec:
+    replicas: 15

--- a/deploy/overlays/staging/kustomization.yaml
+++ b/deploy/overlays/staging/kustomization.yaml
@@ -30,7 +30,7 @@ configMapGenerator:
   namespace: mixer
   literals:
   - projectId=datcom-mixer-staging
-  - serviceName=mixer.endpoints.datcom-mixer-staging.cloud.goog
+  - serviceName=staging.api.datacommons.org
 
 patchesStrategicMerge:
 - |-

--- a/gke/config.yaml
+++ b/gke/config.yaml
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Staging Mixer GKE params
 
-project: datcom-mixer-staging
+# This is a yaml template to create gcp/gke configuration.
+# Copy this file to `config.yaml` and use that.
+
+project: datcom-mixer-autopush
+ip: 34.117.145.125
+domain: autopush.api.datacommons.org
+api_title:
 region: us-central1
-ip: 34.107.161.252
-domain: staging.api.datacommons.org
-api_title: DataCommons API (Staging)
-nodes: 3
+nodes: 1
 store: google.com:datcom-store-dev

--- a/scripts/deploy_gke.sh
+++ b/scripts/deploy_gke.sh
@@ -18,9 +18,9 @@
 #
 # Usage:
 #
-# ./deploy_key.sh <"prod"|"staging"> <commit_hash>
+# ./deploy_key.sh <"prod"|"staging"|"autopush"> <commit_hash>
 #
-# First argument is either "prod" or "staging".
+# First argument is either "prod" or "staging" or "autopush".
 # (Optional) second argument is the git commit hash of the mixer repo.
 #
 # !!! WARNING: Run this script in a clean Git checkout at the desired commit.
@@ -33,8 +33,8 @@ set -e
 
 ENV=$1
 
-if [[ $ENV != "staging" && $ENV != "prod" ]]; then
-  echo "First argument should be 'staging' or 'prod' "
+if [[ $ENV != "staging" && $ENV != "prod" && $ENV != "autopush" ]]; then
+  echo "First argument should be 'staging' or 'prod' or 'autopush'"
   exit
 fi
 

--- a/scripts/update_autopush_version.sh
+++ b/scripts/update_autopush_version.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 
-# This script is used to update the current staging mixer version in the
+# This script is used to update the current autopush mixer version in the
 # `deployment`:https://source.cloud.google.com/datcom-ci/deployment repo.
 # This is used by continous deployment process.
 
@@ -34,9 +34,9 @@ git config user.email $(gcloud auth list --filter=status:ACTIVE --format='value(
 # Update version file
 git checkout master
 
-echo $VERSION > /tmp/deployment/mixer/staging/version.txt
+echo $VERSION > /tmp/deployment/mixer/autopush/version.txt
 
 # Commit the version file
-git add /tmp/deployment/mixer/staging/*
-git commit -m "Update staging mixer versions at commit https://github.com/datacommonsorg/mixer/commit/$VERSION"
+git add /tmp/deployment/mixer/autopush/*
+git commit -m "Update autopush mixer versions at commit https://github.com/datacommonsorg/mixer/commit/$VERSION"
 git push origin master

--- a/test/load_testing/locust-master-controller.yaml
+++ b/test/load_testing/locust-master-controller.yaml
@@ -37,7 +37,7 @@ spec:
             - name: LOCUST_MODE
               value: master
             - name: TARGET_HOST
-              value: https://mixer.endpoints.datcom-mixer-staging.cloud.goog
+              value: https://staging.api.datacommons.org
           ports:
             - name: loc-master-web
               containerPort: 8089

--- a/test/load_testing/locust-worker-controller.yaml
+++ b/test/load_testing/locust-worker-controller.yaml
@@ -38,4 +38,4 @@ spec:
             - name: LOCUST_MASTER
               value: locust-master
             - name: TARGET_HOST
-              value: https://mixer.endpoints.datcom-mixer-staging.cloud.goog
+              value: https://staging.api.datacommons.org


### PR DESCRIPTION
autopush instance will be auto-deployed after each PR commit.
staging instance can only be manually deployed on demand.
also updated autopush/staging domain

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/datacommonsorg/mixer/456)
<!-- Reviewable:end -->
