### PR TITLE
Speed up stat var search and improve bigtable read latency

### DIFF
--- a/internal/server/bigtable_test.go
+++ b/internal/server/bigtable_test.go
@@ -42,7 +42,7 @@ func TestReadOneTable(t *testing.T) {
 			return string(jsonRaw), nil
 		},
 		nil,
-		false,
+		false, /* readBranch */
 	)
 	if err != nil {
 		t.Errorf("btReadRowsParallel got error: %v", err)
@@ -86,7 +86,7 @@ func TestReadTwoTables(t *testing.T) {
 			return string(jsonRaw), nil
 		},
 		nil,
-		true,
+		true, /* readBranch */
 	)
 	if err != nil {
 		t.Errorf("btReadRowsParallel got error: %v", err)

--- a/internal/server/bigtable_test.go
+++ b/internal/server/bigtable_test.go
@@ -35,10 +35,15 @@ func TestReadOneTable(t *testing.T) {
 	}
 	rowList := bigtable.RowList{"key1", "key2"}
 	baseDataMap, _, err := bigTableReadRowsParallel(
-		ctx, store.NewStore(nil, btTable, nil), rowList,
+		ctx,
+		store.NewStore(nil, btTable, nil),
+		rowList,
 		func(dcid string, jsonRaw []byte) (interface{}, error) {
 			return string(jsonRaw), nil
-		}, nil)
+		},
+		nil,
+		false,
+	)
 	if err != nil {
 		t.Errorf("btReadRowsParallel got error: %v", err)
 	}
@@ -74,10 +79,15 @@ func TestReadTwoTables(t *testing.T) {
 
 	rowList := bigtable.RowList{"key1", "key2"}
 	baseDataMap, branchDataMap, err := bigTableReadRowsParallel(
-		ctx, store.NewStore(nil, btTable1, btTable2), rowList,
+		ctx,
+		store.NewStore(nil, btTable1, btTable2),
+		rowList,
 		func(dcid string, jsonRaw []byte) (interface{}, error) {
 			return string(jsonRaw), nil
-		}, nil)
+		},
+		nil,
+		true,
+	)
 	if err != nil {
 		t.Errorf("btReadRowsParallel got error: %v", err)
 	}

--- a/internal/server/landing_page.go
+++ b/internal/server/landing_page.go
@@ -234,16 +234,21 @@ func fetchBtData(
 
 	// Fetch landing page cache data in parallel.
 	// Landing page cache only exists in base cache
-	baseDataMap, _, err := bigTableReadRowsParallel(ctx, s.store, rowList,
+	baseDataMap, _, err := bigTableReadRowsParallel(
+		ctx,
+		s.store,
+		rowList,
 		func(dcid string, jsonRaw []byte) (interface{}, error) {
 			var landingPageData pb.StatVarObsSeries
-
 			err := protojson.Unmarshal(jsonRaw, &landingPageData)
 			if err != nil {
 				return nil, err
 			}
 			return &landingPageData, nil
-		}, nil)
+		},
+		nil,
+		false,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/landing_page.go
+++ b/internal/server/landing_page.go
@@ -247,7 +247,7 @@ func fetchBtData(
 			return &landingPageData, nil
 		},
 		nil,
-		false,
+		false, /* readBranch */
 	)
 	if err != nil {
 		return nil, err

--- a/internal/server/place_stat_vars.go
+++ b/internal/server/place_stat_vars.go
@@ -53,7 +53,10 @@ func (s *Server) GetPlaceStatVars(
 		return nil, status.Error(codes.InvalidArgument, "Missing required arguments: dcid")
 	}
 	rowList := buildPlaceStatsVarKey(dcids)
-	baseDataMap, branchDataMap, err := bigTableReadRowsParallel(ctx, s.store, rowList,
+	baseDataMap, branchDataMap, err := bigTableReadRowsParallel(
+		ctx,
+		s.store,
+		rowList,
 		func(dcid string, jsonRaw []byte) (interface{}, error) {
 			var data PlaceStatsVar
 			err := json.Unmarshal(jsonRaw, &data)
@@ -61,7 +64,10 @@ func (s *Server) GetPlaceStatVars(
 				return nil, err
 			}
 			return data.StatVarIds, nil
-		}, nil)
+		},
+		nil,
+		true,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/place_stat_vars.go
+++ b/internal/server/place_stat_vars.go
@@ -66,7 +66,7 @@ func (s *Server) GetPlaceStatVars(
 			return data.StatVarIds, nil
 		},
 		nil,
-		true,
+		true, /* readBranch */
 	)
 	if err != nil {
 		return nil, err

--- a/internal/server/places.go
+++ b/internal/server/places.go
@@ -45,10 +45,16 @@ func (s *Server) GetPlacesIn(ctx context.Context, in *pb.GetPlacesInRequest) (
 	rowList := buildPlaceInKey(dcids, placeType)
 
 	// Place relations are from base geo imports. Only trust the base cache.
-	baseDataMap, _, err := bigTableReadRowsParallel(ctx, s.store, rowList,
+	baseDataMap, _, err := bigTableReadRowsParallel(
+		ctx,
+		s.store,
+		rowList,
 		func(dcid string, jsonRaw []byte) (interface{}, error) {
 			return strings.Split(string(jsonRaw), ","), nil
-		}, nil)
+		},
+		nil,
+		false,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +117,10 @@ func (s *Server) GetRelatedLocations(ctx context.Context,
 		}
 	}
 	// RelatedPlace cache only exists in base cache
-	baseDataMap, _, err := bigTableReadRowsParallel(ctx, s.store, rowList,
+	baseDataMap, _, err := bigTableReadRowsParallel(
+		ctx,
+		s.store,
+		rowList,
 		func(dcid string, jsonRaw []byte) (interface{}, error) {
 			var btRelatedPlacesInfo RelatedPlacesInfo
 			err := json.Unmarshal(jsonRaw, &btRelatedPlacesInfo)
@@ -119,13 +128,17 @@ func (s *Server) GetRelatedLocations(ctx context.Context,
 				return nil, err
 			}
 			return &btRelatedPlacesInfo, nil
-		}, func(key string) (string, error) {
+		},
+		func(key string) (string, error) {
 			parts := strings.Split(key, "^")
 			if len(parts) <= 1 {
-				return "", status.Errorf(codes.Internal, "Invalid bigtable row key %s", key)
+				return "", status.Errorf(
+					codes.Internal, "Invalid bigtable row key %s", key)
 			}
 			return parts[len(parts)-1], nil
-		})
+		},
+		false,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -164,7 +177,10 @@ func (s *Server) GetLocationsRankings(ctx context.Context,
 		}
 	}
 	// RelatedPlace cache only exists in base cache
-	baseDataMap, _, err := bigTableReadRowsParallel(ctx, s.store, rowList,
+	baseDataMap, _, err := bigTableReadRowsParallel(
+		ctx,
+		s.store,
+		rowList,
 		func(dcid string, jsonRaw []byte) (interface{}, error) {
 			var btRelatedPlacesInfo pb.RelatedPlacesInfo
 			err := protojson.Unmarshal(jsonRaw, &btRelatedPlacesInfo)
@@ -172,13 +188,17 @@ func (s *Server) GetLocationsRankings(ctx context.Context,
 				return nil, err
 			}
 			return &btRelatedPlacesInfo, nil
-		}, func(key string) (string, error) {
+		},
+		func(key string) (string, error) {
 			parts := strings.Split(key, "^")
 			if len(parts) <= 1 {
-				return "", status.Errorf(codes.Internal, "Invalid bigtable row key %s", key)
+				return "", status.Errorf(
+					codes.Internal, "Invalid bigtable row key %s", key)
 			}
 			return parts[len(parts)-1], nil
-		})
+		},
+		false,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/places.go
+++ b/internal/server/places.go
@@ -53,7 +53,7 @@ func (s *Server) GetPlacesIn(ctx context.Context, in *pb.GetPlacesInRequest) (
 			return strings.Split(string(jsonRaw), ","), nil
 		},
 		nil,
-		false,
+		false, /* readBranch */
 	)
 	if err != nil {
 		return nil, err
@@ -137,7 +137,7 @@ func (s *Server) GetRelatedLocations(ctx context.Context,
 			}
 			return parts[len(parts)-1], nil
 		},
-		false,
+		false, /* readBranch */
 	)
 	if err != nil {
 		return nil, err
@@ -197,7 +197,7 @@ func (s *Server) GetLocationsRankings(ctx context.Context,
 			}
 			return parts[len(parts)-1], nil
 		},
