### PR TITLE
Do not return stat var group (dc/g/Root) root when get path

### DIFF
--- a/internal/server/statvar_group.go
+++ b/internal/server/statvar_group.go
@@ -28,6 +28,7 @@ import (
 )
 
 const (
+	svgRoot            = "dc/g/Root"
 	autoGenSvgIDPrefix = "dc/g/"
 	svgDelimiter       = "_"
 )
@@ -295,6 +296,9 @@ func (s *Server) GetStatVarPath(
 	for {
 		if parents, ok := s.cache.ParentSvg[curr]; ok {
 			curr = parents[0]
+			if curr == svgRoot {
+				break
+			}
 			path = append(path, curr)
 		} else {
 			break

--- a/test/integration/get_statvar_path_test.go
+++ b/test/integration/get_statvar_path_test.go
@@ -41,7 +41,6 @@ func TestGetStatVarPath(t *testing.T) {
 				"Count_Person",
 				"dc/g/Variables_Demographics",
 				"dc/g/Demographics",
-				"dc/g/Root",
 			},
 		},
 		{
@@ -52,7 +51,6 @@ func TestGetStatVarPath(t *testing.T) {
 				"dc/g/Person_Age_Employment",
 				"dc/g/Person_Age",
 				"dc/g/Demographics",
-				"dc/g/Root",
 			},
 		},
 	} {


### PR DESCRIPTION
This is a dummy node for linking the top level stat var groups, but not used by client.