### PR TITLE
Add ranking for USFEMA_NationalRiskIndex

### DIFF
--- a/internal/server/ranking/ranking.go
+++ b/internal/server/ranking/ranking.go
@@ -79,6 +79,10 @@ var StatsRanking = map[RankKey]int{
 	// Expected data 2004-2010: 1393, 1379, 1297, 1400, 1381, 1015, 1092
 	{"FBIHateCrimePublications", "*", "*"}: 0, // FBI Hate Crime Publications
 	{"FBIHateCrime", "*", "*"}:             1, // FBI Hate Crime Aggregations
+	
+	// Prefer USDollar over Risk Score for Expected Annual Loss in FEMA National Risk Index (NRI)
+	{"USFEMA_NationalRiskIndex", "Annual_ExpectedLoss_NaturalHazardImpact*", "USDollar"} : 0, // Unit: USDollar
+	{"USFEMA_NationalRiskIndex", "Annual_ExpectedLoss_NaturalHazardImpact*", "FemaNationalRiskScore"} : 1, // Unit: FemaNationalRiskScore
 }
 
 // BaseRank is the base ranking score for sources. If a source is prefered, it

--- a/internal/server/ranking/ranking_test.go
+++ b/internal/server/ranking/ranking_test.go
@@ -96,7 +96,16 @@ func TestSeriesByRank(t *testing.T) {
 				{ImportName: "NASA_WetBulbComputation", MeasurementMethod: "NASA_Mean_HadGEM2-AO", ObservationPeriod: "P1Y"},
 				{ImportName: "NASA_WetBulbComputation", MeasurementMethod: "NASA_Mean_CCSM4", ObservationPeriod: "P1Y"},
 			},
-		},
+		},{ // For FEMA NRI Expected Loss, prefer USDollar over FemaNationalRiskScore
+			[]*pb.SourceSeries{
+				{ImportName: "USFEMA_NationalRiskIndex", MeasuredProperty: "expectedLoss", Unit: "FemaNationalRiskScore"},
+				{ImportName: "USFEMA_NationalRiskIndex", MeasuredProperty: "expectedLoss", Unit: "USDollar"},
+			},
+			[]*pb.SourceSeries{
+				{ImportName: "USFEMA_NationalRiskIndex", MeasuredProperty: "expectedLoss", Unit: "USDollar"},
+				{ImportName: "USFEMA_NationalRiskIndex", MeasuredProperty: "expectedLoss", Unit: "FemaNationalRiskScore"},
+			},
+		}
 	} {
 		sort.Sort(SeriesByRank(c.series))
 		if diff := cmp.Diff(c.expected, c.series, protocmp.Transform()); diff != "" {

--- a/internal/server/ranking/ranking_test.go
+++ b/internal/server/ranking/ranking_test.go
@@ -105,7 +105,7 @@ func TestSeriesByRank(t *testing.T) {
 				{ImportName: "USFEMA_NationalRiskIndex", MeasuredProperty: "expectedLoss", Unit: "USDollar"},
 				{ImportName: "USFEMA_NationalRiskIndex", MeasuredProperty: "expectedLoss", Unit: "FemaNationalRiskScore"},
 			},
-		}
+		},
 	} {
 		sort.Sort(SeriesByRank(c.series))
 		if diff := cmp.Diff(c.expected, c.series, protocmp.Transform()); diff != "" {


### PR DESCRIPTION
Prefer `USDollar` over `FemaNationalRiskScore` for `Annual_ExpectedLoss_NaturalHazardImpact` (aggregate) and `Annual_ExpectedLoss_NaturalHazardImpact_*` (individual hazard types).

Could you please confirm that these changes would also rank `USDollar` over `FemaNationalRiskScore` for `Annual_ExpectedLoss_NaturalHazardImpact_AvalancheEvent`, etc.?