### PR TITLE
[Import Group] Merge for property value cache

### DIFF
--- a/internal/server/node/golden/get_property_values/IG_contained_in_place.json
+++ b/internal/server/node/golden/get_property_values/IG_contained_in_place.json
@@ -1,0 +1,204 @@
+{
+  "geoId/06085": {
+    "in": [
+      {
+        "dcid": "geoId/0677000",
+        "name": "Sunnyvale",
+        "provenanceId": "dc/5n63hr1",
+        "types": [
+          "City"
+        ]
+      },
+      {
+        "dcid": "geoId/0673906",
+        "name": "Stanford",
+        "provenanceId": "dc/5n63hr1",
+        "types": [
+          "City"
+        ]
+      },
+      {
+        "dcid": "geoId/0670280",
+        "name": "Saratoga",
+        "provenanceId": "dc/5n63hr1",
+        "types": [
+          "City"
+        ]
+      },
+      {
+        "dcid": "geoId/0669084",
+        "name": "Santa Clara",
+        "provenanceId": "dc/5n63hr1",
+        "types": [
+          "City"
+        ]
+      },
+      {
+        "dcid": "geoId/0668238",
+        "name": "San Martin",
+        "provenanceId": "dc/5n63hr1",
+        "types": [
+          "City"
+        ]
+      },
+      {
+        "dcid": "geoId/0668000",
+        "name": "San Jose",
+        "provenanceId": "dc/sm3m2w3",
+        "types": [
+          "City"
+        ]
+      },
+      {
+        "dcid": "geoId/0655282",
+        "name": "Palo Alto",
+        "provenanceId": "dc/5n63hr1",
+        "types": [
+          "City"
+        ]
+      },
+      {
+        "dcid": "geoId/0649670",
+        "name": "Mountain View",
+        "provenanceId": "dc/5n63hr1",
+        "types": [
+          "City"
+        ]
+      },
+      {
+        "dcid": "geoId/0649278",
+        "name": "Morgan Hill",
+        "provenanceId": "dc/5n63hr1",
+        "types": [
+          "City"
+        ]
+      },
+      {
+        "dcid": "geoId/0648956",
+        "name": "Monte Sereno",
+        "provenanceId": "dc/5n63hr1",
+        "types": [
+          "City"
+        ]
+      },
+      {
+        "dcid": "geoId/0647766",
+        "name": "Milpitas",
+        "provenanceId": "dc/5n63hr1",
+        "types": [
+          "City"
+        ]
+      },
+      {
+        "dcid": "geoId/0644378",
+        "name": "Loyola",
+        "provenanceId": "dc/5n63hr1",
+        "types": [
+          "City"
+        ]
+      },
+      {
+        "dcid": "geoId/0644112",
+        "name": "Los Gatos",
+        "provenanceId": "dc/5n63hr1",
+        "types": [
+          "City",
+          "Town"
+        ]
+      },
+      {
+        "dcid": "geoId/0643294",
+        "name": "Los Altos Hills",
+        "provenanceId": "dc/5n63hr1",
+        "types": [
+          "City",
+          "Town"
+        ]
+      },
+      {
+        "dcid": "geoId/0643280",
+        "name": "Los Altos",
+        "provenanceId": "dc/5n63hr1",
+        "types": [
+          "City"
+        ]
+      },
+      {
+        "dcid": "geoId/0641282",
+        "name": "Lexington Hills",
+        "provenanceId": "dc/5n63hr1",
+        "types": [
+          "City"
+        ]
+      },
+      {
+        "dcid": "geoId/0629504",
+        "name": "Gilroy",
+        "provenanceId": "dc/5n63hr1",
+        "types": [
+          "City"
+        ]
+      },
+      {
+        "dcid": "geoId/0627080",
+        "name": "Fruitdale",
+        "provenanceId": "dc/sm3m2w3",
+        "types": [
+          "City"
+        ]
+      },
+      {
+        "dcid": "geoId/0620598",
+        "name": "East Foothills",
+        "provenanceId": "dc/sm3m2w3",
+        "types": [
+          "City",
+          "Neighborhood"
+        ]
+      },
+      {
+        "dcid": "geoId/0617610",
+        "name": "Cupertino",
+        "provenanceId": "dc/5n63hr1",
+        "types": [
+          "City"
+        ]
+      },
+      {
+        "dcid": "geoId/0610345",
+        "name": "Campbell",
+        "provenanceId": "dc/5n63hr1",
+        "types": [
+          "City"
+        ]
+      },
+      {
+        "dcid": "geoId/0610088",
+        "name": "Cambrian Park",
+        "provenanceId": "dc/sm3m2w3",
+        "types": [
+          "City"
+        ]
+      },
+      {
+        "dcid": "geoId/0608968",
+        "name": "Burbank",
+        "provenanceId": "dc/5n63hr1",
+        "types": [
+          "City",
+          "Neighborhood"
+        ]
+      },
+      {
+        "dcid": "geoId/0601458",
+        "name": "Alum Rock",
+        "provenanceId": "dc/sm3m2w3",
+        "types": [
+          "City",
+          "Neighborhood"
+        ]
+      }
+    ]
+  },
+  "geoId/0647766": {}
+}

