### PR TITLE
[Private DC] Support manifest.json in the import

### DIFF
--- a/internal/proto/common.pb.go
+++ b/internal/proto/common.pb.go
@@ -147,6 +147,73 @@ func (x *GraphNode) GetValue() string {
 	return ""
 }
 
+// Holds the import manifest information.
+type Manifest struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	// Name of the import
+	ImportName string `protobuf:"bytes,1,opt,name=import_name,json=importName,proto3" json:"import_name,omitempty"`
+	// The url of the data, ususally the source url link
+	ProvenanceUrl string `protobuf:"bytes,2,opt,name=provenance_url,json=provenanceUrl,proto3" json:"provenance_url,omitempty"`
+	// Data download link. For private import, this should be the GCS folder url.
+	DataDownloadUrl string `protobuf:"bytes,3,opt,name=data_download_url,json=dataDownloadUrl,proto3" json:"data_download_url,omitempty"`
+}
+
+func (x *Manifest) Reset() {
+	*x = Manifest{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_common_proto_msgTypes[1]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *Manifest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Manifest) ProtoMessage() {}
+
+func (x *Manifest) ProtoReflect() protoreflect.Message {
+	mi := &file_common_proto_msgTypes[1]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Manifest.ProtoReflect.Descriptor instead.
+func (*Manifest) Descriptor() ([]byte, []int) {
+	return file_common_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *Manifest) GetImportName() string {
+	if x != nil {
+		return x.ImportName
+	}
+	return ""
+}
+
+func (x *Manifest) GetProvenanceUrl() string {
+	if x != nil {
+		return x.ProvenanceUrl
+	}
+	return ""
+}
+
+func (x *Manifest) GetDataDownloadUrl() string {
+	if x != nil {
+		return x.DataDownloadUrl
+	}
+	return ""
+}
+
 // Message to hold a cohort of nodes that have the same predicate and
 // direction.
 type GraphNode_LinkedNodes struct {
@@ -162,7 +229,7 @@ type GraphNode_LinkedNodes struct {
 func (x *GraphNode_LinkedNodes) Reset() {
 	*x = GraphNode_LinkedNodes{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_common_proto_msgTypes[1]
+		mi := &file_common_proto_msgTypes[2]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -175,7 +242,7 @@ func (x *GraphNode_LinkedNodes) String() string {
 func (*GraphNode_LinkedNodes) ProtoMessage() {}
 
 func (x *GraphNode_LinkedNodes) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[1]
+	mi := &file_common_proto_msgTypes[2]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -232,7 +299,15 @@ var file_common_proto_rawDesc = []byte{
 	0x6f, 0x6e, 0x52, 0x09, 0x64, 0x69, 0x72, 0x65, 0x63, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x2c, 0x0a,
 	0x05, 0x6e, 0x6f, 0x64, 0x65, 0x73, 0x18, 0x03, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x16, 0x2e, 0x64,
 	0x61, 0x74, 0x61, 0x63, 0x6f, 0x6d, 0x6d, 0x6f, 0x6e, 0x73, 0x2e, 0x47, 0x72, 0x61, 0x70, 0x68,
-	0x4e, 0x6f, 0x64, 0x65, 0x52, 0x05, 0x6e, 0x6f, 0x64, 0x65, 0x73, 0x2a, 0x4f, 0x0a, 0x11, 0x50,
+	0x4e, 0x6f, 0x64, 0x65, 0x52, 0x05, 0x6e, 0x6f, 0x64, 0x65, 0x73, 0x22, 0x7e, 0x0a, 0x08, 0x4d,
+	0x61, 0x6e, 0x69, 0x66, 0x65, 0x73, 0x74, 0x12, 0x1f, 0x0a, 0x0b, 0x69, 0x6d, 0x70, 0x6f, 0x72,
+	0x74, 0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0a, 0x69, 0x6d,
+	0x70, 0x6f, 0x72, 0x74, 0x4e, 0x61, 0x6d, 0x65, 0x12, 0x25, 0x0a, 0x0e, 0x70, 0x72, 0x6f, 0x76,
+	0x65, 0x6e, 0x61, 0x6e, 0x63, 0x65, 0x5f, 0x75, 0x72, 0x6c, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09,
+	0x52, 0x0d, 0x70, 0x72, 0x6f, 0x76, 0x65, 0x6e, 0x61, 0x6e, 0x63, 0x65, 0x55, 0x72, 0x6c, 0x12,
+	0x2a, 0x0a, 0x11, 0x64, 0x61, 0x74, 0x61, 0x5f, 0x64, 0x6f, 0x77, 0x6e, 0x6c, 0x6f, 0x61, 0x64,
+	0x5f, 0x75, 0x72, 0x6c, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0f, 0x64, 0x61, 0x74, 0x61,
+	0x44, 0x6f, 0x77, 0x6e, 0x6c, 0x6f, 0x61, 0x64, 0x55, 0x72, 0x6c, 0x2a, 0x4f, 0x0a, 0x11, 0x50,
 	0x72, 0x6f, 0x70, 0x65, 0x72, 0x74, 0x79, 0x44, 0x69, 0x72, 0x65, 0x63, 0x74, 0x69, 0x6f, 0x6e,
 	0x12, 0x15, 0x0a, 0x11, 0x44, 0x49, 0x52, 0x45, 0x43, 0x54, 0x49, 0x4f, 0x4e, 0x5f, 0x55, 0x4e,
 	0x4b, 0x4e, 0x4f, 0x57, 0x4e, 0x10, 0x00, 0x12, 0x10, 0x0a, 0x0c, 0x44, 0x49, 0x52, 0x45, 0x43,
@@ -254,14 +329,15 @@ func file_common_proto_rawDescGZIP() []byte {
 }
 
 var file_common_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_common_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
+var file_common_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
 var file_common_proto_goTypes = []interface{}{
 	(PropertyDirection)(0),        // 0: datacommons.PropertyDirection
 	(*GraphNode)(nil),             // 1: datacommons.GraphNode
-	(*GraphNode_LinkedNodes)(nil), // 2: datacommons.GraphNode.LinkedNodes
+	(*Manifest)(nil),              // 2: datacommons.Manifest
+	(*GraphNode_LinkedNodes)(nil), // 3: datacommons.GraphNode.LinkedNodes
 }
 var file_common_proto_depIdxs = []int32{
-	2, // 0: datacommons.GraphNode.neighbours:type_name -> datacommons.GraphNode.LinkedNodes
+	3, // 0: datacommons.GraphNode.neighbours:type_name -> datacommons.GraphNode.LinkedNodes
 	0, // 1: datacommons.GraphNode.LinkedNodes.direction:type_name -> datacommons.PropertyDirection
 	1, // 2: datacommons.GraphNode.LinkedNodes.nodes:type_name -> datacommons.GraphNode
 	3, // [3:3] is the sub-list for method output_type
@@ -290,6 +366,18 @@ func file_common_proto_init() {
 			}
 		}
 		file_common_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*Manifest); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_common_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*GraphNode_LinkedNodes); i {
 			case 0:
 				return &v.state
@@ -308,7 +396,7 @@ func file_common_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_common_proto_rawDesc,
 			NumEnums:      1,
-			NumMessages:   2,
+			NumMessages:   3,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/internal/store/memdb.go
+++ b/internal/store/memdb.go
@@ -171,7 +171,6 @@ func (memDb *MemDb) LoadFromGcs(ctx context.Context, bucket, prefix string) erro
 	}
 	// Read manifest.json
 	for _, object := range objects {
-		log.Println(object)
 		if strings.HasSuffix(object, "manifest.json") {
 			r, err := bkt.Object(object).NewReader(ctx)
 			if err != nil {
@@ -183,7 +182,6 @@ func (memDb *MemDb) LoadFromGcs(ctx context.Context, bucket, prefix string) erro
 				return err
 			}
 			manifest := &pb.Manifest{}
-			log.Println(manifest)
 			err = protojson.Unmarshal(bytes, manifest)
 			if err != nil {
 				return err

--- a/internal/store/memdb.go
+++ b/internal/store/memdb.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/csv"
 	"io"
+	"io/ioutil"
 	"log"
 	"path/filepath"
 	"sort"
@@ -28,23 +29,21 @@ import (
 	"github.com/datacommonsorg/mixer/internal/parser"
 	pb "github.com/datacommonsorg/mixer/internal/proto"
 	"google.golang.org/api/iterator"
-)
-
-// TODO(shifucun): Get the import name from GCS manifest file.
-const (
-	privateImport = "Private Import"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 // MemDb holds imported data in memory.
 type MemDb struct {
 	// statVar -> place -> []Series
 	statSeries map[string]map[string][]*pb.Series
+	manifest   *pb.Manifest
 }
 
 // NewMemDb initialize a MemDb instance.
 func NewMemDb() *MemDb {
 	return &MemDb{
 		statSeries: map[string]map[string][]*pb.Series{},
+		manifest:   &pb.Manifest{},
 	}
 }
 
@@ -86,7 +85,7 @@ func (memDb *MemDb) ReadPointValue(statVar, place, date string) (
 					Date:  date,
 					Value: val,
 					Metadata: &pb.StatMetadata{
-						ImportName: privateImport,
+						ImportName: memDb.manifest.ImportName,
 					}}, series.Metadata
 			}
 		}
@@ -108,7 +107,7 @@ func (memDb *MemDb) ReadPointValue(statVar, place, date string) (
 			return &pb.PointStat{
 				Date:     latestDate,
 				Value:    latestVal,
-				Metadata: &pb.StatMetadata{ImportName: privateImport},
+				Metadata: &pb.StatMetadata{ImportName: memDb.manifest.ImportName},
 			}, meta
 		}
 	}
@@ -170,6 +169,29 @@ func (memDb *MemDb) LoadFromGcs(ctx context.Context, bucket, prefix string) erro
 		}
 		objects = append(objects, attrs.Name)
 	}
+	// Read manifest.json
+	for _, object := range objects {
+		log.Println(object)
+		if strings.HasSuffix(object, "manifest.json") {
+			r, err := bkt.Object(object).NewReader(ctx)
+			if err != nil {
+				return err
+			}
+			defer r.Close()
+			bytes, err := ioutil.ReadAll(r)
+			if err != nil {
+				return err
+			}
+			manifest := &pb.Manifest{}
+			log.Println(manifest)
+			err = protojson.Unmarshal(bytes, manifest)
+			if err != nil {
+				return err
+			}
+			memDb.manifest = manifest
+			break
+		}
+	}
 	// Read TMCF
 	var schemaMapping map[string]*parser.TableSchema
 	for _, object := range objects {
@@ -214,7 +236,7 @@ func (memDb *MemDb) LoadFromGcs(ctx context.Context, bucket, prefix string) erro
 				if err != nil {
 					return err
 				}
-				err = addRow(header, row, schemaMapping[tableName], memDb.statSeries)
+				err = addRow(header, row, schemaMapping[tableName], memDb.statSeries, memDb.manifest)
 				if err != nil {
 					return err
 				}
@@ -241,6 +263,7 @@ func addRow(
 	row []string,
 	schemaMapping *parser.TableSchema,
 	statSeries map[string]map[string][]*pb.Series,
+	manifest *pb.Manifest,
 ) error {
 	// Keyed by node id like "E0"
 	allNodes := map[string]*nodeObs{}
@@ -250,8 +273,8 @@ func addRow(
 			allNodes[node] = &nodeObs{
 				statVar: meta["variableMeasured"],
 				meta: &pb.StatMetadata{
-					ProvenanceUrl: "private.domain",
-					ImportName:    privateImport,
+					ProvenanceUrl: manifest.ProvenanceUrl,
+					ImportName:    manifest.ImportName,
 				},
 			}
 		}

--- a/internal/store/memdb_test.go
+++ b/internal/store/memdb_test.go
@@ -54,6 +54,11 @@ var (
 			},
 		},
 	}
+
+	manifest = &pb.Manifest{
+		ImportName:    "Private Import",
+		ProvenanceUrl: "private.domain",
+	}
 )
 
 func TestAddRow(t *testing.T) {
@@ -171,7 +176,7 @@ func TestAddRow(t *testing.T) {
 	} {
 		data := map[string]map[string][]*pb.Series{}
 		for _, row := range c.rows {
-			err := addRow(c.header, row, ts, data)
+			err := addRow(c.header, row, ts, data, manifest)
 			if err != nil {
 				t.Fail()
 			}

--- a/internal/store/memdb_test.go
+++ b/internal/store/memdb_test.go
@@ -174,14 +174,15 @@ func TestAddRow(t *testing.T) {
 			},
 		},
 	} {
-		data := map[string]map[string][]*pb.Series{}
+		memDb := NewMemDb()
 		for _, row := range c.rows {
-			err := addRow(c.header, row, ts, data, manifest)
+			memDb.manifest = manifest
+			err := memDb.addRow(c.header, row, ts)
 			if err != nil {
 				t.Fail()
 			}
 		}
-		if diff := cmp.Diff(data, c.want, protocmp.Transform()); diff != "" {
+		if diff := cmp.Diff(memDb.statSeries, c.want, protocmp.Transform()); diff != "" {
 			t.Errorf("ParseTmcf got diff: %v", diff)
 			continue
 		}

--- a/proto/common.proto
+++ b/proto/common.proto
@@ -47,5 +47,6 @@ message Manifest {
   // The url of the data, ususally the source url link
   string provenance_url = 2;
   // Data download link. For private import, this should be the GCS folder url.
+  // Example: https://pantheon.corp.google.com/storage/browser/datcom-public/test
   string data_download_url = 3;
 }

--- a/proto/common.proto
+++ b/proto/common.proto
@@ -39,3 +39,13 @@ message GraphNode {
   // Value of the node, could be dcid or node string value.
   string value = 2;
 }
+
+// Holds the import manifest information.
+message Manifest {
+  // Name of the import
+  string import_name = 1;
+  // The url of the data, ususally the source url link
+  string provenance_url = 2;
+  // Data download link. For private import, this should be the GCS folder url.
+  string data_download_url = 3;
+}

--- a/test/integration/golden_response/get_stat_set_series/memdb.json
+++ b/test/integration/golden_response/get_stat_set_series/memdb.json
@@ -142,8 +142,8 @@
             "2021-08-10": 1280239
           },
           "metadata": {
-            "importName": "Private Import",
-            "provenanceUrl": "private.domain",
+            "importName": "Test Private Import",
+            "provenanceUrl": "https://test.datacommons.org",
             "measurementMethod": "Test_Method"
           }
         },
@@ -622,8 +622,8 @@
             "2021-06-13": 2224
           },
           "metadata": {
-            "importName": "Private Import",
-            "provenanceUrl": "private.domain",
+            "importName": "Test Private Import",
+            "provenanceUrl": "https://test.datacommons.org",
             "measurementMethod": "Test_Method"
           }
         }
@@ -662,8 +662,8 @@
             "2021-07-19": 82349
           },
           "metadata": {
-            "importName": "Private Import",
-            "provenanceUrl": "private.domain",
+            "importName": "Test Private Import",
+            "provenanceUrl": "https://test.datacommons.org",
             "measurementMethod": "Test_Method"
           }
         },

--- a/test/integration/golden_response/get_stat_set_within_place/memdb.json
+++ b/test/integration/golden_response/get_stat_set_within_place/memdb.json
@@ -6,42 +6,42 @@
           "date": "2021-08-13",
           "value": 141611,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/AFG": {
           "date": "2021-08-11",
           "value": 1809517,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/AGO": {
           "date": "2021-08-09",
           "value": 1695588,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/AIA": {
           "date": "2021-08-06",
           "value": 18457,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/ALB": {
           "date": "2021-08-10",
           "value": 1280239,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/AND": {
           "date": "2021-07-19",
           "value": 82349,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/ANT": {},
@@ -49,21 +49,21 @@
           "date": "2021-08-13",
           "value": 17313163,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/ARG": {
           "date": "2021-08-13",
           "value": 36038031,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/ARM": {
           "date": "2021-08-08",
           "value": 194902,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/ASM": {},
@@ -74,7 +74,7 @@
           "date": "2021-08-10",
           "value": 70019,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/ATN": {},
@@ -82,21 +82,21 @@
           "date": "2021-08-13",
           "value": 14747221,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/AUT": {
           "date": "2021-08-13",
           "value": 10141918,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/AZE": {
           "date": "2021-08-13",
           "value": 5671138,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/BDI": {},
@@ -104,14 +104,14 @@
           "date": "2021-08-12",
           "value": 15495398,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/BEN": {
           "date": "2021-08-03",
           "value": 70323,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/BES": {},
@@ -119,42 +119,42 @@
           "date": "2021-08-09",
           "value": 38405,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/BGD": {
           "date": "2021-08-13",
           "value": 20362016,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/BGR": {
           "date": "2021-08-13",
           "value": 2149134,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/BHR": {
           "date": "2021-08-13",
           "value": 2412624,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/BHS": {
           "date": "2021-08-09",
           "value": 110443,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/BIH": {
           "date": "2021-08-11",
           "value": 865306,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/BLM": {},
@@ -162,56 +162,56 @@
           "date": "2021-08-10",
           "value": 2541745,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/BLZ": {
           "date": "2021-08-11",
           "value": 202797,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/BMU": {
           "date": "2021-08-13",
           "value": 83297,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/BOL": {
           "date": "2021-08-13",
           "value": 5004937,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/BRA": {
           "date": "2021-08-12",
           "value": 160056922,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/BRB": {
           "date": "2021-08-11",
           "value": 183493,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/BRN": {
           "date": "2021-08-11",
           "value": 201441,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/BTN": {
           "date": "2021-08-09",
           "value": 1010129,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/BVT": {},
@@ -219,21 +219,21 @@
           "date": "2021-08-10",
           "value": 391360,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/CAF": {
           "date": "2021-08-05",
           "value": 95282,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/CAN": {
           "date": "2021-08-13",
           "value": 51290984,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/CCK": {},
@@ -241,84 +241,84 @@
           "date": "2021-08-12",
           "value": 9218419,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/CHL": {
           "date": "2021-08-11",
           "value": 26587659,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/CHN": {
           "date": "2021-08-13",
           "value": 1844382000,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/CIV": {
           "date": "2021-08-12",
           "value": 1194760,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/CMR": {
           "date": "2021-08-09",
           "value": 368280,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/COD": {
           "date": "2021-08-09",
           "value": 86244,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/COG": {
           "date": "2021-08-12",
           "value": 255988,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/COK": {
           "date": "2021-07-20",
           "value": 20509,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/COL": {
           "date": "2021-08-11",
           "value": 31149291,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/COM": {
           "date": "2021-08-09",
           "value": 188875,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/CPV": {
           "date": "2021-08-09",
           "value": 204780,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/CRI": {
           "date": "2021-08-09",
           "value": 3643509,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/CTE": {},
@@ -326,7 +326,7 @@
           "date": "2021-08-11",
           "value": 11059697,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/CUW": {},
@@ -335,77 +335,77 @@
           "date": "2021-08-12",
           "value": 99194,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/CYP": {
           "date": "2021-08-12",
           "value": 1040915,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/CZE": {
           "date": "2021-08-13",
           "value": 10940137,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/DEU": {
           "date": "2021-08-12",
           "value": 96852861,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/DJI": {
           "date": "2021-08-12",
           "value": 53064,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/DMA": {
           "date": "2021-08-13",
           "value": 40795,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/DNK": {
           "date": "2021-08-12",
           "value": 7974868,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/DOM": {
           "date": "2021-08-12",
           "value": 10601438,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/DZA": {
           "date": "2021-07-29",
           "value": 4146091,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/ECU": {
           "date": "2021-08-12",
           "value": 14363025,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/EGY": {
           "date": "2021-08-10",
           "value": 5750549,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/ERI": {},
@@ -414,56 +414,56 @@
           "date": "2021-08-12",
           "value": 60919867,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/EST": {
           "date": "2021-08-13",
           "value": 1201727,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/ETH": {
           "date": "2021-08-12",
           "value": 2302496,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/FIN": {
           "date": "2021-08-13",
           "value": 6115987,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/FJI": {
           "date": "2021-08-09",
           "value": 690888,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/FLK": {
           "date": "2021-04-14",
           "value": 4407,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/FRA": {
           "date": "2021-08-12",
           "value": 79839977,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/FRO": {
           "date": "2021-08-12",
           "value": 68843,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/FSM": {},
@@ -472,49 +472,49 @@
           "date": "2021-08-12",
           "value": 120627,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/GBR": {
           "date": "2021-08-12",
           "value": 87421381,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/GEO": {
           "date": "2021-08-13",
           "value": 767882,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/GGY": {
           "date": "2021-08-13",
           "value": 96687,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/GHA": {
           "date": "2021-07-19",
           "value": 1271393,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/GIB": {
           "date": "2021-08-12",
           "value": 78535,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/GIN": {
           "date": "2021-08-10",
           "value": 938537,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/GLP": {},
@@ -522,49 +522,49 @@
           "date": "2021-07-15",
           "value": 43557,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/GNB": {
           "date": "2021-08-09",
           "value": 30471,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/GNQ": {
           "date": "2021-08-07",
           "value": 314289,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/GRC": {
           "date": "2021-08-13",
           "value": 10965338,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/GRD": {
           "date": "2021-08-09",
           "value": 38872,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/GRL": {
           "date": "2021-08-13",
           "value": 67849,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/GTM": {
           "date": "2021-08-12",
           "value": 3066401,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/GUF": {},
@@ -573,14 +573,14 @@
           "date": "2021-08-12",
           "value": 425580,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/HKG": {
           "date": "2021-08-13",
           "value": 6515453,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/HMD": {},
@@ -588,49 +588,49 @@
           "date": "2021-08-11",
           "value": 2806063,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/HRV": {
           "date": "2021-08-12",
           "value": 3157783,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/HTI": {
           "date": "2021-08-11",
           "value": 19182,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/HUN": {
           "date": "2021-08-01",
           "value": 10481449,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/IDN": {
           "date": "2021-08-12",
           "value": 79054211,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/IMN": {
           "date": "2021-08-11",
           "value": 125593,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/IND": {
           "date": "2021-08-13",
           "value": 536189903,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/IOT": {},
@@ -638,210 +638,210 @@
           "date": "2021-08-12",
           "value": 6288754,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/IRN": {
           "date": "2021-08-09",
           "value": 16213714,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/IRQ": {
           "date": "2021-08-06",
           "value": 2102550,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/ISL": {
           "date": "2021-08-06",
           "value": 477205,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/ISR": {
           "date": "2021-08-13",
           "value": 12062285,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/ITA": {
           "date": "2021-08-13",
           "value": 73592927,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/JAM": {
           "date": "2021-08-13",
           "value": 391076,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/JEY": {
           "date": "2021-08-08",
           "value": 144896,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/JOR": {
           "date": "2021-08-13",
           "value": 5692336,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/JPN": {
           "date": "2021-08-12",
           "value": 108179498,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/KAZ": {
           "date": "2021-08-13",
           "value": 10607929,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/KEN": {
           "date": "2021-08-12",
           "value": 1922085,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/KGZ": {
           "date": "2021-08-13",
           "value": 841077,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/KHM": {
           "date": "2021-08-13",
           "value": 15372439,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/KIR": {
           "date": "2021-08-09",
           "value": 13970,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/KNA": {
           "date": "2021-08-10",
           "value": 43966,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/KOR": {
           "date": "2021-08-13",
           "value": 30649269,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/KWT": {
           "date": "2021-07-03",
           "value": 2375455,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/LAO": {
           "date": "2021-08-08",
           "value": 2574278,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/LBN": {
           "date": "2021-08-13",
           "value": 2190858,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/LBR": {
           "date": "2021-07-12",
           "value": 95423,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/LBY": {
           "date": "2021-08-09",
           "value": 764233,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/LCA": {
           "date": "2021-08-13",
           "value": 59537,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/LIE": {
           "date": "2021-08-12",
           "value": 40614,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/LKA": {
           "date": "2021-08-12",
           "value": 15310726,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/LSO": {
           "date": "2021-07-26",
           "value": 72948,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/LTU": {
           "date": "2021-08-13",
           "value": 2911801,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/LUX": {
           "date": "2021-08-13",
           "value": 741948,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/LVA": {
           "date": "2021-08-13",
           "value": 1418214,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/MAC": {
           "date": "2021-08-13",
           "value": 547953,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/MAF": {},
@@ -849,42 +849,42 @@
           "date": "2021-08-13",
           "value": 27561271,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/MCO": {
           "date": "2021-08-06",
           "value": 44060,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/MDA": {
           "date": "2021-08-13",
           "value": 1136921,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/MDG": {
           "date": "2021-06-28",
           "value": 197001,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/MDV": {
           "date": "2021-08-11",
           "value": 633914,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/MEX": {
           "date": "2021-08-13",
           "value": 75780229,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/MHL": {},
@@ -892,42 +892,42 @@
           "date": "2021-08-12",
           "value": 1033584,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/MLI": {
           "date": "2021-08-09",
           "value": 259719,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/MLT": {
           "date": "2021-08-12",
           "value": 782600,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/MMR": {
           "date": "2021-07-01",
           "value": 3500000,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/MNE": {
           "date": "2021-08-13",
           "value": 355963,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/MNG": {
           "date": "2021-08-13",
           "value": 4232784,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/MNP": {},
@@ -935,21 +935,21 @@
           "date": "2021-08-09",
           "value": 1386326,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/MRT": {
           "date": "2021-08-12",
           "value": 242626,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/MSR": {
           "date": "2021-08-06",
           "value": 2828,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/MTQ": {},
@@ -957,21 +957,21 @@
           "date": "2021-08-09",
           "value": 1297090,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/MWI": {
           "date": "2021-08-12",
           "value": 683097,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/MYS": {
           "date": "2021-08-13",
           "value": 26851765,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/MYT": {},
@@ -979,21 +979,21 @@
           "date": "2021-08-11",
           "value": 244880,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/NCL": {
           "date": "2021-08-09",
           "value": 133804,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/NER": {
           "date": "2021-08-09",
           "value": 425483,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/NFK": {},
@@ -1001,98 +1001,98 @@
           "date": "2021-08-09",
           "value": 3967013,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/NIC": {
           "date": "2021-08-09",
           "value": 919275,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/NIU": {
           "date": "2021-08-09",
           "value": 2406,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/NLD": {
           "date": "2021-08-13",
           "value": 21348406,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/NOR": {
           "date": "2021-08-12",
           "value": 5911464,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/NPL": {
           "date": "2021-08-12",
           "value": 7515766,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/NRU": {
           "date": "2021-07-27",
           "value": 14784,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/NZL": {
           "date": "2021-08-10",
           "value": 2293301,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/OMN": {
           "date": "2021-08-09",
           "value": 2656658,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/PAK": {
           "date": "2021-08-13",
           "value": 42173424,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/PAN": {
           "date": "2021-08-12",
           "value": 3292229,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/PCN": {
           "date": "2021-08-02",
           "value": 83,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/PER": {
           "date": "2021-08-12",
           "value": 15659075,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/PHL": {
           "date": "2021-08-11",
           "value": 26127502,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/PLW": {},
@@ -1100,14 +1100,14 @@
           "date": "2021-08-02",
           "value": 100409,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/POL": {
           "date": "2021-08-12",
           "value": 35281208,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/PRI": {},
@@ -1116,35 +1116,35 @@
           "date": "2021-08-13",
           "value": 13307865,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/PRY": {
           "date": "2021-08-12",
           "value": 2214138,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/PSE": {
           "date": "2021-08-12",
           "value": 1053252,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/PYF": {
           "date": "2021-08-09",
           "value": 174127,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/QAT": {
           "date": "2021-08-13",
           "value": 4067088,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/REU": {},
@@ -1152,49 +1152,49 @@
           "date": "2021-08-12",
           "value": 9558787,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/RUS": {
           "date": "2021-08-13",
           "value": 71033270,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/RWA": {
           "date": "2021-08-03",
           "value": 854194,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/SAU": {
           "date": "2021-08-13",
           "value": 31452285,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/SDN": {
           "date": "2021-08-09",
           "value": 823881,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/SEN": {
           "date": "2021-08-09",
           "value": 1360095,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/SGP": {
           "date": "2021-08-12",
           "value": 8429249,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/SGS": {},
@@ -1202,7 +1202,7 @@
           "date": "2021-05-05",
           "value": 7892,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/SJM": {},
@@ -1210,35 +1210,35 @@
           "date": "2021-08-09",
           "value": 56621,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/SLE": {
           "date": "2021-07-05",
           "value": 225380,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/SLV": {
           "date": "2021-08-13",
           "value": 5143912,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/SMR": {
           "date": "2021-08-12",
           "value": 46057,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/SOM": {
           "date": "2021-08-02",
           "value": 279869,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/SPM": {},
@@ -1246,7 +1246,7 @@
           "date": "2021-08-12",
           "value": 5617810,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/SSD": {},
@@ -1254,42 +1254,42 @@
           "date": "2021-08-03",
           "value": 43978,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/SUR": {
           "date": "2021-08-13",
           "value": 271668,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/SVK": {
           "date": "2021-08-13",
           "value": 4390776,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/SVN": {
           "date": "2021-08-13",
           "value": 1804382,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/SWE": {
           "date": "2021-08-13",
           "value": 11431885,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/SWZ": {
           "date": "2021-08-12",
           "value": 181290,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/SXM": {},
@@ -1297,133 +1297,133 @@
           "date": "2021-07-22",
           "value": 141435,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/SYR": {
           "date": "2021-08-09",
           "value": 355000,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/TCA": {
           "date": "2021-07-23",
           "value": 47263,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/TCD": {
           "date": "2021-08-12",
           "value": 40649,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/TGO": {
           "date": "2021-08-03",
           "value": 474776,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/THA": {
           "date": "2021-08-11",
           "value": 22288819,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/TJK": {
           "date": "2021-08-11",
           "value": 1671475,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/TKL": {
           "date": "2021-08-02",
           "value": 953,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/TKM": {
           "date": "2021-04-04",
           "value": 41993,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/TLS": {
           "date": "2021-08-10",
           "value": 443729,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/TON": {
           "date": "2021-08-02",
           "value": 47553,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/TTO": {
           "date": "2021-08-13",
           "value": 728880,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/TUN": {
           "date": "2021-08-08",
           "value": 3392636,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/TUR": {
           "date": "2021-08-13",
           "value": 82021528,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/TUV": {
           "date": "2021-06-15",
           "value": 4772,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/TWN": {
           "date": "2021-08-13",
           "value": 9749241,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/TZA": {
           "date": "2021-08-08",
           "value": 105745,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/UGA": {
           "date": "2021-08-10",
           "value": 1155265,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/UKR": {
           "date": "2021-08-13",
           "value": 7332550,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/UMI": {},
@@ -1431,21 +1431,21 @@
           "date": "2021-08-13",
           "value": 5014309,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/USA": {
           "date": "2021-08-13",
           "value": 354777950,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/UZB": {
           "date": "2021-08-04",
           "value": 8300000,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/VAT": {},
@@ -1453,21 +1453,21 @@
           "date": "2021-08-10",
           "value": 25796,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/VEN": {
           "date": "2021-07-12",
           "value": 4000000,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/VGB": {
           "date": "2021-08-06",
           "value": 28777,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/VIR": {},
@@ -1475,28 +1475,28 @@
           "date": "2021-08-12",
           "value": 13256472,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/VUT": {
           "date": "2021-07-27",
           "value": 23995,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/WLF": {
           "date": "2021-08-09",
           "value": 9439,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/WSM": {
           "date": "2021-08-09",
           "value": 100610,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/XKS": {},
@@ -1504,7 +1504,7 @@
           "date": "2021-07-27",
           "value": 311483,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/YUG": {},
@@ -1512,28 +1512,28 @@
           "date": "2021-08-12",
           "value": 9185756,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/ZMB": {
           "date": "2021-08-13",
           "value": 518446,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         },
         "country/ZWE": {
           "date": "2021-08-12",
           "value": 3193256,
           "metadata": {
-            "import_name": "Private Import"
+            "import_name": "Test Private Import"
           }
         }
       },
       "metadata": {
-        "Private Import": {
-          "import_name": "Private Import",
-          "provenance_url": "private.domain",
+        "Test Private Import": {
+          "import_name": "Test Private Import",
+          "provenance_url": "https://test.datacommons.org",
           "measurement_method": "Test_Method"
         }
       }


### PR DESCRIPTION
manifest.json contains the minimal required fields for an import: import_name, provenance_url and data_download_url.

This will be used to populate data metadata field, as well as in the data dashboard (to be implemented)