### PR TITLE
[Private DC] support stat var group node API

### DIFF
--- a/internal/server/statvar_group.go
+++ b/internal/server/statvar_group.go
@@ -263,6 +263,43 @@ func (s *Server) GetStatVarGroupNode(
 			}
 		}
 	}
+
+	// Gather stat vars from the private import
+	if s.store.MemDb != nil {
+		hasDataStatVars, noDataStatVars := s.store.MemDb.GetStatVars([]string{})
+		if svg == "dc/g/Root" {
+			result.ChildStatVarGroups = append(
+				result.ChildStatVarGroups,
+				&pb.StatVarGroupNode_ChildSVG{
+					Id:                    "dc/g/Private",
+					SpecializedEntity:     "Private",
+					DisplayName:           "Private",
+					NumDescendentStatVars: int32(len(hasDataStatVars) + len(noDataStatVars)),
+				},
+			)
+		} else if svg == "dc/g/Private" {
+			for _, statVar := range hasDataStatVars {
+				result.ChildStatVars = append(
+					result.ChildStatVars,
+					&pb.StatVarGroupNode_ChildSV{
+						Id:          statVar,
+						DisplayName: statVar,
+						HasData:     true,
+					},
+				)
+			}
+			for _, statVar := range noDataStatVars {
+				result.ChildStatVars = append(
+					result.ChildStatVars,
+					&pb.StatVarGroupNode_ChildSV{
+						Id:          statVar,
+						DisplayName: statVar,
+						HasData:     false,
+					},
+				)
+			}
+		}
+	}
 	return result, nil
 }
 

--- a/internal/store/memdb.go
+++ b/internal/store/memdb.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"log"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -75,6 +76,8 @@ func (memDb *MemDb) GetStatVars(places []string) ([]string, []string) {
 			noDataStatVars = append(noDataStatVars, statVar)
 		}
 	}
+	sort.Strings(hasDataStatVars)
+	sort.Strings(noDataStatVars)
 	return hasDataStatVars, noDataStatVars
 }
 

--- a/internal/store/memdb.go
+++ b/internal/store/memdb.go
@@ -52,6 +52,32 @@ func (memDb *MemDb) ReadSeries(statVar, place string) []*pb.Series {
 	return []*pb.Series{}
 }
 
