### PR TITLE
Update mixer golden diff email and some test suite clean up

### DIFF
--- a/build/ci/cloudbuild.goldendiff.yaml
+++ b/build/ci/cloudbuild.goldendiff.yaml
@@ -21,17 +21,21 @@ steps:
     args:
       - "-c"
       - |
-        gsutil cp gs://datcom-control/latest_base_cache_version.txt /tmp/bigtable.version
+        for src in $(gsutil ls gs://datcom-control/autopush/*_latest_base_cache_version.txt); do
+          echo "Copying $src"
+          echo "$(gsutil cat $src)" >> /tmp/bigtable_import_groups.version
+        done
 
   - name: golang
+    env: ["GO111MODULE=on"]
     entrypoint: "bash"
     args:
       - -c
       - |
-        ./scripts/golden_diff_notify.sh $(head -1 /tmp/bigtable.version)
+        ./scripts/golden_diff_notify.sh "$(</tmp/bigtable_import_groups.version)"
         cd tools/send_email
         go run main.go \
-          --subject="Mixer golden data diff for $(head -1 /tmp/bigtable.version)" \
+          --subject="Mixer golden data diff from latest import group build" \
           --receiver="datacommons-alerts@google.com" \
           --body_file="/tmp/golden-diff.html" \
           --mime_type="text/html"
@@ -40,4 +44,8 @@ options:
   volumes:
     - name: tmp
       path: /tmp
+    - name: go-modules
+      path: /go
   machineType: "N1_HIGHCPU_32"
+
+timeout: 3600s

--- a/build/ci/cloudbuild.goldendiff.yaml
+++ b/build/ci/cloudbuild.goldendiff.yaml
@@ -23,7 +23,7 @@ steps:
       - |
         for src in $(gsutil ls gs://datcom-control/autopush/*_latest_base_cache_version.txt); do
           echo "Copying $src"
-          echo "$(gsutil cat $src)" >> /tmp/bigtable_import_groups.version
+          echo $(gsutil cat "$src") >> /tmp/bigtable_import_groups.version
         done
 
   - name: golang

--- a/internal/server/statvar/golden/get_place_statsvar_test.go
+++ b/internal/server/statvar/golden/get_place_statsvar_test.go
@@ -25,11 +25,10 @@ import (
 func TestGetPlaceStatsVar(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-	client, _, err := e2e.Setup()
+	client, _, err := e2e.Setup(&e2e.TestOption{UseCache: true})
 	if err != nil {
 		t.Fatalf("Failed to set up mixer and client")
 	}
-
 	for _, c := range []struct {
 		dcids    []string
 		want     []string
@@ -61,7 +60,6 @@ func TestGetPlaceStatsVar(t *testing.T) {
 			true,
 		},
 	} {
-
 		req := &pb.GetPlaceStatsVarRequest{
 			Dcids: c.dcids,
 		}

--- a/internal/server/statvar/golden/get_statvar_group_node_test.go
+++ b/internal/server/statvar/golden/get_statvar_group_node_test.go
@@ -31,8 +31,7 @@ func TestGetStatVarGroupNode(t *testing.T) {
 	ctx := context.Background()
 
 	_, filename, _, _ := runtime.Caller(0)
-	goldenPath := path.Join(
-		path.Dir(filename), "get_statvar_group_node")
+	goldenPath := path.Join(path.Dir(filename), "get_statvar_group_node")
 
 	testSuite := func(mixer pb.MixerClient, recon pb.ReconClient, latencyTest bool) {
 		for _, c := range []struct {

--- a/internal/server/statvar/golden/get_statvar_summary_test.go
+++ b/internal/server/statvar/golden/get_statvar_summary_test.go
@@ -31,8 +31,7 @@ func TestGetStatVarSummary(t *testing.T) {
 	ctx := context.Background()
 
 	_, filename, _, _ := runtime.Caller(0)
-	goldenPath := path.Join(
-		path.Dir(filename), "get_statvar_summary")
+	goldenPath := path.Join(path.Dir(filename), "get_statvar_summary")
 
 	testSuite := func(mixer pb.MixerClient, recon pb.ReconClient, latencyTest bool) {
 		for _, c := range []struct {
@@ -87,7 +86,7 @@ func TestGetStatVarSummary(t *testing.T) {
 	}
 
 	if err := e2e.TestDriver(
-		"GetStatVarSummary", &e2e.TestOption{UseCache: true}, testSuite); err != nil {
+		"GetStatVarSummary", &e2e.TestOption{}, testSuite); err != nil {
 		t.Errorf("TestDriver() = %s", err)
 	}
 }

--- a/scripts/deploy_gke.sh
+++ b/scripts/deploy_gke.sh
@@ -61,7 +61,7 @@ if [[ $ENV == "autopush" ]]; then
   > deploy/storage/bigtable_import_groups.version
   for src in $(gsutil ls gs://datcom-control/autopush/*_latest_base_cache_version.txt); do
     echo "Copying $src"
-    echo "$(gsutil cat $src)" >> deploy/storage/bigtable_import_groups.version
+    echo $(gsutil cat "$src") >> deploy/storage/bigtable_import_groups.version
   done
 fi
 export PROJECT_ID=$(yq eval '.project' deploy/gke/$ENV.yaml)

--- a/scripts/golden_diff_notify.sh
+++ b/scripts/golden_diff_notify.sh
@@ -17,6 +17,8 @@
 
 # Send golden diff email for a new Bigtable cache.
 
+set -e
+
 BASE_BT_VERSION=$1
 
 apt-get update -y
@@ -25,8 +27,7 @@ apt-get install -y gawk
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 ROOT="$(dirname "$DIR")"
 
-
-echo "$BASE_BT_VERSION" | tee "$ROOT/deploy/storage/bigtable.version"
+echo "$BASE_BT_VERSION" | tee "$ROOT/deploy/storage/bigtable_import_groups.version"
 
 # Script to convert terminal colors and attributes to HTML
 # https://github.com/pixelb/scripts/blob/master/scripts/ansi2html.sh

--- a/scripts/prepare_release.sh
+++ b/scripts/prepare_release.sh
@@ -15,7 +15,7 @@ function update_version() {
 
   for src in $(gsutil ls gs://datcom-control/autopush/*_latest_base_cache_version.txt); do
     echo "Copying $src"
-    echo "$(gsutil cat $src)" >> deploy/storage/bigtable_import_groups.version
+    echo $(gsutil cat "$src") >> deploy/storage/bigtable_import_groups.version
   done
 
   BQ=$(curl https://autopush.datacommons.org/version 2>/dev/null | awk '{ if ($1~/^datcom-store/) print $1; }')

--- a/scripts/prepare_release.sh
+++ b/scripts/prepare_release.sh
@@ -13,8 +13,10 @@ function update_version() {
   echo ""
   echo "==== Updating BT and BQ versions ===="
 
-  BT=$(curl https://autopush.datacommons.org/version 2>/dev/null | awk '{ if ($1~/^borgcron_/) print $1; }')
-  printf "$BT" > deploy/storage/bigtable.version
+  for src in $(gsutil ls gs://datcom-control/autopush/*_latest_base_cache_version.txt); do
+    echo "Copying $src"
+    echo "$(gsutil cat $src)" >> deploy/storage/bigtable_import_groups.version
+  done
 
   BQ=$(curl https://autopush.datacommons.org/version 2>/dev/null | awk '{ if ($1~/^datcom-store/) print $1; }')
   printf "$BQ" > deploy/storage/bigquery.version

--- a/test/e2e/test_driver.go
+++ b/test/e2e/test_driver.go
@@ -30,14 +30,18 @@ const numTestTimes = 4
 func TestDriver(
 	apiName string,
 	opt *TestOption,
-	testSuite func(pb.MixerClient, pb.ReconClient, bool)) error {
+	testSuite func(pb.MixerClient, pb.ReconClient, bool),
+) error {
 	if LatencyTest {
 		return latencyTest(apiName, opt, testSuite)
 	}
 	return goldenTest(opt, testSuite)
 }
 
-func goldenTest(opt *TestOption, testSuite func(pb.MixerClient, pb.ReconClient, bool)) error {
+func goldenTest(
+	opt *TestOption,
+	testSuite func(pb.MixerClient, pb.ReconClient, bool),
+) error {
 	mixer, recon, err := Setup(opt)
 	if err != nil {
 		return fmt.Errorf("failed to set up mixer and client")
@@ -49,9 +53,9 @@ func goldenTest(opt *TestOption, testSuite func(pb.MixerClient, pb.ReconClient, 
 func latencyTest(
 	apiName string,
 	opt *TestOption,
-	testSuite func(pb.MixerClient, pb.ReconClient, bool)) error {
+	testSuite func(pb.MixerClient, pb.ReconClient, bool),
+) error {
 	durationStore := []float64{}
-
 	mixer, recon, err := Setup(opt)
 	if err != nil {
 		return fmt.Errorf("failed to set up mixer and client")


### PR DESCRIPTION
This is part of clean up task from import group migration. The golden diff email sender should use the import group versions.