--- a/internal/server/node/golden/get_property_values/IG_contained_in_place_all.json
+++ b/internal/server/node/golden/get_property_values/IG_contained_in_place_all.json
@@ -1,0 +1,45 @@
+{
+  "geoId/06085": {
+    "out": [
+      {
+        "dcid": "geoId/06",
+        "name": "California",
+        "provenanceId": "dc/5n63hr1",
+        "types": [
+          "AdministrativeArea1",
+          "State"
+        ]
+      }
+    ]
+  },
+  "geoId/0647766": {
+    "out": [
+      {
+        "dcid": "zip/95035",
+        "name": "95035",
+        "provenanceId": "dc/5n63hr1",
+        "types": [
+          "CensusZipCodeTabulationArea"
+        ]
+      },
+      {
+        "dcid": "geoId/06085",
+        "name": "Santa Clara County",
+        "provenanceId": "dc/5n63hr1",
+        "types": [
+          "AdministrativeArea2",
+          "County"
+        ]
+      },
+      {
+        "dcid": "geoId/06",
+        "name": "California",
+        "provenanceId": "dc/5n63hr1",
+        "types": [
+          "AdministrativeArea1",
+          "State"
+        ]
+      }
+    ]
+  }
+}

--- a/internal/server/node/golden/get_property_values/IG_limit.json
+++ b/internal/server/node/golden/get_property_values/IG_limit.json
@@ -1,0 +1,10 @@
+{
+  "country/USA": {
+    "out": [
+      {
+        "provenanceId": "dc/5n63hr1",
+        "value": "United States of America"
+      }
+    ]
+  }
+}