-		false,
+		false, /* readBranch */
 	)
 	if err != nil {
 		return nil, err

--- a/internal/server/property_label.go
+++ b/internal/server/property_label.go
@@ -38,7 +38,9 @@ func (s *Server) GetPropertyLabels(ctx context.Context,
 	rowList := buildPropertyLabelKey(dcids)
 
 	baseDataMap, branchDataMap, err := bigTableReadRowsParallel(
-		ctx, s.store, rowList,
+		ctx,
+		s.store,
+		rowList,
 		func(dcid string, jsonRaw []byte) (interface{}, error) {
 			var propLabels PropLabelCache
 			err := json.Unmarshal(jsonRaw, &propLabels)
@@ -46,7 +48,10 @@ func (s *Server) GetPropertyLabels(ctx context.Context,
 				return nil, err
 			}
 			return &propLabels, nil
-		}, nil)
+		},
+		nil,
+		true,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/property_label.go
+++ b/internal/server/property_label.go
@@ -50,7 +50,7 @@ func (s *Server) GetPropertyLabels(ctx context.Context,
 			return &propLabels, nil
 		},
 		nil,
-		true,
+		true, /* readBranch */
 	)
 	if err != nil {
 		return nil, err

--- a/internal/server/property_value.go
+++ b/internal/server/property_value.go
@@ -156,7 +156,7 @@ func readPropertyValues(
 			return propVals.Nodes, nil
 		},
 		nil,
-		false,
+		false, /* readBranch */
 	)
 	if err != nil {
 		return nil, err

--- a/internal/server/property_value.go
+++ b/internal/server/property_value.go
@@ -143,7 +143,10 @@ func readPropertyValues(
 ) (map[string][]*Node, error) {
 	// Only read property value from base cache.
 	// Branch cache only contains supplement data but not other properties yet.
-	baseDataMap, _, err := bigTableReadRowsParallel(ctx, store, rowList,
+	baseDataMap, _, err := bigTableReadRowsParallel(
+		ctx,
+		store,
+		rowList,
 		func(dcid string, jsonRaw []byte) (interface{}, error) {
 			var propVals PropValueCache
 			err := json.Unmarshal(jsonRaw, &propVals)
@@ -151,7 +154,10 @@ func readPropertyValues(
 				return nil, err
 			}
 			return propVals.Nodes, nil
-		}, nil)
+		},
+		nil,
+		false,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/stat_bt_reader.go
+++ b/internal/server/stat_bt_reader.go
@@ -33,7 +33,7 @@ func readStats(
 
 	keyToTokenFn := tokenFn(keyTokens)
 	baseDataMap, branchDataMap, err := bigTableReadRowsParallel(
-		ctx, store, rowList, convertToObsSeries, tokenFn(keyTokens), true,
+		ctx, store, rowList, convertToObsSeries, tokenFn(keyTokens), true, /* readBranch */
 	)
 	if err != nil {
 		return nil, err
@@ -70,7 +70,7 @@ func readStatsPb(
 
 	keyToTokenFn := tokenFn(keyTokens)
 	baseDataMap, branchDataMap, err := bigTableReadRowsParallel(
-		ctx, store, rowList, convertToObsSeriesPb, keyToTokenFn, true,
+		ctx, store, rowList, convertToObsSeriesPb, keyToTokenFn, true, /* readBranch */
 	)
 	if err != nil {
 		return nil, err
@@ -114,7 +114,7 @@ func readStatCollection(
 		func(rowKey string) (string, error) {
 			return keyTokens[rowKey], nil
 		},
-		true,
+		true, /* readBranch */
 	)
 	if err != nil {
 		return nil, err

--- a/internal/server/stat_bt_reader.go
+++ b/internal/server/stat_bt_reader.go
@@ -33,7 +33,7 @@ func readStats(
 
 	keyToTokenFn := tokenFn(keyTokens)
 	baseDataMap, branchDataMap, err := bigTableReadRowsParallel(
-		ctx, store, rowList, convertToObsSeries, tokenFn(keyTokens),
+		ctx, store, rowList, convertToObsSeries, tokenFn(keyTokens), true,
 	)
 	if err != nil {
 		return nil, err
@@ -70,7 +70,7 @@ func readStatsPb(
 
 	keyToTokenFn := tokenFn(keyTokens)
 	baseDataMap, branchDataMap, err := bigTableReadRowsParallel(
-		ctx, store, rowList, convertToObsSeriesPb, keyToTokenFn,
+		ctx, store, rowList, convertToObsSeriesPb, keyToTokenFn, true,
 	)
 	if err != nil {
 		return nil, err
@@ -107,10 +107,14 @@ func readStatCollection(
 	map[string]*pb.ObsCollection, error) {
 
 	baseDataMap, branchDataMap, err := bigTableReadRowsParallel(
-		ctx, store, rowList, convertToObsCollection,
+		ctx,
+		store,
+		rowList,
+		convertToObsCollection,
 		func(rowKey string) (string, error) {
 			return keyTokens[rowKey], nil
 		},
+		true,
 	)
 	if err != nil {
 		return nil, err

--- a/internal/server/stat_point.go
+++ b/internal/server/stat_point.go
@@ -166,7 +166,7 @@ func (s *Server) GetStatSetWithinPlace(
 			return strings.Split(string(jsonRaw), ","), nil
 		},
 		nil,
-		false,
+		false, /* readBranch */
 	)
 	if err != nil {
 		return nil, err

--- a/internal/server/stat_point.go
+++ b/internal/server/stat_point.go
@@ -158,10 +158,16 @@ func (s *Server) GetStatSetWithinPlace(
 	// Get all the child places
 	rowList := buildPlaceInKey([]string{parentPlace}, childType)
 	// Place relations are from base geo imports. Only trust the base cache.
-	baseDataMap, _, err := bigTableReadRowsParallel(ctx, s.store, rowList,
+	baseDataMap, _, err := bigTableReadRowsParallel(
+		ctx,
+		s.store,
+		rowList,
 		func(dcid string, jsonRaw []byte) (interface{}, error) {
 			return strings.Split(string(jsonRaw), ","), nil
-		}, nil)
+		},
+		nil,
+		false,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/statvar_group.go
+++ b/internal/server/statvar_group.go
@@ -334,11 +334,16 @@ func checkStatExistence(
 	rowList, keyTokens := buildStatExistenceKey(places, svOrSvgs)
 	keyToTokenFn := tokenFn(keyTokens)
 	baseDataMap, _, err := bigTableReadRowsParallel(
-		ctx, store, rowList, func(string, []byte) (interface{}, error) {
+		ctx,
+		store,
+		rowList,
+		func(string, []byte) (interface{}, error) {
 			// If exist, BT read returns an empty struct. Here just return nil to
 			// indicate the existence of the key.
 			return nil, nil
-		}, keyToTokenFn,
+		},
+		keyToTokenFn,
+		false,
 	)
 	if err != nil {
 		return nil, err

--- a/internal/server/statvar_group.go
+++ b/internal/server/statvar_group.go
@@ -343,7 +343,7 @@ func checkStatExistence(
 			return nil, nil
 		},
 		keyToTokenFn,
-		false,
+		false, /* readBranch */
 	)
 	if err != nil {
 		return nil, err

--- a/internal/server/statvar_search.go
+++ b/internal/server/statvar_search.go
@@ -22,12 +22,16 @@ import (
 	pb "github.com/datacommonsorg/mixer/internal/proto"
 )
 
-const maxNumResult = 1000
+const (
+	maxFilteredIds = 3000 // Twice of maxResult to give buffer for place filter.
+	maxResult      = 1000
+)
 
 // SearchStatVar implements API for Mixer.SearchStatVar.
 func (s *Server) SearchStatVar(
 	ctx context.Context, in *pb.SearchStatVarRequest) (
-	*pb.SearchStatVarResponse, error) {
+	*pb.SearchStatVarResponse, error,
+) {
 	query := in.GetQuery()
 	places := in.GetPlaces()
 
@@ -44,10 +48,20 @@ func (s *Server) SearchStatVar(
 
 	// Filter the stat var and stat var group by places.
 	if len(places) > 0 {
+		// Will read from stat existence cache, and can take several seconds when
+		// there are a lot of ids. So pre-prune the ids, as the result will be
+		// filtered anyway.
 		ids := []string{}
+		if len(svList) > maxFilteredIds {
+			svList = svList[0:maxFilteredIds]
+		}
+		if len(svgList) > maxFilteredIds {
+			svgList = svgList[0:maxFilteredIds]
+		}
 		for _, item := range append(svList, svgList...) {
 			ids = append(ids, item.Dcid)
 		}
+
 		statExistence, err := checkStatExistence(ctx, s.store, ids, places)
 		if err != nil {
 			return nil, err
@@ -56,11 +70,11 @@ func (s *Server) SearchStatVar(
 		svgList = filter(svgList, statExistence, len(places))
 	}
 	// TODO(shifucun): return the total number of result for client to consume.
-	if len(svList) > maxNumResult {
-		svList = svList[0:maxNumResult]
+	if len(svList) > maxResult {
+		svList = svList[0:maxResult]
 	}
-	if len(svgList) > maxNumResult {
-		svgList = svgList[0:maxNumResult]
+	if len(svgList) > maxResult {
+		svgList = svgList[0:maxResult]
 	}
 	result.StatVars = svList
 	result.StatVarGroups = svgList

--- a/internal/server/statvar_search.go
+++ b/internal/server/statvar_search.go
@@ -48,7 +48,7 @@ func (s *Server) SearchStatVar(
 
 	// Filter the stat var and stat var group by places.
 	if len(places) > 0 {
-		// Will read from stat existence cache, and can take several seconds when
+		// Read from stat existence cache, which can take several seconds when
 		// there are a lot of ids. So pre-prune the ids, as the result will be
 		// filtered anyway.
 		ids := []string{}

--- a/internal/server/triple.go
+++ b/internal/server/triple.go
@@ -236,7 +236,7 @@ func readTriples(
 	// stats. This saves time as the triples list size can get big.
 	// Re-evaluate this if branch cache involves other triples.
 	baseDataMap, _, err := bigTableReadRowsParallel(
-		ctx, store, rowList, convertTriplesCache, nil)
+		ctx, store, rowList, convertTriplesCache, nil, false)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/triple.go
+++ b/internal/server/triple.go
@@ -236,7 +236,8 @@ func readTriples(
 	// stats. This saves time as the triples list size can get big.
 	// Re-evaluate this if branch cache involves other triples.
 	baseDataMap, _, err := bigTableReadRowsParallel(
-		ctx, store, rowList, convertTriplesCache, nil, false)
+		ctx, store, rowList, convertTriplesCache, nil, false, /* readBranch */
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/test/integration/golden_response/search_statvar/female.json
+++ b/test/integration/golden_response/search_statvar/female.json
@@ -2,19 +2,11 @@
   "statVars": [
     {
       "name": "Count Of Female",
-      "dcid": "Count_BirthEvent_Female"
-    },
-    {
-      "name": "Count Of Female",
       "dcid": "Count_Death_Female"
     },
     {
       "name": "Count Of Female",
       "dcid": "Count_Person_Female"
-    },
-    {
-      "name": "Count Of Female",
-      "dcid": "Count_Student_Female"
     },
     {
       "name": "Count Of Female, NowMarried",
@@ -37,16 +29,8 @@
       "dcid": "Count_Person_Female_AbovePovertyLevelInThePast12Months"
     },
     {
-      "name": "Count Of Female, AmericanIndianOrAlaskaNative",
-      "dcid": "Count_Student_Female_AmericanIndianOrAlaskaNative"
-    },
-    {
       "name": "Count Of Female, AmericanIndianOrAlaskaNativeAlone",
       "dcid": "Count_Person_Female_AmericanIndianOrAlaskaNativeAlone"
-    },
-    {
-      "name": "Count Of Female, Asian",
-      "dcid": "Count_Student_Female_Asian"
     },
     {
       "name": "Count Of Female, AsianAlone",
@@ -55,10 +39,6 @@
     {
       "name": "Count Of Female, BelowPovertyLevelInThePast12Months",
       "dcid": "Count_Person_Female_BelowPovertyLevelInThePast12Months"
-    },
-    {
-      "name": "Count Of Female, Black",
-      "dcid": "Count_Student_Female_Black"
     },
     {
       "name": "Count Of Female, BlackOrAfricanAmericanAlone",
@@ -81,132 +61,12 @@
       "dcid": "Count_Death_Female_White"
     },
     {
-      "name": "Count Of Female, HawaiianNativeOrPacificIslander",
-      "dcid": "Count_Student_Female_HawaiianNativeOrPacificIslander"
-    },
-    {
-      "name": "Count Of Female, HighSchool",
-      "dcid": "Count_Student_Female_HighSchool"
-    },
-    {
       "name": "Count Of Female, HispanicOrLatino",
       "dcid": "Count_Person_Female_HispanicOrLatino"
     },
     {
-      "name": "Count Of Female, HispanicOrLatino",
-      "dcid": "Count_Student_Female_HispanicOrLatino"
-    },
-    {
-      "name": "Count Of Female, Houseless",
-      "dcid": "Count_Person_Houseless_Female"
-    },
-    {
-      "name": "Count Of Female, Illiterate",
-      "dcid": "Count_Person_Illiterate_Female"
-    },
-    {
-      "name": "Count Of Female, Kindergarten",
-      "dcid": "Count_Student_Female_Kindergarten"
-    },
-    {
-      "name": "Count Of Female, Literate",
-      "dcid": "Count_Person_Literate_Female"
-    },
-    {
-      "name": "Count Of Female, LiveBirth",
-      "dcid": "Count_BirthEvent_LiveBirth_Female"
-    },
-    {
-      "name": "Count Of Female, MainWorker, Worker",
-      "dcid": "Count_Person_MainWorker_Female"
-    },
-    {
-      "name": "Count Of Female, MarginalWorker, Worker",
-      "dcid": "Count_Person_MarginalWorker_Female"
-    },
-    {
-      "name": "Count Of Female, MiddleSchool",
-      "dcid": "Count_Student_Female_MiddleSchool"
-    },
-    {
-      "name": "Count Of Female, NCESUngradedClasses",
-      "dcid": "Count_Student_Female_UngradedClasses"
-    },
-    {
       "name": "Count Of Female, NativeHawaiianOrOtherPacificIslanderAlone",
       "dcid": "Count_Person_Female_NativeHawaiianOrOtherPacificIslanderAlone"
-    },
-    {
-      "name": "Count Of Female, NonWorker",
-      "dcid": "Count_Person_NonWorker_Female"
-    },
-    {
-      "name": "Count Of Female, PreKindergarten",
-      "dcid": "Count_Student_Female_PreKindergarten"
-    },
-    {
-      "name": "Count Of Female, PrimarySchool",
-      "dcid": "Count_Student_Female_PrimarySchool"
-    },
-    {
-      "name": "Count Of Female, Rural",
-      "dcid": "Count_Person_Rural_Female"
-    },
-    {
-      "name": "Count Of Female, ScheduledCaste",
-      "dcid": "Count_Person_ScheduledCaste_Female"
-    },
-    {
-      "name": "Count Of Female, ScheduledTribe",
-      "dcid": "Count_Person_ScheduledTribe_Female"
-    },
-    {
-      "name": "Count Of Female, SchoolGrade1",
-      "dcid": "Count_Student_Female_SchoolGrade1"
-    },
-    {
-      "name": "Count Of Female, SchoolGrade10",
-      "dcid": "Count_Student_Female_SchoolGrade10"
-    },
-    {
-      "name": "Count Of Female, SchoolGrade11",
-      "dcid": "Count_Student_Female_SchoolGrade11"
-    },
-    {
-      "name": "Count Of Female, SchoolGrade12",
-      "dcid": "Count_Student_Female_SchoolGrade12"
-    },
-    {
-      "name": "Count Of Female, SchoolGrade2",
-      "dcid": "Count_Student_Female_SchoolGrade2"
-    },
-    {
-      "name": "Count Of Female, SchoolGrade3",
-      "dcid": "Count_Student_Female_SchoolGrade3"
-    },
-    {
-      "name": "Count Of Female, SchoolGrade4",
-      "dcid": "Count_Student_Female_SchoolGrade4"
-    },
-    {
-      "name": "Count Of Female, SchoolGrade5",
-      "dcid": "Count_Student_Female_SchoolGrade5"
-    },
-    {
-      "name": "Count Of Female, SchoolGrade6",
-      "dcid": "Count_Student_Female_SchoolGrade6"
-    },
-    {
-      "name": "Count Of Female, SchoolGrade7",
-      "dcid": "Count_Student_Female_SchoolGrade7"
-    },
-    {
-      "name": "Count Of Female, SchoolGrade8",
-      "dcid": "Count_Student_Female_SchoolGrade8"
-    },
-    {
-      "name": "Count Of Female, SchoolGrade9",
-      "dcid": "Count_Student_Female_SchoolGrade9"
     },
     {
       "name": "Count Of Female, SomeOtherRaceAlone",
@@ -217,28 +77,12 @@
       "dcid": "Count_Person_Female_TwoOrMoreRaces"
     },
     {
-      "name": "Count Of Female, TwoOrMoreRaces",
-      "dcid": "Count_Student_Female_TwoOrMoreRaces"
-    },
-    {
-      "name": "Count Of Female, Urban",
-      "dcid": "Count_Person_Urban_Female"
-    },
-    {
-      "name": "Count Of Female, White",
-      "dcid": "Count_Student_Female_White"
-    },
-    {
       "name": "Count Of Female, WhiteAlone",
       "dcid": "Count_Person_Female_WhiteAlone"
     },
     {
       "name": "Count Of Female, WhiteAloneNotHispanicOrLatino",
       "dcid": "Count_Person_Female_WhiteAloneNotHispanicOrLatino"
-    },
-    {
-      "name": "Count Of Female, Worker",
-      "dcid": "Count_Person_Workers_Female"
     },
     {
       "name": "Count Of ICD10/A00-B99, Female",
@@ -317,44 +161,12 @@
       "dcid": "Count_Death_AgeNotStated_Female"
     },
     {
-      "name": "Count Of Years0, Female",
-      "dcid": "Count_Person_0Years_Female"
-    },
-    {
-      "name": "Count Of Years1, Female",
-      "dcid": "Count_Person_1Years_Female"
-    },
-    {
-      "name": "Count Of Years10, Female",
-      "dcid": "Count_Person_10Years_Female"
-    },
-    {
       "name": "Count Of Years10To14, Female",
       "dcid": "Count_Death_10To14Years_Female"
     },
     {
       "name": "Count Of Years10To14, Female",
       "dcid": "Count_Person_10To14Years_Female"
-    },
-    {
-      "name": "Count Of Years11, Female",
-      "dcid": "Count_Person_11Years_Female"
-    },
-    {
-      "name": "Count Of Years12, Female",
-      "dcid": "Count_Person_12Years_Female"
-    },
-    {
-      "name": "Count Of Years13, Female",
-      "dcid": "Count_Person_13Years_Female"
-    },
-    {
-      "name": "Count Of Years14, Female",
-      "dcid": "Count_Person_14Years_Female"
-    },
-    {
-      "name": "Count Of Years15, Female",
-      "dcid": "Count_Person_15Years_Female"
     },
     {
       "name": "Count Of Years15Onwards, Female",
@@ -385,24 +197,12 @@
       "dcid": "Count_Person_15To64Years_Female"
     },
     {
-      "name": "Count Of Years16, Female",
-      "dcid": "Count_Person_16Years_Female"
-    },
-    {
       "name": "Count Of Years16Onwards, Female",
       "dcid": "Count_Person_16OrMoreYears_Female"
     },
     {
       "name": "Count Of Years16To19, Female",
       "dcid": "Count_Person_16To19Years_Female"
-    },
-    {
-      "name": "Count Of Years17, Female",
-      "dcid": "Count_Person_17Years_Female"
-    },
-    {
-      "name": "Count Of Years18, Female",
-      "dcid": "Count_Person_18Years_Female"
     },
     {
       "name": "Count Of Years18Onwards, Female",
@@ -421,16 +221,8 @@
       "dcid": "Count_Person_18To64Years_Female"
     },
     {
-      "name": "Count Of Years19, Female",
-      "dcid": "Count_Person_19Years_Female"
-    },
-    {
       "name": "Count Of Years1To4, Female",
       "dcid": "Count_Death_1To4Years_Female"
-    },
-    {
-      "name": "Count Of Years2, Female",
-      "dcid": "Count_Person_2Years_Female"
     },
     {
       "name": "Count Of Years20, Female",
@@ -457,24 +249,8 @@
       "dcid": "Count_Person_21To64Years_Female"
     },
     {
-      "name": "Count Of Years22, Female",
-      "dcid": "Count_Person_22Years_Female"
-    },
-    {
       "name": "Count Of Years22To24, Female",
       "dcid": "Count_Person_22To24Years_Female"
-    },
-    {
-      "name": "Count Of Years23, Female",
-      "dcid": "Count_Person_23Years_Female"
-    },
-    {
-      "name": "Count Of Years24, Female",
-      "dcid": "Count_Person_24Years_Female"
-    },
-    {
-      "name": "Count Of Years25, Female",
-      "dcid": "Count_Person_25Years_Female"
     },
     {
       "name": "Count Of Years25Onwards, Female",
@@ -497,56 +273,12 @@
       "dcid": "Count_Person_25To34Years_Female"
     },
     {
-      "name": "Count Of Years26, Female",
-      "dcid": "Count_Person_26Years_Female"
-    },
-    {
-      "name": "Count Of Years27, Female",
-      "dcid": "Count_Person_27Years_Female"
-    },
-    {
-      "name": "Count Of Years28, Female",
-      "dcid": "Count_Person_28Years_Female"
-    },
-    {
-      "name": "Count Of Years29, Female",
-      "dcid": "Count_Person_29Years_Female"
-    },
-    {
-      "name": "Count Of Years3, Female",
-      "dcid": "Count_Person_3Years_Female"
-    },
-    {
-      "name": "Count Of Years30, Female",
-      "dcid": "Count_Person_30Years_Female"
-    },
-    {
       "name": "Count Of Years30To34, Female",
       "dcid": "Count_Death_30To34Years_Female"
     },
     {
       "name": "Count Of Years30To34, Female",
       "dcid": "Count_Person_30To34Years_Female"
-    },
-    {
-      "name": "Count Of Years31, Female",
-      "dcid": "Count_Person_31Years_Female"
-    },
-    {
-      "name": "Count Of Years32, Female",
-      "dcid": "Count_Person_32Years_Female"
-    },
-    {
-      "name": "Count Of Years33, Female",
-      "dcid": "Count_Person_33Years_Female"
-    },
-    {
-      "name": "Count Of Years34, Female",
-      "dcid": "Count_Person_34Years_Female"
-    },
-    {
-      "name": "Count Of Years35, Female",
-      "dcid": "Count_Person_35Years_Female"
     },
     {
       "name": "Count Of Years35To39, Female",
@@ -565,32 +297,8 @@
       "dcid": "Count_Person_35To44Years_Female"
     },
     {
-      "name": "Count Of Years36, Female",
-      "dcid": "Count_Person_36Years_Female"
-    },
-    {
-      "name": "Count Of Years37, Female",
-      "dcid": "Count_Person_37Years_Female"
-    },
-    {
-      "name": "Count Of Years38, Female",
-      "dcid": "Count_Person_38Years_Female"
-    },
-    {
-      "name": "Count Of Years39, Female",
-      "dcid": "Count_Person_39Years_Female"
-    },
-    {
       "name": "Count Of Years3Onwards, Female",
       "dcid": "Count_Person_3OrMoreYears_Female"
-    },
-    {
-      "name": "Count Of Years4, Female",
-      "dcid": "Count_Person_4Years_Female"
-    },
-    {
-      "name": "Count Of Years40, Female",
-      "dcid": "Count_Person_40Years_Female"
     },
     {
       "name": "Count Of Years40To44, Female",
@@ -603,26 +311,6 @@
     {
       "name": "Count Of Years40To64, Female",
       "dcid": "Count_Person_40To64Years_Female"
-    },
-    {
-      "name": "Count Of Years41, Female",
-      "dcid": "Count_Person_41Years_Female"
-    },
-    {
-      "name": "Count Of Years42, Female",
-      "dcid": "Count_Person_42Years_Female"
-    },
-    {
-      "name": "Count Of Years43, Female",
-      "dcid": "Count_Person_43Years_Female"
-    },
-    {
-      "name": "Count Of Years44, Female",
-      "dcid": "Count_Person_44Years_Female"
-    },
-    {
-      "name": "Count Of Years45, Female",
-      "dcid": "Count_Person_45Years_Female"
     },
     {
       "name": "Count Of Years45To49, Female",
@@ -645,30 +333,6 @@
       "dcid": "Count_Person_45To64Years_Female"
     },
     {
-      "name": "Count Of Years46, Female",
-      "dcid": "Count_Person_46Years_Female"
-    },
-    {
-      "name": "Count Of Years47, Female",
-      "dcid": "Count_Person_47Years_Female"
-    },
-    {
-      "name": "Count Of Years48, Female",
-      "dcid": "Count_Person_48Years_Female"
-    },
-    {
-      "name": "Count Of Years49, Female",
-      "dcid": "Count_Person_49Years_Female"
-    },
-    {
-      "name": "Count Of Years5, Female",
-      "dcid": "Count_Person_5Years_Female"
-    },
-    {
-      "name": "Count Of Years50, Female",
-      "dcid": "Count_Person_50Years_Female"
-    },
-    {
       "name": "Count Of Years50To54, Female",
       "dcid": "Count_Death_50To54Years_Female"
     },
@@ -679,26 +343,6 @@
     {
       "name": "Count Of Years50To64, Female",
       "dcid": "Count_Person_50To64Years_Female"
-    },
-    {
-      "name": "Count Of Years51, Female",
-      "dcid": "Count_Person_51Years_Female"
-    },
-    {
-      "name": "Count Of Years52, Female",
-      "dcid": "Count_Person_52Years_Female"
-    },
-    {
-      "name": "Count Of Years53, Female",
-      "dcid": "Count_Person_53Years_Female"
-    },
-    {
-      "name": "Count Of Years54, Female",
-      "dcid": "Count_Person_54Years_Female"
-    },
-    {
-      "name": "Count Of Years55, Female",
-      "dcid": "Count_Person_55Years_Female"
     },
     {
       "name": "Count Of Years55To59, Female",
@@ -713,22 +357,6 @@
       "dcid": "Count_Death_55To64Years_Female"
     },
     {
-      "name": "Count Of Years56, Female",
-      "dcid": "Count_Person_56Years_Female"
-    },
-    {
-      "name": "Count Of Years57, Female",
-      "dcid": "Count_Person_57Years_Female"
-    },
-    {
-      "name": "Count Of Years58, Female",
-      "dcid": "Count_Person_58Years_Female"
-    },
-    {
-      "name": "Count Of Years59, Female",
-      "dcid": "Count_Person_59Years_Female"
-    },
-    {
       "name": "Count Of Years5To14, Female",
       "dcid": "Count_Death_5To14Years_Female"
     },
@@ -739,14 +367,6 @@
     {
       "name": "Count Of Years5To9, Female",
       "dcid": "Count_Person_5To9Years_Female"
-    },
-    {
-      "name": "Count Of Years6, Female",
-      "dcid": "Count_Person_6Years_Female"
-    },
-    {
-      "name": "Count Of Years60, Female",
-      "dcid": "Count_Person_60Years_Female"
     },
     {
       "name": "Count Of Years60To61, Female",
@@ -761,28 +381,8 @@
       "dcid": "Count_Person_60To64Years_Female"
     },
     {
-      "name": "Count Of Years61, Female",
-      "dcid": "Count_Person_61Years_Female"
-    },
-    {
-      "name": "Count Of Years62, Female",
-      "dcid": "Count_Person_62Years_Female"
-    },
-    {
       "name": "Count Of Years62To64, Female",
       "dcid": "Count_Person_62To64Years_Female"
-    },
-    {
-      "name": "Count Of Years63, Female",
-      "dcid": "Count_Person_63Years_Female"
-    },
-    {
-      "name": "Count Of Years64, Female",
-      "dcid": "Count_Person_64Years_Female"
-    },
-    {
-      "name": "Count Of Years65, Female",
-      "dcid": "Count_Person_65Years_Female"
     },
     {
       "name": "Count Of Years65Onwards, Female",
@@ -809,32 +409,8 @@
       "dcid": "Count_Death_65To74Years_Female"
     },
     {
-      "name": "Count Of Years66, Female",
-      "dcid": "Count_Person_66Years_Female"
-    },
-    {
-      "name": "Count Of Years67, Female",
-      "dcid": "Count_Person_67Years_Female"
-    },
-    {
       "name": "Count Of Years67To69, Female",
       "dcid": "Count_Person_67To69Years_Female"
-    },
-    {
-      "name": "Count Of Years68, Female",
-      "dcid": "Count_Person_68Years_Female"
-    },
-    {
-      "name": "Count Of Years69, Female",
-      "dcid": "Count_Person_69Years_Female"
-    },
-    {
-      "name": "Count Of Years7, Female",
-      "dcid": "Count_Person_7Years_Female"
-    },
-    {
-      "name": "Count Of Years70, Female",
-      "dcid": "Count_Person_70Years_Female"
     },
     {
       "name": "Count Of Years70To74, Female",
@@ -843,26 +419,6 @@
     {
       "name": "Count Of Years70To74, Female",
       "dcid": "Count_Person_70To74Years_Female"
-    },
-    {
-      "name": "Count Of Years71, Female",
-      "dcid": "Count_Person_71Years_Female"
-    },
-    {
-      "name": "Count Of Years72, Female",
-      "dcid": "Count_Person_72Years_Female"
-    },
-    {
-      "name": "Count Of Years73, Female",
-      "dcid": "Count_Person_73Years_Female"
-    },
-    {
-      "name": "Count Of Years74, Female",
-      "dcid": "Count_Person_74Years_Female"
-    },
-    {
-      "name": "Count Of Years75, Female",
-      "dcid": "Count_Person_75Years_Female"
     },
     {
       "name": "Count Of Years75Onwards, Female",
@@ -881,34 +437,6 @@
       "dcid": "Count_Death_75To84Years_Female"
     },
     {
-      "name": "Count Of Years76, Female",
-      "dcid": "Count_Person_76Years_Female"
-    },
-    {
-      "name": "Count Of Years77, Female",
-      "dcid": "Count_Person_77Years_Female"
-    },
-    {
-      "name": "Count Of Years78, Female",
-      "dcid": "Count_Person_78Years_Female"
-    },
-    {
-      "name": "Count Of Years79, Female",
-      "dcid": "Count_Person_79Years_Female"
-    },
-    {
-      "name": "Count Of Years7To14, Female",
-      "dcid": "Count_Person_7To14Years_Female"
-    },
-    {
-      "name": "Count Of Years8, Female",
-      "dcid": "Count_Person_8Years_Female"
-    },
-    {
-      "name": "Count Of Years80, Female",
-      "dcid": "Count_Person_80Years_Female"
-    },
-    {
       "name": "Count Of Years80Onwards, Female",
       "dcid": "Count_Death_80OrMoreYears_Female"
     },
@@ -921,100 +449,12 @@
       "dcid": "Count_Person_80To84Years_Female"
     },
     {
-      "name": "Count Of Years81, Female",
-      "dcid": "Count_Person_81Years_Female"
-    },
-    {
-      "name": "Count Of Years82, Female",
-      "dcid": "Count_Person_82Years_Female"
-    },
-    {
-      "name": "Count Of Years83, Female",
-      "dcid": "Count_Person_83Years_Female"
-    },
-    {
-      "name": "Count Of Years84, Female",
-      "dcid": "Count_Person_84Years_Female"
-    },
-    {
       "name": "Count Of Years85, Female",
       "dcid": "Count_Death_85Years_Female"
     },
     {
-      "name": "Count Of Years85, Female",
-      "dcid": "Count_Person_85Years_Female"
-    },
-    {
       "name": "Count Of Years85Onwards, Female",
       "dcid": "Count_Person_85OrMoreYears_Female"
-    },
-    {
-      "name": "Count Of Years85To89, Female",
-      "dcid": "Count_Person_85To89Years_Female"
-    },
-    {
-      "name": "Count Of Years86, Female",
-      "dcid": "Count_Person_86Years_Female"
-    },
-    {
-      "name": "Count Of Years87, Female",
-      "dcid": "Count_Person_87Years_Female"
-    },
-    {
-      "name": "Count Of Years88, Female",
-      "dcid": "Count_Person_88Years_Female"
-    },
-    {
-      "name": "Count Of Years89, Female",
-      "dcid": "Count_Person_89Years_Female"
-    },
-    {
-      "name": "Count Of Years9, Female",
-      "dcid": "Count_Person_9Years_Female"
-    },
-    {
-      "name": "Count Of Years90, Female",
-      "dcid": "Count_Person_90Years_Female"
-    },
-    {
-      "name": "Count Of Years90Onwards, Female",
-      "dcid": "Count_Person_90OrMoreYears_Female"
-    },
-    {
-      "name": "Count Of Years91, Female",
-      "dcid": "Count_Person_91Years_Female"
-    },
-    {
-      "name": "Count Of Years92, Female",
-      "dcid": "Count_Person_92Years_Female"
-    },
-    {
-      "name": "Count Of Years93, Female",
-      "dcid": "Count_Person_93Years_Female"
-    },
-    {
-      "name": "Count Of Years94, Female",
-      "dcid": "Count_Person_94Years_Female"
-    },
-    {
-      "name": "Count Of Years95, Female",
-      "dcid": "Count_Person_95Years_Female"
-    },
-    {
-      "name": "Count Of Years96, Female",
-      "dcid": "Count_Person_96Years_Female"
-    },
-    {
-      "name": "Count Of Years97, Female",
-      "dcid": "Count_Person_97Years_Female"
-    },
-    {
-      "name": "Count Of Years98, Female",
-      "dcid": "Count_Person_98Years_Female"
-    },
-    {
-      "name": "Count Of Years99, Female",
-      "dcid": "Count_Person_99Years_Female"
     },
     {
       "name": "Count Of YearsUpto1, Female",
@@ -1041,360 +481,8 @@
       "dcid": "Count_Person_Upto5Years_Female"
     },
     {
-      "name": "Count Of YearsUpto6, Female",
-      "dcid": "Count_Person_YearsUpto6_Female"
-    },
-    {
       "name": "Count Of YearsUpto64, Female",
       "dcid": "Count_Person_Upto64Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years1, Female",
-      "dcid": "LifeExpectancy_Person_1Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years10, Female",
-      "dcid": "LifeExpectancy_Person_10Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years11, Female",
-      "dcid": "LifeExpectancy_Person_11Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years12, Female",
-      "dcid": "LifeExpectancy_Person_12Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years13, Female",
-      "dcid": "LifeExpectancy_Person_13Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years14, Female",
-      "dcid": "LifeExpectancy_Person_14Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years15, Female",
-      "dcid": "LifeExpectancy_Person_15Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years16, Female",
-      "dcid": "LifeExpectancy_Person_16Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years17, Female",
-      "dcid": "LifeExpectancy_Person_17Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years18, Female",
-      "dcid": "LifeExpectancy_Person_18Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years19, Female",
-      "dcid": "LifeExpectancy_Person_19Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years2, Female",
-      "dcid": "LifeExpectancy_Person_2Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years20, Female",
-      "dcid": "LifeExpectancy_Person_20Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years21, Female",
-      "dcid": "LifeExpectancy_Person_21Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years22, Female",
-      "dcid": "LifeExpectancy_Person_22Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years23, Female",
-      "dcid": "LifeExpectancy_Person_23Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years24, Female",
-      "dcid": "LifeExpectancy_Person_24Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years25, Female",
-      "dcid": "LifeExpectancy_Person_25Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years26, Female",
-      "dcid": "LifeExpectancy_Person_26Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years27, Female",
-      "dcid": "LifeExpectancy_Person_27Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years28, Female",
-      "dcid": "LifeExpectancy_Person_28Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years29, Female",
-      "dcid": "LifeExpectancy_Person_29Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years3, Female",
-      "dcid": "LifeExpectancy_Person_3Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years30, Female",
-      "dcid": "LifeExpectancy_Person_30Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years31, Female",
-      "dcid": "LifeExpectancy_Person_31Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years32, Female",
-      "dcid": "LifeExpectancy_Person_32Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years33, Female",
-      "dcid": "LifeExpectancy_Person_33Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years34, Female",
-      "dcid": "LifeExpectancy_Person_34Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years35, Female",
-      "dcid": "LifeExpectancy_Person_35Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years36, Female",
-      "dcid": "LifeExpectancy_Person_36Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years37, Female",
-      "dcid": "LifeExpectancy_Person_37Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years38, Female",
-      "dcid": "LifeExpectancy_Person_38Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years39, Female",
-      "dcid": "LifeExpectancy_Person_39Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years4, Female",
-      "dcid": "LifeExpectancy_Person_4Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years40, Female",
-      "dcid": "LifeExpectancy_Person_40Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years41, Female",
-      "dcid": "LifeExpectancy_Person_41Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years42, Female",
-      "dcid": "LifeExpectancy_Person_42Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years43, Female",
-      "dcid": "LifeExpectancy_Person_43Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years44, Female",
-      "dcid": "LifeExpectancy_Person_44Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years45, Female",
-      "dcid": "LifeExpectancy_Person_45Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years46, Female",
-      "dcid": "LifeExpectancy_Person_46Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years47, Female",
-      "dcid": "LifeExpectancy_Person_47Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years48, Female",
-      "dcid": "LifeExpectancy_Person_48Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years49, Female",
-      "dcid": "LifeExpectancy_Person_49Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years5, Female",
-      "dcid": "LifeExpectancy_Person_5Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years50, Female",
-      "dcid": "LifeExpectancy_Person_50Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years51, Female",
-      "dcid": "LifeExpectancy_Person_51Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years52, Female",
-      "dcid": "LifeExpectancy_Person_52Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years53, Female",
-      "dcid": "LifeExpectancy_Person_53Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years54, Female",
-      "dcid": "LifeExpectancy_Person_54Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years55, Female",
-      "dcid": "LifeExpectancy_Person_55Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years56, Female",
-      "dcid": "LifeExpectancy_Person_56Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years57, Female",
-      "dcid": "LifeExpectancy_Person_57Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years58, Female",
-      "dcid": "LifeExpectancy_Person_58Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years59, Female",
-      "dcid": "LifeExpectancy_Person_59Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years6, Female",
-      "dcid": "LifeExpectancy_Person_6Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years60, Female",
-      "dcid": "LifeExpectancy_Person_60Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years61, Female",
-      "dcid": "LifeExpectancy_Person_61Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years62, Female",
-      "dcid": "LifeExpectancy_Person_62Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years63, Female",
-      "dcid": "LifeExpectancy_Person_63Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years64, Female",
-      "dcid": "LifeExpectancy_Person_64Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years65, Female",
-      "dcid": "LifeExpectancy_Person_65Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years66, Female",
-      "dcid": "LifeExpectancy_Person_66Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years67, Female",
-      "dcid": "LifeExpectancy_Person_67Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years68, Female",
-      "dcid": "LifeExpectancy_Person_68Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years69, Female",
-      "dcid": "LifeExpectancy_Person_69Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years7, Female",
-      "dcid": "LifeExpectancy_Person_7Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years70, Female",
-      "dcid": "LifeExpectancy_Person_70Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years71, Female",
-      "dcid": "LifeExpectancy_Person_71Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years72, Female",
-      "dcid": "LifeExpectancy_Person_72Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years73, Female",
-      "dcid": "LifeExpectancy_Person_73Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years74, Female",
-      "dcid": "LifeExpectancy_Person_74Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years75, Female",
-      "dcid": "LifeExpectancy_Person_75Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years76, Female",
-      "dcid": "LifeExpectancy_Person_76Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years77, Female",
-      "dcid": "LifeExpectancy_Person_77Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years78, Female",
-      "dcid": "LifeExpectancy_Person_78Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years79, Female",
-      "dcid": "LifeExpectancy_Person_79Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years8, Female",
-      "dcid": "LifeExpectancy_Person_8Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years80, Female",
-      "dcid": "LifeExpectancy_Person_80Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years81, Female",
-      "dcid": "LifeExpectancy_Person_81Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years82, Female",
-      "dcid": "LifeExpectancy_Person_82Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years83, Female",
-      "dcid": "LifeExpectancy_Person_83Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years84, Female",
-      "dcid": "LifeExpectancy_Person_84Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years85Onwards, Female",
-      "dcid": "LifeExpectancy_Person_85OrMoreYears_Female"
-    },
-    {
-      "name": "LifeExpectancy Of Years9, Female",
-      "dcid": "LifeExpectancy_Person_9Years_Female"
-    },
-    {
-      "name": "LifeExpectancy Of YearsUpto1, Female",
-      "dcid": "LifeExpectancy_Person_Upto1Years_Female"
-    },
-    {
-      "name": "Mean WagesMonthly Of Female",
-      "dcid": "Mean_WagesMonthly_Worker_Female"
     },
     {
       "name": "Median Age Of Female",
@@ -1493,158 +581,6 @@
       "dcid": "Count_Person_Female_AbovePovertyLevelInThePast12Months_WhiteAloneNotHispanicOrLatino"
     },
     {
-      "name": "Count Of Female, AgriculturalLabourers, MainWorker, Worker",
-      "dcid": "Count_Person_MainWorker_AgriculturalLabourers_Female"
-    },
-    {
-      "name": "Count Of Female, AgriculturalLabourers, MarginalWorker, Worker",
-      "dcid": "Count_Person_MarginalWorker_AgriculturalLabourers_Female"
-    },
-    {
-      "name": "Count Of Female, AmericanIndianOrAlaskaNative, HighSchool",
-      "dcid": "Count_Student_Female_AmericanIndianOrAlaskaNative_HighSchool"
-    },
-    {
-      "name": "Count Of Female, AmericanIndianOrAlaskaNative, Kindergarten",
-      "dcid": "Count_Student_Female_AmericanIndianOrAlaskaNative_Kindergarten"
-    },
-    {
-      "name": "Count Of Female, AmericanIndianOrAlaskaNative, MiddleSchool",
-      "dcid": "Count_Student_Female_AmericanIndianOrAlaskaNative_MiddleSchool"
-    },
-    {
-      "name": "Count Of Female, AmericanIndianOrAlaskaNative, NCESUngradedClasses",
-      "dcid": "Count_Student_Female_AmericanIndianOrAlaskaNative_UngradedClasses"
-    },
-    {
-      "name": "Count Of Female, AmericanIndianOrAlaskaNative, PreKindergarten",
-      "dcid": "Count_Student_Female_AmericanIndianOrAlaskaNative_PreKindergarten"
-    },
-    {
-      "name": "Count Of Female, AmericanIndianOrAlaskaNative, PrimarySchool",
-      "dcid": "Count_Student_Female_AmericanIndianOrAlaskaNative_PrimarySchool"
-    },
-    {
-      "name": "Count Of Female, AmericanIndianOrAlaskaNative, SchoolGrade1",
-      "dcid": "Count_Student_Female_AmericanIndianOrAlaskaNative_SchoolGrade1"
-    },
-    {
-      "name": "Count Of Female, AmericanIndianOrAlaskaNative, SchoolGrade10",
-      "dcid": "Count_Student_Female_AmericanIndianOrAlaskaNative_SchoolGrade10"
-    },
-    {
-      "name": "Count Of Female, AmericanIndianOrAlaskaNative, SchoolGrade11",
-      "dcid": "Count_Student_Female_AmericanIndianOrAlaskaNative_SchoolGrade11"
-    },
-    {
-      "name": "Count Of Female, AmericanIndianOrAlaskaNative, SchoolGrade12",
-      "dcid": "Count_Student_Female_AmericanIndianOrAlaskaNative_SchoolGrade12"
-    },
-    {
-      "name": "Count Of Female, AmericanIndianOrAlaskaNative, SchoolGrade2",
-      "dcid": "Count_Student_Female_AmericanIndianOrAlaskaNative_SchoolGrade2"
-    },
-    {
-      "name": "Count Of Female, AmericanIndianOrAlaskaNative, SchoolGrade3",
-      "dcid": "Count_Student_Female_AmericanIndianOrAlaskaNative_SchoolGrade3"
-    },
-    {
-      "name": "Count Of Female, AmericanIndianOrAlaskaNative, SchoolGrade4",
-      "dcid": "Count_Student_Female_AmericanIndianOrAlaskaNative_SchoolGrade4"
-    },
-    {
-      "name": "Count Of Female, AmericanIndianOrAlaskaNative, SchoolGrade5",
-      "dcid": "Count_Student_Female_AmericanIndianOrAlaskaNative_SchoolGrade5"
-    },
-    {
-      "name": "Count Of Female, AmericanIndianOrAlaskaNative, SchoolGrade6",
-      "dcid": "Count_Student_Female_AmericanIndianOrAlaskaNative_SchoolGrade6"
-    },
-    {
-      "name": "Count Of Female, AmericanIndianOrAlaskaNative, SchoolGrade7",
-      "dcid": "Count_Student_Female_AmericanIndianOrAlaskaNative_SchoolGrade7"
-    },
-    {
-      "name": "Count Of Female, AmericanIndianOrAlaskaNative, SchoolGrade8",
-      "dcid": "Count_Student_Female_AmericanIndianOrAlaskaNative_SchoolGrade8"
-    },
-    {
-      "name": "Count Of Female, AmericanIndianOrAlaskaNative, SchoolGrade9",
-      "dcid": "Count_Student_Female_AmericanIndianOrAlaskaNative_SchoolGrade9"
-    },
-    {
-      "name": "Count Of Female, Asian, HighSchool",
-      "dcid": "Count_Student_Female_Asian_HighSchool"
-    },
-    {
-      "name": "Count Of Female, Asian, Kindergarten",
-      "dcid": "Count_Student_Female_Asian_Kindergarten"
-    },
-    {
-      "name": "Count Of Female, Asian, MiddleSchool",
-      "dcid": "Count_Student_Female_Asian_MiddleSchool"
-    },
-    {
-      "name": "Count Of Female, Asian, NCESUngradedClasses",
-      "dcid": "Count_Student_Female_Asian_UngradedClasses"
-    },
-    {
-      "name": "Count Of Female, Asian, PreKindergarten",
-      "dcid": "Count_Student_Female_Asian_PreKindergarten"
-    },
-    {
-      "name": "Count Of Female, Asian, PrimarySchool",
-      "dcid": "Count_Student_Female_Asian_PrimarySchool"
-    },
-    {
-      "name": "Count Of Female, Asian, SchoolGrade1",
-      "dcid": "Count_Student_Female_Asian_SchoolGrade1"
-    },
-    {
-      "name": "Count Of Female, Asian, SchoolGrade10",
-      "dcid": "Count_Student_Female_Asian_SchoolGrade10"
-    },
-    {
-      "name": "Count Of Female, Asian, SchoolGrade11",
-      "dcid": "Count_Student_Female_Asian_SchoolGrade11"
-    },
-    {
-      "name": "Count Of Female, Asian, SchoolGrade12",
-      "dcid": "Count_Student_Female_Asian_SchoolGrade12"
-    },
-    {
-      "name": "Count Of Female, Asian, SchoolGrade2",
-      "dcid": "Count_Student_Female_Asian_SchoolGrade2"
-    },
-    {
-      "name": "Count Of Female, Asian, SchoolGrade3",
-      "dcid": "Count_Student_Female_Asian_SchoolGrade3"
-    },
-    {
-      "name": "Count Of Female, Asian, SchoolGrade4",
-      "dcid": "Count_Student_Female_Asian_SchoolGrade4"
-    },
-    {
-      "name": "Count Of Female, Asian, SchoolGrade5",
-      "dcid": "Count_Student_Female_Asian_SchoolGrade5"
-    },
-    {
-      "name": "Count Of Female, Asian, SchoolGrade6",
-      "dcid": "Count_Student_Female_Asian_SchoolGrade6"
-    },
-    {
-      "name": "Count Of Female, Asian, SchoolGrade7",
-      "dcid": "Count_Student_Female_Asian_SchoolGrade7"
-    },
-    {
-      "name": "Count Of Female, Asian, SchoolGrade8",
-      "dcid": "Count_Student_Female_Asian_SchoolGrade8"
-    },
-    {
-      "name": "Count Of Female, Asian, SchoolGrade9",
-      "dcid": "Count_Student_Female_Asian_SchoolGrade9"
-    },
-    {
       "name": "Count Of Female, BelowPovertyLevelInThePast12Months, AmericanIndianOrAlaskaNativeAlone",
       "dcid": "Count_Person_Female_BelowPovertyLevelInThePast12Months_AmericanIndianOrAlaskaNativeAlone"
     },
@@ -1681,86 +617,6 @@
       "dcid": "Count_Person_Female_BelowPovertyLevelInThePast12Months_WhiteAloneNotHispanicOrLatino"
     },
     {
-      "name": "Count Of Female, Black, HighSchool",
-      "dcid": "Count_Student_Female_Black_HighSchool"
-    },
-    {
-      "name": "Count Of Female, Black, Kindergarten",
-      "dcid": "Count_Student_Female_Black_Kindergarten"
-    },
-    {
-      "name": "Count Of Female, Black, MiddleSchool",
-      "dcid": "Count_Student_Female_Black_MiddleSchool"
-    },
-    {
-      "name": "Count Of Female, Black, NCESUngradedClasses",
-      "dcid": "Count_Student_Female_Black_UngradedClasses"
-    },
-    {
-      "name": "Count Of Female, Black, PreKindergarten",
-      "dcid": "Count_Student_Female_Black_PreKindergarten"
-    },
-    {
-      "name": "Count Of Female, Black, PrimarySchool",
-      "dcid": "Count_Student_Female_Black_PrimarySchool"
-    },
-    {
-      "name": "Count Of Female, Black, SchoolGrade1",
-      "dcid": "Count_Student_Female_Black_SchoolGrade1"
-    },
-    {
-      "name": "Count Of Female, Black, SchoolGrade10",
-      "dcid": "Count_Student_Female_Black_SchoolGrade10"
-    },
-    {
-      "name": "Count Of Female, Black, SchoolGrade11",
-      "dcid": "Count_Student_Female_Black_SchoolGrade11"
-    },
-    {
-      "name": "Count Of Female, Black, SchoolGrade12",
-      "dcid": "Count_Student_Female_Black_SchoolGrade12"
-    },
-    {
-      "name": "Count Of Female, Black, SchoolGrade2",
-      "dcid": "Count_Student_Female_Black_SchoolGrade2"
-    },
-    {
-      "name": "Count Of Female, Black, SchoolGrade3",
-      "dcid": "Count_Student_Female_Black_SchoolGrade3"
-    },
-    {
-      "name": "Count Of Female, Black, SchoolGrade4",
-      "dcid": "Count_Student_Female_Black_SchoolGrade4"
-    },
-    {
-      "name": "Count Of Female, Black, SchoolGrade5",
-      "dcid": "Count_Student_Female_Black_SchoolGrade5"
-    },
-    {
-      "name": "Count Of Female, Black, SchoolGrade6",
-      "dcid": "Count_Student_Female_Black_SchoolGrade6"
-    },
-    {
-      "name": "Count Of Female, Black, SchoolGrade7",
-      "dcid": "Count_Student_Female_Black_SchoolGrade7"
-    },
-    {
-      "name": "Count Of Female, Black, SchoolGrade8",
-      "dcid": "Count_Student_Female_Black_SchoolGrade8"
-    },
-    {
-      "name": "Count Of Female, Black, SchoolGrade9",
-      "dcid": "Count_Student_Female_Black_SchoolGrade9"
-    },
-    {
-      "name": "Count Of Female, Cultivators, MainWorker, Worker",
-      "dcid": "Count_Person_MainWorker_Cultivators_Female"
-    },
-    {
-      "name": "Count Of Female, Cultivators, MarginalWorker, Worker",
-      "dcid": "Count_Person_MarginalWorker_Cultivators_Female"
-    },
-    {
       "name": "Count Of Female, EnrolledInPrivateSchool",
       "dcid": "Count_Person_3OrMoreYears_Female_EnrolledInPrivateSchool"
     },
@@ -1773,472 +629,8 @@
       "dcid": "Count_Person_3OrMoreYears_Female_EnrolledInSchool"
     },
     {
-      "name": "Count Of Female, HawaiianNativeOrPacificIslander, HighSchool",
-      "dcid": "Count_Student_Female_HawaiianNativeOrPacificIslander_HighSchool"
-    },
-    {
-      "name": "Count Of Female, HawaiianNativeOrPacificIslander, Kindergarten",
-      "dcid": "Count_Student_Female_HawaiianNativeOrPacificIslander_Kindergarten"
-    },
-    {
-      "name": "Count Of Female, HawaiianNativeOrPacificIslander, MiddleSchool",
-      "dcid": "Count_Student_Female_HawaiianNativeOrPacificIslander_MiddleSchool"
-    },
-    {
-      "name": "Count Of Female, HawaiianNativeOrPacificIslander, NCESUngradedClasses",
-      "dcid": "Count_Student_Female_HawaiianNativeOrPacificIslander_UngradedClasses"
-    },
-    {
-      "name": "Count Of Female, HawaiianNativeOrPacificIslander, PreKindergarten",
-      "dcid": "Count_Student_Female_HawaiianNativeOrPacificIslander_PreKindergarten"
-    },
-    {
-      "name": "Count Of Female, HawaiianNativeOrPacificIslander, PrimarySchool",
-      "dcid": "Count_Student_Female_HawaiianNativeOrPacificIslander_PrimarySchool"
-    },
-    {
-      "name": "Count Of Female, HawaiianNativeOrPacificIslander, SchoolGrade1",
-      "dcid": "Count_Student_Female_HawaiianNativeOrPacificIslander_SchoolGrade1"
-    },
-    {
-      "name": "Count Of Female, HawaiianNativeOrPacificIslander, SchoolGrade10",
-      "dcid": "Count_Student_Female_HawaiianNativeOrPacificIslander_SchoolGrade10"
-    },
-    {
-      "name": "Count Of Female, HawaiianNativeOrPacificIslander, SchoolGrade11",
-      "dcid": "Count_Student_Female_HawaiianNativeOrPacificIslander_SchoolGrade11"
-    },
-    {
-      "name": "Count Of Female, HawaiianNativeOrPacificIslander, SchoolGrade12",
-      "dcid": "Count_Student_Female_HawaiianNativeOrPacificIslander_SchoolGrade12"
-    },
-    {
-      "name": "Count Of Female, HawaiianNativeOrPacificIslander, SchoolGrade2",
-      "dcid": "Count_Student_Female_HawaiianNativeOrPacificIslander_SchoolGrade2"
-    },
-    {
-      "name": "Count Of Female, HawaiianNativeOrPacificIslander, SchoolGrade3",
-      "dcid": "Count_Student_Female_HawaiianNativeOrPacificIslander_SchoolGrade3"
-    },
-    {
-      "name": "Count Of Female, HawaiianNativeOrPacificIslander, SchoolGrade4",
-      "dcid": "Count_Student_Female_HawaiianNativeOrPacificIslander_SchoolGrade4"
-    },
-    {
-      "name": "Count Of Female, HawaiianNativeOrPacificIslander, SchoolGrade5",
-      "dcid": "Count_Student_Female_HawaiianNativeOrPacificIslander_SchoolGrade5"
-    },
-    {
-      "name": "Count Of Female, HawaiianNativeOrPacificIslander, SchoolGrade6",
-      "dcid": "Count_Student_Female_HawaiianNativeOrPacificIslander_SchoolGrade6"
-    },
-    {
-      "name": "Count Of Female, HawaiianNativeOrPacificIslander, SchoolGrade7",
-      "dcid": "Count_Student_Female_HawaiianNativeOrPacificIslander_SchoolGrade7"
-    },
-    {
-      "name": "Count Of Female, HawaiianNativeOrPacificIslander, SchoolGrade8",
-      "dcid": "Count_Student_Female_HawaiianNativeOrPacificIslander_SchoolGrade8"
-    },
-    {
-      "name": "Count Of Female, HawaiianNativeOrPacificIslander, SchoolGrade9",
-      "dcid": "Count_Student_Female_HawaiianNativeOrPacificIslander_SchoolGrade9"
-    },
-    {
-      "name": "Count Of Female, HispanicOrLatino, HighSchool",
-      "dcid": "Count_Student_Female_HispanicOrLatino_HighSchool"
-    },
-    {
-      "name": "Count Of Female, HispanicOrLatino, Kindergarten",
-      "dcid": "Count_Student_Female_HispanicOrLatino_Kindergarten"
-    },
-    {
-      "name": "Count Of Female, HispanicOrLatino, MiddleSchool",
-      "dcid": "Count_Student_Female_HispanicOrLatino_MiddleSchool"
-    },
-    {
-      "name": "Count Of Female, HispanicOrLatino, NCESUngradedClasses",
-      "dcid": "Count_Student_Female_HispanicOrLatino_UngradedClasses"
-    },
-    {
-      "name": "Count Of Female, HispanicOrLatino, PreKindergarten",
-      "dcid": "Count_Student_Female_HispanicOrLatino_PreKindergarten"
-    },
-    {
-      "name": "Count Of Female, HispanicOrLatino, PrimarySchool",
-      "dcid": "Count_Student_Female_HispanicOrLatino_PrimarySchool"
-    },
-    {
-      "name": "Count Of Female, HispanicOrLatino, SchoolGrade1",
-      "dcid": "Count_Student_Female_HispanicOrLatino_SchoolGrade1"
-    },
-    {
-      "name": "Count Of Female, HispanicOrLatino, SchoolGrade10",
-      "dcid": "Count_Student_Female_HispanicOrLatino_SchoolGrade10"
-    },
-    {
-      "name": "Count Of Female, HispanicOrLatino, SchoolGrade11",
-      "dcid": "Count_Student_Female_HispanicOrLatino_SchoolGrade11"
-    },
-    {
-      "name": "Count Of Female, HispanicOrLatino, SchoolGrade12",
-      "dcid": "Count_Student_Female_HispanicOrLatino_SchoolGrade12"
-    },
-    {
-      "name": "Count Of Female, HispanicOrLatino, SchoolGrade2",
-      "dcid": "Count_Student_Female_HispanicOrLatino_SchoolGrade2"
-    },
-    {
-      "name": "Count Of Female, HispanicOrLatino, SchoolGrade3",
-      "dcid": "Count_Student_Female_HispanicOrLatino_SchoolGrade3"
-    },
-    {
-      "name": "Count Of Female, HispanicOrLatino, SchoolGrade4",
-      "dcid": "Count_Student_Female_HispanicOrLatino_SchoolGrade4"
-    },
-    {
-      "name": "Count Of Female, HispanicOrLatino, SchoolGrade5",
-      "dcid": "Count_Student_Female_HispanicOrLatino_SchoolGrade5"
-    },
-    {
-      "name": "Count Of Female, HispanicOrLatino, SchoolGrade6",
-      "dcid": "Count_Student_Female_HispanicOrLatino_SchoolGrade6"
-    },
-    {
-      "name": "Count Of Female, HispanicOrLatino, SchoolGrade7",
-      "dcid": "Count_Student_Female_HispanicOrLatino_SchoolGrade7"
-    },
-    {
-      "name": "Count Of Female, HispanicOrLatino, SchoolGrade8",
-      "dcid": "Count_Student_Female_HispanicOrLatino_SchoolGrade8"
-    },
-    {
-      "name": "Count Of Female, HispanicOrLatino, SchoolGrade9",
-      "dcid": "Count_Student_Female_HispanicOrLatino_SchoolGrade9"
-    },
-    {
-      "name": "Count Of Female, HouseholdIndustries, MainWorker, Worker",
-      "dcid": "Count_Person_MainWorker_HouseholdIndustries_Female"
-    },
-    {
-      "name": "Count Of Female, HouseholdIndustries, MarginalWorker, Worker",
-      "dcid": "Count_Person_MarginalWorker_HouseholdIndustries_Female"
-    },
-    {
-      "name": "Count Of Female, Houseless, Illiterate",
-      "dcid": "Count_Person_Houseless_Illiterate_Female"
-    },
-    {
-      "name": "Count Of Female, Houseless, Literate",
-      "dcid": "Count_Person_Houseless_Literate_Female"
-    },
-    {
-      "name": "Count Of Female, Houseless, MainWorker, Worker",
-      "dcid": "Count_Person_Houseless_MainWorker_Female"
-    },
-    {
-      "name": "Count Of Female, Houseless, MarginalWorker, Worker",
-      "dcid": "Count_Person_Houseless_MarginalWorker_Female"
-    },
-    {
-      "name": "Count Of Female, Houseless, NonWorker",
-      "dcid": "Count_Person_Houseless_NonWorker_Female"
-    },
-    {
-      "name": "Count Of Female, Houseless, Rural",
-      "dcid": "Count_Person_Houseless_Rural_Female"
-    },
-    {
-      "name": "Count Of Female, Houseless, ScheduledCaste",
-      "dcid": "Count_Person_Houseless_ScheduledCaste_Female"
-    },
-    {
-      "name": "Count Of Female, Houseless, ScheduledTribe",
-      "dcid": "Count_Person_Houseless_ScheduledTribe_Female"
-    },
-    {
-      "name": "Count Of Female, Houseless, Urban",
-      "dcid": "Count_Person_Houseless_Urban_Female"
-    },
-    {
-      "name": "Count Of Female, Houseless, Worker",
-      "dcid": "Count_Person_Houseless_Workers_Female"
-    },
-    {
-      "name": "Count Of Female, Illiterate, Rural",
-      "dcid": "Count_Person_Illiterate_Rural_Female"
-    },
-    {
-      "name": "Count Of Female, Illiterate, ScheduledCaste",
-      "dcid": "Count_Person_ScheduledCaste_Illiterate_Female"
-    },
-    {
-      "name": "Count Of Female, Illiterate, ScheduledTribe",
-      "dcid": "Count_Person_ScheduledTribe_Illiterate_Female"
-    },
-    {
-      "name": "Count Of Female, Illiterate, Urban",
-      "dcid": "Count_Person_Illiterate_Urban_Female"
-    },
-    {
-      "name": "Count Of Female, Literate, Rural",
-      "dcid": "Count_Person_Literate_Rural_Female"
-    },
-    {
-      "name": "Count Of Female, Literate, ScheduledCaste",
-      "dcid": "Count_Person_ScheduledCaste_Literate_Female"
-    },
-    {
-      "name": "Count Of Female, Literate, ScheduledTribe",
-      "dcid": "Count_Person_ScheduledTribe_Literate_Female"
-    },
-    {
-      "name": "Count Of Female, Literate, Urban",
-      "dcid": "Count_Person_Literate_Urban_Female"
-    },
-    {
-      "name": "Count Of Female, Month3To6, MarginalWorker, Worker",
-      "dcid": "Count_Person_MarginalWorker_Worked3To6Months_Female"
-    },
-    {
-      "name": "Count Of Female, MonthUpto3, MarginalWorker, Worker",
-      "dcid": "Count_Person_MarginalWorker_WorkedUpto3Months_Female"
-    },
-    {
       "name": "Count Of Female, NotEnrolledInSchool",
       "dcid": "Count_Person_3OrMoreYears_Female_NotEnrolledInSchool"
-    },
-    {
-      "name": "Count Of Female, OtherWorkers, MainWorker, Worker",
-      "dcid": "Count_Person_MainWorker_OtherWorkers_Female"
-    },
-    {
-      "name": "Count Of Female, OtherWorkers, MarginalWorker, Worker",
-      "dcid": "Count_Person_MarginalWorker_OtherWorkers_Female"
-    },
-    {
-      "name": "Count Of Female, Rural, MainWorker, Worker",
-      "dcid": "Count_Person_MainWorker_Rural_Female"
-    },
-    {
-      "name": "Count Of Female, Rural, MarginalWorker, Worker",
-      "dcid": "Count_Person_MarginalWorker_Rural_Female"
-    },
-    {
-      "name": "Count Of Female, Rural, NonWorker",
-      "dcid": "Count_Person_NonWorker_Rural_Female"
-    },
-    {
-      "name": "Count Of Female, Rural, ScheduledCaste",
-      "dcid": "Count_Person_ScheduledCaste_Rural_Female"
-    },
-    {
-      "name": "Count Of Female, Rural, ScheduledTribe",
-      "dcid": "Count_Person_ScheduledTribe_Rural_Female"
-    },
-    {
-      "name": "Count Of Female, Rural, Worker",
-      "dcid": "Count_Person_Workers_Rural_Female"
-    },
-    {
-      "name": "Count Of Female, ScheduledCaste, MainWorker, Worker",
-      "dcid": "Count_Person_ScheduledCaste_MainWorker_Female"
-    },
-    {
-      "name": "Count Of Female, ScheduledCaste, MarginalWorker, Worker",
-      "dcid": "Count_Person_ScheduledCaste_MarginalWorker_Female"
-    },
-    {
-      "name": "Count Of Female, ScheduledCaste, NonWorker",
-      "dcid": "Count_Person_ScheduledCaste_NonWorker_Female"
-    },
-    {
-      "name": "Count Of Female, ScheduledCaste, Worker",
-      "dcid": "Count_Person_ScheduledCaste_Workers_Female"
-    },
-    {
-      "name": "Count Of Female, ScheduledTribe, MainWorker, Worker",
-      "dcid": "Count_Person_ScheduledTribe_MainWorker_Female"
-    },
-    {
-      "name": "Count Of Female, ScheduledTribe, MarginalWorker, Worker",
-      "dcid": "Count_Person_ScheduledTribe_MarginalWorker_Female"
-    },
-    {
-      "name": "Count Of Female, ScheduledTribe, NonWorker",
-      "dcid": "Count_Person_ScheduledTribe_NonWorker_Female"
-    },
-    {
-      "name": "Count Of Female, ScheduledTribe, Worker",
-      "dcid": "Count_Person_ScheduledTribe_Workers_Female"
-    },
-    {
-      "name": "Count Of Female, TwoOrMoreRaces, HighSchool",
-      "dcid": "Count_Student_Female_TwoOrMoreRaces_HighSchool"
-    },
-    {
-      "name": "Count Of Female, TwoOrMoreRaces, Kindergarten",
-      "dcid": "Count_Student_Female_TwoOrMoreRaces_Kindergarten"
-    },
-    {
-      "name": "Count Of Female, TwoOrMoreRaces, MiddleSchool",
-      "dcid": "Count_Student_Female_TwoOrMoreRaces_MiddleSchool"
-    },
-    {
-      "name": "Count Of Female, TwoOrMoreRaces, NCESUngradedClasses",
-      "dcid": "Count_Student_Female_TwoOrMoreRaces_UngradedClasses"
-    },
-    {
-      "name": "Count Of Female, TwoOrMoreRaces, PreKindergarten",
-      "dcid": "Count_Student_Female_TwoOrMoreRaces_PreKindergarten"
-    },
-    {
-      "name": "Count Of Female, TwoOrMoreRaces, PrimarySchool",
-      "dcid": "Count_Student_Female_TwoOrMoreRaces_PrimarySchool"
-    },
-    {
-      "name": "Count Of Female, TwoOrMoreRaces, SchoolGrade1",
-      "dcid": "Count_Student_Female_TwoOrMoreRaces_SchoolGrade1"
-    },
-    {
-      "name": "Count Of Female, TwoOrMoreRaces, SchoolGrade10",
-      "dcid": "Count_Student_Female_TwoOrMoreRaces_SchoolGrade10"
-    },
-    {
-      "name": "Count Of Female, TwoOrMoreRaces, SchoolGrade11",
-      "dcid": "Count_Student_Female_TwoOrMoreRaces_SchoolGrade11"
-    },
-    {
-      "name": "Count Of Female, TwoOrMoreRaces, SchoolGrade12",
-      "dcid": "Count_Student_Female_TwoOrMoreRaces_SchoolGrade12"
-    },
-    {
-      "name": "Count Of Female, TwoOrMoreRaces, SchoolGrade2",
-      "dcid": "Count_Student_Female_TwoOrMoreRaces_SchoolGrade2"
-    },
-    {
-      "name": "Count Of Female, TwoOrMoreRaces, SchoolGrade3",
-      "dcid": "Count_Student_Female_TwoOrMoreRaces_SchoolGrade3"
-    },
-    {
-      "name": "Count Of Female, TwoOrMoreRaces, SchoolGrade4",
-      "dcid": "Count_Student_Female_TwoOrMoreRaces_SchoolGrade4"
-    },
-    {
-      "name": "Count Of Female, TwoOrMoreRaces, SchoolGrade5",
-      "dcid": "Count_Student_Female_TwoOrMoreRaces_SchoolGrade5"
-    },
-    {
-      "name": "Count Of Female, TwoOrMoreRaces, SchoolGrade6",
-      "dcid": "Count_Student_Female_TwoOrMoreRaces_SchoolGrade6"
-    },
-    {
-      "name": "Count Of Female, TwoOrMoreRaces, SchoolGrade7",
-      "dcid": "Count_Student_Female_TwoOrMoreRaces_SchoolGrade7"
-    },
-    {
-      "name": "Count Of Female, TwoOrMoreRaces, SchoolGrade8",
-      "dcid": "Count_Student_Female_TwoOrMoreRaces_SchoolGrade8"
-    },
-    {
-      "name": "Count Of Female, TwoOrMoreRaces, SchoolGrade9",
-      "dcid": "Count_Student_Female_TwoOrMoreRaces_SchoolGrade9"
-    },
-    {
-      "name": "Count Of Female, Urban, MainWorker, Worker",
-      "dcid": "Count_Person_MainWorker_Urban_Female"
-    },
-    {
-      "name": "Count Of Female, Urban, MarginalWorker, Worker",
-      "dcid": "Count_Person_MarginalWorker_Urban_Female"
-    },
-    {
-      "name": "Count Of Female, Urban, NonWorker",
-      "dcid": "Count_Person_NonWorker_Urban_Female"
-    },
-    {
-      "name": "Count Of Female, Urban, ScheduledCaste",
-      "dcid": "Count_Person_ScheduledCaste_Urban_Female"
-    },
-    {
-      "name": "Count Of Female, Urban, ScheduledTribe",
-      "dcid": "Count_Person_ScheduledTribe_Urban_Female"
-    },
-    {
-      "name": "Count Of Female, Urban, Worker",
-      "dcid": "Count_Person_Workers_Urban_Female"
-    },
-    {
-      "name": "Count Of Female, White, HighSchool",
-      "dcid": "Count_Student_Female_White_HighSchool"
-    },
-    {
-      "name": "Count Of Female, White, Kindergarten",
-      "dcid": "Count_Student_Female_White_Kindergarten"
-    },
-    {
-      "name": "Count Of Female, White, MiddleSchool",
-      "dcid": "Count_Student_Female_White_MiddleSchool"
-    },
-    {
-      "name": "Count Of Female, White, NCESUngradedClasses",
-      "dcid": "Count_Student_Female_White_UngradedClasses"
-    },
-    {
-      "name": "Count Of Female, White, PreKindergarten",
-      "dcid": "Count_Student_Female_White_PreKindergarten"
-    },
-    {
-      "name": "Count Of Female, White, PrimarySchool",
-      "dcid": "Count_Student_Female_White_PrimarySchool"
-    },
-    {
-      "name": "Count Of Female, White, SchoolGrade1",
-      "dcid": "Count_Student_Female_White_SchoolGrade1"
-    },
-    {
-      "name": "Count Of Female, White, SchoolGrade10",
-      "dcid": "Count_Student_Female_White_SchoolGrade10"
-    },
-    {
-      "name": "Count Of Female, White, SchoolGrade11",
-      "dcid": "Count_Student_Female_White_SchoolGrade11"
-    },
-    {
-      "name": "Count Of Female, White, SchoolGrade12",
-      "dcid": "Count_Student_Female_White_SchoolGrade12"
-    },
-    {
-      "name": "Count Of Female, White, SchoolGrade2",
-      "dcid": "Count_Student_Female_White_SchoolGrade2"
-    },
-    {
-      "name": "Count Of Female, White, SchoolGrade3",
-      "dcid": "Count_Student_Female_White_SchoolGrade3"
-    },
-    {
-      "name": "Count Of Female, White, SchoolGrade4",
-      "dcid": "Count_Student_Female_White_SchoolGrade4"
-    },
-    {
-      "name": "Count Of Female, White, SchoolGrade5",
-      "dcid": "Count_Student_Female_White_SchoolGrade5"
-    },
-    {
-      "name": "Count Of Female, White, SchoolGrade6",
-      "dcid": "Count_Student_Female_White_SchoolGrade6"
-    },
-    {
-      "name": "Count Of Female, White, SchoolGrade7",
-      "dcid": "Count_Student_Female_White_SchoolGrade7"
-    },
-    {
-      "name": "Count Of Female, White, SchoolGrade8",
-      "dcid": "Count_Student_Female_White_SchoolGrade8"
-    },
-    {
-      "name": "Count Of Female, White, SchoolGrade9",
-      "dcid": "Count_Student_Female_White_SchoolGrade9"
     },
     {
       "name": "Count Of HighSchoolGraduateIncludesEquivalency, Female",
@@ -3999,28 +2391,1620 @@
     {
       "name": "Count Of Years5To9, Female, SomeOtherRaceAlone",
       "dcid": "Count_Person_5To9Years_Female_SomeOtherRaceAlone"
+    },
+    {
+      "name": "Count Of Years5To9, Female, TwoOrMoreRaces",
+      "dcid": "Count_Person_5To9Years_Female_TwoOrMoreRaces"
+    },
+    {
+      "name": "Count Of Years5To9, Female, WhiteAlone",
+      "dcid": "Count_Person_5To9Years_Female_WhiteAlone"
+    },
+    {
+      "name": "Count Of Years5To9, Female, WhiteAloneNotHispanicOrLatino",
+      "dcid": "Count_Person_5To9Years_Female_WhiteAloneNotHispanicOrLatino"
+    },
+    {
+      "name": "Count Of Years60To61, BLS_InLaborForce, Female",
+      "dcid": "Count_Person_60To61Years_InLaborForce_Female"
+    },
+    {
+      "name": "Count Of Years60To61, BLS_NotInLaborForce, Female",
+      "dcid": "Count_Person_60To61Years_NotInLaborForce_Female"
+    },
+    {
+      "name": "Count Of Years62To64, BLS_InLaborForce, Female",
+      "dcid": "Count_Person_62To64Years_InLaborForce_Female"
+    },
+    {
+      "name": "Count Of Years62To64, BLS_NotInLaborForce, Female",
+      "dcid": "Count_Person_62To64Years_NotInLaborForce_Female"
+    },
+    {
+      "name": "Count Of Years65Onwards, 9ThTo12ThGradeNoDiploma, Female",
+      "dcid": "Count_Person_65OrMoreYears_EducationalAttainment9ThTo12ThGradeNoDiploma_Female"
+    },
+    {
+      "name": "Count Of Years65Onwards, AssociatesDegree, Female",
+      "dcid": "Count_Person_65OrMoreYears_EducationalAttainmentAssociatesDegree_Female"
+    },
+    {
+      "name": "Count Of Years65Onwards, BachelorsDegree, Female",
+      "dcid": "Count_Person_65OrMoreYears_EducationalAttainmentBachelorsDegree_Female"
+    },
+    {
+      "name": "Count Of Years65Onwards, BachelorsDegreeOrHigher, Female",
+      "dcid": "Count_Person_65OrMoreYears_EducationalAttainmentBachelorsDegreeOrHigher_Female"
+    },
+    {
+      "name": "Count Of Years65Onwards, GraduateOrProfessionalDegree, Female",
+      "dcid": "Count_Person_65OrMoreYears_EducationalAttainmentGraduateOrProfessionalDegree_Female"
+    },
+    {
+      "name": "Count Of Years65Onwards, HighSchoolGraduateIncludesEquivalency, Female",
+      "dcid": "Count_Person_65OrMoreYears_EducationalAttainmentHighSchoolGraduateIncludesEquivalency_Female"
+    },
+    {
+      "name": "Count Of Years65Onwards, LessThan9ThGrade, Female",
+      "dcid": "Count_Person_65OrMoreYears_EducationalAttainmentLessThan9ThGrade_Female"
+    },
+    {
+      "name": "Count Of Years65Onwards, SomeCollegeNoDegree, Female",
+      "dcid": "Count_Person_65OrMoreYears_EducationalAttainmentSomeCollegeNoDegree_Female"
+    },
+    {
+      "name": "Count Of Years65To69, BLS_InLaborForce, Female",
+      "dcid": "Count_Person_65To69Years_InLaborForce_Female"
+    },
+    {
+      "name": "Count Of Years65To69, BLS_NotInLaborForce, Female",
+      "dcid": "Count_Person_65To69Years_NotInLaborForce_Female"
+    },
+    {
+      "name": "Count Of Years65To74, Civilian, Female",
+      "dcid": "Count_Person_65To74Years_Civilian_Female"
+    },
+    {
+      "name": "Count Of Years65To74, Female, AbovePovertyLevelInThePast12Months",
+      "dcid": "Count_Person_65To74Years_Female_AbovePovertyLevelInThePast12Months"
+    },
+    {
+      "name": "Count Of Years65To74, Female, AmericanIndianOrAlaskaNativeAlone",
+      "dcid": "Count_Person_65To74Years_Female_AmericanIndianOrAlaskaNativeAlone"
+    },
+    {
+      "name": "Count Of Years65To74, Female, AsianAlone",
+      "dcid": "Count_Person_65To74Years_Female_AsianAlone"
+    },
+    {
+      "name": "Count Of Years65To74, Female, BelowPovertyLevelInThePast12Months",
+      "dcid": "Count_Person_65To74Years_Female_BelowPovertyLevelInThePast12Months"
+    },
+    {
+      "name": "Count Of Years65To74, Female, BlackOrAfricanAmericanAlone",
+      "dcid": "Count_Person_65To74Years_Female_BlackOrAfricanAmericanAlone"
+    },
+    {
+      "name": "Count Of Years65To74, Female, CDC_AmericanIndianAndAlaskaNativeAlone",
+      "dcid": "Count_Death_65To74Years_Female_AmericanIndianAndAlaskaNativeAlone"
+    },
+    {
+      "name": "Count Of Years65To74, Female, CDC_AsianOrPacificIslander",
+      "dcid": "Count_Death_65To74Years_Female_AsianOrPacificIslander"
+    },
+    {
+      "name": "Count Of Years65To74, Female, CDC_BlackOrAfricanAmerican",
+      "dcid": "Count_Death_65To74Years_Female_BlackOrAfricanAmerican"
+    },
+    {
+      "name": "Count Of Years65To74, Female, CDC_White",
+      "dcid": "Count_Death_65To74Years_Female_White"
+    },
+    {
+      "name": "Count Of Years65To74, Female, HispanicOrLatino",
+      "dcid": "Count_Person_65To74Years_Female_HispanicOrLatino"
+    },
+    {
+      "name": "Count Of Years65To74, Female, NativeHawaiianOrOtherPacificIslanderAlone",
+      "dcid": "Count_Person_65To74Years_Female_NativeHawaiianOrOtherPacificIslanderAlone"
+    },
+    {
+      "name": "Count Of Years65To74, Female, SomeOtherRaceAlone",
+      "dcid": "Count_Person_65To74Years_Female_SomeOtherRaceAlone"
+    },
+    {
+      "name": "Count Of Years65To74, Female, TwoOrMoreRaces",
+      "dcid": "Count_Person_65To74Years_Female_TwoOrMoreRaces"
+    },
+    {
+      "name": "Count Of Years65To74, Female, WhiteAlone",
+      "dcid": "Count_Person_65To74Years_Female_WhiteAlone"
+    },
+    {
+      "name": "Count Of Years65To74, Female, WhiteAloneNotHispanicOrLatino",
+      "dcid": "Count_Person_65To74Years_Female_WhiteAloneNotHispanicOrLatino"
+    },
+    {
+      "name": "Count Of Years65To74, ICD10/A00-B99, Female",
+      "dcid": "Count_Death_65To74Years_CertainInfectiousParasiticDiseases_Female"
+    },
+    {
+      "name": "Count Of Years65To74, ICD10/C00-D48, Female",
+      "dcid": "Count_Death_65To74Years_Neoplasms_Female"
+    },
+    {
+      "name": "Count Of Years65To74, ICD10/D50-D89, Female",
+      "dcid": "Count_Death_65To74Years_DiseasesOfBloodAndBloodFormingOrgansAndImmuneDisorders_Female"
+    },
+    {
+      "name": "Count Of Years65To74, ICD10/E00-E88, Female",
+      "dcid": "Count_Death_65To74Years_EndocrineNutritionalMetabolicDiseases_Female"
+    },
+    {
+      "name": "Count Of Years65To74, ICD10/F01-F99, Female",
+      "dcid": "Count_Death_65To74Years_MentalBehaviouralDisorders_Female"
+    },
+    {
+      "name": "Count Of Years65To74, ICD10/G00-G98, Female",
+      "dcid": "Count_Death_65To74Years_DiseasesOfTheNervousSystem_Female"
+    },
+    {
+      "name": "Count Of Years65To74, ICD10/I00-I99, Female",
+      "dcid": "Count_Death_65To74Years_DiseasesOfTheCirculatorySystem_Female"
+    },
+    {
+      "name": "Count Of Years65To74, ICD10/J00-J98, Female",
+      "dcid": "Count_Death_65To74Years_DiseasesOfTheRespiratorySystem_Female"
+    },
+    {
+      "name": "Count Of Years65To74, ICD10/K00-K92, Female",
+      "dcid": "Count_Death_65To74Years_DiseasesOfTheDigestiveSystem_Female"
+    },
+    {
+      "name": "Count Of Years65To74, ICD10/L00-L98, Female",
+      "dcid": "Count_Death_65To74Years_DiseasesOfTheSkinSubcutaneousTissue_Female"
+    },
+    {
+      "name": "Count Of Years65To74, ICD10/M00-M99, Female",
+      "dcid": "Count_Death_65To74Years_DiseasesOfTheMusculoskeletalSystemConnectiveTissue_Female"
+    },
+    {
+      "name": "Count Of Years65To74, ICD10/N00-N98, Female",
+      "dcid": "Count_Death_65To74Years_DiseasesOfTheGenitourinarySystem_Female"
+    },
+    {
+      "name": "Count Of Years65To74, ICD10/R00-R99, Female",
+      "dcid": "Count_Death_65To74Years_AbnormalNotClassfied_Female"
+    },
+    {
+      "name": "Count Of Years65To74, ICD10/V01-Y89, Female",
+      "dcid": "Count_Death_65To74Years_ExternalCauses_Female"
+    },
+    {
+      "name": "Count Of Years6To11, Female, AbovePovertyLevelInThePast12Months",
+      "dcid": "Count_Person_6To11Years_Female_AbovePovertyLevelInThePast12Months"
+    },
+    {
+      "name": "Count Of Years6To11, Female, BelowPovertyLevelInThePast12Months",
+      "dcid": "Count_Person_6To11Years_Female_BelowPovertyLevelInThePast12Months"
+    },
+    {
+      "name": "Count Of Years70To74, BLS_InLaborForce, Female",
+      "dcid": "Count_Person_70To74Years_InLaborForce_Female"
+    },
+    {
+      "name": "Count Of Years70To74, BLS_NotInLaborForce, Female",
+      "dcid": "Count_Person_70To74Years_NotInLaborForce_Female"
+    },
+    {
+      "name": "Count Of Years75Onwards, BLS_InLaborForce, Female",
+      "dcid": "Count_Person_75OrMoreYears_InLaborForce_Female"
+    },
+    {
+      "name": "Count Of Years75Onwards, BLS_NotInLaborForce, Female",
+      "dcid": "Count_Person_75OrMoreYears_NotInLaborForce_Female"
+    },
+    {
+      "name": "Count Of Years75Onwards, Civilian, Female",
+      "dcid": "Count_Person_75OrMoreYears_Civilian_Female"
+    },
+    {
+      "name": "Count Of Years75Onwards, Female, AbovePovertyLevelInThePast12Months",
+      "dcid": "Count_Person_75OrMoreYears_Female_AbovePovertyLevelInThePast12Months"
+    },
+    {
+      "name": "Count Of Years75Onwards, Female, BelowPovertyLevelInThePast12Months",
+      "dcid": "Count_Person_75OrMoreYears_Female_BelowPovertyLevelInThePast12Months"
+    },
+    {
+      "name": "Count Of Years75To84, Female, AmericanIndianOrAlaskaNativeAlone",
+      "dcid": "Count_Person_75To84Years_Female_AmericanIndianOrAlaskaNativeAlone"
+    },
+    {
+      "name": "Count Of Years75To84, Female, AsianAlone",
+      "dcid": "Count_Person_75To84Years_Female_AsianAlone"
+    },
+    {
+      "name": "Count Of Years75To84, Female, BlackOrAfricanAmericanAlone",
+      "dcid": "Count_Person_75To84Years_Female_BlackOrAfricanAmericanAlone"
+    },
+    {
+      "name": "Count Of Years75To84, Female, CDC_AmericanIndianAndAlaskaNativeAlone",
+      "dcid": "Count_Death_75To84Years_Female_AmericanIndianAndAlaskaNativeAlone"
+    },
+    {
+      "name": "Count Of Years75To84, Female, CDC_AsianOrPacificIslander",
+      "dcid": "Count_Death_75To84Years_Female_AsianOrPacificIslander"
+    },
+    {
+      "name": "Count Of Years75To84, Female, CDC_BlackOrAfricanAmerican",
+      "dcid": "Count_Death_75To84Years_Female_BlackOrAfricanAmerican"
+    },
+    {
+      "name": "Count Of Years75To84, Female, CDC_White",
+      "dcid": "Count_Death_75To84Years_Female_White"
+    },
+    {
+      "name": "Count Of Years75To84, Female, HispanicOrLatino",
+      "dcid": "Count_Person_75To84Years_Female_HispanicOrLatino"
+    },
+    {
+      "name": "Count Of Years75To84, Female, NativeHawaiianOrOtherPacificIslanderAlone",
+      "dcid": "Count_Person_75To84Years_Female_NativeHawaiianOrOtherPacificIslanderAlone"
+    },
+    {
+      "name": "Count Of Years75To84, Female, SomeOtherRaceAlone",
+      "dcid": "Count_Person_75To84Years_Female_SomeOtherRaceAlone"
+    },
+    {
+      "name": "Count Of Years75To84, Female, TwoOrMoreRaces",
+      "dcid": "Count_Person_75To84Years_Female_TwoOrMoreRaces"
+    },
+    {
+      "name": "Count Of Years75To84, Female, WhiteAlone",
+      "dcid": "Count_Person_75To84Years_Female_WhiteAlone"
+    },
+    {
+      "name": "Count Of Years75To84, Female, WhiteAloneNotHispanicOrLatino",
+      "dcid": "Count_Person_75To84Years_Female_WhiteAloneNotHispanicOrLatino"
+    },
+    {
+      "name": "Count Of Years75To84, ICD10/A00-B99, Female",
+      "dcid": "Count_Death_75To84Years_CertainInfectiousParasiticDiseases_Female"
+    },
+    {
+      "name": "Count Of Years75To84, ICD10/C00-D48, Female",
+      "dcid": "Count_Death_75To84Years_Neoplasms_Female"
+    },
+    {
+      "name": "Count Of Years75To84, ICD10/D50-D89, Female",
+      "dcid": "Count_Death_75To84Years_DiseasesOfBloodAndBloodFormingOrgansAndImmuneDisorders_Female"
+    },
+    {
+      "name": "Count Of Years75To84, ICD10/E00-E88, Female",
+      "dcid": "Count_Death_75To84Years_EndocrineNutritionalMetabolicDiseases_Female"
+    },
+    {
+      "name": "Count Of Years75To84, ICD10/F01-F99, Female",
+      "dcid": "Count_Death_75To84Years_MentalBehaviouralDisorders_Female"
+    },
+    {
+      "name": "Count Of Years75To84, ICD10/G00-G98, Female",
+      "dcid": "Count_Death_75To84Years_DiseasesOfTheNervousSystem_Female"
+    },
+    {
+      "name": "Count Of Years75To84, ICD10/I00-I99, Female",
+      "dcid": "Count_Death_75To84Years_DiseasesOfTheCirculatorySystem_Female"
+    },
+    {
+      "name": "Count Of Years75To84, ICD10/J00-J98, Female",
+      "dcid": "Count_Death_75To84Years_DiseasesOfTheRespiratorySystem_Female"
+    },
+    {
+      "name": "Count Of Years75To84, ICD10/K00-K92, Female",
+      "dcid": "Count_Death_75To84Years_DiseasesOfTheDigestiveSystem_Female"
+    },
+    {
+      "name": "Count Of Years75To84, ICD10/L00-L98, Female",
+      "dcid": "Count_Death_75To84Years_DiseasesOfTheSkinSubcutaneousTissue_Female"
+    },
+    {
+      "name": "Count Of Years75To84, ICD10/M00-M99, Female",
+      "dcid": "Count_Death_75To84Years_DiseasesOfTheMusculoskeletalSystemConnectiveTissue_Female"
+    },
+    {
+      "name": "Count Of Years75To84, ICD10/N00-N98, Female",
+      "dcid": "Count_Death_75To84Years_DiseasesOfTheGenitourinarySystem_Female"
+    },
+    {
+      "name": "Count Of Years75To84, ICD10/Q00-Q99, Female",
+      "dcid": "Count_Death_75To84Years_CongenitalMalformationsDeformationsChromosomalAbnormalities_Female"
+    },
+    {
+      "name": "Count Of Years75To84, ICD10/R00-R99, Female",
+      "dcid": "Count_Death_75To84Years_AbnormalNotClassfied_Female"
+    },
+    {
+      "name": "Count Of Years75To84, ICD10/V01-Y89, Female",
+      "dcid": "Count_Death_75To84Years_ExternalCauses_Female"
+    },
+    {
+      "name": "Count Of Years85, Female, CDC_AmericanIndianAndAlaskaNativeAlone",
+      "dcid": "Count_Death_85Years_Female_AmericanIndianAndAlaskaNativeAlone"
+    },
+    {
+      "name": "Count Of Years85, Female, CDC_AsianOrPacificIslander",
+      "dcid": "Count_Death_85Years_Female_AsianOrPacificIslander"
+    },
+    {
+      "name": "Count Of Years85, Female, CDC_BlackOrAfricanAmerican",
+      "dcid": "Count_Death_85Years_Female_BlackOrAfricanAmerican"
+    },
+    {
+      "name": "Count Of Years85, Female, CDC_White",
+      "dcid": "Count_Death_85Years_Female_White"
+    },
+    {
+      "name": "Count Of Years85, ICD10/A00-B99, Female",
+      "dcid": "Count_Death_85Years_CertainInfectiousParasiticDiseases_Female"
+    },
+    {
+      "name": "Count Of Years85, ICD10/C00-D48, Female",
+      "dcid": "Count_Death_85Years_Neoplasms_Female"
+    },
+    {
+      "name": "Count Of Years85, ICD10/D50-D89, Female",
+      "dcid": "Count_Death_85Years_DiseasesOfBloodAndBloodFormingOrgansAndImmuneDisorders_Female"
+    },
+    {
+      "name": "Count Of Years85, ICD10/E00-E88, Female",
+      "dcid": "Count_Death_85Years_EndocrineNutritionalMetabolicDiseases_Female"
+    },
+    {
+      "name": "Count Of Years85, ICD10/F01-F99, Female",
+      "dcid": "Count_Death_85Years_MentalBehaviouralDisorders_Female"
+    },
+    {
+      "name": "Count Of Years85, ICD10/G00-G98, Female",
+      "dcid": "Count_Death_85Years_DiseasesOfTheNervousSystem_Female"
+    },
+    {
+      "name": "Count Of Years85, ICD10/I00-I99, Female",
+      "dcid": "Count_Death_85Years_DiseasesOfTheCirculatorySystem_Female"
+    },
+    {
+      "name": "Count Of Years85, ICD10/J00-J98, Female",
+      "dcid": "Count_Death_85Years_DiseasesOfTheRespiratorySystem_Female"
+    },
+    {
+      "name": "Count Of Years85, ICD10/K00-K92, Female",
+      "dcid": "Count_Death_85Years_DiseasesOfTheDigestiveSystem_Female"
+    },
+    {
+      "name": "Count Of Years85, ICD10/L00-L98, Female",
+      "dcid": "Count_Death_85Years_DiseasesOfTheSkinSubcutaneousTissue_Female"
+    },
+    {
+      "name": "Count Of Years85, ICD10/M00-M99, Female",
+      "dcid": "Count_Death_85Years_DiseasesOfTheMusculoskeletalSystemConnectiveTissue_Female"
+    },
+    {
+      "name": "Count Of Years85, ICD10/N00-N98, Female",
+      "dcid": "Count_Death_85Years_DiseasesOfTheGenitourinarySystem_Female"
+    },
+    {
+      "name": "Count Of Years85, ICD10/R00-R99, Female",
+      "dcid": "Count_Death_85Years_AbnormalNotClassfied_Female"
+    },
+    {
+      "name": "Count Of Years85, ICD10/V01-Y89, Female",
+      "dcid": "Count_Death_85Years_ExternalCauses_Female"
+    },
+    {
+      "name": "Count Of Years85Onwards, Female, AmericanIndianOrAlaskaNativeAlone",
+      "dcid": "Count_Person_85OrMoreYears_Female_AmericanIndianOrAlaskaNativeAlone"
+    },
+    {
+      "name": "Count Of Years85Onwards, Female, AsianAlone",
+      "dcid": "Count_Person_85OrMoreYears_Female_AsianAlone"
+    },
+    {
+      "name": "Count Of Years85Onwards, Female, BlackOrAfricanAmericanAlone",
+      "dcid": "Count_Person_85OrMoreYears_Female_BlackOrAfricanAmericanAlone"
+    },
+    {
+      "name": "Count Of Years85Onwards, Female, HispanicOrLatino",
+      "dcid": "Count_Person_85OrMoreYears_Female_HispanicOrLatino"
+    },
+    {
+      "name": "Count Of Years85Onwards, Female, NativeHawaiianOrOtherPacificIslanderAlone",
+      "dcid": "Count_Person_85OrMoreYears_Female_NativeHawaiianOrOtherPacificIslanderAlone"
+    },
+    {
+      "name": "Count Of Years85Onwards, Female, SomeOtherRaceAlone",
+      "dcid": "Count_Person_85OrMoreYears_Female_SomeOtherRaceAlone"
+    },
+    {
+      "name": "Count Of Years85Onwards, Female, TwoOrMoreRaces",
+      "dcid": "Count_Person_85OrMoreYears_Female_TwoOrMoreRaces"
+    },
+    {
+      "name": "Count Of Years85Onwards, Female, WhiteAlone",
+      "dcid": "Count_Person_85OrMoreYears_Female_WhiteAlone"
+    },
+    {
+      "name": "Count Of Years85Onwards, Female, WhiteAloneNotHispanicOrLatino",
+      "dcid": "Count_Person_85OrMoreYears_Female_WhiteAloneNotHispanicOrLatino"
+    },
+    {
+      "name": "Count Of YearsUpto1, Female, CDC_AmericanIndianAndAlaskaNativeAlone",
+      "dcid": "Count_Death_Upto1Years_Female_AmericanIndianAndAlaskaNativeAlone"
+    },
+    {
+      "name": "Count Of YearsUpto1, Female, CDC_AsianOrPacificIslander",
+      "dcid": "Count_Death_Upto1Years_Female_AsianOrPacificIslander"
+    },
+    {
+      "name": "Count Of YearsUpto1, Female, CDC_BlackOrAfricanAmerican",
+      "dcid": "Count_Death_Upto1Years_Female_BlackOrAfricanAmerican"
+    },
+    {
+      "name": "Count Of YearsUpto1, Female, CDC_White",
+      "dcid": "Count_Death_Upto1Years_Female_White"
+    },
+    {
+      "name": "Count Of YearsUpto1, ICD10/A00-B99, Female",
+      "dcid": "Count_Death_Upto1Years_CertainInfectiousParasiticDiseases_Female"
+    },
+    {
+      "name": "Count Of YearsUpto1, ICD10/G00-G98, Female",
+      "dcid": "Count_Death_Upto1Years_DiseasesOfTheNervousSystem_Female"
+    },
+    {
+      "name": "Count Of YearsUpto1, ICD10/I00-I99, Female",
+      "dcid": "Count_Death_Upto1Years_DiseasesOfTheCirculatorySystem_Female"
+    },
+    {
+      "name": "Count Of YearsUpto1, ICD10/J00-J98, Female",
+      "dcid": "Count_Death_Upto1Years_DiseasesOfTheRespiratorySystem_Female"
+    },
+    {
+      "name": "Count Of YearsUpto1, ICD10/P00-P96, Female",
+      "dcid": "Count_Death_Upto1Years_CertainConditionsOriginatingInThePerinatalPeriod_Female"
+    },
+    {
+      "name": "Count Of YearsUpto1, ICD10/Q00-Q99, Female",
+      "dcid": "Count_Death_Upto1Years_CongenitalMalformationsDeformationsChromosomalAbnormalities_Female"
+    },
+    {
+      "name": "Count Of YearsUpto1, ICD10/R00-R99, Female",
+      "dcid": "Count_Death_Upto1Years_AbnormalNotClassfied_Female"
+    },
+    {
+      "name": "Count Of YearsUpto1, ICD10/V01-Y89, Female",
+      "dcid": "Count_Death_Upto1Years_ExternalCauses_Female"
+    },
+    {
+      "name": "Count Of YearsUpto5, Female, AbovePovertyLevelInThePast12Months",
+      "dcid": "Count_Person_Upto5Years_Female_AbovePovertyLevelInThePast12Months"
+    },
+    {
+      "name": "Count Of YearsUpto5, Female, AmericanIndianOrAlaskaNativeAlone",
+      "dcid": "Count_Person_Upto5Years_Female_AmericanIndianOrAlaskaNativeAlone"
+    },
+    {
+      "name": "Count Of YearsUpto5, Female, AsianAlone",
+      "dcid": "Count_Person_Upto5Years_Female_AsianAlone"
+    },
+    {
+      "name": "Count Of YearsUpto5, Female, BelowPovertyLevelInThePast12Months",
+      "dcid": "Count_Person_Upto5Years_Female_BelowPovertyLevelInThePast12Months"
+    },
+    {
+      "name": "Count Of YearsUpto5, Female, BlackOrAfricanAmericanAlone",
+      "dcid": "Count_Person_Upto5Years_Female_BlackOrAfricanAmericanAlone"
+    },
+    {
+      "name": "Count Of YearsUpto5, Female, HispanicOrLatino",
+      "dcid": "Count_Person_Upto5Years_Female_HispanicOrLatino"
+    },
+    {
+      "name": "Count Of YearsUpto5, Female, NativeHawaiianOrOtherPacificIslanderAlone",
+      "dcid": "Count_Person_Upto5Years_Female_NativeHawaiianOrOtherPacificIslanderAlone"
+    },
+    {
+      "name": "Count Of YearsUpto5, Female, SomeOtherRaceAlone",
+      "dcid": "Count_Person_Upto5Years_Female_SomeOtherRaceAlone"
+    },
+    {
+      "name": "Count Of YearsUpto5, Female, TwoOrMoreRaces",
+      "dcid": "Count_Person_Upto5Years_Female_TwoOrMoreRaces"
+    },
+    {
+      "name": "Count Of YearsUpto5, Female, WhiteAlone",
+      "dcid": "Count_Person_Upto5Years_Female_WhiteAlone"
+    },
+    {
+      "name": "Count Of YearsUpto5, Female, WhiteAloneNotHispanicOrLatino",
+      "dcid": "Count_Person_Upto5Years_Female_WhiteAloneNotHispanicOrLatino"
+    },
+    {
+      "name": "Count Of YearsUpto64, Female, BlackOrAfricanAmericanAlone",
+      "dcid": "Count_Person_Upto64Years_Female_BlackOrAfricanAmericanAlone"
+    },
+    {
+      "name": "Count Of YearsUpto64, Female, HispanicOrLatino",
+      "dcid": "Count_Person_Upto64Years_Female_HispanicOrLatino"
+    },
+    {
+      "name": "Count Of YearsUpto64, Female, NoHealthInsurance",
+      "dcid": "Count_Person_Upto64Years_Female_NoHealthInsurance"
+    },
+    {
+      "name": "Count Of YearsUpto64, Female, WhiteAlone",
+      "dcid": "Count_Person_Upto64Years_Female_WhiteAlone"
+    },
+    {
+      "name": "Count Of YearsUpto64, Female, WithHealthInsurance",
+      "dcid": "Count_Person_Upto64Years_Female_WithHealthInsurance"
+    },
+    {
+      "name": "Count Of YearsUpto64, RatioToPovertyLine1.38To4, Female",
+      "dcid": "Count_Person_Upto64Years_RatioToPovertyLine1.38To4_Female"
+    },
+    {
+      "name": "Count Of YearsUpto64, RatioToPovertyLineUpto1.38, Female",
+      "dcid": "Count_Person_Upto64Years_RatioToPovertyLineUpto1.38_Female"
+    },
+    {
+      "name": "Count Of YearsUpto64, RatioToPovertyLineUpto2, Female",
+      "dcid": "Count_Person_Upto64Years_RatioToPovertyLineUpto2_Female"
+    },
+    {
+      "name": "Count Of YearsUpto64, RatioToPovertyLineUpto2.5, Female",
+      "dcid": "Count_Person_Upto64Years_RatioToPovertyLineUpto2.5_Female"
+    },
+    {
+      "name": "Count Of YearsUpto64, RatioToPovertyLineUpto4, Female",
+      "dcid": "Count_Person_Upto64Years_RatioToPovertyLineUpto4_Female"
+    },
+    {
+      "name": "Median Income Of Female",
+      "dcid": "Median_Income_Person_15OrMoreYears_Female_WithIncome"
+    },
+    {
+      "name": "Count Of Female As Fraction Of Count Person Female",
+      "dcid": "Count_Death_Female_AsAFractionOf_Count_Person_Female"
+    },
+    {
+      "name": "AgeAdjusted Count Of Female As Fraction Of Count Person Female",
+      "dcid": "Count_Death_Female_AgeAdjusted_AsAFractionOf_Count_Person_Female"
+    },
+    {
+      "name": "Count Of ICD10/X60-X84, Female As Fraction Of Count Person Female",
+      "dcid": "Count_Death_IntentionalSelfHarm_Female_AsFractionOf_Count_Person_Female"
+    },
+    {
+      "name": "Count Of MurderAndNonNegligentManslaughter, Female As Fraction Of Count Person Female",
+      "dcid": "Count_CriminalActivities_MurderAndNonNegligentManslaughter_Female_AsFractionOf_Count_Person_Female"
+    },
+    {
+      "name": "Count Of YearsUpto1, Female As Fraction Of Count BirthEvent Female",
+      "dcid": "Count_Death_LessThan1Year_Female_AsAFractionOf_Count_BirthEvent_Female"
+    },
+    {
+      "name": "Count Of Years0, Female As Fraction Of Count BirthEvent LiveBirth Female",
+      "dcid": "Count_Death_0Years_Female_AsFractionOf_Count_BirthEvent_LiveBirth_Female"
+    },
+    {
+      "name": "Count Of Years15Onwards, BLS_InLaborForce, Female As Fraction Of Count Person InLaborForce",
+      "dcid": "Count_Person_15OrMoreYears_InLaborForce_Female_AsFractionOf_Count_Person_InLaborForce"
+    },
+    {
+      "name": "Count Of YearsUpto14, Female As Fraction Of Count Person Upto14Years Female",
+      "dcid": "Count_Death_Upto14Years_Female_AsAFractionOf_Count_Person_Upto14Years_Female"
+    },
+    {
+      "name": "Count Of BachelorsDegreeOrHigher, Female As Fraction Of Count Person 25OrMoreYears Female",
+      "dcid": "Count_Person_25OrMoreYears_Female_BachelorsDegreeOrHigher_AsFractionOf_Count_Person_25OrMoreYears_Female"
+    },
+    {
+      "name": "Count Of DoctorateDegree, Female As Fraction Of Count Person 25OrMoreYears Female",
+      "dcid": "Count_Person_25OrMoreYears_Female_DoctorateDegree_AsFractionOf_Count_Person_25OrMoreYears_Female"
+    },
+    {
+      "name": "Count Of MastersDegreeOrHigher, Female As Fraction Of Count Person 25OrMoreYears Female",
+      "dcid": "Count_Person_25OrMoreYears_Female_MastersDegreeOrHigher_AsFractionOf_Count_Person_25OrMoreYears_Female"
+    },
+    {
+      "name": "Count Of TertiaryEducation, Female As Fraction Of Count Person 25OrMoreYears Female",
+      "dcid": "Count_Person_25OrMoreYears_Female_TertiaryEducation_AsFractionOf_Count_Person_25OrMoreYears_Female"
+    },
+    {
+      "name": "Count Of Years15Onwards, Female, Smoking As Fraction Of Count Person 15OrMoreYears Female",
+      "dcid": "Count_Person_15OrMoreYears_Female_Smoking_AsFractionOf_Count_Person_15OrMoreYears_Female"
+    },
+    {
+      "name": "Count Of Years15To64, BLS_InLaborForce, Female As Fraction Of Count Person 15To64Years Female",
+      "dcid": "Count_Person_15To64Years_Female_InLaborForce_AsFractionOf_Count_Person_15To64Years_Female"
+    },
+    {
+      "name": "Count Of BachelorsDegreeOrHigher, Female, AmericanIndianOrAlaskaNativeAlone",
+      "dcid": "dc/4qtse8536dg63"
+    },
+    {
+      "name": "Count Of BachelorsDegreeOrHigher, Female, AsianAlone",
+      "dcid": "dc/eg6rrdr1tkf76"
+    },
+    {
+      "name": "Count Of BachelorsDegreeOrHigher, Female, BlackOrAfricanAmericanAlone",
+      "dcid": "dc/t7403chwvspm"
+    },
+    {
+      "name": "Count Of BachelorsDegreeOrHigher, Female, HispanicOrLatino",
+      "dcid": "dc/06f0jf8xvzw4f"
+    },
+    {
+      "name": "Count Of BachelorsDegreeOrHigher, Female, NativeHawaiianOrOtherPacificIslanderAlone",
+      "dcid": "dc/v7yl3k9w3h7e8"
+    },
+    {
+      "name": "Count Of BachelorsDegreeOrHigher, Female, SomeOtherRaceAlone",
+      "dcid": "dc/skv4cd74gsnpf"
+    },
+    {
+      "name": "Count Of BachelorsDegreeOrHigher, Female, TwoOrMoreRaces",
+      "dcid": "dc/hyfn2tlyz48lb"
+    },
+    {
+      "name": "Count Of BachelorsDegreeOrHigher, Female, WhiteAlone",
+      "dcid": "dc/5hc4etrfyj9qg"
+    },
+    {
+      "name": "Count Of BachelorsDegreeOrHigher, Female, WhiteAloneNotHispanicOrLatino",
+      "dcid": "dc/wd5g31pcj0zr3"
+    },
+    {
+      "name": "Count Of Female, AmericanIndianOrAlaskaNativeAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/r3nyqwc41tdx4"
+    },
+    {
+      "name": "Count Of Female, AmericanIndianOrAlaskaNativeAlone, USC_WorkedFullTime",
+      "dcid": "dc/858f4wnnbjdd9"
+    },
+    {
+      "name": "Count Of Female, AsianAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/6bcwz6fgqsmtc"
+    },
+    {
+      "name": "Count Of Female, AsianAlone, USC_WorkedFullTime",
+      "dcid": "dc/4qkhs33t1v2w1"
+    },
+    {
+      "name": "Count Of Female, BlackOrAfricanAmericanAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/6kkefdzvzwz3c"
+    },
+    {
+      "name": "Count Of Female, BlackOrAfricanAmericanAlone, USC_WorkedFullTime",
+      "dcid": "dc/v9rks84c0kkcc"
+    },
+    {
+      "name": "Count Of Female, Divorced",
+      "dcid": "dc/vhykjf4fxfwm4"
+    },
+    {
+      "name": "Count Of Female, Divorced, AmericanIndianOrAlaskaNativeAlone",
+      "dcid": "dc/ky1hbybytyzq"
+    },
+    {
+      "name": "Count Of Female, Divorced, AsianAlone",
+      "dcid": "dc/jvhsg0tbsk0d4"
+    },
+    {
+      "name": "Count Of Female, Divorced, BlackOrAfricanAmericanAlone",
+      "dcid": "dc/q378bg9lpfnx5"
+    },
+    {
+      "name": "Count Of Female, Divorced, HispanicOrLatino",
+      "dcid": "dc/m5wzmsxyngrh9"
+    },
+    {
+      "name": "Count Of Female, Divorced, NativeHawaiianOrOtherPacificIslanderAlone",
+      "dcid": "dc/7lwnw9syv0hb7"
+    },
+    {
+      "name": "Count Of Female, Divorced, SomeOtherRaceAlone",
+      "dcid": "dc/5f7zv3ydq8ttb"
+    },
+    {
+      "name": "Count Of Female, Divorced, TwoOrMoreRaces",
+      "dcid": "dc/c53jk16c4g1r1"
+    },
+    {
+      "name": "Count Of Female, Divorced, WhiteAlone",
+      "dcid": "dc/d0n993ddpgxr3"
+    },
+    {
+      "name": "Count Of Female, Divorced, WhiteAloneNotHispanicOrLatino",
+      "dcid": "dc/9lq3bgx0gq5x6"
+    },
+    {
+      "name": "Count Of Female, EnrolledInCollegeUndergraduateYears",
+      "dcid": "dc/0yv0ry7tjmwzc"
+    },
+    {
+      "name": "Count Of Female, EnrolledInCollegeUndergraduateYears, PrivateSchool",
+      "dcid": "dc/f0l20sfp6tg34"
+    },
+    {
+      "name": "Count Of Female, EnrolledInCollegeUndergraduateYears, PublicSchool",
+      "dcid": "dc/fgssbtlcqy5bf"
+    },
+    {
+      "name": "Count Of Female, EnrolledInGrade1ToGrade4",
+      "dcid": "dc/xj1ljvqpeqrq9"
+    },
+    {
+      "name": "Count Of Female, EnrolledInGrade1ToGrade4, PrivateSchool",
+      "dcid": "dc/3d1k0tygkzrc9"
+    },
+    {
+      "name": "Count Of Female, EnrolledInGrade1ToGrade4, PublicSchool",
+      "dcid": "dc/f6yygkvshe2sc"
+    },
+    {
+      "name": "Count Of Female, EnrolledInGrade5ToGrade8",
+      "dcid": "dc/9ktyl7hpxcd5d"
+    },
+    {
+      "name": "Count Of Female, EnrolledInGrade5ToGrade8, PrivateSchool",
+      "dcid": "dc/vg4dvk67ynl7"
+    },
+    {
+      "name": "Count Of Female, EnrolledInGrade5ToGrade8, PublicSchool",
+      "dcid": "dc/938xr48xyz1v3"
+    },
+    {
+      "name": "Count Of Female, EnrolledInGrade9ToGrade12",
+      "dcid": "dc/gy5jtysjhg5vb"
+    },
+    {
+      "name": "Count Of Female, EnrolledInGrade9ToGrade12, PrivateSchool",
+      "dcid": "dc/lq7sly0t34sc4"
+    },
+    {
+      "name": "Count Of Female, EnrolledInGrade9ToGrade12, PublicSchool",
+      "dcid": "dc/b37t6pmrzqkmh"
+    },
+    {
+      "name": "Count Of Female, EnrolledInGraduateOrProfessionalSchool",
+      "dcid": "dc/w9fkdyz57spqf"
+    },
+    {
+      "name": "Count Of Female, EnrolledInGraduateOrProfessionalSchool, PrivateSchool",
+      "dcid": "dc/c8tyqc3f69xs5"
+    },
+    {
+      "name": "Count Of Female, EnrolledInGraduateOrProfessionalSchool, PublicSchool",
+      "dcid": "dc/b50mk8kek4fz3"
+    },
+    {
+      "name": "Count Of Female, EnrolledInKindergarten",
+      "dcid": "dc/g8kg52zcxzw9f"
+    },
+    {
+      "name": "Count Of Female, EnrolledInKindergarten, PrivateSchool",
+      "dcid": "dc/kzyx3ll4kpfk1"
+    },
+    {
+      "name": "Count Of Female, EnrolledInKindergarten, PublicSchool",
+      "dcid": "dc/wvxlkgg1rw7k7"
+    },
+    {
+      "name": "Count Of Female, EnrolledInNurserySchoolPreschool",
+      "dcid": "dc/wxhnj8xvjcwl"
+    },
+    {
+      "name": "Count Of Female, EnrolledInNurserySchoolPreschool, PrivateSchool",
+      "dcid": "dc/c9y5pyd6tt8p1"
+    },
+    {
+      "name": "Count Of Female, EnrolledInNurserySchoolPreschool, PublicSchool",
+      "dcid": "dc/lr4ve69p16sch"
+    },
+    {
+      "name": "Count Of Female, HispanicOrLatino, USC_NotWorkedFullTime",
+      "dcid": "dc/9steqj1edh965"
+    },
+    {
+      "name": "Count Of Female, HispanicOrLatino, USC_WorkedFullTime",
+      "dcid": "dc/qb3h0k8rxnm02"
+    },
+    {
+      "name": "Count Of Female, MarriedAndNotSeparated, AmericanIndianOrAlaskaNativeAlone",
+      "dcid": "dc/f0drj0vx374yc"
+    },
+    {
+      "name": "Count Of Female, MarriedAndNotSeparated, AsianAlone",
+      "dcid": "dc/46t96zpewfrhc"
+    },
+    {
+      "name": "Count Of Female, MarriedAndNotSeparated, BlackOrAfricanAmericanAlone",
+      "dcid": "dc/xzstrrsk6mzvg"
+    },
+    {
+      "name": "Count Of Female, MarriedAndNotSeparated, HispanicOrLatino",
+      "dcid": "dc/bdeb78d09xt0f"
+    },
+    {
+      "name": "Count Of Female, MarriedAndNotSeparated, NativeHawaiianOrOtherPacificIslanderAlone",
+      "dcid": "dc/fkn44bzm03t01"
+    },
+    {
+      "name": "Count Of Female, MarriedAndNotSeparated, SomeOtherRaceAlone",
+      "dcid": "dc/3ex5z6ys04wsf"
+    },
+    {
+      "name": "Count Of Female, MarriedAndNotSeparated, TwoOrMoreRaces",
+      "dcid": "dc/gpwcf2wkszh63"
+    },
+    {
+      "name": "Count Of Female, MarriedAndNotSeparated, WhiteAlone",
+      "dcid": "dc/pgpb74yrq7s77"
+    },
+    {
+      "name": "Count Of Female, MarriedAndNotSeparated, WhiteAloneNotHispanicOrLatino",
+      "dcid": "dc/y6srse6jgteg3"
+    },
+    {
+      "name": "Count Of Female, MarriedSpouseAbsent",
+      "dcid": "dc/n5mhly5lm0c9"
+    },
+    {
+      "name": "Count Of Female, MarriedSpousePresent",
+      "dcid": "dc/mpfq5ew1eycqc"
+    },
+    {
+      "name": "Count Of Female, NativeHawaiianOrOtherPacificIslanderAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/yrtqz8lswyfm4"
+    },
+    {
+      "name": "Count Of Female, NativeHawaiianOrOtherPacificIslanderAlone, USC_WorkedFullTime",
+      "dcid": "dc/h8llkcyexqn05"
+    },
+    {
+      "name": "Count Of Female, NeverMarried",
+      "dcid": "dc/gj51bfmwwvrv1"
+    },
+    {
+      "name": "Count Of Female, NeverMarried, AmericanIndianOrAlaskaNativeAlone",
+      "dcid": "dc/x8sw80p2lx1tf"
+    },
+    {
+      "name": "Count Of Female, NeverMarried, AsianAlone",
+      "dcid": "dc/qkp6k68gg0244"
+    },
+    {
+      "name": "Count Of Female, NeverMarried, BlackOrAfricanAmericanAlone",
+      "dcid": "dc/42gsdwxn6km93"
+    },
+    {
+      "name": "Count Of Female, NeverMarried, HispanicOrLatino",
+      "dcid": "dc/qjphp1pbessf8"
+    },
+    {
+      "name": "Count Of Female, NeverMarried, NativeHawaiianOrOtherPacificIslanderAlone",
+      "dcid": "dc/9xw6peejzgbd5"
+    },
+    {
+      "name": "Count Of Female, NeverMarried, SomeOtherRaceAlone",
+      "dcid": "dc/rcg5pcew63bsg"
+    },
+    {
+      "name": "Count Of Female, NeverMarried, TwoOrMoreRaces",
+      "dcid": "dc/f1h8l5d76q239"
+    },
+    {
+      "name": "Count Of Female, NeverMarried, WhiteAlone",
+      "dcid": "dc/03wqmq686n779"
+    },
+    {
+      "name": "Count Of Female, NeverMarried, WhiteAloneNotHispanicOrLatino",
+      "dcid": "dc/ymrh67bhjhzj2"
+    },
+    {
+      "name": "Count Of Female, NoIncome, AmericanIndianOrAlaskaNativeAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/smz2mp1lwjcnf"
+    },
+    {
+      "name": "Count Of Female, NoIncome, AmericanIndianOrAlaskaNativeAlone, USC_WorkedFullTime",
+      "dcid": "dc/nvzs03ep0qfef"
+    },
+    {
+      "name": "Count Of Female, NoIncome, AsianAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/rf9g1y7s42hm5"
+    },
+    {
+      "name": "Count Of Female, NoIncome, AsianAlone, USC_WorkedFullTime",
+      "dcid": "dc/bxzpsdt2kmbv9"
+    },
+    {
+      "name": "Count Of Female, NoIncome, BlackOrAfricanAmericanAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/ek35by2zcb4cg"
+    },
+    {
+      "name": "Count Of Female, NoIncome, BlackOrAfricanAmericanAlone, USC_WorkedFullTime",
+      "dcid": "dc/72tjcl6zf6pc9"
+    },
+    {
+      "name": "Count Of Female, NoIncome, HispanicOrLatino, USC_NotWorkedFullTime",
+      "dcid": "dc/cfv49ve7ej312"
+    },
+    {
+      "name": "Count Of Female, NoIncome, HispanicOrLatino, USC_WorkedFullTime",
+      "dcid": "dc/epnvpcn2g8np"
+    },
+    {
+      "name": "Count Of Female, NoIncome, NativeHawaiianOrOtherPacificIslanderAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/8ew8n4mx4vd4g"
+    },
+    {
+      "name": "Count Of Female, NoIncome, NativeHawaiianOrOtherPacificIslanderAlone, USC_WorkedFullTime",
+      "dcid": "dc/8wwlzlz2cj0e6"
+    },
+    {
+      "name": "Count Of Female, NoIncome, SomeOtherRaceAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/0dwmzph5swe8d"
+    },
+    {
+      "name": "Count Of Female, NoIncome, SomeOtherRaceAlone, USC_WorkedFullTime",
+      "dcid": "dc/twdzfgn2d62k9"
+    },
+    {
+      "name": "Count Of Female, NoIncome, TwoOrMoreRaces, USC_NotWorkedFullTime",
+      "dcid": "dc/4zntbzxs86t46"
+    },
+    {
+      "name": "Count Of Female, NoIncome, TwoOrMoreRaces, USC_WorkedFullTime",
+      "dcid": "dc/ww4cpxjv75bb7"
+    },
+    {
+      "name": "Count Of Female, NoIncome, USC_NotWorkedFullTime",
+      "dcid": "dc/5dw5587jynlq9"
+    },
+    {
+      "name": "Count Of Female, NoIncome, USC_WorkedFullTime",
+      "dcid": "dc/cyks77wkz3796"
+    },
+    {
+      "name": "Count Of Female, NoIncome, WhiteAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/slkk8rrlls9f7"
+    },
+    {
+      "name": "Count Of Female, NoIncome, WhiteAlone, USC_WorkedFullTime",
+      "dcid": "dc/b7cfsl1c3qlfg"
+    },
+    {
+      "name": "Count Of Female, NoIncome, WhiteAloneNotHispanicOrLatino, USC_NotWorkedFullTime",
+      "dcid": "dc/rlyqrgm1ssekb"
+    },
+    {
+      "name": "Count Of Female, NoIncome, WhiteAloneNotHispanicOrLatino, USC_WorkedFullTime",
+      "dcid": "dc/tw7tnd13fm6j3"
+    },
+    {
+      "name": "Count Of Female, Nonveteran",
+      "dcid": "dc/9yqjetxt86ml1"
+    },
+    {
+      "name": "Count Of Female, Other",
+      "dcid": "dc/edbzbwf3ychr4"
+    },
+    {
+      "name": "Count Of Female, Separated",
+      "dcid": "dc/wj5y1vh8thnrb"
+    },
+    {
+      "name": "Count Of Female, Separated, AmericanIndianOrAlaskaNativeAlone",
+      "dcid": "dc/0tx0mhnep19yf"
+    },
+    {
+      "name": "Count Of Female, Separated, AsianAlone",
+      "dcid": "dc/ps4ncxtk7gej2"
+    },
+    {
+      "name": "Count Of Female, Separated, BlackOrAfricanAmericanAlone",
+      "dcid": "dc/b1dn069ptggg7"
+    },
+    {
+      "name": "Count Of Female, Separated, HispanicOrLatino",
+      "dcid": "dc/sthflrgmg8byc"
+    },
+    {
+      "name": "Count Of Female, Separated, NativeHawaiianOrOtherPacificIslanderAlone",
+      "dcid": "dc/2l16dmjljlx36"
+    },
+    {
+      "name": "Count Of Female, Separated, SomeOtherRaceAlone",
+      "dcid": "dc/jyrqxpx2eyxl8"
+    },
+    {
+      "name": "Count Of Female, Separated, TwoOrMoreRaces",
+      "dcid": "dc/4f8yh8l1pf4z4"
+    },
+    {
+      "name": "Count Of Female, Separated, WhiteAlone",
+      "dcid": "dc/hj5tsyykynhxc"
+    },
+    {
+      "name": "Count Of Female, Separated, WhiteAloneNotHispanicOrLatino",
+      "dcid": "dc/j9s1qmrf3yxy8"
+    },
+    {
+      "name": "Count Of Female, SomeOtherRaceAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/602cjzlv5hyzh"
+    },
+    {
+      "name": "Count Of Female, SomeOtherRaceAlone, USC_WorkedFullTime",
+      "dcid": "dc/0zz4drf66j6w7"
+    },
+    {
+      "name": "Count Of Female, TwoOrMoreRaces, USC_NotWorkedFullTime",
+      "dcid": "dc/mfm3brd2b55jb"
+    },
+    {
+      "name": "Count Of Female, TwoOrMoreRaces, USC_WorkedFullTime",
+      "dcid": "dc/tdev61pzs9xk8"
+    },
+    {
+      "name": "Count Of Female, USC_WorkedFullTime",
+      "dcid": "dc/q779fwy6k8skd"
+    },
+    {
+      "name": "Count Of Female, USDollar100000Onwards",
+      "dcid": "dc/9bwh94d7xpj75"
+    },
+    {
+      "name": "Count Of Female, USDollar100000Onwards, AmericanIndianOrAlaskaNativeAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/bdl1bpzj3klq4"
+    },
+    {
+      "name": "Count Of Female, USDollar100000Onwards, AmericanIndianOrAlaskaNativeAlone, USC_WorkedFullTime",
+      "dcid": "dc/8v29dc0442ljg"
+    },
+    {
+      "name": "Count Of Female, USDollar100000Onwards, AsianAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/5zrn0w3nwe9e2"
+    },
+    {
+      "name": "Count Of Female, USDollar100000Onwards, AsianAlone, USC_WorkedFullTime",
+      "dcid": "dc/sk4nqnbdskvhg"
+    },
+    {
+      "name": "Count Of Female, USDollar100000Onwards, BlackOrAfricanAmericanAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/hndxvvnzf2yr1"
+    },
+    {
+      "name": "Count Of Female, USDollar100000Onwards, BlackOrAfricanAmericanAlone, USC_WorkedFullTime",
+      "dcid": "dc/vf30v7c1t5lz5"
+    },
+    {
+      "name": "Count Of Female, USDollar100000Onwards, HispanicOrLatino, USC_NotWorkedFullTime",
+      "dcid": "dc/nwzb4v1hp2jw4"
+    },
+    {
+      "name": "Count Of Female, USDollar100000Onwards, HispanicOrLatino, USC_WorkedFullTime",
+      "dcid": "dc/w5geg8s1lmb04"
+    },
+    {
+      "name": "Count Of Female, USDollar100000Onwards, NativeHawaiianOrOtherPacificIslanderAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/8bwnnflm9kwbg"
+    },
+    {
+      "name": "Count Of Female, USDollar100000Onwards, NativeHawaiianOrOtherPacificIslanderAlone, USC_WorkedFullTime",
+      "dcid": "dc/4r5pvjszn5x03"
+    },
+    {
+      "name": "Count Of Female, USDollar100000Onwards, SomeOtherRaceAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/y70ppl4rxjhjh"
+    },
+    {
+      "name": "Count Of Female, USDollar100000Onwards, SomeOtherRaceAlone, USC_WorkedFullTime",
+      "dcid": "dc/3zq436nrf2d66"
+    },
+    {
+      "name": "Count Of Female, USDollar100000Onwards, TwoOrMoreRaces, USC_NotWorkedFullTime",
+      "dcid": "dc/8lffdmtgqv269"
+    },
+    {
+      "name": "Count Of Female, USDollar100000Onwards, TwoOrMoreRaces, USC_WorkedFullTime",
+      "dcid": "dc/n4z306vm3zdm6"
+    },
+    {
+      "name": "Count Of Female, USDollar100000Onwards, WhiteAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/kd7qcdzs2q8p4"
+    },
+    {
+      "name": "Count Of Female, USDollar100000Onwards, WhiteAlone, USC_WorkedFullTime",
+      "dcid": "dc/gjkbs2qeb9m0g"
+    },
+    {
+      "name": "Count Of Female, USDollar100000Onwards, WhiteAloneNotHispanicOrLatino, USC_NotWorkedFullTime",
+      "dcid": "dc/elr21hp41d4jh"
+    },
+    {
+      "name": "Count Of Female, USDollar100000Onwards, WhiteAloneNotHispanicOrLatino, USC_WorkedFullTime",
+      "dcid": "dc/cqc4zh1dg8s6d"
+    },
+    {
+      "name": "Count Of Female, USDollar10000To12499",
+      "dcid": "dc/mk1360ltj6cxg"
+    },
+    {
+      "name": "Count Of Female, USDollar10000To12499, AmericanIndianOrAlaskaNativeAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/g1lqz36qc6x26"
+    },
+    {
+      "name": "Count Of Female, USDollar10000To12499, AmericanIndianOrAlaskaNativeAlone, USC_WorkedFullTime",
+      "dcid": "dc/nfj1c6f5xvjpf"
+    },
+    {
+      "name": "Count Of Female, USDollar10000To12499, AsianAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/rkylr8pzrhvrb"
+    },
+    {
+      "name": "Count Of Female, USDollar10000To12499, AsianAlone, USC_WorkedFullTime",
+      "dcid": "dc/ecz488knjvddf"
+    },
+    {
+      "name": "Count Of Female, USDollar10000To12499, BlackOrAfricanAmericanAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/zvn4y702wsxe3"
+    },
+    {
+      "name": "Count Of Female, USDollar10000To12499, BlackOrAfricanAmericanAlone, USC_WorkedFullTime",
+      "dcid": "dc/6jgshc72wscd7"
+    },
+    {
+      "name": "Count Of Female, USDollar10000To12499, HispanicOrLatino, USC_NotWorkedFullTime",
+      "dcid": "dc/p5ewnb0xtrrp"
+    },
+    {
+      "name": "Count Of Female, USDollar10000To12499, HispanicOrLatino, USC_WorkedFullTime",
+      "dcid": "dc/7ev9gs9ppxbq2"
+    },
+    {
+      "name": "Count Of Female, USDollar10000To12499, NativeHawaiianOrOtherPacificIslanderAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/xbq05lkgsx8b6"
+    },
+    {
+      "name": "Count Of Female, USDollar10000To12499, NativeHawaiianOrOtherPacificIslanderAlone, USC_WorkedFullTime",
+      "dcid": "dc/nxqjjpwkkxpx4"
+    },
+    {
+      "name": "Count Of Female, USDollar10000To12499, SomeOtherRaceAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/8ws12v06y0sqh"
+    },
+    {
+      "name": "Count Of Female, USDollar10000To12499, SomeOtherRaceAlone, USC_WorkedFullTime",
+      "dcid": "dc/43pxcsbgjksmg"
+    },
+    {
+      "name": "Count Of Female, USDollar10000To12499, TwoOrMoreRaces, USC_NotWorkedFullTime",
+      "dcid": "dc/see1v777j4807"
+    },
+    {
+      "name": "Count Of Female, USDollar10000To12499, TwoOrMoreRaces, USC_WorkedFullTime",
+      "dcid": "dc/422zpgm23b2m7"
+    },
+    {
+      "name": "Count Of Female, USDollar10000To12499, WhiteAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/c42c6rmszjdv7"
+    },
+    {
+      "name": "Count Of Female, USDollar10000To12499, WhiteAlone, USC_WorkedFullTime",
+      "dcid": "dc/bpzm3y2rxt7y9"
+    },
+    {
+      "name": "Count Of Female, USDollar10000To12499, WhiteAloneNotHispanicOrLatino, USC_NotWorkedFullTime",
+      "dcid": "dc/t6b45v6bsdf1"
+    },
+    {
+      "name": "Count Of Female, USDollar10000To12499, WhiteAloneNotHispanicOrLatino, USC_WorkedFullTime",
+      "dcid": "dc/j8dgk3864jpbd"
+    },
+    {
+      "name": "Count Of Female, USDollar12500To14999",
+      "dcid": "dc/qg78yhyjktmmd"
+    },
+    {
+      "name": "Count Of Female, USDollar12500To14999, AmericanIndianOrAlaskaNativeAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/djyl74kbjv759"
+    },
+    {
+      "name": "Count Of Female, USDollar12500To14999, AmericanIndianOrAlaskaNativeAlone, USC_WorkedFullTime",
+      "dcid": "dc/y5khypdllylx2"
+    },
+    {
+      "name": "Count Of Female, USDollar12500To14999, AsianAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/w9f75kjtcjz6h"
+    },
+    {
+      "name": "Count Of Female, USDollar12500To14999, AsianAlone, USC_WorkedFullTime",
+      "dcid": "dc/5p1ghjk4c4g53"
+    },
+    {
+      "name": "Count Of Female, USDollar12500To14999, BlackOrAfricanAmericanAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/ph6nlxqmh2es8"
+    },
+    {
+      "name": "Count Of Female, USDollar12500To14999, BlackOrAfricanAmericanAlone, USC_WorkedFullTime",
+      "dcid": "dc/73gmfshjqdqjf"
+    },
+    {
+      "name": "Count Of Female, USDollar12500To14999, HispanicOrLatino, USC_NotWorkedFullTime",
+      "dcid": "dc/4yxpwfz8v6p8b"
+    },
+    {
+      "name": "Count Of Female, USDollar12500To14999, HispanicOrLatino, USC_WorkedFullTime",
+      "dcid": "dc/g6syfwwpny8k"
+    },
+    {
+      "name": "Count Of Female, USDollar12500To14999, NativeHawaiianOrOtherPacificIslanderAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/w79q3d8zvmefd"
+    },
+    {
+      "name": "Count Of Female, USDollar12500To14999, NativeHawaiianOrOtherPacificIslanderAlone, USC_WorkedFullTime",
+      "dcid": "dc/wz3chgqw22hj9"
+    },
+    {
+      "name": "Count Of Female, USDollar12500To14999, SomeOtherRaceAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/rklwcdf350zcg"
+    },
+    {
+      "name": "Count Of Female, USDollar12500To14999, SomeOtherRaceAlone, USC_WorkedFullTime",
+      "dcid": "dc/24z4tkx8bjzb5"
+    },
+    {
+      "name": "Count Of Female, USDollar12500To14999, TwoOrMoreRaces, USC_NotWorkedFullTime",
+      "dcid": "dc/jnytfgyee118f"
+    },
+    {
+      "name": "Count Of Female, USDollar12500To14999, TwoOrMoreRaces, USC_WorkedFullTime",
+      "dcid": "dc/0wreg2rwy5h3c"
+    },
+    {
+      "name": "Count Of Female, USDollar12500To14999, WhiteAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/x2syp295e5gp5"
+    },
+    {
+      "name": "Count Of Female, USDollar12500To14999, WhiteAlone, USC_WorkedFullTime",
+      "dcid": "dc/6re4xlxt811tb"
+    },
+    {
+      "name": "Count Of Female, USDollar12500To14999, WhiteAloneNotHispanicOrLatino, USC_NotWorkedFullTime",
+      "dcid": "dc/m7rh8832y37d5"
+    },
+    {
+      "name": "Count Of Female, USDollar12500To14999, WhiteAloneNotHispanicOrLatino, USC_WorkedFullTime",
+      "dcid": "dc/yczwl8bb6d431"
+    },
+    {
+      "name": "Count Of Female, USDollar15000To17499",
+      "dcid": "dc/n94wjjlc1yxm1"
+    },
+    {
+      "name": "Count Of Female, USDollar15000To17499, AmericanIndianOrAlaskaNativeAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/f7h4xcfddblmg"
+    },
+    {
+      "name": "Count Of Female, USDollar15000To17499, AmericanIndianOrAlaskaNativeAlone, USC_WorkedFullTime",
+      "dcid": "dc/efvqzne3ypfvf"
+    },
+    {
+      "name": "Count Of Female, USDollar15000To17499, AsianAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/05hbjp5ztrl64"
+    },
+    {
+      "name": "Count Of Female, USDollar15000To17499, AsianAlone, USC_WorkedFullTime",
+      "dcid": "dc/v3yv80ncnvzf7"
+    },
+    {
+      "name": "Count Of Female, USDollar15000To17499, BlackOrAfricanAmericanAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/8jb594x7dr0r8"
+    },
+    {
+      "name": "Count Of Female, USDollar15000To17499, BlackOrAfricanAmericanAlone, USC_WorkedFullTime",
+      "dcid": "dc/xkzjppbj1brdh"
+    },
+    {
+      "name": "Count Of Female, USDollar15000To17499, HispanicOrLatino, USC_NotWorkedFullTime",
+      "dcid": "dc/ls3b25qjy2gjg"
+    },
+    {
+      "name": "Count Of Female, USDollar15000To17499, HispanicOrLatino, USC_WorkedFullTime",
+      "dcid": "dc/qx330gg1k2f9d"
+    },
+    {
+      "name": "Count Of Female, USDollar15000To17499, NativeHawaiianOrOtherPacificIslanderAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/lkh6gywp7h5w6"
+    },
+    {
+      "name": "Count Of Female, USDollar15000To17499, NativeHawaiianOrOtherPacificIslanderAlone, USC_WorkedFullTime",
+      "dcid": "dc/608mps4nt7hqc"
+    },
+    {
+      "name": "Count Of Female, USDollar15000To17499, SomeOtherRaceAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/pwmwttm5e1h42"
+    },
+    {
+      "name": "Count Of Female, USDollar15000To17499, SomeOtherRaceAlone, USC_WorkedFullTime",
+      "dcid": "dc/1zwnmfrbcb3e5"
+    },
+    {
+      "name": "Count Of Female, USDollar15000To17499, TwoOrMoreRaces, USC_NotWorkedFullTime",
+      "dcid": "dc/qbrbhb6wg1zs3"
+    },
+    {
+      "name": "Count Of Female, USDollar15000To17499, TwoOrMoreRaces, USC_WorkedFullTime",
+      "dcid": "dc/80rsssbp3j60c"
+    },
+    {
+      "name": "Count Of Female, USDollar15000To17499, WhiteAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/j4qbp1b3s0dy"
+    },
+    {
+      "name": "Count Of Female, USDollar15000To17499, WhiteAlone, USC_WorkedFullTime",
+      "dcid": "dc/dlqtllebrnyh1"
+    },
+    {
+      "name": "Count Of Female, USDollar15000To17499, WhiteAloneNotHispanicOrLatino, USC_NotWorkedFullTime",
+      "dcid": "dc/p79h95jnf7vj7"
+    },
+    {
+      "name": "Count Of Female, USDollar15000To17499, WhiteAloneNotHispanicOrLatino, USC_WorkedFullTime",
+      "dcid": "dc/l5jmwz4fcyhdb"
+    },
+    {
+      "name": "Count Of Female, USDollar17500To19999",
+      "dcid": "dc/bqgcvte9ed9hb"
+    },
+    {
+      "name": "Count Of Female, USDollar17500To19999, AmericanIndianOrAlaskaNativeAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/y9rqqech6xbt4"
+    },
+    {
+      "name": "Count Of Female, USDollar17500To19999, AmericanIndianOrAlaskaNativeAlone, USC_WorkedFullTime",
+      "dcid": "dc/zz3mhw0qtqzx7"
+    },
+    {
+      "name": "Count Of Female, USDollar17500To19999, AsianAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/6vnbexd9selyh"
+    },
+    {
+      "name": "Count Of Female, USDollar17500To19999, AsianAlone, USC_WorkedFullTime",
+      "dcid": "dc/5q26x7hn8b7g6"
+    },
+    {
+      "name": "Count Of Female, USDollar17500To19999, BlackOrAfricanAmericanAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/22z39hnhx4tg6"
+    },
+    {
+      "name": "Count Of Female, USDollar17500To19999, BlackOrAfricanAmericanAlone, USC_WorkedFullTime",
+      "dcid": "dc/05l81v5blpk95"
+    },
+    {
+      "name": "Count Of Female, USDollar17500To19999, HispanicOrLatino, USC_NotWorkedFullTime",
+      "dcid": "dc/54dmhzwdcr8mc"
+    },
+    {
+      "name": "Count Of Female, USDollar17500To19999, HispanicOrLatino, USC_WorkedFullTime",
+      "dcid": "dc/fen92l3kt7nj8"
+    },
+    {
+      "name": "Count Of Female, USDollar17500To19999, NativeHawaiianOrOtherPacificIslanderAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/2jne6ykt5h736"
+    },
+    {
+      "name": "Count Of Female, USDollar17500To19999, NativeHawaiianOrOtherPacificIslanderAlone, USC_WorkedFullTime",
+      "dcid": "dc/f6xpxxctsbjrf"
+    },
+    {
+      "name": "Count Of Female, USDollar17500To19999, SomeOtherRaceAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/7fh145pfk5w7g"
+    },
+    {
+      "name": "Count Of Female, USDollar17500To19999, SomeOtherRaceAlone, USC_WorkedFullTime",
+      "dcid": "dc/4mcgy5kpkk2k4"
+    },
+    {
+      "name": "Count Of Female, USDollar17500To19999, TwoOrMoreRaces, USC_NotWorkedFullTime",
+      "dcid": "dc/cn06kfj48gc1g"
+    },
+    {
+      "name": "Count Of Female, USDollar17500To19999, TwoOrMoreRaces, USC_WorkedFullTime",
+      "dcid": "dc/rz89lkvrsdms4"
+    },
+    {
+      "name": "Count Of Female, USDollar17500To19999, WhiteAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/nxqjypxp6gdy1"
+    },
+    {
+      "name": "Count Of Female, USDollar17500To19999, WhiteAlone, USC_WorkedFullTime",
+      "dcid": "dc/x7k28ws30k7qf"
+    },
+    {
+      "name": "Count Of Female, USDollar17500To19999, WhiteAloneNotHispanicOrLatino, USC_NotWorkedFullTime",
+      "dcid": "dc/2s3rng6r15n32"
+    },
+    {
+      "name": "Count Of Female, USDollar17500To19999, WhiteAloneNotHispanicOrLatino, USC_WorkedFullTime",
+      "dcid": "dc/m2esdqpbc08e8"
+    },
+    {
+      "name": "Count Of Female, USDollar20000To22499",
+      "dcid": "dc/cj3z7kw5h2hmd"
+    },
+    {
+      "name": "Count Of Female, USDollar20000To22499, AmericanIndianOrAlaskaNativeAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/b7cwfvy39pbd"
+    },
+    {
+      "name": "Count Of Female, USDollar20000To22499, AmericanIndianOrAlaskaNativeAlone, USC_WorkedFullTime",
+      "dcid": "dc/vxbpk7nym2y7h"
+    },
+    {
+      "name": "Count Of Female, USDollar20000To22499, AsianAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/qsktnegj2f737"
+    },
+    {
+      "name": "Count Of Female, USDollar20000To22499, AsianAlone, USC_WorkedFullTime",
+      "dcid": "dc/p0w80gfg2rxkb"
+    },
+    {
+      "name": "Count Of Female, USDollar20000To22499, BlackOrAfricanAmericanAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/zgpqy3dd6kbd8"
+    },
+    {
+      "name": "Count Of Female, USDollar20000To22499, BlackOrAfricanAmericanAlone, USC_WorkedFullTime",
+      "dcid": "dc/4tm08bhy3hxeh"
+    },
+    {
+      "name": "Count Of Female, USDollar20000To22499, HispanicOrLatino, USC_NotWorkedFullTime",
+      "dcid": "dc/yyef5lfy2hmf3"
+    },
+    {
+      "name": "Count Of Female, USDollar20000To22499, HispanicOrLatino, USC_WorkedFullTime",
+      "dcid": "dc/we01prqx8g07"
+    },
+    {
+      "name": "Count Of Female, USDollar20000To22499, NativeHawaiianOrOtherPacificIslanderAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/g06cqvny9mws3"
+    },
+    {
+      "name": "Count Of Female, USDollar20000To22499, NativeHawaiianOrOtherPacificIslanderAlone, USC_WorkedFullTime",
+      "dcid": "dc/3j6w5y46wj606"
+    },
+    {
+      "name": "Count Of Female, USDollar20000To22499, SomeOtherRaceAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/966k8k44667xh"
+    },
+    {
+      "name": "Count Of Female, USDollar20000To22499, SomeOtherRaceAlone, USC_WorkedFullTime",
+      "dcid": "dc/cc819snsng749"
+    },
+    {
+      "name": "Count Of Female, USDollar20000To22499, TwoOrMoreRaces, USC_NotWorkedFullTime",
+      "dcid": "dc/3vvmpcm6xcm41"
+    },
+    {
+      "name": "Count Of Female, USDollar20000To22499, TwoOrMoreRaces, USC_WorkedFullTime",
+      "dcid": "dc/q5vjdmjhfg725"
+    },
+    {
+      "name": "Count Of Female, USDollar20000To22499, WhiteAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/9x9e0t690nrg8"
+    },
+    {
+      "name": "Count Of Female, USDollar20000To22499, WhiteAlone, USC_WorkedFullTime",
+      "dcid": "dc/0dh512t8ln1nh"
+    },
+    {
+      "name": "Count Of Female, USDollar20000To22499, WhiteAloneNotHispanicOrLatino, USC_NotWorkedFullTime",
+      "dcid": "dc/wjvc4s6bgwbr3"
+    },
+    {
+      "name": "Count Of Female, USDollar20000To22499, WhiteAloneNotHispanicOrLatino, USC_WorkedFullTime",
+      "dcid": "dc/nmkp8ry296dq6"
+    },
+    {
+      "name": "Count Of Female, USDollar22500To24999",
+      "dcid": "dc/27zb6ms372v2b"
+    },
+    {
+      "name": "Count Of Female, USDollar22500To24999, AmericanIndianOrAlaskaNativeAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/jmh51zr9v4ysc"
+    },
+    {
+      "name": "Count Of Female, USDollar22500To24999, AmericanIndianOrAlaskaNativeAlone, USC_WorkedFullTime",
+      "dcid": "dc/1q68pe0gmjws4"
+    },
+    {
+      "name": "Count Of Female, USDollar22500To24999, AsianAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/rqbxvbxf86p72"
+    },
+    {
+      "name": "Count Of Female, USDollar22500To24999, AsianAlone, USC_WorkedFullTime",
+      "dcid": "dc/r51s8h37pz365"
+    },
+    {
+      "name": "Count Of Female, USDollar22500To24999, BlackOrAfricanAmericanAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/jvfdsp7z4j2q2"
+    },
+    {
+      "name": "Count Of Female, USDollar22500To24999, BlackOrAfricanAmericanAlone, USC_WorkedFullTime",
+      "dcid": "dc/gm9r88nffehg4"
+    },
+    {
+      "name": "Count Of Female, USDollar22500To24999, HispanicOrLatino, USC_NotWorkedFullTime",
+      "dcid": "dc/8k0mys8k94n65"
+    },
+    {
+      "name": "Count Of Female, USDollar22500To24999, HispanicOrLatino, USC_WorkedFullTime",
+      "dcid": "dc/00jf56bd34sh6"
+    },
+    {
+      "name": "Count Of Female, USDollar22500To24999, NativeHawaiianOrOtherPacificIslanderAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/qj2b0y5thjq4c"
+    },
+    {
+      "name": "Count Of Female, USDollar22500To24999, NativeHawaiianOrOtherPacificIslanderAlone, USC_WorkedFullTime",
+      "dcid": "dc/hdwxmpg0nvzwh"
+    },
+    {
+      "name": "Count Of Female, USDollar22500To24999, SomeOtherRaceAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/66cyp77er4jl3"
+    },
+    {
+      "name": "Count Of Female, USDollar22500To24999, SomeOtherRaceAlone, USC_WorkedFullTime",
+      "dcid": "dc/4d7l8xky6y003"
+    },
+    {
+      "name": "Count Of Female, USDollar22500To24999, TwoOrMoreRaces, USC_NotWorkedFullTime",
+      "dcid": "dc/l07vpq2knjjh8"
+    },
+    {
+      "name": "Count Of Female, USDollar22500To24999, TwoOrMoreRaces, USC_WorkedFullTime",
+      "dcid": "dc/zqdnw2h0j1v17"
+    },
+    {
+      "name": "Count Of Female, USDollar22500To24999, WhiteAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/lwvq6qvw7pnn7"
+    },
+    {
+      "name": "Count Of Female, USDollar22500To24999, WhiteAlone, USC_WorkedFullTime",
+      "dcid": "dc/yynycn1yzt5w9"
+    },
+    {
+      "name": "Count Of Female, USDollar22500To24999, WhiteAloneNotHispanicOrLatino, USC_NotWorkedFullTime",
+      "dcid": "dc/tlwzmzhvp08f3"
+    },
+    {
+      "name": "Count Of Female, USDollar22500To24999, WhiteAloneNotHispanicOrLatino, USC_WorkedFullTime",
+      "dcid": "dc/6z6f2zpjcbmf7"
+    },
+    {
+      "name": "Count Of Female, USDollar25000To29999",
+      "dcid": "dc/qh19c85jm0gl8"
+    },
+    {
+      "name": "Count Of Female, USDollar25000To29999, AmericanIndianOrAlaskaNativeAlone, USC_NotWorkedFullTime",
+      "dcid": "dc/vs2gnv0zvtxh9"
     }
   ],
   "statVarGroups": [
     {
-      "name": "BirthEvent By Gender = Female",
-      "dcid": "dc/g/BirthEvent_Gender-Female"
-    },
-    {
       "name": "CriminalActivities By Gender = Female",
       "dcid": "dc/g/CriminalActivities_Gender-Female"
-    },
-    {
-      "name": "Household By HouseholderGender = Female",
-      "dcid": "dc/g/Household_HouseholderGender-Female"
-    },
-    {
-      "name": "IncarcerationEvent By Gender = Female",
-      "dcid": "dc/g/IncarcerationEvent_Gender-Female"
-    },
-    {
-      "name": "MedicareEnrollee By Gender = Female",
-      "dcid": "dc/g/MedicareEnrollee_Gender-Female"
     },
     {
       "name": "MortalityEvent By Gender = Female",
@@ -4031,120 +4015,12 @@
       "dcid": "dc/g/Person_Gender-Female"
     },
     {
-      "name": "Student By Gender = Female",
-      "dcid": "dc/g/Student_Gender-Female"
-    },
-    {
-      "name": "BirthEvent By Gender = Female, MedicalStatus",
-      "dcid": "dc/g/BirthEvent_Gender-Female_MedicalStatus"
-    },
-    {
-      "name": "BirthEvent By Gender = Female, MedicalStatus = LiveBirth",
-      "dcid": "dc/g/BirthEvent_Gender-Female_MedicalStatus-LiveBirth"
-    },
-    {
       "name": "CriminalActivities By CrimeType = MurderAndNonNegligentManslaughter, Gender = Female",
       "dcid": "dc/g/CriminalActivities_CrimeType-MurderAndNonNegligentManslaughter_Gender-Female"
     },
     {
       "name": "CriminalActivities By CrimeType, Gender = Female",
       "dcid": "dc/g/CriminalActivities_CrimeType_Gender-Female"
-    },
-    {
-      "name": "Household By ChildrenInHousehold = HasChildren, HouseholderGender = Female",
-      "dcid": "dc/g/Household_ChildrenInHousehold-HasChildren_HouseholderGender-Female"
-    },
-    {
-      "name": "Household By ChildrenInHousehold, HouseholderGender = Female",
-      "dcid": "dc/g/Household_ChildrenInHousehold_HouseholderGender-Female"
-    },
-    {
-      "name": "Household By HouseholderGender = Female, Race",
-      "dcid": "dc/g/Household_HouseholderGender-Female_Race"
-    },
-    {
-      "name": "Household By HouseholderGender = Female, Race = USC_BlackOrAfricanAmericanAlone",
-      "dcid": "dc/g/Household_HouseholderGender-Female_Race-USCBlackOrAfricanAmericanAlone"
-    },
-    {
-      "name": "Household By HouseholderGender = Female, Race = USC_HispanicOrLatinoRace",
-      "dcid": "dc/g/Household_HouseholderGender-Female_Race-USCHispanicOrLatinoRace"
-    },
-    {
-      "name": "Household By HouseholderGender = Female, Race = USC_WhiteAloneNotHispanicOrLatino",
-      "dcid": "dc/g/Household_HouseholderGender-Female_Race-USCWhiteAloneNotHispanicOrLatino"
-    },
-    {
-      "name": "IncarcerationEvent By EventType = AdmittedToPrison, Gender = Female",
-      "dcid": "dc/g/IncarcerationEvent_EventType-AdmittedToPrison_Gender-Female"
-    },
-    {
-      "name": "IncarcerationEvent By EventType = ReleasedFromPrison, Gender = Female",
-      "dcid": "dc/g/IncarcerationEvent_EventType-ReleasedFromPrison_Gender-Female"
-    },
-    {
-      "name": "IncarcerationEvent By EventType, Gender = Female",
-      "dcid": "dc/g/IncarcerationEvent_EventType_Gender-Female"
-    },
-    {
-      "name": "IncarcerationEvent By Gender = Female, Institutionalization",
-      "dcid": "dc/g/IncarcerationEvent_Gender-Female_Institutionalization"
-    },
-    {
-      "name": "IncarcerationEvent By Gender = Female, Institutionalization = Incarcerated",
-      "dcid": "dc/g/IncarcerationEvent_Gender-Female_Institutionalization-Incarcerated"
-    },
-    {
-      "name": "IncarcerationEvent By Gender = Female, MaxPrisonSentence",
-      "dcid": "dc/g/IncarcerationEvent_Gender-Female_MaxPrisonSentence"
-    },
-    {
-      "name": "IncarcerationEvent By Gender = Female, MaxPrisonSentence = Years2Onwards",
-      "dcid": "dc/g/IncarcerationEvent_Gender-Female_MaxPrisonSentence-Years2Onwards"
-    },
-    {
-      "name": "IncarcerationEvent By Gender = Female, PrisonSentenceStatus",
-      "dcid": "dc/g/IncarcerationEvent_Gender-Female_PrisonSentenceStatus"
-    },
-    {
-      "name": "IncarcerationEvent By Gender = Female, PrisonSentenceStatus = Sentenced",
-      "dcid": "dc/g/IncarcerationEvent_Gender-Female_PrisonSentenceStatus-Sentenced"
-    },
-    {
-      "name": "MedicareEnrollee By Age = Years67To69, Gender = Female",
-      "dcid": "dc/g/MedicareEnrollee_Age-Years67To69_Gender-Female"
-    },
-    {
-      "name": "MedicareEnrollee By Age, Gender = Female",
-      "dcid": "dc/g/MedicareEnrollee_Age_Gender-Female"
-    },
-    {
-      "name": "MedicareEnrollee By Gender = Female, HealthPreventionEnum",
-      "dcid": "dc/g/MedicareEnrollee_Gender-Female_HealthPreventionEnum"
-    },
-    {
-      "name": "MedicareEnrollee By Gender = Female, HealthPreventionEnum = Mammography",
-      "dcid": "dc/g/MedicareEnrollee_Gender-Female_HealthPreventionEnum-Mammography"
-    },
-    {
-      "name": "MedicareEnrollee By Gender = Female, MedicareType",
-      "dcid": "dc/g/MedicareEnrollee_Gender-Female_MedicareType"
-    },
-    {
-      "name": "MedicareEnrollee By Gender = Female, MedicareType = MedicareB",
-      "dcid": "dc/g/MedicareEnrollee_Gender-Female_MedicareType-MedicareB"
-    },
-    {
-      "name": "MedicareEnrollee By Gender = Female, Race",
-      "dcid": "dc/g/MedicareEnrollee_Gender-Female_Race"
-    },
-    {
-      "name": "MedicareEnrollee By Gender = Female, Race = DAD_Black",
-      "dcid": "dc/g/MedicareEnrollee_Gender-Female_Race-DADBlack"
-    },
-    {
-      "name": "MedicareEnrollee By Gender = Female, Race = DAD_NonBlack",
-      "dcid": "dc/g/MedicareEnrollee_Gender-Female_Race-DADNonBlack"
     },
     {
       "name": "MortalityEvent By Age = USC_AgeNotStated, Gender = Female",
@@ -4283,22 +4159,6 @@
       "dcid": "dc/g/MortalityEvent_Age_Gender-Female"
     },
     {
-      "name": "MortalityEvent By CauseOfDeath = AIDS, Gender = Female",
-      "dcid": "dc/g/MortalityEvent_CauseOfDeath-AIDS_Gender-Female"
-    },
-    {
-      "name": "MortalityEvent By CauseOfDeath = Accidents(UnintentionalInjuries), Gender = Female",
-      "dcid": "dc/g/MortalityEvent_CauseOfDeath-Accidents(UnintentionalInjuries)_Gender-Female"
-    },
-    {
-      "name": "MortalityEvent By CauseOfDeath = Assault(Homicide), Gender = Female",
-      "dcid": "dc/g/MortalityEvent_CauseOfDeath-Assault(Homicide)_Gender-Female"
-    },
-    {
-      "name": "MortalityEvent By CauseOfDeath = DeathDueToAnotherPerson, Gender = Female",
-      "dcid": "dc/g/MortalityEvent_CauseOfDeath-DeathDueToAnotherPerson_Gender-Female"
-    },
-    {
       "name": "MortalityEvent By CauseOfDeath = ICD10/A00-B99, Gender = Female",
       "dcid": "dc/g/MortalityEvent_CauseOfDeath-ICD10/A00B99_Gender-Female"
     },
@@ -4375,32 +4235,8 @@
       "dcid": "dc/g/MortalityEvent_CauseOfDeath-ICD10/X60X84_Gender-Female"
     },
     {
-      "name": "MortalityEvent By CauseOfDeath = IllnessOrNaturalCause, Gender = Female",
-      "dcid": "dc/g/MortalityEvent_CauseOfDeath-IllnessOrNaturalCause_Gender-Female"
-    },
-    {
-      "name": "MortalityEvent By CauseOfDeath = IntentionalSelf-Harm(Suicide), Gender = Female",
-      "dcid": "dc/g/MortalityEvent_CauseOfDeath-IntentionalSelfHarm(Suicide)_Gender-Female"
-    },
-    {
-      "name": "MortalityEvent By CauseOfDeath = JudicialExecution, Gender = Female",
-      "dcid": "dc/g/MortalityEvent_CauseOfDeath-JudicialExecution_Gender-Female"
-    },
-    {
-      "name": "MortalityEvent By CauseOfDeath = NPSOtherCauseOfDeath, Gender = Female",
-      "dcid": "dc/g/MortalityEvent_CauseOfDeath-NPSOtherCauseOfDeath_Gender-Female"
-    },
-    {
       "name": "MortalityEvent By CauseOfDeath, Gender = Female",
       "dcid": "dc/g/MortalityEvent_CauseOfDeath_Gender-Female"
-    },
-    {
-      "name": "MortalityEvent By Gender = Female, Institutionalization",
-      "dcid": "dc/g/MortalityEvent_Gender-Female_Institutionalization"
-    },
-    {
-      "name": "MortalityEvent By Gender = Female, Institutionalization = Incarcerated",
-      "dcid": "dc/g/MortalityEvent_Gender-Female_Institutionalization-Incarcerated"
     },
     {
       "name": "MortalityEvent By Gender = Female, Race",
@@ -4423,44 +4259,12 @@
       "dcid": "dc/g/MortalityEvent_Gender-Female_Race-CDCWhite"
     },
     {
-      "name": "Person By Age = Years0, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years0_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years0To17, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years0To17_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years1, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years1_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years10, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years10_Gender-Female"
-    },
-    {
       "name": "Person By Age = Years10To14, Gender = Female",
       "dcid": "dc/g/Person_Age-Years10To14_Gender-Female"
     },
     {
-      "name": "Person By Age = Years11, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years11_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years12, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years12_Gender-Female"
-    },
-    {
       "name": "Person By Age = Years12To14, Gender = Female",
       "dcid": "dc/g/Person_Age-Years12To14_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years13, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years13_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years14, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years14_Gender-Female"
     },
     {
       "name": "Person By Age = Years15, Gender = Female",
@@ -4483,10 +4287,6 @@
       "dcid": "dc/g/Person_Age-Years15To64_Gender-Female"
     },
     {
-      "name": "Person By Age = Years16, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years16_Gender-Female"
-    },
-    {
       "name": "Person By Age = Years16Onwards, Gender = Female",
       "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female"
     },
@@ -4497,14 +4297,6 @@
     {
       "name": "Person By Age = Years16To19, Gender = Female",
       "dcid": "dc/g/Person_Age-Years16To19_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years17, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years17_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years18, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years18_Gender-Female"
     },
     {
       "name": "Person By Age = Years18Onwards, Gender = Female",
@@ -4527,16 +4319,8 @@
       "dcid": "dc/g/Person_Age-Years18To64_Gender-Female"
     },
     {
-      "name": "Person By Age = Years19, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years19_Gender-Female"
-    },
-    {
       "name": "Person By Age = Years19To25, Gender = Female",
       "dcid": "dc/g/Person_Age-Years19To25_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years2, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years2_Gender-Female"
     },
     {
       "name": "Person By Age = Years20, Gender = Female",
@@ -4559,28 +4343,8 @@
       "dcid": "dc/g/Person_Age-Years21To64_Gender-Female"
     },
     {
-      "name": "Person By Age = Years21To65, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years21To65_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years22, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years22_Gender-Female"
-    },
-    {
       "name": "Person By Age = Years22To24, Gender = Female",
       "dcid": "dc/g/Person_Age-Years22To24_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years23, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years23_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years24, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years24_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years25, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years25_Gender-Female"
     },
     {
       "name": "Person By Age = Years25Onwards, Gender = Female",
@@ -4595,64 +4359,16 @@
       "dcid": "dc/g/Person_Age-Years25To34_Gender-Female"
     },
     {
-      "name": "Person By Age = Years25To64, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years25To64_Gender-Female"
-    },
-    {
       "name": "Person By Age = Years25To74, Gender = Female",
       "dcid": "dc/g/Person_Age-Years25To74_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years26, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years26_Gender-Female"
     },
     {
       "name": "Person By Age = Years26To34, Gender = Female",
       "dcid": "dc/g/Person_Age-Years26To34_Gender-Female"
     },
     {
-      "name": "Person By Age = Years27, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years27_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years28, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years28_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years29, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years29_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years3, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years3_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years30, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years30_Gender-Female"
-    },
-    {
       "name": "Person By Age = Years30To34, Gender = Female",
       "dcid": "dc/g/Person_Age-Years30To34_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years31, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years31_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years32, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years32_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years33, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years33_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years34, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years34_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years35, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years35_Gender-Female"
     },
     {
       "name": "Person By Age = Years35Onwards, Gender = Female",
@@ -4671,22 +4387,6 @@
       "dcid": "dc/g/Person_Age-Years35To54_Gender-Female"
     },
     {
-      "name": "Person By Age = Years36, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years36_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years37, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years37_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years38, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years38_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years39, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years39_Gender-Female"
-    },
-    {
       "name": "Person By Age = Years3Onwards, Gender = Female",
       "dcid": "dc/g/Person_Age-Years3Onwards_Gender-Female"
     },
@@ -4695,40 +4395,12 @@
       "dcid": "dc/g/Person_Age-Years3To4_Gender-Female"
     },
     {
-      "name": "Person By Age = Years4, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years4_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years40, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years40_Gender-Female"
-    },
-    {
       "name": "Person By Age = Years40To44, Gender = Female",
       "dcid": "dc/g/Person_Age-Years40To44_Gender-Female"
     },
     {
       "name": "Person By Age = Years40To64, Gender = Female",
       "dcid": "dc/g/Person_Age-Years40To64_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years41, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years41_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years42, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years42_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years43, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years43_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years44, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years44_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years45, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years45_Gender-Female"
     },
     {
       "name": "Person By Age = Years45To49, Gender = Female",
@@ -4743,28 +4415,8 @@
       "dcid": "dc/g/Person_Age-Years45To64_Gender-Female"
     },
     {
-      "name": "Person By Age = Years46, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years46_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years47, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years47_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years48, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years48_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years49, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years49_Gender-Female"
-    },
-    {
       "name": "Person By Age = Years5, Gender = Female",
       "dcid": "dc/g/Person_Age-Years5_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years50, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years50_Gender-Female"
     },
     {
       "name": "Person By Age = Years50To54, Gender = Female",
@@ -4775,30 +4427,6 @@
       "dcid": "dc/g/Person_Age-Years50To64_Gender-Female"
     },
     {
-      "name": "Person By Age = Years50To74, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years50To74_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years51, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years51_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years52, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years52_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years53, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years53_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years54, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years54_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years55, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years55_Gender-Female"
-    },
-    {
       "name": "Person By Age = Years55To59, Gender = Female",
       "dcid": "dc/g/Person_Age-Years55To59_Gender-Female"
     },
@@ -4807,32 +4435,8 @@
       "dcid": "dc/g/Person_Age-Years55To64_Gender-Female"
     },
     {
-      "name": "Person By Age = Years56, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years56_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years57, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years57_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years58, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years58_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years59, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years59_Gender-Female"
-    },
-    {
       "name": "Person By Age = Years5To9, Gender = Female",
       "dcid": "dc/g/Person_Age-Years5To9_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years6, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years6_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years60, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years60_Gender-Female"
     },
     {
       "name": "Person By Age = Years60To61, Gender = Female",
@@ -4843,28 +4447,8 @@
       "dcid": "dc/g/Person_Age-Years60To64_Gender-Female"
     },
     {
-      "name": "Person By Age = Years61, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years61_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years62, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years62_Gender-Female"
-    },
-    {
       "name": "Person By Age = Years62To64, Gender = Female",
       "dcid": "dc/g/Person_Age-Years62To64_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years63, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years63_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years64, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years64_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years65, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years65_Gender-Female"
     },
     {
       "name": "Person By Age = Years65Onwards, Gender = Female",
@@ -4883,24 +4467,8 @@
       "dcid": "dc/g/Person_Age-Years65To74_Gender-Female"
     },
     {
-      "name": "Person By Age = Years66, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years66_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years67, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years67_Gender-Female"
-    },
-    {
       "name": "Person By Age = Years67To69, Gender = Female",
       "dcid": "dc/g/Person_Age-Years67To69_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years68, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years68_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years69, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years69_Gender-Female"
     },
     {
       "name": "Person By Age = Years6To11, Gender = Female",
@@ -4915,36 +4483,8 @@
       "dcid": "dc/g/Person_Age-Years6To18_Gender-Female"
     },
     {
-      "name": "Person By Age = Years7, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years7_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years70, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years70_Gender-Female"
-    },
-    {
       "name": "Person By Age = Years70To74, Gender = Female",
       "dcid": "dc/g/Person_Age-Years70To74_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years71, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years71_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years72, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years72_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years73, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years73_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years74, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years74_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years75, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years75_Gender-Female"
     },
     {
       "name": "Person By Age = Years75Onwards, Gender = Female",
@@ -4959,34 +4499,6 @@
       "dcid": "dc/g/Person_Age-Years75To84_Gender-Female"
     },
     {
-      "name": "Person By Age = Years76, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years76_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years77, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years77_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years78, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years78_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years79, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years79_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years7To14, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years7To14_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years8, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years8_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years80, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years80_Gender-Female"
-    },
-    {
       "name": "Person By Age = Years80Onwards, Gender = Female",
       "dcid": "dc/g/Person_Age-Years80Onwards_Gender-Female"
     },
@@ -4995,100 +4507,8 @@
       "dcid": "dc/g/Person_Age-Years80To84_Gender-Female"
     },
     {
-      "name": "Person By Age = Years81, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years81_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years82, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years82_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years83, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years83_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years84, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years84_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years85, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years85_Gender-Female"
-    },
-    {
       "name": "Person By Age = Years85Onwards, Gender = Female",
       "dcid": "dc/g/Person_Age-Years85Onwards_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years85To89, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years85To89_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years86, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years86_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years87, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years87_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years88, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years88_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years89, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years89_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years9, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years9_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years90, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years90_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years90Onwards, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years90Onwards_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years91, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years91_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years92, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years92_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years93, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years93_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years94, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years94_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years95, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years95_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years96, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years96_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years97, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years97_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years98, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years98_Gender-Female"
-    },
-    {
-      "name": "Person By Age = Years99, Gender = Female",
-      "dcid": "dc/g/Person_Age-Years99_Gender-Female"
-    },
-    {
-      "name": "Person By Age = YearsUpto1, Gender = Female",
-      "dcid": "dc/g/Person_Age-YearsUpto1_Gender-Female"
     },
     {
       "name": "Person By Age = YearsUpto14, Gender = Female",
@@ -5131,26 +4551,6 @@
       "dcid": "dc/g/Person_ArmedForcesStatus_Gender-Female"
     },
     {
-      "name": "Person By Citizenship = NotAUSCitizen, Gender = Female",
-      "dcid": "dc/g/Person_Citizenship-NotAUSCitizen_Gender-Female"
-    },
-    {
-      "name": "Person By Citizenship, Gender = Female",
-      "dcid": "dc/g/Person_Citizenship_Gender-Female"
-    },
-    {
-      "name": "Person By CitizenshipStatus = NotAUSCitizen, Gender = Female",
-      "dcid": "dc/g/Person_CitizenshipStatus-NotAUSCitizen_Gender-Female"
-    },
-    {
-      "name": "Person By CitizenshipStatus = USCitizenByNaturalization, Gender = Female",
-      "dcid": "dc/g/Person_CitizenshipStatus-USCitizenByNaturalization_Gender-Female"
-    },
-    {
-      "name": "Person By CitizenshipStatus, Gender = Female",
-      "dcid": "dc/g/Person_CitizenshipStatus_Gender-Female"
-    },
-    {
       "name": "Person By CollegeOrGraduateSchoolEnrollment = EnrolledInPrivateCollegeOrGraduateSchool, Gender = Female",
       "dcid": "dc/g/Person_CollegeOrGraduateSchoolEnrollment-EnrolledInPrivateCollegeOrGraduateSchool_Gender-Female"
     },
@@ -5165,54 +4565,6 @@
     {
       "name": "Person By CollegeOrGraduateSchoolEnrollment, Gender = Female",
       "dcid": "dc/g/Person_CollegeOrGraduateSchoolEnrollment_Gender-Female"
-    },
-    {
-      "name": "Person By CorrectionalFacilityLocation = InState, Gender = Female",
-      "dcid": "dc/g/Person_CorrectionalFacilityLocation-InState_Gender-Female"
-    },
-    {
-      "name": "Person By CorrectionalFacilityLocation = Local, Gender = Female",
-      "dcid": "dc/g/Person_CorrectionalFacilityLocation-Local_Gender-Female"
-    },
-    {
-      "name": "Person By CorrectionalFacilityLocation = OutOfState, Gender = Female",
-      "dcid": "dc/g/Person_CorrectionalFacilityLocation-OutOfState_Gender-Female"
-    },
-    {
-      "name": "Person By CorrectionalFacilityLocation, Gender = Female",
-      "dcid": "dc/g/Person_CorrectionalFacilityLocation_Gender-Female"
-    },
-    {
-      "name": "Person By CorrectionalFacilityOperator = FederallyOperated, Gender = Female",
-      "dcid": "dc/g/Person_CorrectionalFacilityOperator-FederallyOperated_Gender-Female"
-    },
-    {
-      "name": "Person By CorrectionalFacilityOperator = LocallyOperated, Gender = Female",
-      "dcid": "dc/g/Person_CorrectionalFacilityOperator-LocallyOperated_Gender-Female"
-    },
-    {
-      "name": "Person By CorrectionalFacilityOperator = PrivatelyOperated, Gender = Female",
-      "dcid": "dc/g/Person_CorrectionalFacilityOperator-PrivatelyOperated_Gender-Female"
-    },
-    {
-      "name": "Person By CorrectionalFacilityOperator = StateOperated\u0026FederallyOperated\u0026PrivatelyOperated, Gender = Female",
-      "dcid": "dc/g/Person_CorrectionalFacilityOperator-StateOperated\u0026FederallyOperated\u0026PrivatelyOperated_Gender-Female"
-    },
-    {
-      "name": "Person By CorrectionalFacilityOperator = StateOperated, Gender = Female",
-      "dcid": "dc/g/Person_CorrectionalFacilityOperator-StateOperated_Gender-Female"
-    },
-    {
-      "name": "Person By CorrectionalFacilityOperator, Gender = Female",
-      "dcid": "dc/g/Person_CorrectionalFacilityOperator_Gender-Female"
-    },
-    {
-      "name": "Person By EducationStatus = USC_BachelorDegreeOrHigher, Gender = Female",
-      "dcid": "dc/g/Person_EducationStatus-USCBachelorDegreeOrHigher_Gender-Female"
-    },
-    {
-      "name": "Person By EducationStatus, Gender = Female",
-      "dcid": "dc/g/Person_EducationStatus_Gender-Female"
     },
     {
       "name": "Person By EducationalAttainment = 10ThGrade, Gender = Female",
@@ -5279,14 +4631,6 @@
       "dcid": "dc/g/Person_EducationalAttainment-LessThanHighSchoolDiploma_Gender-Female"
     },
     {
-      "name": "Person By EducationalAttainment = LessThanHighSchoolGraduate, Gender = Female",
-      "dcid": "dc/g/Person_EducationalAttainment-LessThanHighSchoolGraduate_Gender-Female"
-    },
-    {
-      "name": "Person By EducationalAttainment = LessThanPrimaryEducation\u0026PrimaryEducation\u0026LowerSecondaryEducation, Gender = Female",
-      "dcid": "dc/g/Person_EducationalAttainment-LessThanPrimaryEducation\u0026PrimaryEducation\u0026LowerSecondaryEducation_Gender-Female"
-    },
-    {
       "name": "Person By EducationalAttainment = MastersDegree, Gender = Female",
       "dcid": "dc/g/Person_EducationalAttainment-MastersDegree_Gender-Female"
     },
@@ -5327,14 +4671,6 @@
       "dcid": "dc/g/Person_EducationalAttainment-TertiaryEducation_Gender-Female"
     },
     {
-      "name": "Person By EducationalAttainment = UpperSecondaryEducation\u0026PostSecondaryNonTertiaryEducation, Gender = Female",
-      "dcid": "dc/g/Person_EducationalAttainment-UpperSecondaryEducation\u0026PostSecondaryNonTertiaryEducation_Gender-Female"
-    },
-    {
-      "name": "Person By EducationalAttainment = UpperSecondaryEducationOrHigher, Gender = Female",
-      "dcid": "dc/g/Person_EducationalAttainment-UpperSecondaryEducationOrHigher_Gender-Female"
-    },
-    {
       "name": "Person By EducationalAttainment, Gender = Female",
       "dcid": "dc/g/Person_EducationalAttainment_Gender-Female"
     },
@@ -5347,16 +4683,8 @@
       "dcid": "dc/g/Person_Employment-BLSUnemployed_Gender-Female"
     },
     {
-      "name": "Person By Employment = Employed, Gender = Female",
-      "dcid": "dc/g/Person_Employment-Employed_Gender-Female"
-    },
-    {
       "name": "Person By Employment, Gender = Female",
       "dcid": "dc/g/Person_Employment_Gender-Female"
-    },
-    {
-      "name": "Person By EmploymentStatus = BLS_Employed, Gender = Female",
-      "dcid": "dc/g/Person_EmploymentStatus-BLSEmployed_Gender-Female"
     },
     {
       "name": "Person By EmploymentStatus = BLS_InLaborForce, Gender = Female",
@@ -5369,14 +4697,6 @@
     {
       "name": "Person By EmploymentStatus, Gender = Female",
       "dcid": "dc/g/Person_EmploymentStatus_Gender-Female"
-    },
-    {
-      "name": "Person By EnrollmentStatus = EnrolledInEducationOrTraining, Gender = Female",
-      "dcid": "dc/g/Person_EnrollmentStatus-EnrolledInEducationOrTraining_Gender-Female"
-    },
-    {
-      "name": "Person By EnrollmentStatus, Gender = Female",
-      "dcid": "dc/g/Person_EnrollmentStatus_Gender-Female"
     },
     {
       "name": "Person By FamilyIncome = RatioToPovertyLine1.38To4, Gender = Female",
@@ -5535,18 +4855,6 @@
       "dcid": "dc/g/Person_Gender-Female_HealthBehavior"
     },
     {
-      "name": "Person By Gender = Female, HealthBehavior = Obesity",
-      "dcid": "dc/g/Person_Gender-Female_HealthBehavior-Obesity"
-    },
-    {
-      "name": "Person By Gender = Female, HealthBehavior = Overweight",
-      "dcid": "dc/g/Person_Gender-Female_HealthBehavior-Overweight"
-    },
-    {
-      "name": "Person By Gender = Female, HealthBehavior = PhysicalInactivity",
-      "dcid": "dc/g/Person_Gender-Female_HealthBehavior-PhysicalInactivity"
-    },
-    {
       "name": "Person By Gender = Female, HealthBehavior = Smoking",
       "dcid": "dc/g/Person_Gender-Female_HealthBehavior-Smoking"
     },
@@ -5577,38 +4885,6 @@
     {
       "name": "Person By Gender = Female, HealthInsurance = WithPublicHealthInsurance",
       "dcid": "dc/g/Person_Gender-Female_HealthInsurance-WithPublicHealthInsurance"
-    },
-    {
-      "name": "Person By Gender = Female, HealthOutcome",
-      "dcid": "dc/g/Person_Gender-Female_HealthOutcome"
-    },
-    {
-      "name": "Person By Gender = Female, HealthOutcome = Diabetes",
-      "dcid": "dc/g/Person_Gender-Female_HealthOutcome-Diabetes"
-    },
-    {
-      "name": "Person By Gender = Female, HealthPrevention",
-      "dcid": "dc/g/Person_Gender-Female_HealthPrevention"
-    },
-    {
-      "name": "Person By Gender = Female, HealthPrevention = CorePreventiveServices",
-      "dcid": "dc/g/Person_Gender-Female_HealthPrevention-CorePreventiveServices"
-    },
-    {
-      "name": "Person By Gender = Female, HealthPrevention = Mammography",
-      "dcid": "dc/g/Person_Gender-Female_HealthPrevention-Mammography"
-    },
-    {
-      "name": "Person By Gender = Female, HealthPrevention = PapSmearTest",
-      "dcid": "dc/g/Person_Gender-Female_HealthPrevention-PapSmearTest"
-    },
-    {
-      "name": "Person By Gender = Female, HouseholdType",
-      "dcid": "dc/g/Person_Gender-Female_HouseholdType"
-    },
-    {
-      "name": "Person By Gender = Female, HouseholdType = Houseless",
-      "dcid": "dc/g/Person_Gender-Female_HouseholdType-Houseless"
     },
     {
       "name": "Person By Gender = Female, Income",
@@ -5703,20 +4979,12 @@
       "dcid": "dc/g/Person_Gender-Female_IncomeStatus-NoIncome"
     },
     {
-      "name": "Person By Gender = Female, IncomeStatus = WithEarnings",
-      "dcid": "dc/g/Person_Gender-Female_IncomeStatus-WithEarnings"
-    },
-    {
       "name": "Person By Gender = Female, IncomeStatus = WithIncome",
       "dcid": "dc/g/Person_Gender-Female_IncomeStatus-WithIncome"
     },
     {
       "name": "Person By Gender = Female, Institutionalization",
       "dcid": "dc/g/Person_Gender-Female_Institutionalization"
-    },
-    {
-      "name": "Person By Gender = Female, Institutionalization = Incarcerated",
-      "dcid": "dc/g/Person_Gender-Female_Institutionalization-Incarcerated"
     },
     {
       "name": "Person By Gender = Female, Institutionalization = USC_NonInstitutionalized",
@@ -5755,18 +5023,6 @@
       "dcid": "dc/g/Person_Gender-Female_LevelOfSchool-EnrolledInNurserySchoolPreschool"
     },
     {
-      "name": "Person By Gender = Female, LiteracyStatus",
-      "dcid": "dc/g/Person_Gender-Female_LiteracyStatus"
-    },
-    {
-      "name": "Person By Gender = Female, LiteracyStatus = Illiterate",
-      "dcid": "dc/g/Person_Gender-Female_LiteracyStatus-Illiterate"
-    },
-    {
-      "name": "Person By Gender = Female, LiteracyStatus = Literate",
-      "dcid": "dc/g/Person_Gender-Female_LiteracyStatus-Literate"
-    },
-    {
       "name": "Person By Gender = Female, MaritalStatus",
       "dcid": "dc/g/Person_Gender-Female_MaritalStatus"
     },
@@ -5793,30 +5049,6 @@
     {
       "name": "Person By Gender = Female, MaritalStatus = Widowed",
       "dcid": "dc/g/Person_Gender-Female_MaritalStatus-Widowed"
-    },
-    {
-      "name": "Person By Gender = Female, MaxPrisonSentence",
-      "dcid": "dc/g/Person_Gender-Female_MaxPrisonSentence"
-    },
-    {
-      "name": "Person By Gender = Female, MaxPrisonSentence = Years2Onwards",
-      "dcid": "dc/g/Person_Gender-Female_MaxPrisonSentence-Years2Onwards"
-    },
-    {
-      "name": "Person By Gender = Female, MaxPrisonSentence = YearsUpto1",
-      "dcid": "dc/g/Person_Gender-Female_MaxPrisonSentence-YearsUpto1"
-    },
-    {
-      "name": "Person By Gender = Female, MedicalCondition",
-      "dcid": "dc/g/Person_Gender-Female_MedicalCondition"
-    },
-    {
-      "name": "Person By Gender = Female, MedicalCondition = SevereWasting",
-      "dcid": "dc/g/Person_Gender-Female_MedicalCondition-SevereWasting"
-    },
-    {
-      "name": "Person By Gender = Female, MedicalCondition = Wasting",
-      "dcid": "dc/g/Person_Gender-Female_MedicalCondition-Wasting"
     },
     {
       "name": "Person By Gender = Female, Naics",
@@ -5903,30 +5135,6 @@
       "dcid": "dc/g/Person_Gender-Female_Naics-NAICS/92"
     },
     {
-      "name": "Person By Gender = Female, Nativity",
-      "dcid": "dc/g/Person_Gender-Female_Nativity"
-    },
-    {
-      "name": "Person By Gender = Female, Nativity = USC_ForeignBorn",
-      "dcid": "dc/g/Person_Gender-Female_Nativity-USCForeignBorn"
-    },
-    {
-      "name": "Person By Gender = Female, Nativity = USC_Native",
-      "dcid": "dc/g/Person_Gender-Female_Nativity-USCNative"
-    },
-    {
-      "name": "Person By Gender = Female, PlaceOfResidenceClassification",
-      "dcid": "dc/g/Person_Gender-Female_PlaceOfResidenceClassification"
-    },
-    {
-      "name": "Person By Gender = Female, PlaceOfResidenceClassification = Rural",
-      "dcid": "dc/g/Person_Gender-Female_PlaceOfResidenceClassification-Rural"
-    },
-    {
-      "name": "Person By Gender = Female, PlaceOfResidenceClassification = Urban",
-      "dcid": "dc/g/Person_Gender-Female_PlaceOfResidenceClassification-Urban"
-    },
-    {
       "name": "Person By Gender = Female, PovertyStatus",
       "dcid": "dc/g/Person_Gender-Female_PovertyStatus"
     },
@@ -5937,22 +5145,6 @@
     {
       "name": "Person By Gender = Female, PovertyStatus = BelowPovertyLevelInThePast12Months",
       "dcid": "dc/g/Person_Gender-Female_PovertyStatus-BelowPovertyLevelInThePast12Months"
-    },
-    {
-      "name": "Person By Gender = Female, PovertyStatus = USC_IncomeInThePast12MonthsBelowPovertyLevel",
-      "dcid": "dc/g/Person_Gender-Female_PovertyStatus-USCIncomeInThePast12MonthsBelowPovertyLevel"
-    },
-    {
-      "name": "Person By Gender = Female, PrisonSentenceStatus",
-      "dcid": "dc/g/Person_Gender-Female_PrisonSentenceStatus"
-    },
-    {
-      "name": "Person By Gender = Female, PrisonSentenceStatus = Sentenced",
-      "dcid": "dc/g/Person_Gender-Female_PrisonSentenceStatus-Sentenced"
-    },
-    {
-      "name": "Person By Gender = Female, PrisonSentenceStatus = Unsentenced",
-      "dcid": "dc/g/Person_Gender-Female_PrisonSentenceStatus-Unsentenced"
     },
     {
       "name": "Person By Gender = Female, Race",
@@ -6015,18 +5207,6 @@
       "dcid": "dc/g/Person_Gender-Female_SchoolEnrollment-NotEnrolledInSchool"
     },
     {
-      "name": "Person By Gender = Female, SocialCategory",
-      "dcid": "dc/g/Person_Gender-Female_SocialCategory"
-    },
-    {
-      "name": "Person By Gender = Female, SocialCategory = ScheduledCaste",
-      "dcid": "dc/g/Person_Gender-Female_SocialCategory-ScheduledCaste"
-    },
-    {
-      "name": "Person By Gender = Female, SocialCategory = ScheduledTribe",
-      "dcid": "dc/g/Person_Gender-Female_SocialCategory-ScheduledTribe"
-    },
-    {
       "name": "Person By Gender = Female, SpouseAbsentReason",
       "dcid": "dc/g/Person_Gender-Female_SpouseAbsentReason"
     },
@@ -6075,26 +5255,6 @@
       "dcid": "dc/g/Person_Gender-Female_VeteranStatus-Veteran"
     },
     {
-      "name": "Person By Gender = Female, WorkCategory",
-      "dcid": "dc/g/Person_Gender-Female_WorkCategory"
-    },
-    {
-      "name": "Person By Gender = Female, WorkCategory = AgriculturalLabourers",
-      "dcid": "dc/g/Person_Gender-Female_WorkCategory-AgriculturalLabourers"
-    },
-    {
-      "name": "Person By Gender = Female, WorkCategory = Cultivators",
-      "dcid": "dc/g/Person_Gender-Female_WorkCategory-Cultivators"
-    },
-    {
-      "name": "Person By Gender = Female, WorkCategory = HouseholdIndustries",
-      "dcid": "dc/g/Person_Gender-Female_WorkCategory-HouseholdIndustries"
-    },
-    {
-      "name": "Person By Gender = Female, WorkCategory = OtherWorkers",
-      "dcid": "dc/g/Person_Gender-Female_WorkCategory-OtherWorkers"
-    },
-    {
       "name": "Person By Gender = Female, WorkExperience",
       "dcid": "dc/g/Person_Gender-Female_WorkExperience"
     },
@@ -6105,414 +5265,6 @@
     {
       "name": "Person By Gender = Female, WorkExperience = USC_WorkedFullTime",
       "dcid": "dc/g/Person_Gender-Female_WorkExperience-USCWorkedFullTime"
-    },
-    {
-      "name": "Person By Gender = Female, WorkPeriod",
-      "dcid": "dc/g/Person_Gender-Female_WorkPeriod"
-    },
-    {
-      "name": "Person By Gender = Female, WorkPeriod = Month3To6",
-      "dcid": "dc/g/Person_Gender-Female_WorkPeriod-Month3To6"
-    },
-    {
-      "name": "Person By Gender = Female, WorkPeriod = MonthUpto3",
-      "dcid": "dc/g/Person_Gender-Female_WorkPeriod-MonthUpto3"
-    },
-    {
-      "name": "Person By Gender = Female, WorkStatus",
-      "dcid": "dc/g/Person_Gender-Female_WorkStatus"
-    },
-    {
-      "name": "Person By Gender = Female, WorkStatus = USC_FullTimeYearRoundWorker",
-      "dcid": "dc/g/Person_Gender-Female_WorkStatus-USCFullTimeYearRoundWorker"
-    },
-    {
-      "name": "Person By Gender = Female, WorkerClassification",
-      "dcid": "dc/g/Person_Gender-Female_WorkerClassification"
-    },
-    {
-      "name": "Person By Gender = Female, WorkerClassification = MainWorker",
-      "dcid": "dc/g/Person_Gender-Female_WorkerClassification-MainWorker"
-    },
-    {
-      "name": "Person By Gender = Female, WorkerClassification = MarginalWorker",
-      "dcid": "dc/g/Person_Gender-Female_WorkerClassification-MarginalWorker"
-    },
-    {
-      "name": "Person By Gender = Female, WorkerStatus",
-      "dcid": "dc/g/Person_Gender-Female_WorkerStatus"
-    },
-    {
-      "name": "Person By Gender = Female, WorkerStatus = NonWorker",
-      "dcid": "dc/g/Person_Gender-Female_WorkerStatus-NonWorker"
-    },
-    {
-      "name": "Person By Gender = Female, WorkerStatus = Worker",
-      "dcid": "dc/g/Person_Gender-Female_WorkerStatus-Worker"
-    },
-    {
-      "name": "Student By Gender = Female, Race",
-      "dcid": "dc/g/Student_Gender-Female_Race"
-    },
-    {
-      "name": "Student By Gender = Female, Race = AmericanIndianOrAlaskaNative",
-      "dcid": "dc/g/Student_Gender-Female_Race-AmericanIndianOrAlaskaNative"
-    },
-    {
-      "name": "Student By Gender = Female, Race = Asian",
-      "dcid": "dc/g/Student_Gender-Female_Race-Asian"
-    },
-    {
-      "name": "Student By Gender = Female, Race = Black",
-      "dcid": "dc/g/Student_Gender-Female_Race-Black"
-    },
-    {
-      "name": "Student By Gender = Female, Race = HawaiianNativeOrPacificIslander",
-      "dcid": "dc/g/Student_Gender-Female_Race-HawaiianNativeOrPacificIslander"
-    },
-    {
-      "name": "Student By Gender = Female, Race = HispanicOrLatino",
-      "dcid": "dc/g/Student_Gender-Female_Race-HispanicOrLatino"
-    },
-    {
-      "name": "Student By Gender = Female, Race = TwoOrMoreRaces",
-      "dcid": "dc/g/Student_Gender-Female_Race-TwoOrMoreRaces"
-    },
-    {
-      "name": "Student By Gender = Female, Race = White",
-      "dcid": "dc/g/Student_Gender-Female_Race-White"
-    },
-    {
-      "name": "Student By Gender = Female, SchoolGradeLevel",
-      "dcid": "dc/g/Student_Gender-Female_SchoolGradeLevel"
-    },
-    {
-      "name": "Student By Gender = Female, SchoolGradeLevel = HighSchool",
-      "dcid": "dc/g/Student_Gender-Female_SchoolGradeLevel-HighSchool"
-    },
-    {
-      "name": "Student By Gender = Female, SchoolGradeLevel = Kindergarten",
-      "dcid": "dc/g/Student_Gender-Female_SchoolGradeLevel-Kindergarten"
-    },
-    {
-      "name": "Student By Gender = Female, SchoolGradeLevel = MiddleSchool",
-      "dcid": "dc/g/Student_Gender-Female_SchoolGradeLevel-MiddleSchool"
-    },
-    {
-      "name": "Student By Gender = Female, SchoolGradeLevel = NCESEighthGrade",
-      "dcid": "dc/g/Student_Gender-Female_SchoolGradeLevel-NCESEighthGrade"
-    },
-    {
-      "name": "Student By Gender = Female, SchoolGradeLevel = NCESFifthGrade",
-      "dcid": "dc/g/Student_Gender-Female_SchoolGradeLevel-NCESFifthGrade"
-    },
-    {
-      "name": "Student By Gender = Female, SchoolGradeLevel = NCESFourthGrade",
-      "dcid": "dc/g/Student_Gender-Female_SchoolGradeLevel-NCESFourthGrade"
-    },
-    {
-      "name": "Student By Gender = Female, SchoolGradeLevel = NCESSeventhGrade",
-      "dcid": "dc/g/Student_Gender-Female_SchoolGradeLevel-NCESSeventhGrade"
-    },
-    {
-      "name": "Student By Gender = Female, SchoolGradeLevel = NCESSixthGrade",
-      "dcid": "dc/g/Student_Gender-Female_SchoolGradeLevel-NCESSixthGrade"
-    },
-    {
-      "name": "Student By Gender = Female, SchoolGradeLevel = NCESThirdGrade",
-      "dcid": "dc/g/Student_Gender-Female_SchoolGradeLevel-NCESThirdGrade"
-    },
-    {
-      "name": "Student By Gender = Female, SchoolGradeLevel = NCESUngradedClasses",
-      "dcid": "dc/g/Student_Gender-Female_SchoolGradeLevel-NCESUngradedClasses"
-    },
-    {
-      "name": "Student By Gender = Female, SchoolGradeLevel = PreKindergarten",
-      "dcid": "dc/g/Student_Gender-Female_SchoolGradeLevel-PreKindergarten"
-    },
-    {
-      "name": "Student By Gender = Female, SchoolGradeLevel = PrimarySchool",
-      "dcid": "dc/g/Student_Gender-Female_SchoolGradeLevel-PrimarySchool"
-    },
-    {
-      "name": "Student By Gender = Female, SchoolGradeLevel = SchoolGrade1",
-      "dcid": "dc/g/Student_Gender-Female_SchoolGradeLevel-SchoolGrade1"
-    },
-    {
-      "name": "Student By Gender = Female, SchoolGradeLevel = SchoolGrade10",
-      "dcid": "dc/g/Student_Gender-Female_SchoolGradeLevel-SchoolGrade10"
-    },
-    {
-      "name": "Student By Gender = Female, SchoolGradeLevel = SchoolGrade11",
-      "dcid": "dc/g/Student_Gender-Female_SchoolGradeLevel-SchoolGrade11"
-    },
-    {
-      "name": "Student By Gender = Female, SchoolGradeLevel = SchoolGrade12",
-      "dcid": "dc/g/Student_Gender-Female_SchoolGradeLevel-SchoolGrade12"
-    },
-    {
-      "name": "Student By Gender = Female, SchoolGradeLevel = SchoolGrade2",
-      "dcid": "dc/g/Student_Gender-Female_SchoolGradeLevel-SchoolGrade2"
-    },
-    {
-      "name": "Student By Gender = Female, SchoolGradeLevel = SchoolGrade3",
-      "dcid": "dc/g/Student_Gender-Female_SchoolGradeLevel-SchoolGrade3"
-    },
-    {
-      "name": "Student By Gender = Female, SchoolGradeLevel = SchoolGrade4",
-      "dcid": "dc/g/Student_Gender-Female_SchoolGradeLevel-SchoolGrade4"
-    },
-    {
-      "name": "Student By Gender = Female, SchoolGradeLevel = SchoolGrade5",
-      "dcid": "dc/g/Student_Gender-Female_SchoolGradeLevel-SchoolGrade5"
-    },
-    {
-      "name": "Student By Gender = Female, SchoolGradeLevel = SchoolGrade6",
-      "dcid": "dc/g/Student_Gender-Female_SchoolGradeLevel-SchoolGrade6"
-    },
-    {
-      "name": "Student By Gender = Female, SchoolGradeLevel = SchoolGrade7",
-      "dcid": "dc/g/Student_Gender-Female_SchoolGradeLevel-SchoolGrade7"
-    },
-    {
-      "name": "Student By Gender = Female, SchoolGradeLevel = SchoolGrade8",
-      "dcid": "dc/g/Student_Gender-Female_SchoolGradeLevel-SchoolGrade8"
-    },
-    {
-      "name": "Student By Gender = Female, SchoolGradeLevel = SchoolGrade9",
-      "dcid": "dc/g/Student_Gender-Female_SchoolGradeLevel-SchoolGrade9"
-    },
-    {
-      "name": "Student By Gender = Female, SchoolSubject",
-      "dcid": "dc/g/Student_Gender-Female_SchoolSubject"
-    },
-    {
-      "name": "Student By Gender = Female, SchoolSubject = EnglishLanguageArts",
-      "dcid": "dc/g/Student_Gender-Female_SchoolSubject-EnglishLanguageArts"
-    },
-    {
-      "name": "Student By Gender = Female, SchoolSubject = Mathematics",
-      "dcid": "dc/g/Student_Gender-Female_SchoolSubject-Mathematics"
-    },
-    {
-      "name": "Household By ChildrenInHousehold = HasChildren, HouseholderGender = Female, Race",
-      "dcid": "dc/g/Household_ChildrenInHousehold-HasChildren_HouseholderGender-Female_Race"
-    },
-    {
-      "name": "Household By ChildrenInHousehold = HasChildren, HouseholderGender = Female, Race = USC_BlackOrAfricanAmericanAlone",
-      "dcid": "dc/g/Household_ChildrenInHousehold-HasChildren_HouseholderGender-Female_Race-USCBlackOrAfricanAmericanAlone"
-    },
-    {
-      "name": "Household By ChildrenInHousehold = HasChildren, HouseholderGender = Female, Race = USC_HispanicOrLatinoRace",
-      "dcid": "dc/g/Household_ChildrenInHousehold-HasChildren_HouseholderGender-Female_Race-USCHispanicOrLatinoRace"
-    },
-    {
-      "name": "Household By ChildrenInHousehold = HasChildren, HouseholderGender = Female, Race = USC_WhiteAloneNotHispanicOrLatino",
-      "dcid": "dc/g/Household_ChildrenInHousehold-HasChildren_HouseholderGender-Female_Race-USCWhiteAloneNotHispanicOrLatino"
-    },
-    {
-      "name": "Household By ChildrenInHousehold, HouseholderGender = Female, Race = USC_BlackOrAfricanAmericanAlone",
-      "dcid": "dc/g/Household_ChildrenInHousehold_HouseholderGender-Female_Race-USCBlackOrAfricanAmericanAlone"
-    },
-    {
-      "name": "Household By ChildrenInHousehold, HouseholderGender = Female, Race = USC_HispanicOrLatinoRace",
-      "dcid": "dc/g/Household_ChildrenInHousehold_HouseholderGender-Female_Race-USCHispanicOrLatinoRace"
-    },
-    {
-      "name": "Household By ChildrenInHousehold, HouseholderGender = Female, Race = USC_WhiteAloneNotHispanicOrLatino",
-      "dcid": "dc/g/Household_ChildrenInHousehold_HouseholderGender-Female_Race-USCWhiteAloneNotHispanicOrLatino"
-    },
-    {
-      "name": "IncarcerationEvent By EventType = AdmittedToPrison, Gender = Female, Institutionalization",
-      "dcid": "dc/g/IncarcerationEvent_EventType-AdmittedToPrison_Gender-Female_Institutionalization"
-    },
-    {
-      "name": "IncarcerationEvent By EventType = AdmittedToPrison, Gender = Female, Institutionalization = Incarcerated",
-      "dcid": "dc/g/IncarcerationEvent_EventType-AdmittedToPrison_Gender-Female_Institutionalization-Incarcerated"
-    },
-    {
-      "name": "IncarcerationEvent By EventType = AdmittedToPrison, Gender = Female, MaxPrisonSentence",
-      "dcid": "dc/g/IncarcerationEvent_EventType-AdmittedToPrison_Gender-Female_MaxPrisonSentence"
-    },
-    {
-      "name": "IncarcerationEvent By EventType = AdmittedToPrison, Gender = Female, MaxPrisonSentence = Years2Onwards",
-      "dcid": "dc/g/IncarcerationEvent_EventType-AdmittedToPrison_Gender-Female_MaxPrisonSentence-Years2Onwards"
-    },
-    {
-      "name": "IncarcerationEvent By EventType = AdmittedToPrison, Gender = Female, PrisonSentenceStatus",
-      "dcid": "dc/g/IncarcerationEvent_EventType-AdmittedToPrison_Gender-Female_PrisonSentenceStatus"
-    },
-    {
-      "name": "IncarcerationEvent By EventType = AdmittedToPrison, Gender = Female, PrisonSentenceStatus = Sentenced",
-      "dcid": "dc/g/IncarcerationEvent_EventType-AdmittedToPrison_Gender-Female_PrisonSentenceStatus-Sentenced"
-    },
-    {
-      "name": "IncarcerationEvent By EventType = ReleasedFromPrison, Gender = Female, Institutionalization",
-      "dcid": "dc/g/IncarcerationEvent_EventType-ReleasedFromPrison_Gender-Female_Institutionalization"
-    },
-    {
-      "name": "IncarcerationEvent By EventType = ReleasedFromPrison, Gender = Female, Institutionalization = Incarcerated",
-      "dcid": "dc/g/IncarcerationEvent_EventType-ReleasedFromPrison_Gender-Female_Institutionalization-Incarcerated"
-    },
-    {
-      "name": "IncarcerationEvent By EventType = ReleasedFromPrison, Gender = Female, MaxPrisonSentence",
-      "dcid": "dc/g/IncarcerationEvent_EventType-ReleasedFromPrison_Gender-Female_MaxPrisonSentence"
-    },
-    {
-      "name": "IncarcerationEvent By EventType = ReleasedFromPrison, Gender = Female, MaxPrisonSentence = Years2Onwards",
-      "dcid": "dc/g/IncarcerationEvent_EventType-ReleasedFromPrison_Gender-Female_MaxPrisonSentence-Years2Onwards"
-    },
-    {
-      "name": "IncarcerationEvent By EventType = ReleasedFromPrison, Gender = Female, PrisonSentenceStatus",
-      "dcid": "dc/g/IncarcerationEvent_EventType-ReleasedFromPrison_Gender-Female_PrisonSentenceStatus"
-    },
-    {
-      "name": "IncarcerationEvent By EventType = ReleasedFromPrison, Gender = Female, PrisonSentenceStatus = Sentenced",
-      "dcid": "dc/g/IncarcerationEvent_EventType-ReleasedFromPrison_Gender-Female_PrisonSentenceStatus-Sentenced"
-    },
-    {
-      "name": "IncarcerationEvent By EventType, Gender = Female, Institutionalization = Incarcerated",
-      "dcid": "dc/g/IncarcerationEvent_EventType_Gender-Female_Institutionalization-Incarcerated"
-    },
-    {
-      "name": "IncarcerationEvent By EventType, Gender = Female, MaxPrisonSentence = Years2Onwards",
-      "dcid": "dc/g/IncarcerationEvent_EventType_Gender-Female_MaxPrisonSentence-Years2Onwards"
-    },
-    {
-      "name": "IncarcerationEvent By EventType, Gender = Female, PrisonSentenceStatus = Sentenced",
-      "dcid": "dc/g/IncarcerationEvent_EventType_Gender-Female_PrisonSentenceStatus-Sentenced"
-    },
-    {
-      "name": "IncarcerationEvent By Gender = Female, Institutionalization = Incarcerated, MaxPrisonSentence",
-      "dcid": "dc/g/IncarcerationEvent_Gender-Female_Institutionalization-Incarcerated_MaxPrisonSentence"
-    },
-    {
-      "name": "IncarcerationEvent By Gender = Female, Institutionalization = Incarcerated, MaxPrisonSentence = Years2Onwards",
-      "dcid": "dc/g/IncarcerationEvent_Gender-Female_Institutionalization-Incarcerated_MaxPrisonSentence-Years2Onwards"
-    },
-    {
-      "name": "IncarcerationEvent By Gender = Female, Institutionalization = Incarcerated, PrisonSentenceStatus",
-      "dcid": "dc/g/IncarcerationEvent_Gender-Female_Institutionalization-Incarcerated_PrisonSentenceStatus"
-    },
-    {
-      "name": "IncarcerationEvent By Gender = Female, Institutionalization = Incarcerated, PrisonSentenceStatus = Sentenced",
-      "dcid": "dc/g/IncarcerationEvent_Gender-Female_Institutionalization-Incarcerated_PrisonSentenceStatus-Sentenced"
-    },
-    {
-      "name": "IncarcerationEvent By Gender = Female, Institutionalization, MaxPrisonSentence = Years2Onwards",
-      "dcid": "dc/g/IncarcerationEvent_Gender-Female_Institutionalization_MaxPrisonSentence-Years2Onwards"
-    },
-    {
-      "name": "IncarcerationEvent By Gender = Female, Institutionalization, PrisonSentenceStatus = Sentenced",
-      "dcid": "dc/g/IncarcerationEvent_Gender-Female_Institutionalization_PrisonSentenceStatus-Sentenced"
-    },
-    {
-      "name": "IncarcerationEvent By Gender = Female, MaxPrisonSentence = Years2Onwards, PrisonSentenceStatus",
-      "dcid": "dc/g/IncarcerationEvent_Gender-Female_MaxPrisonSentence-Years2Onwards_PrisonSentenceStatus"
-    },
-    {
-      "name": "IncarcerationEvent By Gender = Female, MaxPrisonSentence = Years2Onwards, PrisonSentenceStatus = Sentenced",
-      "dcid": "dc/g/IncarcerationEvent_Gender-Female_MaxPrisonSentence-Years2Onwards_PrisonSentenceStatus-Sentenced"
-    },
-    {
-      "name": "IncarcerationEvent By Gender = Female, MaxPrisonSentence, PrisonSentenceStatus = Sentenced",
-      "dcid": "dc/g/IncarcerationEvent_Gender-Female_MaxPrisonSentence_PrisonSentenceStatus-Sentenced"
-    },
-    {
-      "name": "MedicareEnrollee By Age = Years67To69, Gender = Female, HealthPreventionEnum",
-      "dcid": "dc/g/MedicareEnrollee_Age-Years67To69_Gender-Female_HealthPreventionEnum"
-    },
-    {
-      "name": "MedicareEnrollee By Age = Years67To69, Gender = Female, HealthPreventionEnum = Mammography",
-      "dcid": "dc/g/MedicareEnrollee_Age-Years67To69_Gender-Female_HealthPreventionEnum-Mammography"
-    },
-    {
-      "name": "MedicareEnrollee By Age = Years67To69, Gender = Female, MedicareType",
-      "dcid": "dc/g/MedicareEnrollee_Age-Years67To69_Gender-Female_MedicareType"
-    },
-    {
-      "name": "MedicareEnrollee By Age = Years67To69, Gender = Female, MedicareType = MedicareB",
-      "dcid": "dc/g/MedicareEnrollee_Age-Years67To69_Gender-Female_MedicareType-MedicareB"
-    },
-    {
-      "name": "MedicareEnrollee By Age = Years67To69, Gender = Female, Race",
-      "dcid": "dc/g/MedicareEnrollee_Age-Years67To69_Gender-Female_Race"
-    },
-    {
-      "name": "MedicareEnrollee By Age = Years67To69, Gender = Female, Race = DAD_Black",
-      "dcid": "dc/g/MedicareEnrollee_Age-Years67To69_Gender-Female_Race-DADBlack"
-    },
-    {
-      "name": "MedicareEnrollee By Age = Years67To69, Gender = Female, Race = DAD_NonBlack",
-      "dcid": "dc/g/MedicareEnrollee_Age-Years67To69_Gender-Female_Race-DADNonBlack"
-    },
-    {
-      "name": "MedicareEnrollee By Age, Gender = Female, HealthPreventionEnum = Mammography",
-      "dcid": "dc/g/MedicareEnrollee_Age_Gender-Female_HealthPreventionEnum-Mammography"
-    },
-    {
-      "name": "MedicareEnrollee By Age, Gender = Female, MedicareType = MedicareB",
-      "dcid": "dc/g/MedicareEnrollee_Age_Gender-Female_MedicareType-MedicareB"
-    },
-    {
-      "name": "MedicareEnrollee By Age, Gender = Female, Race = DAD_Black",
-      "dcid": "dc/g/MedicareEnrollee_Age_Gender-Female_Race-DADBlack"
-    },
-    {
-      "name": "MedicareEnrollee By Age, Gender = Female, Race = DAD_NonBlack",
-      "dcid": "dc/g/MedicareEnrollee_Age_Gender-Female_Race-DADNonBlack"
-    },
-    {
-      "name": "MedicareEnrollee By Gender = Female, HealthPreventionEnum = Mammography, MedicareType",
-      "dcid": "dc/g/MedicareEnrollee_Gender-Female_HealthPreventionEnum-Mammography_MedicareType"
-    },
-    {
-      "name": "MedicareEnrollee By Gender = Female, HealthPreventionEnum = Mammography, MedicareType = MedicareB",
-      "dcid": "dc/g/MedicareEnrollee_Gender-Female_HealthPreventionEnum-Mammography_MedicareType-MedicareB"
-    },
-    {
-      "name": "MedicareEnrollee By Gender = Female, HealthPreventionEnum = Mammography, Race",
-      "dcid": "dc/g/MedicareEnrollee_Gender-Female_HealthPreventionEnum-Mammography_Race"
-    },
-    {
-      "name": "MedicareEnrollee By Gender = Female, HealthPreventionEnum = Mammography, Race = DAD_Black",
-      "dcid": "dc/g/MedicareEnrollee_Gender-Female_HealthPreventionEnum-Mammography_Race-DADBlack"
-    },
-    {
-      "name": "MedicareEnrollee By Gender = Female, HealthPreventionEnum = Mammography, Race = DAD_NonBlack",
-      "dcid": "dc/g/MedicareEnrollee_Gender-Female_HealthPreventionEnum-Mammography_Race-DADNonBlack"
-    },
-    {
-      "name": "MedicareEnrollee By Gender = Female, HealthPreventionEnum, MedicareType = MedicareB",
-      "dcid": "dc/g/MedicareEnrollee_Gender-Female_HealthPreventionEnum_MedicareType-MedicareB"
-    },
-    {
-      "name": "MedicareEnrollee By Gender = Female, HealthPreventionEnum, Race = DAD_Black",
-      "dcid": "dc/g/MedicareEnrollee_Gender-Female_HealthPreventionEnum_Race-DADBlack"
-    },
-    {
-      "name": "MedicareEnrollee By Gender = Female, HealthPreventionEnum, Race = DAD_NonBlack",
-      "dcid": "dc/g/MedicareEnrollee_Gender-Female_HealthPreventionEnum_Race-DADNonBlack"
-    },
-    {
-      "name": "MedicareEnrollee By Gender = Female, MedicareType = MedicareB, Race",
-      "dcid": "dc/g/MedicareEnrollee_Gender-Female_MedicareType-MedicareB_Race"
-    },
-    {
-      "name": "MedicareEnrollee By Gender = Female, MedicareType = MedicareB, Race = DAD_Black",
-      "dcid": "dc/g/MedicareEnrollee_Gender-Female_MedicareType-MedicareB_Race-DADBlack"
-    },
-    {
-      "name": "MedicareEnrollee By Gender = Female, MedicareType = MedicareB, Race = DAD_NonBlack",
-      "dcid": "dc/g/MedicareEnrollee_Gender-Female_MedicareType-MedicareB_Race-DADNonBlack"
-    },
-    {
-      "name": "MedicareEnrollee By Gender = Female, MedicareType, Race = DAD_Black",
-      "dcid": "dc/g/MedicareEnrollee_Gender-Female_MedicareType_Race-DADBlack"
-    },
-    {
-      "name": "MedicareEnrollee By Gender = Female, MedicareType, Race = DAD_NonBlack",
-      "dcid": "dc/g/MedicareEnrollee_Gender-Female_MedicareType_Race-DADNonBlack"
     },
     {
       "name": "MortalityEvent By Age = USC_AgeNotStated, CauseOfDeath = ICD10/R00-R99, Gender = Female",
@@ -7403,38 +6155,6 @@
       "dcid": "dc/g/MortalityEvent_Age_Gender-Female_Race-CDCWhite"
     },
     {
-      "name": "MortalityEvent By CauseOfDeath = AIDS, Gender = Female, Institutionalization",
-      "dcid": "dc/g/MortalityEvent_CauseOfDeath-AIDS_Gender-Female_Institutionalization"
-    },
-    {
-      "name": "MortalityEvent By CauseOfDeath = AIDS, Gender = Female, Institutionalization = Incarcerated",
-      "dcid": "dc/g/MortalityEvent_CauseOfDeath-AIDS_Gender-Female_Institutionalization-Incarcerated"
-    },
-    {
-      "name": "MortalityEvent By CauseOfDeath = Accidents(UnintentionalInjuries), Gender = Female, Institutionalization",
-      "dcid": "dc/g/MortalityEvent_CauseOfDeath-Accidents(UnintentionalInjuries)_Gender-Female_Institutionalization"
-    },
-    {
-      "name": "MortalityEvent By CauseOfDeath = Accidents(UnintentionalInjuries), Gender = Female, Institutionalization = Incarcerated",
-      "dcid": "dc/g/MortalityEvent_CauseOfDeath-Accidents(UnintentionalInjuries)_Gender-Female_Institutionalization-Incarcerated"
-    },
-    {
-      "name": "MortalityEvent By CauseOfDeath = Assault(Homicide), Gender = Female, Institutionalization",
-      "dcid": "dc/g/MortalityEvent_CauseOfDeath-Assault(Homicide)_Gender-Female_Institutionalization"
-    },
-    {
-      "name": "MortalityEvent By CauseOfDeath = Assault(Homicide), Gender = Female, Institutionalization = Incarcerated",
-      "dcid": "dc/g/MortalityEvent_CauseOfDeath-Assault(Homicide)_Gender-Female_Institutionalization-Incarcerated"
-    },
-    {
-      "name": "MortalityEvent By CauseOfDeath = DeathDueToAnotherPerson, Gender = Female, Institutionalization",
-      "dcid": "dc/g/MortalityEvent_CauseOfDeath-DeathDueToAnotherPerson_Gender-Female_Institutionalization"
-    },
-    {
-      "name": "MortalityEvent By CauseOfDeath = DeathDueToAnotherPerson, Gender = Female, Institutionalization = Incarcerated",
-      "dcid": "dc/g/MortalityEvent_CauseOfDeath-DeathDueToAnotherPerson_Gender-Female_Institutionalization-Incarcerated"
-    },
-    {
       "name": "MortalityEvent By CauseOfDeath = ICD10/A00-B99, Gender = Female, Race",
       "dcid": "dc/g/MortalityEvent_CauseOfDeath-ICD10/A00B99_Gender-Female_Race"
     },
@@ -7755,42 +6475,6 @@
       "dcid": "dc/g/MortalityEvent_CauseOfDeath-ICD10/V01Y89_Gender-Female_Race-CDCWhite"
     },
     {
-      "name": "MortalityEvent By CauseOfDeath = IllnessOrNaturalCause, Gender = Female, Institutionalization",
-      "dcid": "dc/g/MortalityEvent_CauseOfDeath-IllnessOrNaturalCause_Gender-Female_Institutionalization"
-    },
-    {
-      "name": "MortalityEvent By CauseOfDeath = IllnessOrNaturalCause, Gender = Female, Institutionalization = Incarcerated",
-      "dcid": "dc/g/MortalityEvent_CauseOfDeath-IllnessOrNaturalCause_Gender-Female_Institutionalization-Incarcerated"
-    },
-    {
-      "name": "MortalityEvent By CauseOfDeath = IntentionalSelf-Harm(Suicide), Gender = Female, Institutionalization",
-      "dcid": "dc/g/MortalityEvent_CauseOfDeath-IntentionalSelfHarm(Suicide)_Gender-Female_Institutionalization"
-    },
-    {
-      "name": "MortalityEvent By CauseOfDeath = IntentionalSelf-Harm(Suicide), Gender = Female, Institutionalization = Incarcerated",
-      "dcid": "dc/g/MortalityEvent_CauseOfDeath-IntentionalSelfHarm(Suicide)_Gender-Female_Institutionalization-Incarcerated"
-    },
-    {
-      "name": "MortalityEvent By CauseOfDeath = JudicialExecution, Gender = Female, Institutionalization",
-      "dcid": "dc/g/MortalityEvent_CauseOfDeath-JudicialExecution_Gender-Female_Institutionalization"
-    },
-    {
-      "name": "MortalityEvent By CauseOfDeath = JudicialExecution, Gender = Female, Institutionalization = Incarcerated",
-      "dcid": "dc/g/MortalityEvent_CauseOfDeath-JudicialExecution_Gender-Female_Institutionalization-Incarcerated"
-    },
-    {
-      "name": "MortalityEvent By CauseOfDeath = NPSOtherCauseOfDeath, Gender = Female, Institutionalization",
-      "dcid": "dc/g/MortalityEvent_CauseOfDeath-NPSOtherCauseOfDeath_Gender-Female_Institutionalization"
-    },
-    {
-      "name": "MortalityEvent By CauseOfDeath = NPSOtherCauseOfDeath, Gender = Female, Institutionalization = Incarcerated",
-      "dcid": "dc/g/MortalityEvent_CauseOfDeath-NPSOtherCauseOfDeath_Gender-Female_Institutionalization-Incarcerated"
-    },
-    {
-      "name": "MortalityEvent By CauseOfDeath, Gender = Female, Institutionalization = Incarcerated",
-      "dcid": "dc/g/MortalityEvent_CauseOfDeath_Gender-Female_Institutionalization-Incarcerated"
-    },
-    {
       "name": "MortalityEvent By CauseOfDeath, Gender = Female, Race = CDC_AmericanIndianAndAlaskaNativeAlone",
       "dcid": "dc/g/MortalityEvent_CauseOfDeath_Gender-Female_Race-CDCAmericanIndianAndAlaskaNativeAlone"
     },
@@ -7805,14 +6489,6 @@
     {
       "name": "MortalityEvent By CauseOfDeath, Gender = Female, Race = CDC_White",
       "dcid": "dc/g/MortalityEvent_CauseOfDeath_Gender-Female_Race-CDCWhite"
-    },
-    {
-      "name": "Person By Age = Years0To17, Gender = Female, Institutionalization",
-      "dcid": "dc/g/Person_Age-Years0To17_Gender-Female_Institutionalization"
-    },
-    {
-      "name": "Person By Age = Years0To17, Gender = Female, Institutionalization = Incarcerated",
-      "dcid": "dc/g/Person_Age-Years0To17_Gender-Female_Institutionalization-Incarcerated"
     },
     {
       "name": "Person By Age = Years10To14, Gender = Female, Race",
@@ -8001,6 +6677,1330 @@
     {
       "name": "Person By Age = Years15Onwards, Gender = Female, HealthBehavior",
       "dcid": "dc/g/Person_Age-Years15Onwards_Gender-Female_HealthBehavior"
+    },
+    {
+      "name": "Person By Age = Years15Onwards, Gender = Female, HealthBehavior = Smoking",
+      "dcid": "dc/g/Person_Age-Years15Onwards_Gender-Female_HealthBehavior-Smoking"
+    },
+    {
+      "name": "Person By Age = Years15Onwards, Gender = Female, Race",
+      "dcid": "dc/g/Person_Age-Years15Onwards_Gender-Female_Race"
+    },
+    {
+      "name": "Person By Age = Years15Onwards, Gender = Female, Race = AmericanIndianOrAlaskaNativeAlone",
+      "dcid": "dc/g/Person_Age-Years15Onwards_Gender-Female_Race-AmericanIndianOrAlaskaNativeAlone"
+    },
+    {
+      "name": "Person By Age = Years15Onwards, Gender = Female, Race = AsianAlone",
+      "dcid": "dc/g/Person_Age-Years15Onwards_Gender-Female_Race-AsianAlone"
+    },
+    {
+      "name": "Person By Age = Years15Onwards, Gender = Female, Race = BlackOrAfricanAmericanAlone",
+      "dcid": "dc/g/Person_Age-Years15Onwards_Gender-Female_Race-BlackOrAfricanAmericanAlone"
+    },
+    {
+      "name": "Person By Age = Years15Onwards, Gender = Female, Race = HispanicOrLatino",
+      "dcid": "dc/g/Person_Age-Years15Onwards_Gender-Female_Race-HispanicOrLatino"
+    },
+    {
+      "name": "Person By Age = Years15Onwards, Gender = Female, Race = NativeHawaiianOrOtherPacificIslanderAlone",
+      "dcid": "dc/g/Person_Age-Years15Onwards_Gender-Female_Race-NativeHawaiianOrOtherPacificIslanderAlone"
+    },
+    {
+      "name": "Person By Age = Years15Onwards, Gender = Female, Race = SomeOtherRaceAlone",
+      "dcid": "dc/g/Person_Age-Years15Onwards_Gender-Female_Race-SomeOtherRaceAlone"
+    },
+    {
+      "name": "Person By Age = Years15Onwards, Gender = Female, Race = TwoOrMoreRaces",
+      "dcid": "dc/g/Person_Age-Years15Onwards_Gender-Female_Race-TwoOrMoreRaces"
+    },
+    {
+      "name": "Person By Age = Years15Onwards, Gender = Female, Race = WhiteAlone",
+      "dcid": "dc/g/Person_Age-Years15Onwards_Gender-Female_Race-WhiteAlone"
+    },
+    {
+      "name": "Person By Age = Years15Onwards, Gender = Female, Race = WhiteAloneNotHispanicOrLatino",
+      "dcid": "dc/g/Person_Age-Years15Onwards_Gender-Female_Race-WhiteAloneNotHispanicOrLatino"
+    },
+    {
+      "name": "Person By Age = Years15To17, CollegeOrGraduateSchoolEnrollment = EnrolledInPrivateCollegeOrGraduateSchool, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years15To17_CollegeOrGraduateSchoolEnrollment-EnrolledInPrivateCollegeOrGraduateSchool_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years15To17, CollegeOrGraduateSchoolEnrollment = EnrolledInPublicCollegeOrGraduateSchool, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years15To17_CollegeOrGraduateSchoolEnrollment-EnrolledInPublicCollegeOrGraduateSchool_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years15To17, CollegeOrGraduateSchoolEnrollment = NotEnrolledInCollegeOrGraduateSchool, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years15To17_CollegeOrGraduateSchoolEnrollment-NotEnrolledInCollegeOrGraduateSchool_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years15To17, CollegeOrGraduateSchoolEnrollment, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years15To17_CollegeOrGraduateSchoolEnrollment_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years15To17, Gender = Female, Race",
+      "dcid": "dc/g/Person_Age-Years15To17_Gender-Female_Race"
+    },
+    {
+      "name": "Person By Age = Years15To17, Gender = Female, Race = AmericanIndianOrAlaskaNativeAlone",
+      "dcid": "dc/g/Person_Age-Years15To17_Gender-Female_Race-AmericanIndianOrAlaskaNativeAlone"
+    },
+    {
+      "name": "Person By Age = Years15To17, Gender = Female, Race = AsianAlone",
+      "dcid": "dc/g/Person_Age-Years15To17_Gender-Female_Race-AsianAlone"
+    },
+    {
+      "name": "Person By Age = Years15To17, Gender = Female, Race = BlackOrAfricanAmericanAlone",
+      "dcid": "dc/g/Person_Age-Years15To17_Gender-Female_Race-BlackOrAfricanAmericanAlone"
+    },
+    {
+      "name": "Person By Age = Years15To17, Gender = Female, Race = HispanicOrLatino",
+      "dcid": "dc/g/Person_Age-Years15To17_Gender-Female_Race-HispanicOrLatino"
+    },
+    {
+      "name": "Person By Age = Years15To17, Gender = Female, Race = NativeHawaiianOrOtherPacificIslanderAlone",
+      "dcid": "dc/g/Person_Age-Years15To17_Gender-Female_Race-NativeHawaiianOrOtherPacificIslanderAlone"
+    },
+    {
+      "name": "Person By Age = Years15To17, Gender = Female, Race = SomeOtherRaceAlone",
+      "dcid": "dc/g/Person_Age-Years15To17_Gender-Female_Race-SomeOtherRaceAlone"
+    },
+    {
+      "name": "Person By Age = Years15To17, Gender = Female, Race = TwoOrMoreRaces",
+      "dcid": "dc/g/Person_Age-Years15To17_Gender-Female_Race-TwoOrMoreRaces"
+    },
+    {
+      "name": "Person By Age = Years15To17, Gender = Female, Race = WhiteAlone",
+      "dcid": "dc/g/Person_Age-Years15To17_Gender-Female_Race-WhiteAlone"
+    },
+    {
+      "name": "Person By Age = Years15To17, Gender = Female, Race = WhiteAloneNotHispanicOrLatino",
+      "dcid": "dc/g/Person_Age-Years15To17_Gender-Female_Race-WhiteAloneNotHispanicOrLatino"
+    },
+    {
+      "name": "Person By Age = Years15To17, Gender = Female, SchoolEnrollment",
+      "dcid": "dc/g/Person_Age-Years15To17_Gender-Female_SchoolEnrollment"
+    },
+    {
+      "name": "Person By Age = Years15To17, Gender = Female, SchoolEnrollment = EnrolledInPrivateSchool",
+      "dcid": "dc/g/Person_Age-Years15To17_Gender-Female_SchoolEnrollment-EnrolledInPrivateSchool"
+    },
+    {
+      "name": "Person By Age = Years15To17, Gender = Female, SchoolEnrollment = EnrolledInPublicSchool",
+      "dcid": "dc/g/Person_Age-Years15To17_Gender-Female_SchoolEnrollment-EnrolledInPublicSchool"
+    },
+    {
+      "name": "Person By Age = Years15To17, Gender = Female, SchoolEnrollment = NotEnrolledInSchool",
+      "dcid": "dc/g/Person_Age-Years15To17_Gender-Female_SchoolEnrollment-NotEnrolledInSchool"
+    },
+    {
+      "name": "Person By Age = Years15To64, EmploymentStatus = BLS_InLaborForce, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years15To64_EmploymentStatus-BLSInLaborForce_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years15To64, EmploymentStatus, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years15To64_EmploymentStatus_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, ArmedForcesStatus = Civilian, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years16Onwards_ArmedForcesStatus-Civilian_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, ArmedForcesStatus, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years16Onwards_ArmedForcesStatus_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Employment = BLS_Employed, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Employment-BLSEmployed_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Employment, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Employment_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, EmploymentStatus = BLS_InLaborForce, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years16Onwards_EmploymentStatus-BLSInLaborForce_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, EmploymentStatus, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years16Onwards_EmploymentStatus_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, HasOccupation",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_HasOccupation"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, HasOccupation = SOCv2018/11-0000",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_HasOccupation-SOCv2018/110000"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, HasOccupation = SOCv2018/13-0000",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_HasOccupation-SOCv2018/130000"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, HasOccupation = SOCv2018/15-0000",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_HasOccupation-SOCv2018/150000"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, HasOccupation = SOCv2018/17-0000",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_HasOccupation-SOCv2018/170000"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, HasOccupation = SOCv2018/19-0000",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_HasOccupation-SOCv2018/190000"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, HasOccupation = SOCv2018/21-0000",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_HasOccupation-SOCv2018/210000"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, HasOccupation = SOCv2018/23-0000",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_HasOccupation-SOCv2018/230000"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, HasOccupation = SOCv2018/25-0000",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_HasOccupation-SOCv2018/250000"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, HasOccupation = SOCv2018/27-0000",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_HasOccupation-SOCv2018/270000"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, HasOccupation = SOCv2018/29-0000",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_HasOccupation-SOCv2018/290000"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, HasOccupation = SOCv2018/29-2000",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_HasOccupation-SOCv2018/292000"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, HasOccupation = SOCv2018/31-0000",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_HasOccupation-SOCv2018/310000"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, HasOccupation = SOCv2018/33-0000",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_HasOccupation-SOCv2018/330000"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, HasOccupation = SOCv2018/35-0000",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_HasOccupation-SOCv2018/350000"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, HasOccupation = SOCv2018/37-0000",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_HasOccupation-SOCv2018/370000"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, HasOccupation = SOCv2018/39-0000",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_HasOccupation-SOCv2018/390000"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, HasOccupation = SOCv2018/41-0000",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_HasOccupation-SOCv2018/410000"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, HasOccupation = SOCv2018/43-0000",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_HasOccupation-SOCv2018/430000"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, HasOccupation = SOCv2018/45-0000",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_HasOccupation-SOCv2018/450000"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, HasOccupation = SOCv2018/47-0000",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_HasOccupation-SOCv2018/470000"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, HasOccupation = SOCv2018/49-0000",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_HasOccupation-SOCv2018/490000"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, HasOccupation = SOCv2018/51-0000",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_HasOccupation-SOCv2018/510000"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, HasOccupation = SOCv2018/highLevelAggregation-1",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_HasOccupation-SOCv2018/highLevelAggregation1"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, HasOccupation = SOCv2018/highLevelAggregation-2",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_HasOccupation-SOCv2018/highLevelAggregation2"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, HasOccupation = SOCv2018/highLevelAggregation-3",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_HasOccupation-SOCv2018/highLevelAggregation3"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, HasOccupation = SOCv2018/highLevelAggregation-4",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_HasOccupation-SOCv2018/highLevelAggregation4"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, HasOccupation = SOCv2018/highLevelAggregation-5",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_HasOccupation-SOCv2018/highLevelAggregation5"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, HasOccupation = SOCv2018/intermediateAggregation-1",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_HasOccupation-SOCv2018/intermediateAggregation1"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, HasOccupation = SOCv2018/intermediateAggregation-2",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_HasOccupation-SOCv2018/intermediateAggregation2"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, HasOccupation = SOCv2018/intermediateAggregation-3",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_HasOccupation-SOCv2018/intermediateAggregation3"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, HasOccupation = SOCv2018/intermediateAggregation-5",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_HasOccupation-SOCv2018/intermediateAggregation5"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Income",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Income"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Income = USDollar100000Onwards",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Income-USDollar100000Onwards"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Income = USDollar10000To12499",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Income-USDollar10000To12499"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Income = USDollar12500To14999",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Income-USDollar12500To14999"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Income = USDollar15000To17499",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Income-USDollar15000To17499"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Income = USDollar17500To19999",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Income-USDollar17500To19999"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Income = USDollar20000To22499",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Income-USDollar20000To22499"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Income = USDollar22500To24999",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Income-USDollar22500To24999"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Income = USDollar25000To29999",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Income-USDollar25000To29999"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Income = USDollar2500To4999",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Income-USDollar2500To4999"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Income = USDollar30000To34999",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Income-USDollar30000To34999"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Income = USDollar35000To39999",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Income-USDollar35000To39999"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Income = USDollar40000To44999",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Income-USDollar40000To44999"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Income = USDollar45000To49999",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Income-USDollar45000To49999"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Income = USDollar50000To54999",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Income-USDollar50000To54999"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Income = USDollar5000To7499",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Income-USDollar5000To7499"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Income = USDollar55000To64999",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Income-USDollar55000To64999"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Income = USDollar65000To74999",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Income-USDollar65000To74999"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Income = USDollar75000To99999",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Income-USDollar75000To99999"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Income = USDollar7500To9999",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Income-USDollar7500To9999"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Income = USDollarUpto2499",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Income-USDollarUpto2499"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Naics",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Naics"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Naics = NAICS/11",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Naics-NAICS/11"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Naics = NAICS/21",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Naics-NAICS/21"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Naics = NAICS/22",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Naics-NAICS/22"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Naics = NAICS/23",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Naics-NAICS/23"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Naics = NAICS/31-33",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Naics-NAICS/3133"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Naics = NAICS/42",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Naics-NAICS/42"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Naics = NAICS/44-45",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Naics-NAICS/4445"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Naics = NAICS/48-49",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Naics-NAICS/4849"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Naics = NAICS/51",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Naics-NAICS/51"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Naics = NAICS/52",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Naics-NAICS/52"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Naics = NAICS/53",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Naics-NAICS/53"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Naics = NAICS/54",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Naics-NAICS/54"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Naics = NAICS/55",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Naics-NAICS/55"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Naics = NAICS/56",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Naics-NAICS/56"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Naics = NAICS/61",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Naics-NAICS/61"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Naics = NAICS/62",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Naics-NAICS/62"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Naics = NAICS/71",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Naics-NAICS/71"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Naics = NAICS/72",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Naics-NAICS/72"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Naics = NAICS/81",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Naics-NAICS/81"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Naics = NAICS/92",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Naics-NAICS/92"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Race",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Race"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Race = AmericanIndianOrAlaskaNativeAlone",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Race-AmericanIndianOrAlaskaNativeAlone"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Race = AsianAlone",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Race-AsianAlone"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Race = BlackOrAfricanAmericanAlone",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Race-BlackOrAfricanAmericanAlone"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Race = HispanicOrLatino",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Race-HispanicOrLatino"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Race = NativeHawaiianOrOtherPacificIslanderAlone",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Race-NativeHawaiianOrOtherPacificIslanderAlone"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Race = SomeOtherRaceAlone",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Race-SomeOtherRaceAlone"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Race = TwoOrMoreRaces",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Race-TwoOrMoreRaces"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Race = WhiteAlone",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Race-WhiteAlone"
+    },
+    {
+      "name": "Person By Age = Years16Onwards, Gender = Female, Race = WhiteAloneNotHispanicOrLatino",
+      "dcid": "dc/g/Person_Age-Years16Onwards_Gender-Female_Race-WhiteAloneNotHispanicOrLatino"
+    },
+    {
+      "name": "Person By Age = Years16To17, Gender = Female, PovertyStatus",
+      "dcid": "dc/g/Person_Age-Years16To17_Gender-Female_PovertyStatus"
+    },
+    {
+      "name": "Person By Age = Years16To17, Gender = Female, PovertyStatus = AbovePovertyLevelInThePast12Months",
+      "dcid": "dc/g/Person_Age-Years16To17_Gender-Female_PovertyStatus-AbovePovertyLevelInThePast12Months"
+    },
+    {
+      "name": "Person By Age = Years16To17, Gender = Female, PovertyStatus = BelowPovertyLevelInThePast12Months",
+      "dcid": "dc/g/Person_Age-Years16To17_Gender-Female_PovertyStatus-BelowPovertyLevelInThePast12Months"
+    },
+    {
+      "name": "Person By Age = Years16To17, Gender = Female, Race",
+      "dcid": "dc/g/Person_Age-Years16To17_Gender-Female_Race"
+    },
+    {
+      "name": "Person By Age = Years16To17, Gender = Female, Race = AmericanIndianOrAlaskaNativeAlone",
+      "dcid": "dc/g/Person_Age-Years16To17_Gender-Female_Race-AmericanIndianOrAlaskaNativeAlone"
+    },
+    {
+      "name": "Person By Age = Years16To17, Gender = Female, Race = AsianAlone",
+      "dcid": "dc/g/Person_Age-Years16To17_Gender-Female_Race-AsianAlone"
+    },
+    {
+      "name": "Person By Age = Years16To17, Gender = Female, Race = BlackOrAfricanAmericanAlone",
+      "dcid": "dc/g/Person_Age-Years16To17_Gender-Female_Race-BlackOrAfricanAmericanAlone"
+    },
+    {
+      "name": "Person By Age = Years16To17, Gender = Female, Race = HispanicOrLatino",
+      "dcid": "dc/g/Person_Age-Years16To17_Gender-Female_Race-HispanicOrLatino"
+    },
+    {
+      "name": "Person By Age = Years16To17, Gender = Female, Race = NativeHawaiianOrOtherPacificIslanderAlone",
+      "dcid": "dc/g/Person_Age-Years16To17_Gender-Female_Race-NativeHawaiianOrOtherPacificIslanderAlone"
+    },
+    {
+      "name": "Person By Age = Years16To17, Gender = Female, Race = SomeOtherRaceAlone",
+      "dcid": "dc/g/Person_Age-Years16To17_Gender-Female_Race-SomeOtherRaceAlone"
+    },
+    {
+      "name": "Person By Age = Years16To17, Gender = Female, Race = TwoOrMoreRaces",
+      "dcid": "dc/g/Person_Age-Years16To17_Gender-Female_Race-TwoOrMoreRaces"
+    },
+    {
+      "name": "Person By Age = Years16To17, Gender = Female, Race = WhiteAlone",
+      "dcid": "dc/g/Person_Age-Years16To17_Gender-Female_Race-WhiteAlone"
+    },
+    {
+      "name": "Person By Age = Years16To17, Gender = Female, Race = WhiteAloneNotHispanicOrLatino",
+      "dcid": "dc/g/Person_Age-Years16To17_Gender-Female_Race-WhiteAloneNotHispanicOrLatino"
+    },
+    {
+      "name": "Person By Age = Years16To19, ArmedForcesStatus = Civilian, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years16To19_ArmedForcesStatus-Civilian_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years16To19, ArmedForcesStatus = InArmedForces, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years16To19_ArmedForcesStatus-InArmedForces_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years16To19, ArmedForcesStatus, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years16To19_ArmedForcesStatus_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years16To19, Employment = BLS_Employed, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years16To19_Employment-BLSEmployed_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years16To19, Employment = BLS_Unemployed, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years16To19_Employment-BLSUnemployed_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years16To19, Employment, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years16To19_Employment_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years16To19, EmploymentStatus = BLS_InLaborForce, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years16To19_EmploymentStatus-BLSInLaborForce_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years16To19, EmploymentStatus = BLS_NotInLaborForce, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years16To19_EmploymentStatus-BLSNotInLaborForce_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years16To19, EmploymentStatus, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years16To19_EmploymentStatus_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years18Onwards, Gender = Female, VeteranStatus",
+      "dcid": "dc/g/Person_Age-Years18Onwards_Gender-Female_VeteranStatus"
+    },
+    {
+      "name": "Person By Age = Years18Onwards, Gender = Female, VeteranStatus = Nonveteran",
+      "dcid": "dc/g/Person_Age-Years18Onwards_Gender-Female_VeteranStatus-Nonveteran"
+    },
+    {
+      "name": "Person By Age = Years18Onwards, Gender = Female, VeteranStatus = Veteran",
+      "dcid": "dc/g/Person_Age-Years18Onwards_Gender-Female_VeteranStatus-Veteran"
+    },
+    {
+      "name": "Person By Age = Years18To19, Gender = Female, Race",
+      "dcid": "dc/g/Person_Age-Years18To19_Gender-Female_Race"
+    },
+    {
+      "name": "Person By Age = Years18To19, Gender = Female, Race = AmericanIndianOrAlaskaNativeAlone",
+      "dcid": "dc/g/Person_Age-Years18To19_Gender-Female_Race-AmericanIndianOrAlaskaNativeAlone"
+    },
+    {
+      "name": "Person By Age = Years18To19, Gender = Female, Race = AsianAlone",
+      "dcid": "dc/g/Person_Age-Years18To19_Gender-Female_Race-AsianAlone"
+    },
+    {
+      "name": "Person By Age = Years18To19, Gender = Female, Race = BlackOrAfricanAmericanAlone",
+      "dcid": "dc/g/Person_Age-Years18To19_Gender-Female_Race-BlackOrAfricanAmericanAlone"
+    },
+    {
+      "name": "Person By Age = Years18To19, Gender = Female, Race = HispanicOrLatino",
+      "dcid": "dc/g/Person_Age-Years18To19_Gender-Female_Race-HispanicOrLatino"
+    },
+    {
+      "name": "Person By Age = Years18To19, Gender = Female, Race = NativeHawaiianOrOtherPacificIslanderAlone",
+      "dcid": "dc/g/Person_Age-Years18To19_Gender-Female_Race-NativeHawaiianOrOtherPacificIslanderAlone"
+    },
+    {
+      "name": "Person By Age = Years18To19, Gender = Female, Race = SomeOtherRaceAlone",
+      "dcid": "dc/g/Person_Age-Years18To19_Gender-Female_Race-SomeOtherRaceAlone"
+    },
+    {
+      "name": "Person By Age = Years18To19, Gender = Female, Race = TwoOrMoreRaces",
+      "dcid": "dc/g/Person_Age-Years18To19_Gender-Female_Race-TwoOrMoreRaces"
+    },
+    {
+      "name": "Person By Age = Years18To19, Gender = Female, Race = WhiteAlone",
+      "dcid": "dc/g/Person_Age-Years18To19_Gender-Female_Race-WhiteAlone"
+    },
+    {
+      "name": "Person By Age = Years18To19, Gender = Female, Race = WhiteAloneNotHispanicOrLatino",
+      "dcid": "dc/g/Person_Age-Years18To19_Gender-Female_Race-WhiteAloneNotHispanicOrLatino"
+    },
+    {
+      "name": "Person By Age = Years18To19, Gender = Female, SchoolEnrollment",
+      "dcid": "dc/g/Person_Age-Years18To19_Gender-Female_SchoolEnrollment"
+    },
+    {
+      "name": "Person By Age = Years18To19, Gender = Female, SchoolEnrollment = EnrolledInPrivateSchool",
+      "dcid": "dc/g/Person_Age-Years18To19_Gender-Female_SchoolEnrollment-EnrolledInPrivateSchool"
+    },
+    {
+      "name": "Person By Age = Years18To19, Gender = Female, SchoolEnrollment = EnrolledInPublicSchool",
+      "dcid": "dc/g/Person_Age-Years18To19_Gender-Female_SchoolEnrollment-EnrolledInPublicSchool"
+    },
+    {
+      "name": "Person By Age = Years18To19, Gender = Female, SchoolEnrollment = NotEnrolledInSchool",
+      "dcid": "dc/g/Person_Age-Years18To19_Gender-Female_SchoolEnrollment-NotEnrolledInSchool"
+    },
+    {
+      "name": "Person By Age = Years18To24, ArmedForcesStatus = Civilian, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years18To24_ArmedForcesStatus-Civilian_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years18To24, ArmedForcesStatus, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years18To24_ArmedForcesStatus_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years18To24, CollegeOrGraduateSchoolEnrollment = EnrolledInPrivateCollegeOrGraduateSchool, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years18To24_CollegeOrGraduateSchoolEnrollment-EnrolledInPrivateCollegeOrGraduateSchool_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years18To24, CollegeOrGraduateSchoolEnrollment = EnrolledInPublicCollegeOrGraduateSchool, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years18To24_CollegeOrGraduateSchoolEnrollment-EnrolledInPublicCollegeOrGraduateSchool_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years18To24, CollegeOrGraduateSchoolEnrollment = NotEnrolledInCollegeOrGraduateSchool, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years18To24_CollegeOrGraduateSchoolEnrollment-NotEnrolledInCollegeOrGraduateSchool_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years18To24, CollegeOrGraduateSchoolEnrollment, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years18To24_CollegeOrGraduateSchoolEnrollment_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years18To24, EducationalAttainment = 9ThTo12ThGradeNoDiploma, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years18To24_EducationalAttainment-9ThTo12ThGradeNoDiploma_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years18To24, EducationalAttainment = AssociatesDegree, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years18To24_EducationalAttainment-AssociatesDegree_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years18To24, EducationalAttainment = BachelorsDegree, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years18To24_EducationalAttainment-BachelorsDegree_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years18To24, EducationalAttainment = BachelorsDegreeOrHigher, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years18To24_EducationalAttainment-BachelorsDegreeOrHigher_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years18To24, EducationalAttainment = GraduateOrProfessionalDegree, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years18To24_EducationalAttainment-GraduateOrProfessionalDegree_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years18To24, EducationalAttainment = HighSchoolGraduateGedOrAlternative, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years18To24_EducationalAttainment-HighSchoolGraduateGedOrAlternative_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years18To24, EducationalAttainment = HighSchoolGraduateIncludesEquivalency, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years18To24_EducationalAttainment-HighSchoolGraduateIncludesEquivalency_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years18To24, EducationalAttainment = LessThan9ThGrade, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years18To24_EducationalAttainment-LessThan9ThGrade_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years18To24, EducationalAttainment = SomeCollegeNoDegree, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years18To24_EducationalAttainment-SomeCollegeNoDegree_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years18To24, EducationalAttainment, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years18To24_EducationalAttainment_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years18To24, Gender = Female, HealthInsurance",
+      "dcid": "dc/g/Person_Age-Years18To24_Gender-Female_HealthInsurance"
+    },
+    {
+      "name": "Person By Age = Years18To24, Gender = Female, HealthInsurance = NoHealthInsurance",
+      "dcid": "dc/g/Person_Age-Years18To24_Gender-Female_HealthInsurance-NoHealthInsurance"
+    },
+    {
+      "name": "Person By Age = Years18To24, Gender = Female, HealthInsurance = NoPrivateHealthInsurance",
+      "dcid": "dc/g/Person_Age-Years18To24_Gender-Female_HealthInsurance-NoPrivateHealthInsurance"
+    },
+    {
+      "name": "Person By Age = Years18To24, Gender = Female, HealthInsurance = NoPublicHealthInsurance",
+      "dcid": "dc/g/Person_Age-Years18To24_Gender-Female_HealthInsurance-NoPublicHealthInsurance"
+    },
+    {
+      "name": "Person By Age = Years18To24, Gender = Female, HealthInsurance = WithHealthInsurance",
+      "dcid": "dc/g/Person_Age-Years18To24_Gender-Female_HealthInsurance-WithHealthInsurance"
+    },
+    {
+      "name": "Person By Age = Years18To24, Gender = Female, HealthInsurance = WithPrivateHealthInsurance",
+      "dcid": "dc/g/Person_Age-Years18To24_Gender-Female_HealthInsurance-WithPrivateHealthInsurance"
+    },
+    {
+      "name": "Person By Age = Years18To24, Gender = Female, HealthInsurance = WithPublicHealthInsurance",
+      "dcid": "dc/g/Person_Age-Years18To24_Gender-Female_HealthInsurance-WithPublicHealthInsurance"
+    },
+    {
+      "name": "Person By Age = Years18To24, Gender = Female, Institutionalization",
+      "dcid": "dc/g/Person_Age-Years18To24_Gender-Female_Institutionalization"
+    },
+    {
+      "name": "Person By Age = Years18To24, Gender = Female, Institutionalization = USC_NonInstitutionalized",
+      "dcid": "dc/g/Person_Age-Years18To24_Gender-Female_Institutionalization-USCNonInstitutionalized"
+    },
+    {
+      "name": "Person By Age = Years18To24, Gender = Female, PovertyStatus",
+      "dcid": "dc/g/Person_Age-Years18To24_Gender-Female_PovertyStatus"
+    },
+    {
+      "name": "Person By Age = Years18To24, Gender = Female, PovertyStatus = AbovePovertyLevelInThePast12Months",
+      "dcid": "dc/g/Person_Age-Years18To24_Gender-Female_PovertyStatus-AbovePovertyLevelInThePast12Months"
+    },
+    {
+      "name": "Person By Age = Years18To24, Gender = Female, PovertyStatus = BelowPovertyLevelInThePast12Months",
+      "dcid": "dc/g/Person_Age-Years18To24_Gender-Female_PovertyStatus-BelowPovertyLevelInThePast12Months"
+    },
+    {
+      "name": "Person By Age = Years18To24, Gender = Female, Race",
+      "dcid": "dc/g/Person_Age-Years18To24_Gender-Female_Race"
+    },
+    {
+      "name": "Person By Age = Years18To24, Gender = Female, Race = AmericanIndianOrAlaskaNativeAlone",
+      "dcid": "dc/g/Person_Age-Years18To24_Gender-Female_Race-AmericanIndianOrAlaskaNativeAlone"
+    },
+    {
+      "name": "Person By Age = Years18To24, Gender = Female, Race = AsianAlone",
+      "dcid": "dc/g/Person_Age-Years18To24_Gender-Female_Race-AsianAlone"
+    },
+    {
+      "name": "Person By Age = Years18To24, Gender = Female, Race = BlackOrAfricanAmericanAlone",
+      "dcid": "dc/g/Person_Age-Years18To24_Gender-Female_Race-BlackOrAfricanAmericanAlone"
+    },
+    {
+      "name": "Person By Age = Years18To24, Gender = Female, Race = HispanicOrLatino",
+      "dcid": "dc/g/Person_Age-Years18To24_Gender-Female_Race-HispanicOrLatino"
+    },
+    {
+      "name": "Person By Age = Years18To24, Gender = Female, Race = NativeHawaiianOrOtherPacificIslanderAlone",
+      "dcid": "dc/g/Person_Age-Years18To24_Gender-Female_Race-NativeHawaiianOrOtherPacificIslanderAlone"
+    },
+    {
+      "name": "Person By Age = Years18To24, Gender = Female, Race = SomeOtherRaceAlone",
+      "dcid": "dc/g/Person_Age-Years18To24_Gender-Female_Race-SomeOtherRaceAlone"
+    },
+    {
+      "name": "Person By Age = Years18To24, Gender = Female, Race = TwoOrMoreRaces",
+      "dcid": "dc/g/Person_Age-Years18To24_Gender-Female_Race-TwoOrMoreRaces"
+    },
+    {
+      "name": "Person By Age = Years18To24, Gender = Female, Race = WhiteAlone",
+      "dcid": "dc/g/Person_Age-Years18To24_Gender-Female_Race-WhiteAlone"
+    },
+    {
+      "name": "Person By Age = Years18To24, Gender = Female, Race = WhiteAloneNotHispanicOrLatino",
+      "dcid": "dc/g/Person_Age-Years18To24_Gender-Female_Race-WhiteAloneNotHispanicOrLatino"
+    },
+    {
+      "name": "Person By Age = Years18To34, ArmedForcesStatus = Civilian, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years18To34_ArmedForcesStatus-Civilian_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years18To34, ArmedForcesStatus, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years18To34_ArmedForcesStatus_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years18To34, Gender = Female, VeteranStatus",
+      "dcid": "dc/g/Person_Age-Years18To34_Gender-Female_VeteranStatus"
+    },
+    {
+      "name": "Person By Age = Years18To34, Gender = Female, VeteranStatus = Nonveteran",
+      "dcid": "dc/g/Person_Age-Years18To34_Gender-Female_VeteranStatus-Nonveteran"
+    },
+    {
+      "name": "Person By Age = Years18To34, Gender = Female, VeteranStatus = Veteran",
+      "dcid": "dc/g/Person_Age-Years18To34_Gender-Female_VeteranStatus-Veteran"
+    },
+    {
+      "name": "Person By Age = Years18To64, FamilyIncome = RatioToPovertyLine1.38To4, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years18To64_FamilyIncome-RatioToPovertyLine1.38To4_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years18To64, FamilyIncome = RatioToPovertyLineUpto1.38, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years18To64_FamilyIncome-RatioToPovertyLineUpto1.38_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years18To64, FamilyIncome = RatioToPovertyLineUpto2, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years18To64_FamilyIncome-RatioToPovertyLineUpto2_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years18To64, FamilyIncome = RatioToPovertyLineUpto2.5, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years18To64_FamilyIncome-RatioToPovertyLineUpto2.5_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years18To64, FamilyIncome = RatioToPovertyLineUpto4, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years18To64_FamilyIncome-RatioToPovertyLineUpto4_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years18To64, FamilyIncome, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years18To64_FamilyIncome_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years18To64, Gender = Female, HealthInsurance",
+      "dcid": "dc/g/Person_Age-Years18To64_Gender-Female_HealthInsurance"
+    },
+    {
+      "name": "Person By Age = Years18To64, Gender = Female, HealthInsurance = NoHealthInsurance",
+      "dcid": "dc/g/Person_Age-Years18To64_Gender-Female_HealthInsurance-NoHealthInsurance"
+    },
+    {
+      "name": "Person By Age = Years18To64, Gender = Female, HealthInsurance = WithHealthInsurance",
+      "dcid": "dc/g/Person_Age-Years18To64_Gender-Female_HealthInsurance-WithHealthInsurance"
+    },
+    {
+      "name": "Person By Age = Years18To64, Gender = Female, Race",
+      "dcid": "dc/g/Person_Age-Years18To64_Gender-Female_Race"
+    },
+    {
+      "name": "Person By Age = Years18To64, Gender = Female, Race = BlackOrAfricanAmericanAlone",
+      "dcid": "dc/g/Person_Age-Years18To64_Gender-Female_Race-BlackOrAfricanAmericanAlone"
+    },
+    {
+      "name": "Person By Age = Years18To64, Gender = Female, Race = HispanicOrLatino",
+      "dcid": "dc/g/Person_Age-Years18To64_Gender-Female_Race-HispanicOrLatino"
+    },
+    {
+      "name": "Person By Age = Years18To64, Gender = Female, Race = WhiteAlone",
+      "dcid": "dc/g/Person_Age-Years18To64_Gender-Female_Race-WhiteAlone"
+    },
+    {
+      "name": "Person By Age = Years19To25, ArmedForcesStatus = Civilian, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years19To25_ArmedForcesStatus-Civilian_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years19To25, ArmedForcesStatus, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years19To25_ArmedForcesStatus_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years19To25, Gender = Female, HealthInsurance",
+      "dcid": "dc/g/Person_Age-Years19To25_Gender-Female_HealthInsurance"
+    },
+    {
+      "name": "Person By Age = Years19To25, Gender = Female, HealthInsurance = NoHealthInsurance",
+      "dcid": "dc/g/Person_Age-Years19To25_Gender-Female_HealthInsurance-NoHealthInsurance"
+    },
+    {
+      "name": "Person By Age = Years19To25, Gender = Female, HealthInsurance = NoPrivateHealthInsurance",
+      "dcid": "dc/g/Person_Age-Years19To25_Gender-Female_HealthInsurance-NoPrivateHealthInsurance"
+    },
+    {
+      "name": "Person By Age = Years19To25, Gender = Female, HealthInsurance = NoPublicHealthInsurance",
+      "dcid": "dc/g/Person_Age-Years19To25_Gender-Female_HealthInsurance-NoPublicHealthInsurance"
+    },
+    {
+      "name": "Person By Age = Years19To25, Gender = Female, HealthInsurance = WithHealthInsurance",
+      "dcid": "dc/g/Person_Age-Years19To25_Gender-Female_HealthInsurance-WithHealthInsurance"
+    },
+    {
+      "name": "Person By Age = Years19To25, Gender = Female, HealthInsurance = WithPrivateHealthInsurance",
+      "dcid": "dc/g/Person_Age-Years19To25_Gender-Female_HealthInsurance-WithPrivateHealthInsurance"
+    },
+    {
+      "name": "Person By Age = Years19To25, Gender = Female, HealthInsurance = WithPublicHealthInsurance",
+      "dcid": "dc/g/Person_Age-Years19To25_Gender-Female_HealthInsurance-WithPublicHealthInsurance"
+    },
+    {
+      "name": "Person By Age = Years19To25, Gender = Female, Institutionalization",
+      "dcid": "dc/g/Person_Age-Years19To25_Gender-Female_Institutionalization"
+    },
+    {
+      "name": "Person By Age = Years19To25, Gender = Female, Institutionalization = USC_NonInstitutionalized",
+      "dcid": "dc/g/Person_Age-Years19To25_Gender-Female_Institutionalization-USCNonInstitutionalized"
+    },
+    {
+      "name": "Person By Age = Years20To21, ArmedForcesStatus = Civilian, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years20To21_ArmedForcesStatus-Civilian_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years20To21, ArmedForcesStatus = InArmedForces, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years20To21_ArmedForcesStatus-InArmedForces_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years20To21, ArmedForcesStatus, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years20To21_ArmedForcesStatus_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years20To21, Employment = BLS_Employed, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years20To21_Employment-BLSEmployed_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years20To21, Employment = BLS_Unemployed, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years20To21_Employment-BLSUnemployed_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years20To21, Employment, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years20To21_Employment_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years20To21, EmploymentStatus = BLS_InLaborForce, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years20To21_EmploymentStatus-BLSInLaborForce_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years20To21, EmploymentStatus = BLS_NotInLaborForce, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years20To21_EmploymentStatus-BLSNotInLaborForce_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years20To21, EmploymentStatus, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years20To21_EmploymentStatus_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years20To24, Gender = Female, Race",
+      "dcid": "dc/g/Person_Age-Years20To24_Gender-Female_Race"
+    },
+    {
+      "name": "Person By Age = Years20To24, Gender = Female, Race = AmericanIndianOrAlaskaNativeAlone",
+      "dcid": "dc/g/Person_Age-Years20To24_Gender-Female_Race-AmericanIndianOrAlaskaNativeAlone"
+    },
+    {
+      "name": "Person By Age = Years20To24, Gender = Female, Race = AsianAlone",
+      "dcid": "dc/g/Person_Age-Years20To24_Gender-Female_Race-AsianAlone"
+    },
+    {
+      "name": "Person By Age = Years20To24, Gender = Female, Race = BlackOrAfricanAmericanAlone",
+      "dcid": "dc/g/Person_Age-Years20To24_Gender-Female_Race-BlackOrAfricanAmericanAlone"
+    },
+    {
+      "name": "Person By Age = Years20To24, Gender = Female, Race = HispanicOrLatino",
+      "dcid": "dc/g/Person_Age-Years20To24_Gender-Female_Race-HispanicOrLatino"
+    },
+    {
+      "name": "Person By Age = Years20To24, Gender = Female, Race = NativeHawaiianOrOtherPacificIslanderAlone",
+      "dcid": "dc/g/Person_Age-Years20To24_Gender-Female_Race-NativeHawaiianOrOtherPacificIslanderAlone"
+    },
+    {
+      "name": "Person By Age = Years20To24, Gender = Female, Race = SomeOtherRaceAlone",
+      "dcid": "dc/g/Person_Age-Years20To24_Gender-Female_Race-SomeOtherRaceAlone"
+    },
+    {
+      "name": "Person By Age = Years20To24, Gender = Female, Race = TwoOrMoreRaces",
+      "dcid": "dc/g/Person_Age-Years20To24_Gender-Female_Race-TwoOrMoreRaces"
+    },
+    {
+      "name": "Person By Age = Years20To24, Gender = Female, Race = WhiteAlone",
+      "dcid": "dc/g/Person_Age-Years20To24_Gender-Female_Race-WhiteAlone"
+    },
+    {
+      "name": "Person By Age = Years20To24, Gender = Female, Race = WhiteAloneNotHispanicOrLatino",
+      "dcid": "dc/g/Person_Age-Years20To24_Gender-Female_Race-WhiteAloneNotHispanicOrLatino"
+    },
+    {
+      "name": "Person By Age = Years20To24, Gender = Female, SchoolEnrollment",
+      "dcid": "dc/g/Person_Age-Years20To24_Gender-Female_SchoolEnrollment"
+    },
+    {
+      "name": "Person By Age = Years20To24, Gender = Female, SchoolEnrollment = EnrolledInPrivateSchool",
+      "dcid": "dc/g/Person_Age-Years20To24_Gender-Female_SchoolEnrollment-EnrolledInPrivateSchool"
+    },
+    {
+      "name": "Person By Age = Years20To24, Gender = Female, SchoolEnrollment = EnrolledInPublicSchool",
+      "dcid": "dc/g/Person_Age-Years20To24_Gender-Female_SchoolEnrollment-EnrolledInPublicSchool"
+    },
+    {
+      "name": "Person By Age = Years20To24, Gender = Female, SchoolEnrollment = NotEnrolledInSchool",
+      "dcid": "dc/g/Person_Age-Years20To24_Gender-Female_SchoolEnrollment-NotEnrolledInSchool"
+    },
+    {
+      "name": "Person By Age = Years21To64, FamilyIncome = RatioToPovertyLine1.38To4, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years21To64_FamilyIncome-RatioToPovertyLine1.38To4_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years21To64, FamilyIncome = RatioToPovertyLineUpto1.38, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years21To64_FamilyIncome-RatioToPovertyLineUpto1.38_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years21To64, FamilyIncome = RatioToPovertyLineUpto2, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years21To64_FamilyIncome-RatioToPovertyLineUpto2_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years21To64, FamilyIncome = RatioToPovertyLineUpto2.5, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years21To64_FamilyIncome-RatioToPovertyLineUpto2.5_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years21To64, FamilyIncome = RatioToPovertyLineUpto4, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years21To64_FamilyIncome-RatioToPovertyLineUpto4_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years21To64, FamilyIncome, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years21To64_FamilyIncome_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years21To64, Gender = Female, HealthInsurance",
+      "dcid": "dc/g/Person_Age-Years21To64_Gender-Female_HealthInsurance"
+    },
+    {
+      "name": "Person By Age = Years21To64, Gender = Female, HealthInsurance = NoHealthInsurance",
+      "dcid": "dc/g/Person_Age-Years21To64_Gender-Female_HealthInsurance-NoHealthInsurance"
+    },
+    {
+      "name": "Person By Age = Years21To64, Gender = Female, HealthInsurance = WithHealthInsurance",
+      "dcid": "dc/g/Person_Age-Years21To64_Gender-Female_HealthInsurance-WithHealthInsurance"
+    },
+    {
+      "name": "Person By Age = Years21To64, Gender = Female, Race",
+      "dcid": "dc/g/Person_Age-Years21To64_Gender-Female_Race"
+    },
+    {
+      "name": "Person By Age = Years21To64, Gender = Female, Race = BlackOrAfricanAmericanAlone",
+      "dcid": "dc/g/Person_Age-Years21To64_Gender-Female_Race-BlackOrAfricanAmericanAlone"
+    },
+    {
+      "name": "Person By Age = Years21To64, Gender = Female, Race = HispanicOrLatino",
+      "dcid": "dc/g/Person_Age-Years21To64_Gender-Female_Race-HispanicOrLatino"
+    },
+    {
+      "name": "Person By Age = Years21To64, Gender = Female, Race = WhiteAlone",
+      "dcid": "dc/g/Person_Age-Years21To64_Gender-Female_Race-WhiteAlone"
+    },
+    {
+      "name": "Person By Age = Years22To24, ArmedForcesStatus = Civilian, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years22To24_ArmedForcesStatus-Civilian_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years22To24, ArmedForcesStatus = InArmedForces, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years22To24_ArmedForcesStatus-InArmedForces_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years22To24, ArmedForcesStatus, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years22To24_ArmedForcesStatus_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years22To24, Employment = BLS_Employed, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years22To24_Employment-BLSEmployed_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years22To24, Employment = BLS_Unemployed, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years22To24_Employment-BLSUnemployed_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years22To24, Employment, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years22To24_Employment_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years22To24, EmploymentStatus = BLS_InLaborForce, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years22To24_EmploymentStatus-BLSInLaborForce_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years22To24, EmploymentStatus = BLS_NotInLaborForce, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years22To24_EmploymentStatus-BLSNotInLaborForce_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years22To24, EmploymentStatus, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years22To24_EmploymentStatus_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years25Onwards, Gender = Female, Race",
+      "dcid": "dc/g/Person_Age-Years25Onwards_Gender-Female_Race"
+    },
+    {
+      "name": "Person By Age = Years25Onwards, Gender = Female, Race = AmericanIndianOrAlaskaNativeAlone",
+      "dcid": "dc/g/Person_Age-Years25Onwards_Gender-Female_Race-AmericanIndianOrAlaskaNativeAlone"
+    },
+    {
+      "name": "Person By Age = Years25Onwards, Gender = Female, Race = AsianAlone",
+      "dcid": "dc/g/Person_Age-Years25Onwards_Gender-Female_Race-AsianAlone"
+    },
+    {
+      "name": "Person By Age = Years25Onwards, Gender = Female, Race = BlackOrAfricanAmericanAlone",
+      "dcid": "dc/g/Person_Age-Years25Onwards_Gender-Female_Race-BlackOrAfricanAmericanAlone"
+    },
+    {
+      "name": "Person By Age = Years25Onwards, Gender = Female, Race = HispanicOrLatino",
+      "dcid": "dc/g/Person_Age-Years25Onwards_Gender-Female_Race-HispanicOrLatino"
+    },
+    {
+      "name": "Person By Age = Years25Onwards, Gender = Female, Race = NativeHawaiianOrOtherPacificIslanderAlone",
+      "dcid": "dc/g/Person_Age-Years25Onwards_Gender-Female_Race-NativeHawaiianOrOtherPacificIslanderAlone"
+    },
+    {
+      "name": "Person By Age = Years25Onwards, Gender = Female, Race = SomeOtherRaceAlone",
+      "dcid": "dc/g/Person_Age-Years25Onwards_Gender-Female_Race-SomeOtherRaceAlone"
+    },
+    {
+      "name": "Person By Age = Years25Onwards, Gender = Female, Race = TwoOrMoreRaces",
+      "dcid": "dc/g/Person_Age-Years25Onwards_Gender-Female_Race-TwoOrMoreRaces"
+    },
+    {
+      "name": "Person By Age = Years25Onwards, Gender = Female, Race = WhiteAlone",
+      "dcid": "dc/g/Person_Age-Years25Onwards_Gender-Female_Race-WhiteAlone"
+    },
+    {
+      "name": "Person By Age = Years25Onwards, Gender = Female, Race = WhiteAloneNotHispanicOrLatino",
+      "dcid": "dc/g/Person_Age-Years25Onwards_Gender-Female_Race-WhiteAloneNotHispanicOrLatino"
+    },
+    {
+      "name": "Person By Age = Years25To29, ArmedForcesStatus = Civilian, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years25To29_ArmedForcesStatus-Civilian_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years25To29, ArmedForcesStatus = InArmedForces, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years25To29_ArmedForcesStatus-InArmedForces_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years25To29, ArmedForcesStatus, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years25To29_ArmedForcesStatus_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years25To29, Employment = BLS_Employed, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years25To29_Employment-BLSEmployed_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years25To29, Employment = BLS_Unemployed, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years25To29_Employment-BLSUnemployed_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years25To29, Employment, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years25To29_Employment_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years25To29, EmploymentStatus = BLS_InLaborForce, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years25To29_EmploymentStatus-BLSInLaborForce_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years25To29, EmploymentStatus = BLS_NotInLaborForce, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years25To29_EmploymentStatus-BLSNotInLaborForce_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years25To29, EmploymentStatus, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years25To29_EmploymentStatus_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years25To29, Gender = Female, Race",
+      "dcid": "dc/g/Person_Age-Years25To29_Gender-Female_Race"
+    },
+    {
+      "name": "Person By Age = Years25To29, Gender = Female, Race = AmericanIndianOrAlaskaNativeAlone",
+      "dcid": "dc/g/Person_Age-Years25To29_Gender-Female_Race-AmericanIndianOrAlaskaNativeAlone"
+    },
+    {
+      "name": "Person By Age = Years25To29, Gender = Female, Race = AsianAlone",
+      "dcid": "dc/g/Person_Age-Years25To29_Gender-Female_Race-AsianAlone"
+    },
+    {
+      "name": "Person By Age = Years25To29, Gender = Female, Race = BlackOrAfricanAmericanAlone",
+      "dcid": "dc/g/Person_Age-Years25To29_Gender-Female_Race-BlackOrAfricanAmericanAlone"
+    },
+    {
+      "name": "Person By Age = Years25To29, Gender = Female, Race = HispanicOrLatino",
+      "dcid": "dc/g/Person_Age-Years25To29_Gender-Female_Race-HispanicOrLatino"
+    },
+    {
+      "name": "Person By Age = Years25To29, Gender = Female, Race = NativeHawaiianOrOtherPacificIslanderAlone",
+      "dcid": "dc/g/Person_Age-Years25To29_Gender-Female_Race-NativeHawaiianOrOtherPacificIslanderAlone"
+    },
+    {
+      "name": "Person By Age = Years25To29, Gender = Female, Race = SomeOtherRaceAlone",
+      "dcid": "dc/g/Person_Age-Years25To29_Gender-Female_Race-SomeOtherRaceAlone"
+    },
+    {
+      "name": "Person By Age = Years25To29, Gender = Female, Race = TwoOrMoreRaces",
+      "dcid": "dc/g/Person_Age-Years25To29_Gender-Female_Race-TwoOrMoreRaces"
+    },
+    {
+      "name": "Person By Age = Years25To29, Gender = Female, Race = WhiteAlone",
+      "dcid": "dc/g/Person_Age-Years25To29_Gender-Female_Race-WhiteAlone"
+    },
+    {
+      "name": "Person By Age = Years25To29, Gender = Female, Race = WhiteAloneNotHispanicOrLatino",
+      "dcid": "dc/g/Person_Age-Years25To29_Gender-Female_Race-WhiteAloneNotHispanicOrLatino"
+    },
+    {
+      "name": "Person By Age = Years25To34, ArmedForcesStatus = Civilian, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years25To34_ArmedForcesStatus-Civilian_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years25To34, ArmedForcesStatus, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years25To34_ArmedForcesStatus_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years25To34, CollegeOrGraduateSchoolEnrollment = EnrolledInPrivateCollegeOrGraduateSchool, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years25To34_CollegeOrGraduateSchoolEnrollment-EnrolledInPrivateCollegeOrGraduateSchool_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years25To34, CollegeOrGraduateSchoolEnrollment = EnrolledInPublicCollegeOrGraduateSchool, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years25To34_CollegeOrGraduateSchoolEnrollment-EnrolledInPublicCollegeOrGraduateSchool_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years25To34, CollegeOrGraduateSchoolEnrollment = NotEnrolledInCollegeOrGraduateSchool, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years25To34_CollegeOrGraduateSchoolEnrollment-NotEnrolledInCollegeOrGraduateSchool_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years25To34, CollegeOrGraduateSchoolEnrollment, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years25To34_CollegeOrGraduateSchoolEnrollment_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years25To34, EducationalAttainment = 9ThTo12ThGradeNoDiploma, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years25To34_EducationalAttainment-9ThTo12ThGradeNoDiploma_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years25To34, EducationalAttainment = AssociatesDegree, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years25To34_EducationalAttainment-AssociatesDegree_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years25To34, EducationalAttainment = BachelorsDegree, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years25To34_EducationalAttainment-BachelorsDegree_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years25To34, EducationalAttainment = BachelorsDegreeOrHigher, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years25To34_EducationalAttainment-BachelorsDegreeOrHigher_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years25To34, EducationalAttainment = GraduateOrProfessionalDegree, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years25To34_EducationalAttainment-GraduateOrProfessionalDegree_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years25To34, EducationalAttainment = HighSchoolGraduateGedOrAlternative, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years25To34_EducationalAttainment-HighSchoolGraduateGedOrAlternative_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years25To34, EducationalAttainment = HighSchoolGraduateIncludesEquivalency, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years25To34_EducationalAttainment-HighSchoolGraduateIncludesEquivalency_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years25To34, EducationalAttainment = LessThan9ThGrade, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years25To34_EducationalAttainment-LessThan9ThGrade_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years25To34, EducationalAttainment = SomeCollegeNoDegree, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years25To34_EducationalAttainment-SomeCollegeNoDegree_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years25To34, EducationalAttainment, Gender = Female",
+      "dcid": "dc/g/Person_Age-Years25To34_EducationalAttainment_Gender-Female"
+    },
+    {
+      "name": "Person By Age = Years25To34, Gender = Female, HealthInsurance",
+      "dcid": "dc/g/Person_Age-Years25To34_Gender-Female_HealthInsurance"
+    },
+    {
+      "name": "Person By Age = Years25To34, Gender = Female, HealthInsurance = NoHealthInsurance",
+      "dcid": "dc/g/Person_Age-Years25To34_Gender-Female_HealthInsurance-NoHealthInsurance"
+    },
+    {
+      "name": "Person By Age = Years25To34, Gender = Female, HealthInsurance = NoPrivateHealthInsurance",
+      "dcid": "dc/g/Person_Age-Years25To34_Gender-Female_HealthInsurance-NoPrivateHealthInsurance"
+    },
+    {
+      "name": "Person By Age = Years25To34, Gender = Female, HealthInsurance = NoPublicHealthInsurance",
+      "dcid": "dc/g/Person_Age-Years25To34_Gender-Female_HealthInsurance-NoPublicHealthInsurance"
+    },
+    {
+      "name": "Person By Age = Years25To34, Gender = Female, HealthInsurance = WithHealthInsurance",
+      "dcid": "dc/g/Person_Age-Years25To34_Gender-Female_HealthInsurance-WithHealthInsurance"
+    },
+    {
+      "name": "Person By Age = Years25To34, Gender = Female, HealthInsurance = WithPrivateHealthInsurance",
+      "dcid": "dc/g/Person_Age-Years25To34_Gender-Female_HealthInsurance-WithPrivateHealthInsurance"
+    },
+    {
+      "name": "Person By Age = Years25To34, Gender = Female, HealthInsurance = WithPublicHealthInsurance",
+      "dcid": "dc/g/Person_Age-Years25To34_Gender-Female_HealthInsurance-WithPublicHealthInsurance"
+    },
+    {
+      "name": "Person By Age = Years25To34, Gender = Female, Institutionalization",
+      "dcid": "dc/g/Person_Age-Years25To34_Gender-Female_Institutionalization"
+    },
+    {
+      "name": "Person By Age = Years25To34, Gender = Female, Institutionalization = USC_NonInstitutionalized",
+      "dcid": "dc/g/Person_Age-Years25To34_Gender-Female_Institutionalization-USCNonInstitutionalized"
+    },
+    {
+      "name": "Person By Age = Years25To34, Gender = Female, PovertyStatus",
+      "dcid": "dc/g/Person_Age-Years25To34_Gender-Female_PovertyStatus"
+    },
+    {
+      "name": "Person By Age = Years25To34, Gender = Female, PovertyStatus = AbovePovertyLevelInThePast12Months",
+      "dcid": "dc/g/Person_Age-Years25To34_Gender-Female_PovertyStatus-AbovePovertyLevelInThePast12Months"
+    },
+    {
+      "name": "Person By Age = Years25To34, Gender = Female, PovertyStatus = BelowPovertyLevelInThePast12Months",
+      "dcid": "dc/g/Person_Age-Years25To34_Gender-Female_PovertyStatus-BelowPovertyLevelInThePast12Months"
+    },
+    {
+      "name": "Person By Age = Years25To34, Gender = Female, Race",
+      "dcid": "dc/g/Person_Age-Years25To34_Gender-Female_Race"
+    },
+    {
+      "name": "Person By Age = Years25To34, Gender = Female, Race = AmericanIndianOrAlaskaNativeAlone",
+      "dcid": "dc/g/Person_Age-Years25To34_Gender-Female_Race-AmericanIndianOrAlaskaNativeAlone"
     }
   ]
 }

--- a/test/integration/search_statvar_test.go
+++ b/test/integration/search_statvar_test.go
@@ -54,7 +54,7 @@ func TestSearchStatVar(t *testing.T) {
 		},
 		{
 			"female",
-			[]string{},
+			[]string{"country/USA"},
 			"female.json",
 		},
 	} {


### PR DESCRIPTION
In case where there are O(10k) stat var dcids, it takes seconds to read the existence cache. Since we do filter at the end anyway, perform a pre-filter before lookup existence cache.

Also improves readability for functions with long list of arguments.