### PR TITLE
PlaceType Allowlist for Place Page ParentPlaces

### DIFF
--- a/internal/server/placepage/place_page.go
+++ b/internal/server/placepage/place_page.go
@@ -82,6 +82,7 @@ var allWantedPlaceTypes = map[string]struct{}{
 	"CensusZipCodeTabulationArea": {}, "EurostatNUTS1": {}, "EurostatNUTS2": {},
 	"EurostatNUTS3": {}, "AdministrativeArea1": {}, "AdministrativeArea2": {},
 	"AdministrativeArea3": {}, "AdministrativeArea4": {}, "AdministrativeArea5": {},
+	"Continent": {},
 }
 
 // These place types are equivalent: prefer the key.
@@ -443,10 +444,13 @@ func getParentPlaces(ctx context.Context, store *store.Store, dcid string) (
 	result := []string{}
 	if data, ok := placeMetadata.Data[dcid]; ok {
 		for _, parent := range data.Parents {
-			if parent.Type == "CensusZipCodeTabulationArea" || parent.Dcid == "Earth" {
-				continue
+			// Only want to include parents with type that is included in
+			// allWantedPlaceTypes except and not type CensusZipCodeTabulationArea
+			if _, ok := allWantedPlaceTypes[parent.Type]; ok {
+				if parent.Type != "CensusZipCodeTabulationArea" {
+					result = append(result, parent.Dcid)
+				}
 			}
-			result = append(result, parent.Dcid)
 		}
 	}
 	return result, nil


### PR DESCRIPTION
- as discussed in [this buganizer](https://b.corp.google.com/issues/220148645#comment5), filter parentPlaces returned by place page api for places that are of a type in the allowlist