### PR TITLE
Add back GKE resource limit to future investigate ESP issue

### DIFF
--- a/deploy/base/deployment.yaml
+++ b/deploy/base/deployment.yaml
@@ -48,6 +48,10 @@ spec:
         - name: mixer
           image: gcr.io/datcom-ci/datacommons-mixer:latest
           imagePullPolicy: Always
+          resources:
+            limits:
+              memory: "3G"
+              cpu: "500m"
           args:
             - --mixer_project=$(MIXER_PROJECT)
             - --store_project=$(STORE_PROJECT)
@@ -109,6 +113,10 @@ spec:
                 configMapKeyRef:
                   name: mixer-configmap
                   key: serviceName
+          resources:
+            limits:
+              memory: "0.5G"
+              cpu: "100m"
           readinessProbe:
             httpGet:
               path: /healthz

--- a/deploy/base/deployment.yaml
+++ b/deploy/base/deployment.yaml
@@ -52,6 +52,9 @@ spec:
             limits:
               memory: "3G"
               cpu: "1000m"
+            requests:
+              memory: "3G"
+              cpu: "1000m"
           args:
             - --mixer_project=$(MIXER_PROJECT)
             - --store_project=$(STORE_PROJECT)
@@ -116,7 +119,10 @@ spec:
           resources:
             limits:
               memory: "0.5G"
-              cpu: "100m"
+              cpu: "200m"
+            requests:
+              memory: "0.5G"
+              cpu: "200m"
           readinessProbe:
             httpGet:
               path: /healthz

--- a/deploy/base/deployment.yaml
+++ b/deploy/base/deployment.yaml
@@ -51,7 +51,7 @@ spec:
           resources:
             limits:
               memory: "3G"
-              cpu: "500m"
+              cpu: "1000m"
           args:
             - --mixer_project=$(MIXER_PROJECT)
             - --store_project=$(STORE_PROJECT)

--- a/deploy/overlays/autopush/kustomization.yaml
+++ b/deploy/overlays/autopush/kustomization.yaml
@@ -39,7 +39,7 @@ patchesStrategicMerge:
     metadata:
       name: mixer-grpc
     spec:
-      replicas: 10
+      replicas: 8
   - |-
     apiVersion: extensions/v1beta1
     kind: Ingress

--- a/deploy/overlays/autopush/kustomization.yaml
+++ b/deploy/overlays/autopush/kustomization.yaml
@@ -39,7 +39,7 @@ patchesStrategicMerge:
     metadata:
       name: mixer-grpc
     spec:
-      replicas: 15
+      replicas: 10
   - |-
     apiVersion: extensions/v1beta1
     kind: Ingress

--- a/deploy/overlays/prod/kustomization.yaml
+++ b/deploy/overlays/prod/kustomization.yaml
@@ -14,7 +14,7 @@
 
 # Kustomization for production mixer running on GCP `datcom-mixer` project.
 # - Adds "prod" suffix to all the resources.
-# - Use replica of 60.
+# - Use replica of 55.
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -39,7 +39,7 @@ patchesStrategicMerge:
     metadata:
       name: mixer-grpc
     spec:
-      replicas: 60
+      replicas: 55
   - |-
     apiVersion: extensions/v1beta1
     kind: Ingress

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -43,7 +43,7 @@ which is compiled using [API Compiler](https://github.com/googleapis/api-compile
 ### Start mixer in minikube
 
 ```bash
-minikube start
+minikube start --memory=6G
 minikube addons enable gcp-auth
 eval $(minikube docker-env)
 kubectl config use-context minikube

--- a/internal/server/stat_point.go
+++ b/internal/server/stat_point.go
@@ -16,7 +16,9 @@ package server
 
 import (
 	"context"
+	"log"
 	"strings"
+	"time"
 
 	pb "github.com/datacommonsorg/mixer/internal/proto"
 	"google.golang.org/grpc/codes"
@@ -69,6 +71,7 @@ func getStatSet(
 	ctx context.Context, s *Server, places []string, statVars []string, date string) (
 	*pb.GetStatSetResponse, error) {
 	// Initialize result with stat vars and place dcids.
+	ts := time.Now()
 	result := &pb.GetStatSetResponse{
 		Data: make(map[string]*pb.PlacePointStat),
 	}
@@ -98,6 +101,8 @@ func getStatSet(
 			}
 		}
 	}
+	log.Printf("getStatSet() completed for %d places, %d stat vars, in %s seconds",
+		len(places), len(statVars), time.Now().Sub(ts))
 	return result, nil
 }
 
@@ -130,6 +135,13 @@ func (s *Server) GetStatSetWithinPlace(
 	childType := in.GetChildType()
 	date := in.GetDate()
 
+	log.Printf(
+		"GetStatSetWithinPlace: parentPlace: %s, statVars: %v, childType: %s, date: %s",
+		parentPlace,
+		statVars,
+		childType,
+		date,
+	)
 	if parentPlace == "" {
 		return nil, status.Errorf(codes.InvalidArgument,
 			"Missing required argument: parent_place")

--- a/internal/server/stat_point.go
+++ b/internal/server/stat_point.go
@@ -102,7 +102,7 @@ func getStatSet(
 		}
 	}
 	log.Printf("getStatSet() completed for %d places, %d stat vars, in %s seconds",
-		len(places), len(statVars), time.Now().Sub(ts))
+		len(places), len(statVars), time.Since(ts))
 	return result, nil
 }
 


### PR DESCRIPTION
Seeing pods getting evicted in autopush mixer due to memory issue. I saw several large peaks of requests to the auotpush mixer in the past days, which is a bit mysterious, as it should only take the web-driver tests. 

I investigated the cpu and memory usage a little more with logging locally. With resources limit set, mixer actually was able to complete a large request under 15s, but ESP does not return the response back. 

Check in logging here and deploy to GKE under real load for more investigation.

Compare with past version, also added "requests" field to ensure the cpu and mem allocation.

![image](https://user-images.githubusercontent.com/5951856/117741663-d5db9080-b1b7-11eb-9a8b-2fff29c4c403.png)
