### PR TITLE
GetTriples support for StatVar Observation node

### DIFF
--- a/internal/server/triple.go
+++ b/internal/server/triple.go
@@ -17,6 +17,8 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -33,11 +35,30 @@ const (
 	obsAncestorTypeComparedNode = "1"
 )
 
+type Prop struct {
+	name  string
+	isObj bool
+}
+
+var obsProps = []Prop{
+	{"observationAbout", true},
+	{"variableMeasured", true},
+	{"value", false},
+	{"observationDate", false},
+	{"observationPeriod", false},
+	{"measurementMethod", true},
+	{"unit", true},
+	{"scalingFactor", false},
+	{"samplePopulation", true},
+	{"location", true},
+}
+
 // GetTriples implements API for Mixer.GetTriples.
 func (s *Server) GetTriples(ctx context.Context, in *pb.GetTriplesRequest) (
 	*pb.GetTriplesResponse, error) {
 	dcids := in.GetDcids()
 	limit := in.GetLimit()
+	svobsMode := s.metadata.SvObsMode
 
 	if len(dcids) == 0 {
 		return nil, status.Errorf(codes.InvalidArgument, "Missing argument: dcids")
@@ -90,54 +111,125 @@ func (s *Server) GetTriples(ctx context.Context, in *pb.GetTriplesRequest) (
 
 	// Observation DCIDs.
 	if len(obsDcids) > 0 {
-		for _, param := range []struct {
-			predKey, pred string
-		}{
-			{obsAncestorTypeObservedNode, "observedNode"},
-			{obsAncestorTypeComparedNode, "comparedNode"},
-		} {
-			rowList := buildObservedNodeKey(obsDcids, param.predKey)
-			baseDataMap, branchDataMap, err := bigTableReadRowsParallel(
-				ctx, s.store, rowList,
-				func(dcid string, raw []byte) (interface{}, error) {
-					return string(raw), nil
-				}, nil)
-			if err != nil {
-				return nil, err
-			}
-			// Map from observation dcid to observedNode dcid.
-			observedNodeMap := map[string]string{}
+		if svobsMode {
+			dcidList := ""
 			for _, dcid := range obsDcids {
-				if data, ok := branchDataMap[dcid]; ok {
-					observedNodeMap[dcid] = data.(string)
-				} else if data, ok := baseDataMap[dcid]; ok {
-					observedNodeMap[dcid] = data.(string)
+				dcidList += fmt.Sprintf("\"%s\" ", dcid)
+			}
+			selectStatment := "SELECT ?o ?provenance "
+			tripleStatment := "?o typeOf StatVarObservation . ?o provenance ?provenance . "
+			for _, prop := range obsProps {
+				selectStatment += fmt.Sprintf("?%s ", prop.name)
+				tripleStatment += fmt.Sprintf("?o %s ?%s . ", prop.name, prop.name)
+			}
+			tripleStatment += fmt.Sprintf("?o dcid (%s)", dcidList)
+			sparql := fmt.Sprintf(
+				`%s
+				WHERE {
+					%s
 				}
-			}
-			// Get the observedNode names.
-			observedNodes := []string{}
-			for _, dcid := range observedNodeMap {
-				observedNodes = append(observedNodes, dcid)
-			}
-			nameRowList := buildPropertyValuesKey(observedNodes, "name", true)
-			nameNodes, err := readPropertyValues(ctx, s.store, nameRowList)
+				`, selectStatment, tripleStatment,
+			)
+			resp, err := s.Query(ctx, &pb.QueryRequest{Sparql: sparql})
 			if err != nil {
 				return nil, err
 			}
-			for dcid, observedNode := range observedNodeMap {
-				if _, exist := resultsMap[dcid]; !exist {
-					resultsMap[dcid] = []*Triple{}
+			for _, row := range resp.GetRows() {
+				dcid := row.GetCells()[0].Value
+				prov := row.GetCells()[1].Value
+				objDcids := []string{}
+				objTriples := map[string]*Triple{}
+				for i, prop := range obsProps {
+					if row.GetCells()[i+2].Value != "" {
+						if prop.isObj {
+							// The object is a node; need to fetch the name.
+							objDcid := row.GetCells()[i+2].Value
+							objDcids = append(objDcids, objDcid)
+							objTriples[objDcid] = &Triple{
+								SubjectID:    dcid,
+								Predicate:    prop.name,
+								ObjectID:     objDcid,
+								ProvenanceID: prov,
+							}
+						} else {
+							resultsMap[dcid] = append(resultsMap[dcid], &Triple{
+								SubjectID:    dcid,
+								Predicate:    prop.name,
+								ObjectValue:  row.GetCells()[i+2].Value,
+								ProvenanceID: prov,
+							})
+						}
+					}
 				}
-				name := observedNode
-				if len(nameNodes[observedNode]) > 0 {
-					name = nameNodes[observedNode][0].Value
+				nameNodes, err := getPropertyValuesHelper(ctx, s.store, objDcids, "name", true)
+				if err != nil {
+					return nil, err
 				}
-				resultsMap[dcid] = append(resultsMap[dcid], &Triple{
-					SubjectID:  dcid,
-					Predicate:  param.pred,
-					ObjectID:   observedNode,
-					ObjectName: name,
-				})
+				for prop, nodes := range nameNodes {
+					if len(nodes) > 0 {
+						objTriples[prop].ObjectName = nodes[0].Value
+					}
+				}
+				// Sort the triples to get determinisic result.
+				keys := make([]string, 0)
+				for k := range objTriples {
+					keys = append(keys, k)
+				}
+				sort.Strings(keys)
+				for _, key := range keys {
+					resultsMap[dcid] = append(resultsMap[dcid], objTriples[key])
+				}
+			}
+		} else {
+			for _, param := range []struct {
+				predKey, pred string
+			}{
+				{obsAncestorTypeObservedNode, "observedNode"},
+				{obsAncestorTypeComparedNode, "comparedNode"},
+			} {
+				rowList := buildObservedNodeKey(obsDcids, param.predKey)
+				baseDataMap, branchDataMap, err := bigTableReadRowsParallel(
+					ctx, s.store, rowList,
+					func(dcid string, raw []byte) (interface{}, error) {
+						return string(raw), nil
+					}, nil)
+				if err != nil {
+					return nil, err
+				}
+				// Map from observation dcid to observedNode dcid.
+				observedNodeMap := map[string]string{}
+				for _, dcid := range obsDcids {
+					if data, ok := branchDataMap[dcid]; ok {
+						observedNodeMap[dcid] = data.(string)
+					} else if data, ok := baseDataMap[dcid]; ok {
+						observedNodeMap[dcid] = data.(string)
+					}
+				}
+				// Get the observedNode names.
+				observedNodes := []string{}
+				for _, dcid := range observedNodeMap {
+					observedNodes = append(observedNodes, dcid)
+				}
+				nameRowList := buildPropertyValuesKey(observedNodes, "name", true)
+				nameNodes, err := readPropertyValues(ctx, s.store, nameRowList)
+				if err != nil {
+					return nil, err
+				}
+				for dcid, observedNode := range observedNodeMap {
+					if _, exist := resultsMap[dcid]; !exist {
+						resultsMap[dcid] = []*Triple{}
+					}
+					name := observedNode
+					if len(nameNodes[observedNode]) > 0 {
+						name = nameNodes[observedNode][0].Value
+					}
+					resultsMap[dcid] = append(resultsMap[dcid], &Triple{
+						SubjectID:  dcid,
+						Predicate:  param.pred,
+						ObjectID:   observedNode,
+						ObjectName: name,
+					})
+				}
 			}
 		}
 	}

--- a/internal/server/triple.go
+++ b/internal/server/triple.go
@@ -244,7 +244,7 @@ func (s *Server) GetTriples(ctx context.Context, in *pb.GetTriplesRequest) (
 	// Observation DCIDs.
 	if len(obsDcids) > 0 {
 		var err error
-		obsResult := map[string][]*Triple{}
+		var obsResult map[string][]*Triple
 		if svobsMode {
 			obsResult, err = getObsTriplesSvObs(ctx, s, obsDcids)
 			if err != nil {

--- a/internal/server/triple.go
+++ b/internal/server/triple.go
@@ -35,12 +35,12 @@ const (
 	obsAncestorTypeComparedNode = "1"
 )
 
-type Prop struct {
+type prop struct {
 	name  string
 	isObj bool
 }
 
-var obsProps = []Prop{
+var obsProps = []prop{
 	{"observationAbout", true},
 	{"variableMeasured", true},
 	{"value", false},

--- a/internal/server/triple.go
+++ b/internal/server/triple.go
@@ -53,6 +53,138 @@ var obsProps = []prop{
 	{"location", true},
 }
 
+func getObsTriplesSvObs(
+	ctx context.Context, s *Server, obsDcids []string) (map[string][]*Triple, error) {
+	dcidList := ""
+	for _, dcid := range obsDcids {
+		dcidList += fmt.Sprintf("\"%s\" ", dcid)
+	}
+	selectStatment := "SELECT ?o ?provenance "
+	tripleStatment := "?o typeOf StatVarObservation . ?o provenance ?provenance . "
+	for _, prop := range obsProps {
+		selectStatment += fmt.Sprintf("?%s ", prop.name)
+		tripleStatment += fmt.Sprintf("?o %s ?%s . ", prop.name, prop.name)
+	}
+	tripleStatment += fmt.Sprintf("?o dcid (%s)", dcidList)
+	sparql := fmt.Sprintf(
+		`%s
+				WHERE {
+					%s
+				}
+				`, selectStatment, tripleStatment,
+	)
+	resp, err := s.Query(ctx, &pb.QueryRequest{Sparql: sparql})
+	if err != nil {
+		return nil, err
+	}
+	result := map[string][]*Triple{}
+	for _, row := range resp.GetRows() {
+		dcid := row.GetCells()[0].Value
+		prov := row.GetCells()[1].Value
+		objDcids := []string{}
+		objTriples := map[string]*Triple{}
+		for i, prop := range obsProps {
+			objCell := row.GetCells()[i+2].Value
+			if objCell != "" {
+				if prop.isObj {
+					// The object is a node; need to fetch the name.
+					objDcid := objCell
+					objDcids = append(objDcids, objDcid)
+					objTriples[objDcid] = &Triple{
+						SubjectID:    dcid,
+						Predicate:    prop.name,
+						ObjectID:     objDcid,
+						ProvenanceID: prov,
+					}
+				} else {
+					result[dcid] = append(result[dcid], &Triple{
+						SubjectID:    dcid,
+						Predicate:    prop.name,
+						ObjectValue:  objCell,
+						ProvenanceID: prov,
+					})
+				}
+			}
+		}
+		nameNodes, err := getPropertyValuesHelper(ctx, s.store, objDcids, "name", true)
+		if err != nil {
+			return nil, err
+		}
+		for prop, nodes := range nameNodes {
+			if len(nodes) > 0 {
+				objTriples[prop].ObjectName = nodes[0].Value
+			}
+		}
+		// Sort the triples to get determinisic result.
+		keys := make([]string, 0)
+		for k := range objTriples {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			result[dcid] = append(result[dcid], objTriples[key])
+		}
+	}
+	return result, nil
+}
+
+func getObsTriplesPopObs(
+	ctx context.Context, s *Server, obsDcids []string) (map[string][]*Triple, error) {
+	result := map[string][]*Triple{}
+	for _, param := range []struct {
+		predKey, pred string
+	}{
+		{obsAncestorTypeObservedNode, "observedNode"},
+		{obsAncestorTypeComparedNode, "comparedNode"},
+	} {
+		rowList := buildObservedNodeKey(obsDcids, param.predKey)
+		baseDataMap, branchDataMap, err := bigTableReadRowsParallel(
+			ctx, s.store, rowList,
+			func(dcid string, raw []byte) (interface{}, error) {
+				return string(raw), nil
+			}, nil)
+		if err != nil {
+			return nil, err
+		}
+		// Map from observation dcid to observedNode dcid.
+		observedNodeMap := map[string]string{}
+		for _, dcid := range obsDcids {
+			if data, ok := branchDataMap[dcid]; ok {
+				observedNodeMap[dcid] = data.(string)
+			} else if data, ok := baseDataMap[dcid]; ok {
+				observedNodeMap[dcid] = data.(string)
+			}
+		}
+		// Get the observedNode names.
+		observedNodes := []string{}
+		for _, dcid := range observedNodeMap {
+			observedNodes = append(observedNodes, dcid)
+		}
+		nameRowList := buildPropertyValuesKey(observedNodes, "name", true)
+		nameNodes, err := readPropertyValues(ctx, s.store, nameRowList)
+		if err != nil {
+			return nil, err
+		}
+
+		for dcid, observedNode := range observedNodeMap {
+			if _, exist := result[dcid]; !exist {
+				result[dcid] = []*Triple{}
+			}
+			name := observedNode
+			if len(nameNodes[observedNode]) > 0 {
+				name = nameNodes[observedNode][0].Value
+			}
+			result[dcid] = append(result[dcid], &Triple{
+				SubjectID:  dcid,
+				Predicate:  param.pred,
+				ObjectID:   observedNode,
+				ObjectName: name,
+			})
+		}
+	}
+	return result, nil
+}
+
 // GetTriples implements API for Mixer.GetTriples.
 func (s *Server) GetTriples(ctx context.Context, in *pb.GetTriplesRequest) (
 	*pb.GetTriplesResponse, error) {
@@ -111,126 +243,21 @@ func (s *Server) GetTriples(ctx context.Context, in *pb.GetTriplesRequest) (
 
 	// Observation DCIDs.
 	if len(obsDcids) > 0 {
+		var err error
+		obsResult := map[string][]*Triple{}
 		if svobsMode {
-			dcidList := ""
-			for _, dcid := range obsDcids {
-				dcidList += fmt.Sprintf("\"%s\" ", dcid)
-			}
-			selectStatment := "SELECT ?o ?provenance "
-			tripleStatment := "?o typeOf StatVarObservation . ?o provenance ?provenance . "
-			for _, prop := range obsProps {
-				selectStatment += fmt.Sprintf("?%s ", prop.name)
-				tripleStatment += fmt.Sprintf("?o %s ?%s . ", prop.name, prop.name)
-			}
-			tripleStatment += fmt.Sprintf("?o dcid (%s)", dcidList)
-			sparql := fmt.Sprintf(
-				`%s
-				WHERE {
-					%s
-				}
-				`, selectStatment, tripleStatment,
-			)
-			resp, err := s.Query(ctx, &pb.QueryRequest{Sparql: sparql})
+			obsResult, err = getObsTriplesSvObs(ctx, s, obsDcids)
 			if err != nil {
 				return nil, err
 			}
-			for _, row := range resp.GetRows() {
-				dcid := row.GetCells()[0].Value
-				prov := row.GetCells()[1].Value
-				objDcids := []string{}
-				objTriples := map[string]*Triple{}
-				for i, prop := range obsProps {
-					if row.GetCells()[i+2].Value != "" {
-						if prop.isObj {
-							// The object is a node; need to fetch the name.
-							objDcid := row.GetCells()[i+2].Value
-							objDcids = append(objDcids, objDcid)
-							objTriples[objDcid] = &Triple{
-								SubjectID:    dcid,
-								Predicate:    prop.name,
-								ObjectID:     objDcid,
-								ProvenanceID: prov,
-							}
-						} else {
-							resultsMap[dcid] = append(resultsMap[dcid], &Triple{
-								SubjectID:    dcid,
-								Predicate:    prop.name,
-								ObjectValue:  row.GetCells()[i+2].Value,
-								ProvenanceID: prov,
-							})
-						}
-					}
-				}
-				nameNodes, err := getPropertyValuesHelper(ctx, s.store, objDcids, "name", true)
-				if err != nil {
-					return nil, err
-				}
-				for prop, nodes := range nameNodes {
-					if len(nodes) > 0 {
-						objTriples[prop].ObjectName = nodes[0].Value
-					}
-				}
-				// Sort the triples to get determinisic result.
-				keys := make([]string, 0)
-				for k := range objTriples {
-					keys = append(keys, k)
-				}
-				sort.Strings(keys)
-				for _, key := range keys {
-					resultsMap[dcid] = append(resultsMap[dcid], objTriples[key])
-				}
-			}
 		} else {
-			for _, param := range []struct {
-				predKey, pred string
-			}{
-				{obsAncestorTypeObservedNode, "observedNode"},
-				{obsAncestorTypeComparedNode, "comparedNode"},
-			} {
-				rowList := buildObservedNodeKey(obsDcids, param.predKey)
-				baseDataMap, branchDataMap, err := bigTableReadRowsParallel(
-					ctx, s.store, rowList,
-					func(dcid string, raw []byte) (interface{}, error) {
-						return string(raw), nil
-					}, nil)
-				if err != nil {
-					return nil, err
-				}
-				// Map from observation dcid to observedNode dcid.
-				observedNodeMap := map[string]string{}
-				for _, dcid := range obsDcids {
-					if data, ok := branchDataMap[dcid]; ok {
-						observedNodeMap[dcid] = data.(string)
-					} else if data, ok := baseDataMap[dcid]; ok {
-						observedNodeMap[dcid] = data.(string)
-					}
-				}
-				// Get the observedNode names.
-				observedNodes := []string{}
-				for _, dcid := range observedNodeMap {
-					observedNodes = append(observedNodes, dcid)
-				}
-				nameRowList := buildPropertyValuesKey(observedNodes, "name", true)
-				nameNodes, err := readPropertyValues(ctx, s.store, nameRowList)
-				if err != nil {
-					return nil, err
-				}
-				for dcid, observedNode := range observedNodeMap {
-					if _, exist := resultsMap[dcid]; !exist {
-						resultsMap[dcid] = []*Triple{}
-					}
-					name := observedNode
-					if len(nameNodes[observedNode]) > 0 {
-						name = nameNodes[observedNode][0].Value
-					}
-					resultsMap[dcid] = append(resultsMap[dcid], &Triple{
-						SubjectID:  dcid,
-						Predicate:  param.pred,
-						ObjectID:   observedNode,
-						ObjectName: name,
-					})
-				}
+			obsResult, err = getObsTriplesPopObs(ctx, s, obsDcids)
+			if err != nil {
+				return nil, err
 			}
+		}
+		for k, v := range obsResult {
+			resultsMap[k] = append(resultsMap[k], v...)
 		}
 	}
 

--- a/test/integration/get_triples_test.go
+++ b/test/integration/get_triples_test.go
@@ -91,12 +91,12 @@ func TestGetTriples(t *testing.T) {
 		},
 		{
 			[]string{
-				"dc/o/w2z8nx9y43k97",
-				"dc/o/mc1g2ew9yegq8",
-				"dc/o/28b93wpnlkjgc",
-				"dc/o/88cs3xqnmpp55",
-				"dc/o/23gt9k7fql176",
-				"dc/o/kyv7dxe4s18eh",
+				"dc/o/w2z8nx9y43k97", // LifeExpectancy_Person_Female
+				"dc/o/mc1g2ew9yegq8", // Amount_Consumption_Energy_PerCapita<>
+				"dc/o/28b93wpnlkjgc", // Amount_EconomicActivity_GrossDomesticProduction_Nominal<>
+				"dc/o/88cs3xqnmpp55", // Count_Person<CensusPEPSurvey>
+				"dc/o/23gt9k7fql176", // Count_Person<dcAggregate/CensusACS5yrSurvey>
+				"dc/o/kyv7dxe4s18eh", // Count_Person<>
 			},
 			"observation_svobs.json",
 			false,

--- a/test/integration/golden_response/staging/get_triples/observation_svobs.json
+++ b/test/integration/golden_response/staging/get_triples/observation_svobs.json
@@ -1,0 +1,222 @@
+{
+  "dc/o/23gt9k7fql176": [
+    {
+      "subjectId": "dc/o/23gt9k7fql176",
+      "predicate": "value",
+      "objectValue": "324473370",
+      "provenanceId": "dc/qmsyx4"
+    },
+    {
+      "subjectId": "dc/o/23gt9k7fql176",
+      "predicate": "observationDate",
+      "objectValue": "2017",
+      "provenanceId": "dc/qmsyx4"
+    },
+    {
+      "subjectId": "dc/o/23gt9k7fql176",
+      "predicate": "variableMeasured",
+      "objectId": "Count_Person",
+      "provenanceId": "dc/qmsyx4"
+    },
+    {
+      "subjectId": "dc/o/23gt9k7fql176",
+      "predicate": "observationAbout",
+      "objectId": "country/USA",
+      "objectName": "United States of America",
+      "provenanceId": "dc/qmsyx4"
+    },
+    {
+      "subjectId": "dc/o/23gt9k7fql176",
+      "predicate": "measurementMethod",
+      "objectId": "dcAggregate/CensusACS5yrSurvey",
+      "provenanceId": "dc/qmsyx4"
+    }
+  ],
+  "dc/o/28b93wpnlkjgc": [
+    {
+      "subjectId": "dc/o/28b93wpnlkjgc",
+      "predicate": "value",
+      "objectValue": "79453254441374.8",
+      "provenanceId": "dc/jccrh82"
+    },
+    {
+      "subjectId": "dc/o/28b93wpnlkjgc",
+      "predicate": "observationDate",
+      "objectValue": "2014",
+      "provenanceId": "dc/jccrh82"
+    },
+    {
+      "subjectId": "dc/o/28b93wpnlkjgc",
+      "predicate": "observationPeriod",
+      "objectValue": "P1Y",
+      "provenanceId": "dc/jccrh82"
+    },
+    {
+      "subjectId": "dc/o/28b93wpnlkjgc",
+      "predicate": "variableMeasured",
+      "objectId": "Amount_EconomicActivity_GrossDomesticProduction_Nominal",
+      "provenanceId": "dc/jccrh82"
+    },
+    {
+      "subjectId": "dc/o/28b93wpnlkjgc",
+      "predicate": "observationAbout",
+      "objectId": "Earth",
+      "objectName": "Earth",
+      "provenanceId": "dc/jccrh82"
+    },
+    {
+      "subjectId": "dc/o/28b93wpnlkjgc",
+      "predicate": "unit",
+      "objectId": "USDollar",
+      "objectName": "USDollar",
+      "provenanceId": "dc/jccrh82"
+    }
+  ],
+  "dc/o/88cs3xqnmpp55": [
+    {
+      "subjectId": "dc/o/88cs3xqnmpp55",
+      "predicate": "value",
+      "objectValue": "235824908",
+      "provenanceId": "dc/ks7tgs3"
+    },
+    {
+      "subjectId": "dc/o/88cs3xqnmpp55",
+      "predicate": "observationDate",
+      "objectValue": "1984",
+      "provenanceId": "dc/ks7tgs3"
+    },
+    {
+      "subjectId": "dc/o/88cs3xqnmpp55",
+      "predicate": "measurementMethod",
+      "objectId": "CensusPEPSurvey",
+      "provenanceId": "dc/ks7tgs3"
+    },
+    {
+      "subjectId": "dc/o/88cs3xqnmpp55",
+      "predicate": "variableMeasured",
+      "objectId": "Count_Person",
+      "provenanceId": "dc/ks7tgs3"
+    },
+    {
+      "subjectId": "dc/o/88cs3xqnmpp55",
+      "predicate": "observationAbout",
+      "objectId": "country/USA",
+      "objectName": "United States of America",
+      "provenanceId": "dc/ks7tgs3"
+    }
+  ],
+  "dc/o/kyv7dxe4s18eh": [
+    {
+      "subjectId": "dc/o/kyv7dxe4s18eh",
+      "predicate": "value",
+      "objectValue": "301231207",
+      "provenanceId": "dc/jccrh82"
+    },
+    {
+      "subjectId": "dc/o/kyv7dxe4s18eh",
+      "predicate": "observationDate",
+      "objectValue": "2007",
+      "provenanceId": "dc/jccrh82"
+    },
+    {
+      "subjectId": "dc/o/kyv7dxe4s18eh",
+      "predicate": "observationPeriod",
+      "objectValue": "P1Y",
+      "provenanceId": "dc/jccrh82"
+    },
+    {
+      "subjectId": "dc/o/kyv7dxe4s18eh",
+      "predicate": "variableMeasured",
+      "objectId": "Count_Person",
+      "provenanceId": "dc/jccrh82"
+    },
+    {
+      "subjectId": "dc/o/kyv7dxe4s18eh",
+      "predicate": "observationAbout",
+      "objectId": "country/USA",
+      "objectName": "United States of America",
+      "provenanceId": "dc/jccrh82"
+    }
+  ],
+  "dc/o/mc1g2ew9yegq8": [
+    {
+      "subjectId": "dc/o/mc1g2ew9yegq8",
+      "predicate": "value",
+      "objectValue": "1739.28702088157",
+      "provenanceId": "dc/jccrh82"
+    },
+    {
+      "subjectId": "dc/o/mc1g2ew9yegq8",
+      "predicate": "observationDate",
+      "objectValue": "2004",
+      "provenanceId": "dc/jccrh82"
+    },
+    {
+      "subjectId": "dc/o/mc1g2ew9yegq8",
+      "predicate": "observationPeriod",
+      "objectValue": "P1Y",
+      "provenanceId": "dc/jccrh82"
+    },
+    {
+      "subjectId": "dc/o/mc1g2ew9yegq8",
+      "predicate": "variableMeasured",
+      "objectId": "Amount_Consumption_Energy_PerCapita",
+      "provenanceId": "dc/jccrh82"
+    },
+    {
+      "subjectId": "dc/o/mc1g2ew9yegq8",
+      "predicate": "observationAbout",
+      "objectId": "Earth",
+      "objectName": "Earth",
+      "provenanceId": "dc/jccrh82"
+    },
+    {
+      "subjectId": "dc/o/mc1g2ew9yegq8",
+      "predicate": "unit",
+      "objectId": "KilogramOfOilEquivalent",
+      "objectName": "KilogramOfOilEquivalent",
+      "provenanceId": "dc/jccrh82"
+    }
+  ],
+  "dc/o/w2z8nx9y43k97": [
+    {
+      "subjectId": "dc/o/w2z8nx9y43k97",
+      "predicate": "value",
+      "objectValue": "71.5062059465",
+      "provenanceId": "dc/jccrh82"
+    },
+    {
+      "subjectId": "dc/o/w2z8nx9y43k97",
+      "predicate": "observationDate",
+      "objectValue": "2006",
+      "provenanceId": "dc/jccrh82"
+    },
+    {
+      "subjectId": "dc/o/w2z8nx9y43k97",
+      "predicate": "observationPeriod",
+      "objectValue": "P1Y",
+      "provenanceId": "dc/jccrh82"
+    },
+    {
+      "subjectId": "dc/o/w2z8nx9y43k97",
+      "predicate": "observationAbout",
+      "objectId": "Earth",
+      "objectName": "Earth",
+      "provenanceId": "dc/jccrh82"
+    },
+    {
+      "subjectId": "dc/o/w2z8nx9y43k97",
+      "predicate": "variableMeasured",
+      "objectId": "LifeExpectancy_Person_Female",
+      "objectName": "Life expectancy at birth, female (years)",
+      "provenanceId": "dc/jccrh82"
+    },
+    {
+      "subjectId": "dc/o/w2z8nx9y43k97",
+      "predicate": "unit",
+      "objectId": "Year",
+      "objectName": "Year",
+      "provenanceId": "dc/jccrh82"
+    }
+  ]
+}

--- a/test/integration/golden_response/staging/get_triples/stat_var_svobs.json
+++ b/test/integration/golden_response/staging/get_triples/stat_var_svobs.json
@@ -1,0 +1,528 @@
+{
+  "Count_Person": [
+    {
+      "subjectId": "Count_Person",
+      "predicate": "typeOf",
+      "objectId": "StatisticalVariable",
+      "objectName": "StatisticalVariable",
+      "objectTypes": [
+        "Class"
+      ],
+      "provenanceId": "dc/d7tbsb1"
+    },
+    {
+      "subjectId": "Count_Person",
+      "predicate": "statType",
+      "objectId": "measuredValue",
+      "objectName": "measuredValue",
+      "objectTypes": [
+        "Property"
+      ],
+      "provenanceId": "dc/d7tbsb1"
+    },
+    {
+      "subjectId": "Count_Person",
+      "predicate": "provenance",
+      "objectId": "dc/d7tbsb1",
+      "objectName": "https://www.datacommons.org",
+      "objectTypes": [
+        "Provenance"
+      ],
+      "provenanceId": "dc/d7tbsb1"
+    },
+    {
+      "subjectId": "Count_Person",
+      "predicate": "populationType",
+      "objectId": "Person",
+      "objectName": "Person",
+      "objectTypes": [
+        "Class"
+      ],
+      "provenanceId": "dc/d7tbsb1"
+    },
+    {
+      "subjectId": "dc/vec47kj93z2m6",
+      "subjectTypes": [
+        "StatisticalVariable"
+      ],
+      "predicate": "measurementDenominator",
+      "objectId": "Count_Person",
+      "objectTypes": [
+        "StatisticalVariable"
+      ],
+      "provenanceId": "dc/6zzrcr2"
+    },
+    {
+      "subjectId": "dc/me61e2819fr9g",
+      "subjectTypes": [
+        "StatisticalVariable"
+      ],
+      "predicate": "measurementDenominator",
+      "objectId": "Count_Person",
+      "objectTypes": [
+        "StatisticalVariable"
+      ],
+      "provenanceId": "dc/6zzrcr2"
+    },
+    {
+      "subjectId": "dc/jzqt6tmmb7p0h",
+      "subjectTypes": [
+        "StatisticalVariable"
+      ],
+      "predicate": "measurementDenominator",
+      "objectId": "Count_Person",
+      "objectTypes": [
+        "StatisticalVariable"
+      ],
+      "provenanceId": "dc/6zzrcr2"
+    },
+    {
+      "subjectId": "dc/h00kfxhs73dhc",
+      "subjectTypes": [
+        "StatisticalVariable"
+      ],
+      "predicate": "measurementDenominator",
+      "objectId": "Count_Person",
+      "objectTypes": [
+        "StatisticalVariable"
+      ],
+      "provenanceId": "dc/6zzrcr2"
+    },
+    {
+      "subjectId": "dc/d20yq6r828zrc",
+      "subjectTypes": [
+        "StatisticalVariable"
+      ],
+      "predicate": "measurementDenominator",
+      "objectId": "Count_Person",
+      "objectTypes": [
+        "StatisticalVariable"
+      ],
+      "provenanceId": "dc/6zzrcr2"
+    },
+    {
+      "subjectId": "dc/cwk07wqzew6t8",
+      "subjectTypes": [
+        "StatisticalVariable"
+      ],
+      "predicate": "measurementDenominator",
+      "objectId": "Count_Person",
+      "objectTypes": [
+        "StatisticalVariable"
+      ],
+      "provenanceId": "dc/6zzrcr2"
+    },
+    {
+      "subjectId": "dc/btjrtzjfksspd",
+      "subjectTypes": [
+        "StatisticalVariable"
+      ],
+      "predicate": "measurementDenominator",
+      "objectId": "Count_Person",
+      "objectTypes": [
+        "StatisticalVariable"
+      ],
+      "provenanceId": "dc/6zzrcr2"
+    },
+    {
+      "subjectId": "dc/6kk2e7env541h",
+      "subjectTypes": [
+        "StatisticalVariable"
+      ],
+      "predicate": "measurementDenominator",
+      "objectId": "Count_Person",
+      "objectTypes": [
+        "StatisticalVariable"
+      ],
+      "provenanceId": "dc/6zzrcr2"
+    },
+    {
+      "subjectId": "dc/64exg7jchnekb",
+      "subjectTypes": [
+        "StatisticalVariable"
+      ],
+      "predicate": "measurementDenominator",
+      "objectId": "Count_Person",
+      "objectTypes": [
+        "StatisticalVariable"
+      ],
+      "provenanceId": "dc/6zzrcr2"
+    },
+    {
+      "subjectId": "dc/1xmcs407enr51",
+      "subjectTypes": [
+        "StatisticalVariable"
+      ],
+      "predicate": "measurementDenominator",
+      "objectId": "Count_Person",
+      "objectTypes": [
+        "StatisticalVariable"
+      ],
+      "provenanceId": "dc/6zzrcr2"
+    },
+    {
+      "subjectId": "dc/06w4nhpt1vz26",
+      "subjectTypes": [
+        "StatisticalVariable"
+      ],
+      "predicate": "measurementDenominator",
+      "objectId": "Count_Person",
+      "objectTypes": [
+        "StatisticalVariable"
+      ],
+      "provenanceId": "dc/6zzrcr2"
+    },
+    {
+      "subjectId": "Count_Product_MobileCellularSubscription_AsFractionOf_Count_Person",
+      "subjectTypes": [
+        "StatisticalVariable"
+      ],
+      "predicate": "measurementDenominator",
+      "objectId": "Count_Person",
+      "objectTypes": [
+        "StatisticalVariable"
+      ],
+      "provenanceId": "dc/d7tbsb1"
+    },
+    {
+      "subjectId": "Count_Person_ResidingLessThan5MetersAboveSeaLevel_AsFractionOf_Count_Person",
+      "subjectTypes": [
+        "StatisticalVariable"
+      ],
+      "predicate": "measurementDenominator",
+      "objectId": "Count_Person",
+      "objectTypes": [
+        "StatisticalVariable"
+      ],
+      "provenanceId": "dc/d7tbsb1"
+    },
+    {
+      "subjectId": "Count_Person_BelowPovertyLevelInThePast12Months_AsFractionOf_Count_Person",
+      "subjectTypes": [
+        "StatisticalVariable"
+      ],
+      "predicate": "measurementDenominator",
+      "objectId": "Count_Person",
+      "objectTypes": [
+        "StatisticalVariable"
+      ],
+      "provenanceId": "dc/d7tbsb1"
+    },
+    {
+      "subjectId": "Count_Death_IntentionalSelfHarm_AsFractionOf_Count_Person",
+      "subjectTypes": [
+        "StatisticalVariable"
+      ],
+      "predicate": "measurementDenominator",
+      "objectId": "Count_Person",
+      "objectTypes": [
+        "StatisticalVariable"
+      ],
+      "provenanceId": "dc/d7tbsb1"
+    },
+    {
+      "subjectId": "Count_Death_AsAFractionOfCount_Person",
+      "subjectTypes": [
+        "StatisticalVariable"
+      ],
+      "predicate": "measurementDenominator",
+      "objectId": "Count_Person",
+      "objectTypes": [
+        "StatisticalVariable"
+      ],
+      "provenanceId": "dc/d7tbsb1"
+    },
+    {
+      "subjectId": "Count_Death_AgeAdjusted_AsAFractionOf_Count_Person",
+      "subjectTypes": [
+        "StatisticalVariable"
+      ],
+      "predicate": "measurementDenominator",
+      "objectId": "Count_Person",
+      "objectTypes": [
+        "StatisticalVariable"
+      ],
+      "provenanceId": "dc/d7tbsb1"
+    },
+    {
+      "subjectId": "Count_CriminalActivities_MurderAndNonNegligentManslaughter_AsFractionOf_Count_Person",
+      "subjectTypes": [
+        "StatisticalVariable"
+      ],
+      "predicate": "measurementDenominator",
+      "objectId": "Count_Person",
+      "objectTypes": [
+        "StatisticalVariable"
+      ],
+      "provenanceId": "dc/d7tbsb1"
+    },
+    {
+      "subjectId": "Count_BirthEvent_LiveBirth_AsFractionOf_Count_Person",
+      "subjectTypes": [
+        "StatisticalVariable"
+      ],
+      "predicate": "measurementDenominator",
+      "objectId": "Count_Person",
+      "objectTypes": [
+        "StatisticalVariable"
+      ],
+      "provenanceId": "dc/d7tbsb1"
+    },
+    {
+      "subjectId": "Count_BirthEvent_AsAFractionOfCount_Person",
+      "subjectTypes": [
+        "StatisticalVariable"
+      ],
+      "predicate": "measurementDenominator",
+      "objectId": "Count_Person",
+      "objectTypes": [
+        "StatisticalVariable"
+      ],
+      "provenanceId": "dc/d7tbsb1"
+    },
+    {
+      "subjectId": "Amount_EconomicActivity_GrossDomesticProduction_Nominal_AsAFractionOf_Count_Person",
+      "subjectTypes": [
+        "StatisticalVariable"
+      ],
+      "predicate": "measurementDenominator",
+      "objectId": "Count_Person",
+      "objectTypes": [
+        "StatisticalVariable"
+      ],
+      "provenanceId": "dc/d7tbsb1"
+    },
+    {
+      "subjectId": "Amount_EconomicActivity_ExpenditureActivity_HealthcareExpenditure_AsFractionOf_Count_Person",
+      "subjectTypes": [
+        "StatisticalVariable"
+      ],
+      "predicate": "measurementDenominator",
+      "objectId": "Count_Person",
+      "objectTypes": [
+        "StatisticalVariable"
+      ],
+      "provenanceId": "dc/d7tbsb1"
+    },
+    {
+      "subjectId": "Count_Person",
+      "predicate": "measuredProperty",
+      "objectId": "count",
+      "objectName": "count",
+      "objectTypes": [
+        "Property"
+      ],
+      "provenanceId": "dc/d7tbsb1"
+    },
+    {
+      "subjectId": "Count_Person",
+      "predicate": "censusACSTableId",
+      "objectValue": "B26108",
+      "provenanceId": "dc/d7tbsb1"
+    },
+    {
+      "subjectId": "Count_Person",
+      "predicate": "censusACSTableId",
+      "objectValue": "B06001",
+      "provenanceId": "dc/d7tbsb1"
+    },
+    {
+      "subjectId": "Count_Person",
+      "predicate": "censusACSTableId",
+      "objectValue": "B05001",
+      "provenanceId": "dc/d7tbsb1"
+    },
+    {
+      "subjectId": "Count_Person",
+      "predicate": "censusACSTableId",
+      "objectValue": "B02001",
+      "provenanceId": "dc/d7tbsb1"
+    },
+    {
+      "subjectId": "Count_Person",
+      "predicate": "censusACSTableId",
+      "objectValue": "B01003",
+      "provenanceId": "dc/d7tbsb1"
+    },
+    {
+      "subjectId": "Count_Person",
+      "predicate": "censusACSTableId",
+      "objectValue": "B01001",
+      "provenanceId": "dc/d7tbsb1"
+    }
+  ],
+  "Count_Person_Female": [
+    {
+      "subjectId": "Count_Person_Female",
+      "predicate": "typeOf",
+      "objectId": "StatisticalVariable",
+      "objectName": "StatisticalVariable",
+      "objectTypes": [
+        "Class"
+      ],
+      "provenanceId": "dc/d7tbsb1"
+    },
+    {
+      "subjectId": "Count_Person_Female",
+      "predicate": "statType",
+      "objectId": "measuredValue",
+      "objectName": "measuredValue",
+      "objectTypes": [
+        "Property"
+      ],
+      "provenanceId": "dc/d7tbsb1"
+    },
+    {
+      "subjectId": "Count_Person_Female",
+      "predicate": "provenance",
+      "objectId": "dc/d7tbsb1",
+      "objectName": "https://www.datacommons.org",
+      "objectTypes": [
+        "Provenance"
+      ],
+      "provenanceId": "dc/d7tbsb1"
+    },
+    {
+      "subjectId": "Count_Person_Female",
+      "predicate": "populationType",
+      "objectId": "Person",
+      "objectName": "Person",
+      "objectTypes": [
+        "Class"
+      ],
+      "provenanceId": "dc/d7tbsb1"
+    },
+    {
+      "subjectId": "dc/yhbqx0489qcc",
+      "subjectTypes": [
+        "StatisticalVariable"
+      ],
+      "predicate": "measurementDenominator",
+      "objectId": "Count_Person_Female",
+      "objectTypes": [
+        "StatisticalVariable"
+      ],
+      "provenanceId": "dc/6zzrcr2"
+    },
+    {
+      "subjectId": "dc/twktdj71ngkz1",
+      "subjectTypes": [
+        "StatisticalVariable"
+      ],
+      "predicate": "measurementDenominator",
+      "objectId": "Count_Person_Female",
+      "objectTypes": [
+        "StatisticalVariable"
+      ],
+      "provenanceId": "dc/6zzrcr2"
+    },
+    {
+      "subjectId": "dc/begqg4vhfbtdb",
+      "subjectTypes": [
+        "StatisticalVariable"
+      ],
+      "predicate": "measurementDenominator",
+      "objectId": "Count_Person_Female",
+      "objectTypes": [
+        "StatisticalVariable"
+      ],
+      "provenanceId": "dc/6zzrcr2"
+    },
+    {
+      "subjectId": "dc/3n1cbgh69ys4c",
+      "subjectTypes": [
+        "StatisticalVariable"
+      ],
+      "predicate": "measurementDenominator",
+      "objectId": "Count_Person_Female",
+      "objectTypes": [
+        "StatisticalVariable"
+      ],
+      "provenanceId": "dc/6zzrcr2"
+    },
+    {
+      "subjectId": "Count_Death_IntentionalSelfHarm_Female_AsFractionOf_Count_Person_Female",
+      "subjectTypes": [
+        "StatisticalVariable"
+      ],
+      "predicate": "measurementDenominator",
+      "objectId": "Count_Person_Female",
+      "objectTypes": [
+        "StatisticalVariable"
+      ],
+      "provenanceId": "dc/d7tbsb1"
+    },
+    {
+      "subjectId": "Count_Death_Female_AsAFractionOf_Count_Person_Female",
+      "subjectTypes": [
+        "StatisticalVariable"
+      ],
+      "predicate": "measurementDenominator",
+      "objectId": "Count_Person_Female",
+      "objectTypes": [
+        "StatisticalVariable"
+      ],
+      "provenanceId": "dc/d7tbsb1"
+    },
+    {
+      "subjectId": "Count_Death_Female_AgeAdjusted_AsAFractionOf_Count_Person_Female",
+      "subjectTypes": [
+        "StatisticalVariable"
+      ],
+      "predicate": "measurementDenominator",
+      "objectId": "Count_Person_Female",
+      "objectTypes": [
+        "StatisticalVariable"
+      ],
+      "provenanceId": "dc/d7tbsb1"
+    },
+    {
+      "subjectId": "Count_CriminalActivities_MurderAndNonNegligentManslaughter_Female_AsFractionOf_Count_Person_Female",
+      "subjectTypes": [
+        "StatisticalVariable"
+      ],
+      "predicate": "measurementDenominator",
+      "objectId": "Count_Person_Female",
+      "objectTypes": [
+        "StatisticalVariable"
+      ],
+      "provenanceId": "dc/d7tbsb1"
+    },
+    {
+      "subjectId": "Count_Person_Female",
+      "predicate": "measuredProperty",
+      "objectId": "count",
+      "objectName": "count",
+      "objectTypes": [
+        "Property"
+      ],
+      "provenanceId": "dc/d7tbsb1"
+    },
+    {
+      "subjectId": "Count_Person_Female",
+      "predicate": "gender",
+      "objectId": "Female",
+      "objectName": "Female",
+      "objectTypes": [
+        "GenderType"
+      ],
+      "provenanceId": "dc/d7tbsb1"
+    },
+    {
+      "subjectId": "Count_Person_Female",
+      "predicate": "constraintProperties",
+      "objectId": "gender",
+      "objectName": "gender",
+      "objectTypes": [
+        "Property"
+      ],
+      "provenanceId": "dc/d7tbsb1"
+    },
+    {
+      "subjectId": "Count_Person_Female",
+      "predicate": "censusACSTableId",
+      "objectValue": "B01001",
+      "provenanceId": "dc/d7tbsb1"
+    }
+  ]
+}


### PR DESCRIPTION
We don't have materialized triples data in Cloud Bigtable for Observation, as it blows up the storage and it's only accessed for debugging.

This PR adds support to read triples for StatVarObservation through Sparql. It's reasonable fast.