### PR TITLE
Update ranking imports.

### DIFF
--- a/internal/server/ranking/ranking.go
+++ b/internal/server/ranking/ranking.go
@@ -64,9 +64,9 @@ var StatsRanking = map[RankKey]int{
 	{"NOAA_EPA_Observed_Historical_Weather", "*", "*"}: 0, // Observational
 	{"Copernicus_ECMWF_ERA5_Monthly", "*", "*"}:        1, // Gridded reanalysis
 	{"NASA_NEXDCP30", "NASA_Mean_CCSM4", "P1M"}:        2, // IPCC Projections
-	{"NASA_NEXGDDP", "NASA_Mean_CMIP5_CCSM4", "P1M"}:   3, // IPCC Projections
-	{"NASA_NEXDCP30_StatVarSeriesAggr", "*", "P1M"}:    4, // IPCC Projections
-	{"NASA_NEXGDDP_StatVarSeriesAggr", "*", "P1M"}:     5, // IPCC Projections
+	{"NASA_NEXDCP30_AggrDiffStats", "*", "P1M"}:        3, // IPCC Projections
+	// TODO: Remove this once disppears from backend (replaced by NASA_NEXDCP30_AggrDiffStats).
+	{"NASA_NEXDCP30_StatVarSeriesAggr", "*", "P1M"}: 4, // IPCC Projections
 
 	{"NASA_WetBulbComputation_Aggregation", "NASA_Mean_HadGEM2-AO", "*"}: 0, // Wet bulb year aggregation
 	{"NASA_WetBulbComputation_Aggregation", "*", "*"}:                    1, // Wet bulb year aggregation


### PR DESCRIPTION
- NASA_NEXGDDP doesn't exist in the backend any more.
- NASA_NEXDCP30_StatVarSeriesAggr will be replaced by NASA_NEXDCP30_AggrDiffStats.