### PR TITLE
Periodic builds of Data Commons repositories

### DIFF
--- a/build/ci/cloudbuild.allrepos.yaml
+++ b/build/ci/cloudbuild.allrepos.yaml
@@ -1,0 +1,27 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+  - id: "build all repos"
+    name: gcr.io/google.com/cloudsdktool/google-cloud-cli:latest
+    entrypoint: "bash"
+    args: ["./tools/periodic_builds/build_all_repos.sh"]
+
+  - id: "send emails for failed builds"
+    name: golang
+    entrypoint: bash
+    args: ["./tools/periodic_builds/notify_results.sh"]
+
+# long timeout because we are building all repos (albeit in parallel)
+timeout: 3600s

--- a/tools/periodic_builds/README.md
+++ b/tools/periodic_builds/README.md
@@ -1,0 +1,8 @@
+This folder contains a pair of a cloudbuild yaml and a bash script that clones
+and builds all Data Commons repositories.
+
+To launch this build job, run the following at the base of the mixer repo.
+You'll need to have `gcloud` installed.
+```
+gcloud builds submit --config build/ci/cloudbuild.allrepos.yaml .
+```

--- a/tools/periodic_builds/build_all_repos.sh
+++ b/tools/periodic_builds/build_all_repos.sh
@@ -1,0 +1,78 @@
+# Submits a cloud build job and pipes output to a file
+# Moves the output file to folder `success` if return code is 0
+# Otherwise, moves it to folder `failed`
+#
+# Parameters
+# $1 is the path to the config file
+# $2 is the path to the code folder
+# $3 is the name of the file to pipe output to
+function submit_cloud_build {
+	gcloud builds submit --config $1 $2 &> $3
+	if [ $? -ne 0 ]; then
+		mv $3 /workspace/failed/
+	else
+		mv $3 /workspace/success/
+	fi
+}
+
+
+function build_import {
+	git clone https://github.com/datacommonsorg/import
+	submit_cloud_build import/build/cloudbuild.java.yaml import import_java.out.txt
+	submit_cloud_build import/build/cloudbuild.npm.yaml import import_npm.out.txt
+}
+
+function build_data {
+	git clone https://github.com/datacommonsorg/data
+	submit_cloud_build data/cloudbuild.go.yaml data data_go.out.txt
+	submit_cloud_build data/cloudbuild.py.yaml data data_py.out.txt
+}
+
+function build_api_r {
+	git clone https://github.com/datacommonsorg/api-r
+	submit_cloud_build api-r/cloudbuild.yaml api-r api-r.out.txt
+}
+
+function build_api_python {
+	git clone https://github.com/datacommonsorg/api-python
+	submit_cloud_build api-python/cloudbuild.yaml api-python api-python.out.txt
+}
+
+function build_mixer {
+	git clone https://github.com/datacommonsorg/mixer
+	submit_cloud_build mixer/build/ci/cloudbuild.test.yaml mixer mixer.out.txt
+}
+
+function build_recon {
+	git clone https://github.com/datacommonsorg/reconciliation
+	submit_cloud_build reconciliation/build/ci/cloudbuild.test.yaml reconciliation reconciliation.out.txt
+}
+
+function build_website {
+	git clone https://github.com/datacommonsorg/website
+	submit_cloud_build website/build/ci/cloudbuild.npm.yaml website website.out.txt
+	submit_cloud_build website/build/ci/cloudbuild.py.yaml website website.out.txt
+	submit_cloud_build website/build/ci/cloudbuild.webdriver.yaml website website.out.txt
+}
+
+mkdir allrepos_tmp
+cd allrepos_tmp
+
+mkdir /workspace/failed
+mkdir /workspace/success
+
+
+# Parallelize the build functions, reference: https://stackoverflow.com/a/26240420
+pids=""
+build_cmds_to_run=('build_import' 'build_data' 'build_api_r' 'build_api_python' 'build_mixer' 'build_recon' 'build_website')
+for build_cmd in ${build_cmds_to_run[*]}; do
+	echo "running build function: $build_cmd"
+	$build_cmd &
+	pid=$!
+	echo "$build_cmd pid is $pid"
+	pids="$pids $pid"
+done
+
+echo "waiting on pids: ${pids[*]}"
+wait $pids
+echo "all processes returned, returning."

--- a/tools/periodic_builds/notify_results.sh
+++ b/tools/periodic_builds/notify_results.sh
@@ -1,0 +1,21 @@
+success_dir="/workspace/success/*"
+failed_dir="/workspace/failed/*"
+
+cd tools/send_email
+for f in $failed_dir
+do
+	printf "stubbed out email; $(basename $f)\n"
+#	go run main.go \
+#	  --subject="[Periodic Build Notification] $(basename $f)" \
+#	  --receiver="snny@google.com" \
+#	  --body_file="$f" \
+#	  --mime_type="text/plain"
+done
+
+printf "count success: $(ls -l $success_dir | wc -l)\n\n"
+printf "success: \n $(ls -l $success_dir)\n\n"
+
+printf "\n\n\n"
+
+printf "count failed: $(ls -l $failed_dir | wc -l)\n\n"
+printf "failed: \n $(ls -l $failed_dir)\n\n"


### PR DESCRIPTION
- build/ci/cloudbuild.allrepos.yaml is the entry point to the scripts
  in tools/periodic_builds. It is a Google Cloud Build job that will
  launch build jobs for all repos and notify users
- tools/periodic_builds/
  - README.md outlines usage
  - build_all_repos.sh sends build jobs for all repos (in parallel) and
    stores results in `/workspace` for the next step, which is;
  - notify_results.sh reads the build job output files from the previous
    step and sends out an email

TODO:
- email functionality is stubbed out with a printf because project
  access needs to be coordinated.