### PR TITLE
Add logging to GetStats() API

### DIFF
--- a/internal/server/stat_series.go
+++ b/internal/server/stat_series.go
@@ -17,6 +17,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"log"
 	"sort"
 
 	"cloud.google.com/go/bigtable"
@@ -119,6 +120,12 @@ func (s *Server) GetStats(ctx context.Context, in *pb.GetStatsRequest) (
 
 	placeDcids := in.GetPlace()
 	statsVarDcid := in.GetStatsVar()
+
+	log.Printf(
+		"GetStats(): placeDcids: %s, statsVarDcid: %v",
+		placeDcids,
+		statsVarDcid,
+	)
 
 	if len(placeDcids) == 0 {
 		return nil, status.Errorf(codes.InvalidArgument,

--- a/internal/server/stat_series.go
+++ b/internal/server/stat_series.go
@@ -28,9 +28,9 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-func logIfDurationTooLong(t time.Time, threshold_sec float32, msg string) {
+func logIfDurationTooLong(t time.Time, thresholdSec float32, msg string) {
 	duration := time.Since(t).Seconds()
-	if duration > float64(threshold_sec) {
+	if duration > float64(thresholdSec) {
 		log.Printf("%f seconds:\n%s", duration, msg)
 	}
 }


### PR DESCRIPTION
We have seen several 200+ seconds latency on this API. Logging the params for better debugging.