--- a/internal/server/node/golden/get_property_values/IG_location.json
+++ b/internal/server/node/golden/get_property_values/IG_location.json
@@ -1,0 +1,306 @@
+{
+  "geoId/05": {
+    "in": [
+      {
+        "dcid": "election/2022_S_AR00",
+        "name": "2022 US Senate Elections - AR",
+        "provenanceId": "dc/gld24w2",
+        "types": [
+          "Election"
+        ]
+      },
+      {
+        "dcid": "election/2020_S_AR00",
+        "name": "2020 US Senate Elections - AR",
+        "provenanceId": "dc/gld24w2",
+        "types": [
+          "Election"
+        ]
+      },
+      {
+        "dcid": "election/2016_S_AR00",
+        "name": "2016 US Senate Elections - AR",
+        "provenanceId": "dc/gld24w2",
+        "types": [
+          "Election"
+        ]
+      },
+      {
+        "dcid": "election/2014_S_AR00",
+        "name": "2014 US Senate Elections - AR",
+        "provenanceId": "dc/gld24w2",
+        "types": [
+          "Election"
+        ]
+      },
+      {
+        "dcid": "election/2010_S_AR00",
+        "name": "2010 US Senate Elections - AR",
+        "provenanceId": "dc/gld24w2",
+        "types": [
+          "Election"
+        ]
+      },
+      {
+        "dcid": "election/2008_S_AR00",
+        "name": "2008 US Senate Elections - AR",
+        "provenanceId": "dc/gld24w2",
+        "types": [
+          "Election"
+        ]
+      },
+      {
+        "dcid": "election/2004_S_AR00",
+        "name": "2004 US Senate Elections - AR",
+        "provenanceId": "dc/gld24w2",
+        "types": [
+          "Election"
+        ]
+      },
+      {
+        "dcid": "election/2002_S_AR00",
+        "name": "2002 US Senate Elections - AR",
+        "provenanceId": "dc/gld24w2",
+        "types": [
+          "Election"
+        ]
+      },
+      {
+        "dcid": "election/1998_S_AR00",
+        "name": "1998 US Senate Elections - AR",
+        "provenanceId": "dc/gld24w2",
+        "types": [
+          "Election"
+        ]
+      },
+      {
+        "dcid": "election/1996_S_AR00",
+        "name": "1996 US Senate Elections - AR",
+        "provenanceId": "dc/gld24w2",
+        "types": [
+          "Election"
+        ]
+      },
+      {
+        "dcid": "election/1992_S_AR00",
+        "name": "1992 US Senate Elections - AR",
+        "provenanceId": "dc/gld24w2",
+        "types": [
+          "Election"
+        ]
+      },
+      {
+        "dcid": "election/1990_S_AR00",
+        "name": "1990 US Senate Elections - AR",
+        "provenanceId": "dc/gld24w2",
+        "types": [
+          "Election"
+        ]
+      },
+      {
+        "dcid": "election/1986_S_AR00",
+        "name": "1986 US Senate Elections - AR",
+        "provenanceId": "dc/gld24w2",
+        "types": [
+          "Election"
+        ]
+      },
+      {
+        "dcid": "election/1984_S_AR00",
+        "name": "1984 US Senate Elections - AR",
+        "provenanceId": "dc/gld24w2",
+        "types": [
+          "Election"
+        ]
+      },
+      {
+        "dcid": "election/1980_S_AR00",
+        "name": "1980 US Senate Elections - AR",
+        "provenanceId": "dc/gld24w2",
+        "types": [
+          "Election"
+        ]
+      },
+      {
+        "dcid": "election/1978_S_AR00",
+        "name": "1978 US Senate Elections - AR",
+        "provenanceId": "dc/gld24w2",
+        "types": [
+          "Election"
+        ]
+      }
+    ]
+  },
+  "geoId/06": {
+    "in": [
+      {
+        "dcid": "election/2024_S_CA00",
+        "name": "2024 US Senate Elections - CA",
+        "provenanceId": "dc/gld24w2",
+        "types": [
+          "Election"
+        ]
+      },
+      {
+        "dcid": "election/2022_S_CA00",
+        "name": "2022 US Senate Elections - CA",
+        "provenanceId": "dc/gld24w2",
+        "types": [
+          "Election"
+        ]
+      },
+      {
+        "dcid": "election/2020_S_CA00",
+        "name": "2020 US Senate Elections - CA",
+        "provenanceId": "dc/gld24w2",
+        "types": [
+          "Election"
+        ]
+      },
+      {
+        "dcid": "election/2019_S_CA00",
+        "name": "2019 US Senate Elections - CA",
+        "provenanceId": "dc/gld24w2",
+        "types": [
+          "Election"
+        ]
+      },
+      {
+        "dcid": "election/2018_S_CA00",
+        "name": "2018 US Senate Elections - CA",
+        "provenanceId": "dc/gld24w2",
+        "types": [
+          "Election"
+        ]
+      },
+      {
+        "dcid": "election/2016_S_CA00",
+        "name": "2016 US Senate Elections - CA",
+        "provenanceId": "dc/gld24w2",
+        "types": [
+          "Election"
+        ]
+      },
+      {
+        "dcid": "election/2012_S_CA00",
+        "name": "2012 US Senate Elections - CA",
+        "provenanceId": "dc/gld24w2",
+        "types": [
+          "Election"
+        ]
+      },
+      {
+        "dcid": "election/2010_S_CA00",
+        "name": "2010 US Senate Elections - CA",
+        "provenanceId": "dc/gld24w2",
+        "types": [
+          "Election"
+        ]
+      },
+      {
+        "dcid": "election/2006_S_CA00",
+        "name": "2006 US Senate Elections - CA",
+        "provenanceId": "dc/gld24w2",
+        "types": [
+          "Election"
+        ]
+      },
+      {
+        "dcid": "election/2004_S_CA00",
+        "name": "2004 US Senate Elections - CA",
+        "provenanceId": "dc/gld24w2",
+        "types": [
+          "Election"
+        ]
+      },
+      {
+        "dcid": "election/2002_S_CA00",
+        "name": "2002 US Senate Elections - CA",
+        "provenanceId": "dc/gld24w2",
+        "types": [
+          "Election"
+        ]
+      },
+      {
+        "dcid": "election/2000_S_CA00",
+        "name": "2000 US Senate Elections - CA",
+        "provenanceId": "dc/gld24w2",
+        "types": [
+          "Election"
+        ]
+      },
+      {
+        "dcid": "election/1998_S_CA00",
+        "name": "1998 US Senate Elections - CA",
+        "provenanceId": "dc/gld24w2",
+        "types": [
+          "Election"
+        ]
+      },
+      {
+        "dcid": "election/1996_S_CA00",
+        "name": "1996 US Senate Elections - CA",
+        "provenanceId": "dc/gld24w2",
+        "types": [
+          "Election"
+        ]
+      },
+      {
+        "dcid": "election/1994_S_CA00",
+        "name": "1994 US Senate Elections - CA",
+        "provenanceId": "dc/gld24w2",
+        "types": [
+          "Election"
+        ]
+      },
+      {
+        "dcid": "election/1992_S_CA00",
+        "name": "1992 US Senate Elections - CA",
+        "provenanceId": "dc/gld24w2",
+        "types": [
+          "Election"
+        ]
+      },
+      {
+        "dcid": "election/1988_S_CA00",
+        "name": "1988 US Senate Elections - CA",
+        "provenanceId": "dc/gld24w2",
+        "types": [
+          "Election"
+        ]
+      },
+      {
+        "dcid": "election/1986_S_CA00",
+        "name": "1986 US Senate Elections - CA",
+        "provenanceId": "dc/gld24w2",
+        "types": [
+          "Election"
+        ]
+      },
+      {
+        "dcid": "election/1982_S_CA00",
+        "name": "1982 US Senate Elections - CA",
+        "provenanceId": "dc/gld24w2",
+        "types": [
+          "Election"
+        ]
+      },
+      {
+        "dcid": "election/1980_S_CA00",
+        "name": "1980 US Senate Elections - CA",
+        "provenanceId": "dc/gld24w2",
+        "types": [
+          "Election"
+        ]
+      },
+      {
+        "dcid": "election/1976_S_CA00",
+        "name": "1976 US Senate Elections - CA",
+        "provenanceId": "dc/gld24w2",
+        "types": [
+          "Election"
+        ]
+      }
+    ]
+  }
+}

