### PR TITLE
Update resource constraint: more memory for esp; remove cpu limit

### DIFF
--- a/deploy/base/deployment.yaml
+++ b/deploy/base/deployment.yaml
@@ -51,10 +51,8 @@ spec:
           resources:
             limits:
               memory: "6G"
-              cpu: "800m"
             requests:
               memory: "6G"
-              cpu: "800m"
           args:
             - --mixer_project=$(MIXER_PROJECT)
             - --store_project=$(STORE_PROJECT)
@@ -122,11 +120,9 @@ spec:
                   key: serviceName
           resources:
             limits:
-              memory: "1G"
-              cpu: "200m"
+              memory: "2G"
             requests:
-              memory: "1G"
-              cpu: "200m"
+              memory: "2G"
           readinessProbe:
             httpGet:
               path: /healthz

--- a/deploy/overlays/local/patch_deployment.yaml
+++ b/deploy/overlays/local/patch_deployment.yaml
@@ -29,24 +29,10 @@ spec:
         - name: mixer
           image: datacommons/mixer
           imagePullPolicy: Never
-          resources:
-            limits:
-              memory: "5G"
-              cpu: "1000m"
-            requests:
-              memory: "5G"
-              cpu: "1000m"
         - name: esp
           volumeMounts:
             - mountPath: /esp
               name: mixer-grpc-json
-          resources:
-            limits:
-              memory: "0.5G"
-              cpu: "100m"
-            requests:
-              memory: "0.5G"
-              cpu: "100m"
         - name: api-compiler
           image: datacommons/api-compiler
           imagePullPolicy: Never

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -51,7 +51,7 @@ which is compiled using [API Compiler](https://github.com/googleapis/api-compile
 ### Start mixer in minikube
 
 ```bash
-minikube start --memory=6G
+minikube start
 minikube addons enable gcp-auth
 eval $(minikube docker-env)
 kubectl config use-context minikube


### PR DESCRIPTION
A few articles have suggested to remove cpu limit (https://github.com/datacommonsorg/mixer/issues/661). Basically even the cpu is far below limit, it can still get throttled and result in poor performance.

We have seen issues with "/stat-var/group/all" endpoints not returning anything, as the size grows. I tested with `curl http://localhost:8081/stat-var/group/all --output svg.json`. The observation is as follow:

1) The data is read from server cache, so mixer has nothing to read or process.
2) When esp has memory limit of 1G as we have now, it won't return the result, giving error "server didn't response".
3) When esp has memory limit of 2G, it works fine, with the response json size of 226M. As esp has to convert protobuf to JSON and send it out, so 1G of memory could be too tight.