### PR TITLE
Increase mixer memory to accomodate for larger stat var (group) size

### DIFF
--- a/deploy/base/deployment.yaml
+++ b/deploy/base/deployment.yaml
@@ -54,9 +54,9 @@ spec:
           imagePullPolicy: Always
           resources:
             limits:
-              memory: "6G"
+              memory: "8G"
             requests:
-              memory: "6G"
+              memory: "8G"
           args:
             - --mixer_project=$(MIXER_PROJECT)
             - --store_project=$(STORE_PROJECT)

--- a/deploy/overlays/autopush/kustomization.yaml
+++ b/deploy/overlays/autopush/kustomization.yaml
@@ -39,7 +39,7 @@ patchesStrategicMerge:
     metadata:
       name: mixer-grpc
     spec:
-      replicas: 32
+      replicas: 24
   - |-
     apiVersion: networking.k8s.io/v1
     kind: Ingress

--- a/deploy/overlays/prod/kustomization.yaml
+++ b/deploy/overlays/prod/kustomization.yaml
@@ -39,7 +39,7 @@ patchesStrategicMerge:
     metadata:
       name: mixer-grpc
     spec:
-      replicas: 54
+      replicas: 48
   - |-
     apiVersion: networking.k8s.io/v1
     kind: Ingress


### PR DESCRIPTION
There are increased server restart in deployment which is due to OOM issue. This is due to the increased size of stat var (group) in stat var search computation. 

Longer term, should investigate the bottleneck and make the computation scalable.