--- a/internal/server/node/golden/get_property_values/IG_name.json
+++ b/internal/server/node/golden/get_property_values/IG_name.json
@@ -1,0 +1,27 @@
+{
+  "Count_Person": {
+    "out": [
+      {
+        "provenanceId": "dc/d7tbsb1",
+        "value": "Population"
+      }
+    ]
+  },
+  "State": {
+    "out": [
+      {
+        "provenanceId": "dc/5l5zxr1",
+        "value": "State"
+      }
+    ]
+  },
+  "dc/p/cmtdk79lnk2pd": {},
+  "geoId/05": {
+    "out": [
+      {
+        "provenanceId": "dc/5n63hr1",
+        "value": "Arkansas"
+      }
+    ]
+  }
+}

--- a/internal/server/node/golden/get_property_values_test.go
+++ b/internal/server/node/golden/get_property_values_test.go
@@ -29,103 +29,112 @@ import (
 )
 
 func TestGetPropertyValues(t *testing.T) {
-	ctx := context.Background()
-	client, _, err := e2e.Setup()
-	if err != nil {
-		t.Fatalf("Failed to set up mixer and client")
-	}
-	_, filename, _, _ := runtime.Caller(0)
-	goldenPath := path.Join(
-		path.Dir(filename), "get_property_values")
-
 	t.Parallel()
-	for _, c := range []struct {
-		goldenFile string
-		dcids      []string
-		property   string
-		direction  string
-		valueType  string
-		limit      int32
-	}{
-		{
-			"name.json",
-			[]string{"State", "geoId/05", "Count_Person", "dc/p/cmtdk79lnk2pd"},
-			"name",
-			"out",
-			"",
-			0,
-		},
-		{
-			"contained_in_place.json",
-			[]string{"geoId/06085", "geoId/0647766"},
-			"containedInPlace",
-			"",
-			"City",
-			0,
-		},
-		{
-			"contained_in_place_all.json",
-			[]string{"geoId/06085", "geoId/0647766"},
-			"containedInPlace",
-			"out",
-			"",
-			0,
-		},
-		{
-			"location.json",
-			[]string{"geoId/05", "geoId/06"},
-			"location",
-			"",
-			"Election",
-			0,
-		},
-		{
-			"limit.json",
-			[]string{"country/USA"},
-			"name",
-			"out",
-			"",
-			1,
-		},
+	ctx := context.Background()
+
+	for _, opt := range []*e2e.TestOption{
+		{},
+		{UseImportGroup: true},
 	} {
-		req := &pb.GetPropertyValuesRequest{
-			Dcids:     c.dcids,
-			Property:  c.property,
-			Direction: c.direction,
-			ValueType: c.valueType,
-		}
-		if c.limit > 0 {
-			req.Limit = c.limit
-		}
-		resp, err := client.GetPropertyValues(ctx, req)
+		client, _, err := e2e.Setup(opt)
 		if err != nil {
-			t.Errorf("could not GetPropertyValues: %s", err)
-			continue
+			t.Fatalf("Failed to set up mixer and client")
 		}
-		goldenFile := path.Join(goldenPath, c.goldenFile)
+		_, filename, _, _ := runtime.Caller(0)
+		goldenPath := path.Join(
+			path.Dir(filename), "get_property_values")
 
-		var result map[string]map[string][]*model.Node
-		err = json.Unmarshal([]byte(resp.GetPayload()), &result)
-		if err != nil {
-			t.Errorf("Can not Unmarshal payload")
-			continue
-		}
+		for _, c := range []struct {
+			goldenFile string
+			dcids      []string
+			property   string
+			direction  string
+			valueType  string
+			limit      int32
+		}{
+			{
+				"name.json",
+				[]string{"State", "geoId/05", "Count_Person", "dc/p/cmtdk79lnk2pd"},
+				"name",
+				"out",
+				"",
+				0,
+			},
+			{
+				"contained_in_place.json",
+				[]string{"geoId/06085", "geoId/0647766"},
+				"containedInPlace",
+				"",
+				"City",
+				0,
+			},
+			{
+				"contained_in_place_all.json",
+				[]string{"geoId/06085", "geoId/0647766"},
+				"containedInPlace",
+				"out",
+				"",
+				0,
+			},
+			{
+				"location.json",
+				[]string{"geoId/05", "geoId/06"},
+				"location",
+				"",
+				"Election",
+				0,
+			},
+			{
+				"limit.json",
+				[]string{"country/USA"},
+				"name",
+				"out",
+				"",
+				1,
+			},
+		} {
+			if opt.UseImportGroup {
+				c.goldenFile = "IG_" + c.goldenFile
+			}
+			req := &pb.GetPropertyValuesRequest{
+				Dcids:     c.dcids,
+				Property:  c.property,
+				Direction: c.direction,
+				ValueType: c.valueType,
+			}
+			if c.limit > 0 {
+				req.Limit = c.limit
+			}
+			resp, err := client.GetPropertyValues(ctx, req)
+			if err != nil {
+				t.Errorf("could not GetPropertyValues: %s", err)
+				continue
+			}
+			goldenFile := path.Join(goldenPath, c.goldenFile)
 
-		if e2e.GenerateGolden {
-			e2e.UpdateGolden(result, goldenPath, c.goldenFile)
-			continue
-		}
+			var result map[string]map[string][]*model.Node
+			err = json.Unmarshal([]byte(resp.GetPayload()), &result)
+			if err != nil {
+				t.Errorf("Can not Unmarshal payload")
+				continue
+			}
 
-		var expected map[string]map[string][]*model.Node
-		file, _ := ioutil.ReadFile(goldenFile)
-		err = json.Unmarshal(file, &expected)
-		if err != nil {
-			t.Errorf("Can not Unmarshal golden file %s: %v", c.goldenFile, err)
-			continue
-		}
-		if diff := cmp.Diff(result, expected); diff != "" {
-			t.Errorf("payload got diff: %v", diff)
-			continue
+			if e2e.GenerateGolden {
+				e2e.UpdateGolden(result, goldenPath, c.goldenFile)
+				continue
+			}
+
+			var expected map[string]map[string][]*model.Node
+			file, _ := ioutil.ReadFile(goldenFile)
+			err = json.Unmarshal(file, &expected)
+			if err != nil {
+				t.Errorf("Can not Unmarshal golden file %s: %v", c.goldenFile, err)
+				continue
+			}
+			if diff := cmp.Diff(result, expected); diff != "" {
+				t.Errorf("payload got diff: %v", diff)
+				continue
+			}
 		}
 	}
 }

--- a/internal/server/node/golden/get_property_values_test.go
+++ b/internal/server/node/golden/get_property_values_test.go
@@ -113,8 +113,7 @@ func TestGetPropertyValues(t *testing.T) {
 			goldenFile := path.Join(goldenPath, c.goldenFile)
 
 			var result map[string]map[string][]*model.Node
-			err = json.Unmarshal([]byte(resp.GetPayload()), &result)
-			if err != nil {
+			if err := json.Unmarshal([]byte(resp.GetPayload()), &result); err != nil {
 				t.Errorf("Can not Unmarshal payload")
 				continue
 			}

--- a/internal/server/node/property_value.go
+++ b/internal/server/node/property_value.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 
-	cbt "cloud.google.com/go/bigtable"
 	"github.com/datacommonsorg/mixer/internal/server/model"
 	"github.com/datacommonsorg/mixer/internal/store/bigtable"
 	"google.golang.org/grpc/codes"
@@ -31,8 +30,11 @@ import (
 )
 
 // GetPropertyValues implements API for Mixer.GetPropertyValues.
-func GetPropertyValues(ctx context.Context,
-	in *pb.GetPropertyValuesRequest, store *store.Store) (*pb.GetPropertyValuesResponse, error) {
+func GetPropertyValues(
+	ctx context.Context,
+	in *pb.GetPropertyValuesRequest,
+	store *store.Store,
+) (*pb.GetPropertyValuesResponse, error) {
 	dcids := in.GetDcids()
 	prop := in.GetProperty()
 	typ := in.GetValueType()
@@ -40,11 +42,14 @@ func GetPropertyValues(ctx context.Context,
 	limit := int(in.GetLimit())
 
 	// Check arguments
-	if prop == "" || len(dcids) == 0 {
-		return nil, status.Errorf(codes.InvalidArgument, "Missing required arguments")
+	if prop == "" {
+		return nil, status.Errorf(codes.InvalidArgument, "missing required argument: property")
+	}
+	if len(dcids) == 0 {
+		return nil, status.Errorf(codes.InvalidArgument, "missing required arguments: dcids")
 	}
 	if !util.CheckValidDCIDs(dcids) {
-		return nil, status.Errorf(codes.InvalidArgument, "Invalid DCIDs")
+		return nil, status.Errorf(codes.InvalidArgument, "invalid DCIDs %s", dcids)
 	}
 
 	// Get in, out or both direction
@@ -108,12 +113,57 @@ func GetPropertyValuesHelper(
 	arcOut bool,
 ) (map[string][]*model.Node, error) {
 	rowList := bigtable.BuildPropertyValuesKey(dcids, prop, arcOut)
-	// Current branch cache is targeted on new stats (without addition of schema etc),
-	// so only use base cache data for property value.
-	//
-	// TODO(shifucun): perform a systematic check on current cache data and see
-	// if this is still true.
-	return readPropertyValues(ctx, store, rowList)
+	baseDataList, _, err := bigtable.Read(
+		ctx,
+		store.BtGroup,
+		rowList,
+		func(dcid string, jsonRaw []byte) (interface{}, error) {
+			var propVals model.PropValueCache
+			err := json.Unmarshal(jsonRaw, &propVals)
+			if err != nil {
+				return nil, err
+			}
+			return propVals.Nodes, nil
+		},
+		nil,
+		true, /* readBranch */
+	)
+	if err != nil {
+		return nil, err
+	}
+	result := map[string][]*model.Node{}
+	visited := map[string]map[string]struct{}{}
+	// Loop the import groups. They are ordered by the preferences. So only add
+	// a node if it is not seen yet.
+	for _, baseData := range baseDataList {
+		for dcid, data := range baseData {
+			if _, ok := result[dcid]; !ok {
+				result[dcid] = []*model.Node{}
+			}
+			if _, ok := visited[dcid]; !ok {
+				visited[dcid] = map[string]struct{}{}
+			}
+			if data != nil {
+				nodes := data.([]*model.Node)
+				for _, n := range nodes {
+					// Check if a duplicate node has been added to the result.
+					// Duplication is based on either the DCID or the value.
+					if n.Dcid != "" {
+						if _, ok := visited[dcid][n.Dcid]; !ok {
+							result[dcid] = append(result[dcid], n)
+							visited[dcid][n.Dcid] = struct{}{}
+						}
+					} else if n.Value != "" {
+						if _, ok := visited[dcid][n.Value]; !ok {
+							result[dcid] = append(result[dcid], n)
+							visited[dcid][n.Value] = struct{}{}
+						}
+					}
+				}
+			}
+		}
+	}
+	return result, nil
 }
 
 func trimNodes(nodes []*model.Node, typ string, limit int) []*model.Node {
@@ -137,38 +187,4 @@ func trimNodes(nodes []*model.Node, typ string, limit int) []*model.Node {
 		}
 	}
 	return result
-}
-
-func readPropertyValues(
-	ctx context.Context,
-	store *store.Store,
-	rowList cbt.RowList,
-) (map[string][]*model.Node, error) {
-	// Only read property value from base cache.
-	// Branch cache only contains supplement data but not other properties yet.
-	baseDataList, _, err := bigtable.Read(
-		ctx,
-		store.BtGroup,
-		rowList,
-		func(dcid string, jsonRaw []byte) (interface{}, error) {
-			var propVals model.PropValueCache
-			err := json.Unmarshal(jsonRaw, &propVals)
-			if err != nil {
-				return nil, err
-			}
-			return propVals.Nodes, nil
-		},
-		nil,
-		false, /* readBranch */
-	)
-	if err != nil {
-		return nil, err
-	}
-	result := map[string][]*model.Node{}
-	for dcid, data := range baseDataList[0] {
-		if data != nil {
-			result[dcid] = data.([]*model.Node)
-		}
-	}
-	return result, nil
 }

--- a/internal/server/node/property_value.go
+++ b/internal/server/node/property_value.go
@@ -119,8 +119,7 @@ func GetPropertyValuesHelper(
 		rowList,
 		func(dcid string, jsonRaw []byte) (interface{}, error) {
 			var propVals model.PropValueCache
-			err := json.Unmarshal(jsonRaw, &propVals)
-			if err != nil {
+			if err := json.Unmarshal(jsonRaw, &propVals); err != nil {
 				return nil, err
 			}
 			return propVals.Nodes, nil

--- a/internal/server/node/property_value.go
+++ b/internal/server/node/property_value.go
@@ -133,8 +133,9 @@ func GetPropertyValuesHelper(
 	}
 	result := map[string][]*model.Node{}
 	visited := map[string]map[string]struct{}{}
-	// Loop the import groups. They are ordered by the preferences. So only add
-	// a node if it is not seen yet.
+	// Loop over the import groups. They are ordered by the preferences in
+	// /deploy/storage/bigtable_import_groups.json. So only add a node if it is
+	// not seen yet.
 	for _, baseData := range baseDataList {
 		for dcid, data := range baseData {
 			if _, ok := result[dcid]; !ok {


### PR DESCRIPTION
Nodes are read from the most preferred group first. When the same node is seen in less preferred group, only add it if it has not been added. 

Note out arcs only get from preferred import group. In arcs are merged across import groups.