### PR TITLE
Redesign ranking scoring algorithm

### DIFF
--- a/internal/server/ranking/ranking.go
+++ b/internal/server/ranking/ranking.go
@@ -133,52 +133,22 @@ func GetScoreRk(rk RankKey) int {
 }
 
 func GetScorePb(s *pb.SourceSeries) int {
-	for _, propCombination := range []struct {
-		mm string
-		op string
-	}{
-		// Check exact match first
-		{s.MeasurementMethod, s.ObservationPeriod},
-		{s.MeasurementMethod, "*"},
-		{"*", s.ObservationPeriod},
-		{"*", "*"},
-	} {
-		key := RankKey{
-			ImportName:        s.ImportName,
-			MeasurementMethod: propCombination.mm,
-			ObservationPeriod: propCombination.op,
-		}
-		score, ok := StatsRanking[key]
-		if ok {
-			return score
-		}
-	}
-	return BaseRank
+    rk := RankKey{
+        ImportName:        s.ImportName,
+        MeasurementMethod: s.MeasurementMethod,
+        ObservationPeriod: s.ObservationPeriod,
+    }
+	return GetScoreRk(rk)
 }
 
 // GetMetadataScore computes score for pb.StatMetadata
 func GetMetadataScore(m *pb.StatMetadata) int {
-	for _, propCombination := range []struct {
-		mm string
-		op string
-	}{
-		// Check exact match first
-		{m.MeasurementMethod, m.ObservationPeriod},
-		{m.MeasurementMethod, "*"},
-		{"*", m.ObservationPeriod},
-		{"*", "*"},
-	} {
-		key := RankKey{
-			ImportName:        m.ImportName,
-			MeasurementMethod: propCombination.mm,
-			ObservationPeriod: propCombination.op,
-		}
-		score, ok := StatsRanking[key]
-		if ok {
-			return score
-		}
-	}
-	return BaseRank
+    rk := RankKey{
+        ImportName:        m.ImportName,
+        MeasurementMethod: m.MeasurementMethod,
+        ObservationPeriod: m.ObservationPeriod,
+    }
+	return GetScoreRk(rk)
 }
 
 func (a CohortByRank) Len() int {
@@ -299,27 +269,12 @@ func (a SeriesByRank) Less(i, j int) bool {
 //
 // If no entry is found, a BaseRank is assigned to the source series.
 func GetScore(s *model.SourceSeries) int {
-	for _, propCombination := range []struct {
-		mm string
-		op string
-	}{
-		// Check exact match first
-		{s.MeasurementMethod, s.ObservationPeriod},
-		{s.MeasurementMethod, "*"},
-		{"*", s.ObservationPeriod},
-		{"*", "*"},
-	} {
-		key := RankKey{
-			ImportName:        s.ImportName,
-			MeasurementMethod: propCombination.mm,
-			ObservationPeriod: propCombination.op,
-		}
-		score, ok := StatsRanking[key]
-		if ok {
-			return score
-		}
-	}
-	return BaseRank
+    rk := RankKey{
+        ImportName:        s.ImportName,
+        MeasurementMethod: s.MeasurementMethod,
+        ObservationPeriod: s.ObservationPeriod,
+    }
+    return GetScoreRk(rk)
 }
 
 // ByRank implements sort.Interface for []*SourceSeries based on

--- a/internal/server/ranking/ranking.go
+++ b/internal/server/ranking/ranking.go
@@ -93,7 +93,7 @@ const BaseRank = 100
 // cohort instead of time series.
 type CohortByRank []*pb.SourceSeries
 
-// GetScorePb derives the ranking score for a source series.
+// GetScoreRk derives the ranking score for a source series.
 //
 // The score depends on ImportName and other SVObs properties, by checking the
 // StatsRanking dict. To get the score, ImportName is required, with optional
@@ -105,9 +105,6 @@ type CohortByRank []*pb.SourceSeries
 // score, otherwise can also match to wildcard options (indicated by *).
 //
 // If no entry is found, a BaseRank is assigned to the source series.
-
-// Uses the Get Score algorithm for a RankKey struct that is used to hold
-// the different fields that we use when scoring.
 func GetScoreRk(rk RankKey) int {
 	for _, propCombination := range []struct {
 		mm string
@@ -132,6 +129,7 @@ func GetScoreRk(rk RankKey) int {
 	return BaseRank
 }
 
+// GetScoreRk adapter for pb.SourceSeries
 func GetScorePb(s *pb.SourceSeries) int {
     rk := RankKey{
         ImportName:        s.ImportName,
@@ -141,7 +139,7 @@ func GetScorePb(s *pb.SourceSeries) int {
 	return GetScoreRk(rk)
 }
 
-// GetMetadataScore computes score for pb.StatMetadata
+// GetScoreRk adapter for pb.StatMetadata
 func GetMetadataScore(m *pb.StatMetadata) int {
     rk := RankKey{
         ImportName:        m.ImportName,
@@ -256,18 +254,7 @@ func (a SeriesByRank) Less(i, j int) bool {
 }
 
 // TODO(shifucun): Remove `SourceSeries` and use pb.SourceSeries everywhere.
-// GetScore derives the ranking score for a source series.
-//
-// The score depends on ImportName and other SVObs properties, by checking the
-// StatsRanking dict. To get the score, ImportName is required, with optional
-// properties:
-// - MeasurementMethod
-// - ObservationPeriod
-//
-// When there are exact match of the properties in StatsRanking, then use that
-// score, otherwise can also match to wildcard options (indicated by *).
-//
-// If no entry is found, a BaseRank is assigned to the source series.
+// GetScoreRk adapter for model.SourceSeries 
 func GetScore(s *model.SourceSeries) int {
     rk := RankKey{
         ImportName:        s.ImportName,

--- a/internal/server/ranking/ranking_test.go
+++ b/internal/server/ranking/ranking_test.go
@@ -48,6 +48,10 @@ func TestGetScorePb(t *testing.T) {
 			&pb.SourceSeries{ImportName: "NASA_NEXDCP30", MeasurementMethod: "NASA_Mean_CCSM4", ObservationPeriod: "P1M"},
 			2,
 		},
+        { // test that an import name that does not exist returns the BaseRank
+			&pb.SourceSeries{ImportName: "THIS_IMPORT_DOES_NOT_EXIST", MeasurementMethod: "DOES_NOT_EXIST", ObservationPeriod: "DOES_NOT_EXIST"},
+			100,
+        },
 	} {
 		score := GetScorePb(c.series)
 		if diff := cmp.Diff(score, c.score); diff != "" {


### PR DESCRIPTION
The previous implementation has exponential time (and code lines) complexity w.r.t to the number of fields of `RankKey`.

New implementation is only linear, because we can assume the number of `<RankKey, score>` mappings per import to be constant (currently, all import names have only 1 mapping, besides two of them which have 2 pairs each).

The new implementation is supported by extracting `ImportName` from RankKey to an outer key of `StatsRanking`. `ImportName` is used in every instance of `RankKey` and is the main axis of variability, so this retains the performance benefits of using a map.