### PR TITLE
Fix a translator bug that leads to infinite loop

### DIFF
--- a/internal/translator/translate.go
+++ b/internal/translator/translate.go
@@ -771,9 +771,19 @@ func getSQL(
 			}
 			futureTables = append(futureTables, otherCol.Table)
 		}
-		for _, v := range futureTables {
-			if _, ok := joinConstraints[v]; ok {
-				currTable = v
+
+		if len(futureTables) > 0 {
+			for _, v := range futureTables {
+				if _, ok := joinConstraints[v]; ok {
+					currTable = v
+					break
+				}
+			}
+		} else {
+			// It's possible future tables have all matched and become empty.
+			// In this case, pick currTable from joinConstraints.
+			for t := range joinConstraints {
+				currTable = t
 				break
 			}
 		}

--- a/internal/translator/translate_test.go
+++ b/internal/translator/translate_test.go
@@ -1037,12 +1037,38 @@ func TestSparql(t *testing.T) {
 			"adminarea1",
 			`
 			SELECT ?name
-      WHERE {
-      	?state typeOf AdministrativeArea1 .
-        ?state name ?name .
-      }
+		  WHERE {
+		  	?state typeOf AdministrativeArea1 .
+		    ?state name ?name .
+		  }
 			`,
 			"SELECT _dc_v3_Place_0.name AS name FROM `dc_v3.Place` AS _dc_v3_Place_0 WHERE _dc_v3_Place_0.type = \"AdministrativeArea1\"",
+		},
+		{
+			"bio",
+			`
+			SELECT distinct ?d
+			WHERE {
+				?ccdt typeOf ChemicalCompoundDiseaseTreatment .
+				?ccdt compoundID ?c .
+				?ccdt diseaseID ?dis .
+				?dis commonName ?d .
+				?c drugName "Prednisone" .
+			}
+			LIMIT 100
+			`,
+			"SELECT _dc_v3_Triple_3.object_value AS d FROM `dc_v3.Triple` AS _dc_v3_Triple_0 " +
+				"JOIN `dc_v3.Triple` AS _dc_v3_Triple_1 ON _dc_v3_Triple_0.subject_id = _dc_v3_Triple_1.subject_id " +
+				"JOIN `dc_v3.Triple` AS _dc_v3_Triple_2 ON _dc_v3_Triple_0.subject_id = _dc_v3_Triple_2.subject_id " +
+				"JOIN `dc_v3.Triple` AS _dc_v3_Triple_4 ON _dc_v3_Triple_1.object_id = _dc_v3_Triple_4.subject_id " +
+				"JOIN `dc_v3.Triple` AS _dc_v3_Triple_3 ON _dc_v3_Triple_2.object_id = _dc_v3_Triple_3.subject_id " +
+				"WHERE _dc_v3_Triple_0.object_id = \"ChemicalCompoundDiseaseTreatment\" " +
+				"AND _dc_v3_Triple_0.predicate = \"typeOf\" " +
+				"AND _dc_v3_Triple_1.predicate = \"compoundID\" " +
+				"AND _dc_v3_Triple_2.predicate = \"diseaseID\" " +
+				"AND _dc_v3_Triple_3.predicate = \"commonName\" " +
+				"AND _dc_v3_Triple_4.object_value = \"Prednisone\" " +
+				"AND _dc_v3_Triple_4.predicate = \"drugName\"",
 		},
 	} {
 		nodes, queries, _, err := sparql.ParseQuery(c.queryStr)


### PR DESCRIPTION
This is responsible for the timeout of the following command:

`curl --request POST --url https://api.datacommons.org/query  --header 'content-type: application/json' --data '{ "sparql": "SELECT distinct ?d  WHERE { ?ccdt typeOf ChemicalCompoundDiseaseTreatment . ?ccdt compoundID ?c . ?c drugName Prednisone . ?ccdt diseaseID ?dis . ?dis commonName ?d }  LIMIT 10"}'`

and likely the cause for some of the previous bio queries where long Triples tables join are performed