### PR TITLE
Add self managed ssl certificate to applicable mixer deployment

### DIFF
--- a/deploy/base/ingress.yaml
+++ b/deploy/base/ingress.yaml
@@ -22,12 +22,12 @@ metadata:
   name: mixer-ingress
   annotations:
     kubernetes.io/ingress.global-static-ip-name: mixer-ip
-    networking.gke.io/managed-certificates: mixer-certificate
+    ingress.gcp.kubernetes.io/pre-shared-cert: mixer-certificate
 spec:
   rules:
-  -  http:
-      paths:
-      - path: /*
-        backend:
-          serviceName: mixer-service
-          servicePort: 80
+    - http:
+        paths:
+          - path: /*
+            backend:
+              serviceName: mixer-service
+              servicePort: 80

--- a/deploy/overlays/autopush/kustomization.yaml
+++ b/deploy/overlays/autopush/kustomization.yaml
@@ -22,21 +22,28 @@ kind: Kustomization
 nameSuffix: -autopush
 
 resources:
-- ../../datacommons
+  - ../../datacommons
 
 configMapGenerator:
-- name: mixer-configmap
-  behavior: create
-  namespace: mixer
-  literals:
-  - mixerProject=datcom-mixer-autopush
-  - serviceName=autopush.api.datacommons.org
+  - name: mixer-configmap
+    behavior: create
+    namespace: mixer
+    literals:
+      - mixerProject=datcom-mixer-autopush
+      - serviceName=autopush.api.datacommons.org
 
 patchesStrategicMerge:
-- |-
-  apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    name: mixer-grpc
-  spec:
-    replicas: 15
+  - |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: mixer-grpc
+    spec:
+      replicas: 15
+  - |-
+    apiVersion: extensions/v1beta1
+    kind: Ingress
+    metadata:
+      name: mixer-ingress
+      annotations:
+        ingress.gcp.kubernetes.io/pre-shared-cert: mixer-certificate,multi-domain

--- a/deploy/overlays/prod/kustomization.yaml
+++ b/deploy/overlays/prod/kustomization.yaml
@@ -22,21 +22,28 @@ kind: Kustomization
 nameSuffix: -prod
 
 resources:
-- ../../datacommons
+  - ../../datacommons
 
 configMapGenerator:
-- name: mixer-configmap
-  behavior: create
-  namespace: mixer
-  literals:
-  - mixerProject=datcom-mixer
-  - serviceName=api.datacommons.org
+  - name: mixer-configmap
+    behavior: create
+    namespace: mixer
+    literals:
+      - mixerProject=datcom-mixer
+      - serviceName=api.datacommons.org
 
 patchesStrategicMerge:
-- |-
-  apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    name: mixer-grpc
-  spec:
-    replicas: 60
+  - |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: mixer-grpc
+    spec:
+      replicas: 60
+  - |-
+    apiVersion: extensions/v1beta1
+    kind: Ingress
+    metadata:
+      name: mixer-ingress
+      annotations:
+        ingress.gcp.kubernetes.io/pre-shared-cert: mixer-certificate,multi-domain

--- a/deploy/overlays/staging/kustomization.yaml
+++ b/deploy/overlays/staging/kustomization.yaml
@@ -22,21 +22,28 @@ kind: Kustomization
 nameSuffix: -staging
 
 resources:
-- ../../datacommons
+  - ../../datacommons
 
 configMapGenerator:
-- name: mixer-configmap
-  behavior: create
-  namespace: mixer
-  literals:
-  - mixerProject=datcom-mixer-staging
-  - serviceName=staging.api.datacommons.org
+  - name: mixer-configmap
+    behavior: create
+    namespace: mixer
+    literals:
+      - mixerProject=datcom-mixer-staging
+      - serviceName=staging.api.datacommons.org
 
 patchesStrategicMerge:
-- |-
-  apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    name: mixer-grpc
-  spec:
-    replicas: 24
+  - |-
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: mixer-grpc
+    spec:
+      replicas: 24
+  - |-
+    apiVersion: extensions/v1beta1
+    kind: Ingress
+    metadata:
+      name: mixer-ingress
+      annotations:
+        ingress.gcp.kubernetes.io/pre-shared-cert: mixer-certificate,multi-domain


### PR DESCRIPTION
For prod, staging and autopush deployment, self managed ssl certificate "multi-domain" is created in the load balancer.

This PR adds this certificate to the Ingress yaml file, so the managed and self created SSL would attach to the Ingress each time it is deployed.