### PR TITLE
Update mixer local development config

### DIFF
--- a/deploy/overlays/local/patch_deployment.yaml
+++ b/deploy/overlays/local/patch_deployment.yaml
@@ -31,22 +31,22 @@ spec:
           imagePullPolicy: Never
           resources:
             limits:
-              memory: "3G"
-              cpu: "800m"
+              memory: "2G"
+              cpu: "400m"
             requests:
-              memory: "3G"
-              cpu: "800m"
+              memory: "2G"
+              cpu: "400m"
         - name: esp
           volumeMounts:
             - mountPath: /esp
               name: mixer-grpc-json
           resources:
             limits:
-              memory: "1G"
-              cpu: "200m"
+              memory: "0.5G"
+              cpu: "100m"
             requests:
-              memory: "1G"
-              cpu: "200m"
+              memory: "0.5G"
+              cpu: "100m"
         - name: api-compiler
           image: datacommons/api-compiler
           imagePullPolicy: Never

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -50,12 +50,12 @@ kubectl config use-context minikube
 skaffold dev --port-forward -n mixer
 ```
 
-This exposes the local mixer service at `localhost:9090`.
+This exposes the local mixer service at `localhost:8081`.
 
 To verify the server serving request:
 
 ```bash
-curl http://localhost:9090/node/property-labels?dcids=Class
+curl http://localhost:8081/node/property-labels?dcids=Class
 ```
 
 After code edit, the container images are automatically rebuilt and re-deployed to the local cluster.

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -44,4 +44,4 @@ portForward:
   resourceName: mixer-service-local
   namespace: mixer
   port: 80
-  localPort: 9090
+  localPort: 8081


### PR DESCRIPTION
- Reduce resources so minikube can restart a new deployment without first deleting current deployment. Note minikube should have > 2x memory of one deployment to make this work
- Change local deployment port to 8081, which matches the GKE port.