### PR TITLE
Do not set GKE pod cpu and memory limit

### DIFF
--- a/deploy/base/deployment.yaml
+++ b/deploy/base/deployment.yaml
@@ -48,10 +48,6 @@ spec:
         - name: mixer
           image: gcr.io/datcom-ci/datacommons-mixer:latest
           imagePullPolicy: Always
-          resources:
-            limits:
-              memory: "3G"
-              cpu: "500m"
           args:
             - --mixer_project=$(MIXER_PROJECT)
             - --store_project=$(STORE_PROJECT)
@@ -113,10 +109,6 @@ spec:
                 configMapKeyRef:
                   name: mixer-configmap
                   key: serviceName
-          resources:
-            limits:
-              memory: "0.5G"
-              cpu: "100m"
           readinessProbe:
             httpGet:
               path: /healthz

--- a/deploy/overlays/dev/patch_deployment.yaml
+++ b/deploy/overlays/dev/patch_deployment.yaml
@@ -18,40 +18,37 @@ metadata:
   name: mixer-grpc
 spec:
   selector:
-      matchLabels:
-        app: mixer-grpc
+    matchLabels:
+      app: mixer-grpc
   template:
     spec:
       volumes:
         - name: mixer-grpc-json
           emptyDir: {}
       containers:
-      - name: mixer
-        image: datacommons/mixer
-        imagePullPolicy: Never
-        resources:
-          limits:
-            memory: "1G"
-      - name: esp
-        volumeMounts:
-          - mountPath: /esp
-            name: mixer-grpc-json
-      - name: api-compiler
-        image: datacommons/api-compiler
-        imagePullPolicy: Never
-        command: ["/bin/sh"]
-        args:
-          - "-c"
-          - >
-            cp /output/mixer-grpc.json /esp/ &&
-            while true; do
-              echo "api-compiler running"
-              sleep 3600;
-            done
-        volumeMounts:
-          - name: mixer-grpc-json
-            mountPath: /esp
-        readinessProbe:
-          exec:
-            command: ["ls", "/esp/mixer-grpc.json"]
-          periodSeconds: 1
+        - name: mixer
+          image: datacommons/mixer
+          imagePullPolicy: Never
+        - name: esp
+          volumeMounts:
+            - mountPath: /esp
+              name: mixer-grpc-json
+        - name: api-compiler
+          image: datacommons/api-compiler
+          imagePullPolicy: Never
+          command: ["/bin/sh"]
+          args:
+            - "-c"
+            - >
+              cp /output/mixer-grpc.json /esp/ &&
+              while true; do
+                echo "api-compiler running"
+                sleep 3600;
+              done
+          volumeMounts:
+            - name: mixer-grpc-json
+              mountPath: /esp
+          readinessProbe:
+            exec:
+              command: ["ls", "/esp/mixer-grpc.json"]
+            periodSeconds: 1


### PR DESCRIPTION
When debugging the mixer 5xx errors for long processing API with large amount data (stats of cities in US), I found it's due to the cpu and memory limit. When looking at the GKE monitoring, the peak cpu and memory are within the limit, however the behavior is not predictable. Client can get various 5xx errors, which may depending how the socket is terminated (mixer processing termination, restart or esp restart, etc.).

Turning off the limit has the following effect based on the [doc1](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/), [doc2](https://kubernetes.io/docs/concepts/policy/limit-range/) : Each Pod/Container can use the cpu/memory up to that of the cluster node, and when exceed, will result in OOM of the node, hence impacting other Pod.

Considering our use pattern that majority of requests are with small payload while some requests need really large memory and cp. Turning off the resource seems more beneficial.

I have tested this by manually deploying to autopush mixer. GetStatSetWithinPlace() of Cities in US for two statvars return within 10 seconds. Before it takes 30+ seconds and most time ends up with 5xx error.

Note this should also help the previous Bio Sparql query issue.