### PR TITLE
Remove redundent cache merge in GetPropertyValue API

### DIFF
--- a/internal/server/property_value.go
+++ b/internal/server/property_value.go
@@ -105,7 +105,9 @@ func getPropertyValuesHelper(
 	arcOut bool,
 ) (map[string][]*Node, error) {
 	rowList := buildPropertyValuesKey(dcids, prop, arcOut)
-	// Add base cache data
+	// Only use base cache data for property value.
+	// TODO(shifucun): perform a systematic check on current cache data and see
+	// if this is still true.
 	return readPropertyValues(ctx, store, rowList)
 }
 

--- a/internal/server/property_value.go
+++ b/internal/server/property_value.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 
-	mapset "github.com/deckarep/golang-set"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -107,36 +106,7 @@ func getPropertyValuesHelper(
 ) (map[string][]*Node, error) {
 	rowList := buildPropertyValuesKey(dcids, prop, arcOut)
 	// Add base cache data
-	nodeMap, err := readPropertyValues(ctx, store, rowList)
-	if err != nil {
-		return nil, err
-	}
-	// Add branch cache data
-	branchNodeMap, err := readPropertyValues(ctx, store, rowList)
-	if err != nil {
-		return nil, err
-	}
-
-	for dcid := range branchNodeMap {
-		branchNodes := branchNodeMap[dcid]
-		baseNodes, exist := nodeMap[dcid]
-		if !exist {
-			nodeMap[dcid] = branchNodes
-		} else if len(branchNodes) > 0 {
-			// Merge branch cache into base cache.
-			itemKeys := mapset.NewSet()
-			for _, n := range baseNodes {
-				itemKeys.Add(n.Dcid + n.Value)
-			}
-			for _, n := range branchNodes {
-				if itemKeys.Contains(n.Dcid + n.Value) {
-					continue
-				}
-				nodeMap[dcid] = append(nodeMap[dcid], n)
-			}
-		}
-	}
-	return nodeMap, nil
+	return readPropertyValues(ctx, store, rowList)
 }
 
 func trimNodes(nodes []*Node, typ string, limit int) []*Node {

--- a/internal/server/property_value.go
+++ b/internal/server/property_value.go
@@ -105,7 +105,9 @@ func getPropertyValuesHelper(
 	arcOut bool,
 ) (map[string][]*Node, error) {
 	rowList := buildPropertyValuesKey(dcids, prop, arcOut)
-	// Only use base cache data for property value.
+	// Current branch cache is targeted on new stats (without addition of schema etc),
+	// so only use base cache data for property value.
+	//
 	// TODO(shifucun): perform a systematic check on current cache data and see
 	// if this is still true.
 	return readPropertyValues(ctx, store, rowList)


### PR DESCRIPTION
Currently readPropertyValues() function only uses the base cache [1], so it's unnecessary to perform cache merging. This currently incurs 2 Bigtable read, hence a much longer time for request that performs O(10K) row read.

[1] https://github.com/datacommonsorg/mixer/blob/542c6aebb26958a831019989a817560f67d48d8e/internal/server/property_value.go