+// GetStatVars retrieves the stat vars from private import that have data for
+// the given places.
+func (memDb *MemDb) GetStatVars(places []string) ([]string, []string) {
+	hasDataStatVars := []string{}
+	noDataStatVars := []string{}
+	for statVar, statVarData := range memDb.statSeries {
+		valid := false
+		if len(places) == 0 {
+			valid = true
+		} else {
+			for _, place := range places {
+				if _, ok := statVarData[place]; ok {
+					valid = true
+					break
+				}
+			}
+		}
+		if valid {
+			hasDataStatVars = append(hasDataStatVars, statVar)
+		} else {
+			noDataStatVars = append(noDataStatVars, statVar)
+		}
+	}
+	return hasDataStatVars, noDataStatVars
+}
+
 // LoadFromGcs loads tmcf + csv files into memory database
 func (memDb *MemDb) LoadFromGcs(ctx context.Context, bucket, prefix string) error {
 	gcsClient, err := storage.NewClient(ctx)

--- a/test/integration/get_statvar_group_node_test.go
+++ b/test/integration/get_statvar_group_node_test.go
@@ -84,6 +84,11 @@ func TestGetStatVarGroupNode(t *testing.T) {
 			"dc/g/Person_CitizenshipStatus-NotAUSCitizen_CorrectionalFacilityOperator-StateOperated&FederallyOperated&PrivatelyOperated",
 			"citizenship.json",
 		},
+		{
+			[]string{"country/ALB"},
+			"dc/g/Private",
+			"private.json",
+		},
 	} {
 		resp, err := client.GetStatVarGroupNode(ctx, &pb.GetStatVarGroupNodeRequest{
 			Places:       c.places,

--- a/test/integration/golden_response/get_statvar_group_node/private.json
+++ b/test/integration/golden_response/get_statvar_group_node/private.json
@@ -1,0 +1,54 @@
+{
+  "childStatVars": [
+    {
+      "id": "Test_Stat_Var_2",
+      "displayName": "Test_Stat_Var_2",
+      "hasData": true
+    },
+    {
+      "id": "Test_Stat_Var_4",
+      "displayName": "Test_Stat_Var_4",
+      "hasData": true
+    },
+    {
+      "id": "Test_Stat_Var_9",
+      "displayName": "Test_Stat_Var_9",
+      "hasData": true
+    },
+    {
+      "id": "Test_Stat_Var_1",
+      "displayName": "Test_Stat_Var_1",
+      "hasData": true
+    },
+    {
+      "id": "Test_Stat_Var_10",
+      "displayName": "Test_Stat_Var_10",
+      "hasData": true
+    },
+    {
+      "id": "Test_Stat_Var_6",
+      "displayName": "Test_Stat_Var_6",
+      "hasData": true
+    },
+    {
+      "id": "Test_Stat_Var_7",
+      "displayName": "Test_Stat_Var_7",
+      "hasData": true
+    },
+    {
+      "id": "Test_Stat_Var_5",
+      "displayName": "Test_Stat_Var_5",
+      "hasData": true
+    },
+    {
+      "id": "Test_Stat_Var_8",
+      "displayName": "Test_Stat_Var_8",
+      "hasData": true
+    },
+    {
+      "id": "Test_Stat_Var_3",
+      "displayName": "Test_Stat_Var_3",
+      "hasData": true
+    }
+  ]
+}

--- a/test/integration/golden_response/get_statvar_group_node/private.json
+++ b/test/integration/golden_response/get_statvar_group_node/private.json
@@ -1,8 +1,23 @@
 {
   "childStatVars": [
     {
+      "id": "Test_Stat_Var_1",
+      "displayName": "Test_Stat_Var_1",
+      "hasData": true
+    },
+    {
+      "id": "Test_Stat_Var_10",
+      "displayName": "Test_Stat_Var_10",
+      "hasData": true
+    },
+    {
       "id": "Test_Stat_Var_2",
       "displayName": "Test_Stat_Var_2",
+      "hasData": true
+    },
+    {
+      "id": "Test_Stat_Var_3",
+      "displayName": "Test_Stat_Var_3",
       "hasData": true
     },
     {
@@ -11,18 +26,8 @@
       "hasData": true
     },
     {
-      "id": "Test_Stat_Var_9",
-      "displayName": "Test_Stat_Var_9",
-      "hasData": true
-    },
-    {
-      "id": "Test_Stat_Var_1",
-      "displayName": "Test_Stat_Var_1",
-      "hasData": true
-    },
-    {
-      "id": "Test_Stat_Var_10",
-      "displayName": "Test_Stat_Var_10",
+      "id": "Test_Stat_Var_5",
+      "displayName": "Test_Stat_Var_5",
       "hasData": true
     },
     {
@@ -36,18 +41,13 @@
       "hasData": true
     },
     {
-      "id": "Test_Stat_Var_5",
-      "displayName": "Test_Stat_Var_5",
-      "hasData": true
-    },
-    {
       "id": "Test_Stat_Var_8",
       "displayName": "Test_Stat_Var_8",
       "hasData": true
     },
     {
-      "id": "Test_Stat_Var_3",
-      "displayName": "Test_Stat_Var_3",
+      "id": "Test_Stat_Var_9",
+      "displayName": "Test_Stat_Var_9",
       "hasData": true
     }
   ]

--- a/test/integration/golden_response/get_statvar_group_node/root.json
+++ b/test/integration/golden_response/get_statvar_group_node/root.json
@@ -78,6 +78,12 @@
       "specializedEntity": "Uncategorized",
       "displayName": "Uncategorized",
       "numDescendentStatVars": 5516
+    },
+    {
+      "id": "dc/g/Private",
+      "specializedEntity": "Private",
+      "displayName": "Private",
+      "numDescendentStatVars": 10
     }
   ],
   "numDescendentStatVars": 60618

--- a/test/integration/golden_response/get_statvar_group_node/root_mtv.json
+++ b/test/integration/golden_response/get_statvar_group_node/root_mtv.json
@@ -75,6 +75,12 @@
       "specializedEntity": "Uncategorized",
       "displayName": "Uncategorized",
       "numDescendentStatVars": 10
+    },
+    {
+      "id": "dc/g/Private",
+      "specializedEntity": "Private",
+      "displayName": "Private",
+      "numDescendentStatVars": 10
     }
   ],
   "numDescendentStatVars": 6958

--- a/test/integration/golden_response/get_statvar_group_node/root_mtv_jpn.json
+++ b/test/integration/golden_response/get_statvar_group_node/root_mtv_jpn.json
@@ -78,6 +78,12 @@
       "specializedEntity": "Uncategorized",
       "displayName": "Uncategorized",
       "numDescendentStatVars": 1007
+    },
+    {
+      "id": "dc/g/Private",
+      "specializedEntity": "Private",
+      "displayName": "Private",
+      "numDescendentStatVars": 10
     }
   ],
   "numDescendentStatVars": 6958


### PR DESCRIPTION
All the private stat vars are added under "dc/g/Private" categories.

This change makes the private stat vars explorer-able from the hierarchy widget.