### PR TITLE
Less aggressive rolling update

### DIFF
--- a/deploy/base/deployment.yaml
+++ b/deploy/base/deployment.yaml
@@ -25,9 +25,10 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      # maximum number of Pods that can be created over the desired number of Pods
+      # Maximum number of pods that can be created over the desired number of pods.
       maxSurge: 1
-      # maximum number of Pods that can be unavailable during the update process
+      # Maximum number of pods that can be unavailable during the update process
+      # Environment have different number of pods, this is roughly 8% in prod.
       maxUnavailable: 5
   selector:
     matchLabels:

--- a/deploy/base/deployment.yaml
+++ b/deploy/base/deployment.yaml
@@ -28,7 +28,7 @@ spec:
       # maximum number of Pods that can be created over the desired number of Pods
       maxSurge: 1
       # maximum number of Pods that can be unavailable during the update process
-      maxUnavailable: 25%
+      maxUnavailable: 5
   selector:
     matchLabels:
       app: mixer-grpc

--- a/deploy/overlays/autopush/kustomization.yaml
+++ b/deploy/overlays/autopush/kustomization.yaml
@@ -40,11 +40,6 @@ patchesStrategicMerge:
       name: mixer-grpc
     spec:
       replicas: 32
-      strategy:
-        type: RollingUpdate
-        rollingUpdate:
-          maxSurge: 10
-          maxUnavailable: 75%
   - |-
     apiVersion: networking.k8s.io/v1
     kind: Ingress


### PR DESCRIPTION
Too many pods concurrently rolling updates can cause peak resources usages, especially now there is intense computation to build stat var search index. This causes frequent restart and slower completion.