### PR TITLE
Fix v0 endpoint rule selector issue

### DIFF
--- a/esp/endpoints.yaml.tmpl
+++ b/esp/endpoints.yaml.tmpl
@@ -39,67 +39,67 @@ usage:
   # This will be removed once the V0 users are fully migrated.
   - selector: "*"
     allow_unregistered_calls: false
-  - selector: "*.Mixer.Query"
+  - selector: "<DOMAIN>.Mixer.Query"
     allow_unregistered_calls: true
-  - selector: "*.Mixer.GetPropertyLabels"
+  - selector: "<DOMAIN>.Mixer.GetPropertyLabels"
     allow_unregistered_calls: true
-  - selector: "*.Mixer.GetPropertyValues"
+  - selector: "<DOMAIN>.Mixer.GetPropertyValues"
     allow_unregistered_calls: true
-  - selector: "*.Mixer.GetTriples"
+  - selector: "<DOMAIN>.Mixer.GetTriples"
     allow_unregistered_calls: true
-  - selector: "*.Mixer.GetPlacesIn"
+  - selector: "<DOMAIN>.Mixer.GetPlacesIn"
     allow_unregistered_calls: true
-  - selector: "*.Mixer.GetStats"
+  - selector: "<DOMAIN>.Mixer.GetStats"
     allow_unregistered_calls: true
-  - selector: "*.Mixer.GetStatSetSeries"
+  - selector: "<DOMAIN>.Mixer.GetStatSetSeries"
     allow_unregistered_calls: true
-  - selector: "*.Mixer.GetStatValue"
+  - selector: "<DOMAIN>.Mixer.GetStatValue"
     allow_unregistered_calls: true
-  - selector: "*.Mixer.GetStatSeries"
+  - selector: "<DOMAIN>.Mixer.GetStatSeries"
     allow_unregistered_calls: true
-  - selector: "*.Mixer.GetStatAll"
+  - selector: "<DOMAIN>.Mixer.GetStatAll"
     allow_unregistered_calls: true
-  - selector: "*.Mixer.GetStatSetWithinPlace"
+  - selector: "<DOMAIN>.Mixer.GetStatSetWithinPlace"
     allow_unregistered_calls: true
-  - selector: "*.Mixer.GetStatSetWithinPlaceAll"
+  - selector: "<DOMAIN>.Mixer.GetStatSetWithinPlaceAll"
     allow_unregistered_calls: true
-  - selector: "*.Mixer.GetStatSet"
+  - selector: "<DOMAIN>.Mixer.GetStatSet"
     allow_unregistered_calls: true
-  - selector: "*.Mixer.GetStatSetSeriesWithinPlace"
+  - selector: "<DOMAIN>.Mixer.GetStatSetSeriesWithinPlace"
     allow_unregistered_calls: true
-  - selector: "*.Mixer.GetLocationsRankings"
+  - selector: "<DOMAIN>.Mixer.GetLocationsRankings"
     allow_unregistered_calls: true
-  - selector: "*.Mixer.GetRelatedLocations"
+  - selector: "<DOMAIN>.Mixer.GetRelatedLocations"
     allow_unregistered_calls: true
-  - selector: "*.Mixer.GetPlacePageData"
+  - selector: "<DOMAIN>.Mixer.GetPlacePageData"
     allow_unregistered_calls: true
-  - selector: "*.Mixer.GetBioPageData"
+  - selector: "<DOMAIN>.Mixer.GetBioPageData"
     allow_unregistered_calls: true
-  - selector: "*.Mixer.Translate"
+  - selector: "<DOMAIN>.Mixer.Translate"
     allow_unregistered_calls: true
-  - selector: "*.Mixer.Search"
+  - selector: "<DOMAIN>.Mixer.Search"
     allow_unregistered_calls: true
-  - selector: "*.Mixer.GetVersion"
+  - selector: "<DOMAIN>.Mixer.GetVersion"
     allow_unregistered_calls: true
-  - selector: "*.Mixer.GetPlaceStatsVar"
+  - selector: "<DOMAIN>.Mixer.GetPlaceStatsVar"
     allow_unregistered_calls: true
-  - selector: "*.Mixer.GetPlaceMetadata"
+  - selector: "<DOMAIN>.Mixer.GetPlaceMetadata"
     allow_unregistered_calls: true
-  - selector: "*.Mixer.GetPlaceStatVarsUnionV1"
+  - selector: "<DOMAIN>.Mixer.GetPlaceStatVarsUnionV1"
     allow_unregistered_calls: true
-  - selector: "*.Mixer.GetPlaceStatDateWithinPlace"
+  - selector: "<DOMAIN>.Mixer.GetPlaceStatDateWithinPlace"
     allow_unregistered_calls: true
-  - selector: "*.Mixer.GetStatDateWithinPlace"
+  - selector: "<DOMAIN>.Mixer.GetStatDateWithinPlace"
     allow_unregistered_calls: true
-  - selector: "*.Mixer.GetStatVarGroup"
+  - selector: "<DOMAIN>.Mixer.GetStatVarGroup"
     allow_unregistered_calls: true
-  - selector: "*.Mixer.GetStatVarGroupNode"
+  - selector: "<DOMAIN>.Mixer.GetStatVarGroupNode"
     allow_unregistered_calls: true
-  - selector: "*.Mixer.GetStatVarPath"
+  - selector: "<DOMAIN>.Mixer.GetStatVarPath"
     allow_unregistered_calls: true
-  - selector: "*.Mixer.SearchStatVar"
+  - selector: "<DOMAIN>.Mixer.SearchStatVar"
     allow_unregistered_calls: true
-  - selector: "*.Mixer.GetStatVarSummary"
+  - selector: "<DOMAIN>.Mixer.GetStatVarSummary"
     allow_unregistered_calls: true
-  - selector: "*.Mixer.GetStatVarMatch"
+  - selector: "<DOMAIN>.Mixer.GetStatVarMatch"
     allow_unregistered_calls: true

--- a/scripts/deploy_gke.sh
+++ b/scripts/deploy_gke.sh
@@ -84,7 +84,6 @@ kubectl apply -f kustomize-build.yaml
 
 # Deploy Cloud Endpoints
 cp $ROOT/esp/endpoints.yaml.tmpl endpoints.yaml
-echo $DOMAIN
 sed -i -e "s/<DOMAIN>/"$DOMAIN"/g" endpoints.yaml
 yq eval -i '.name = env(DOMAIN)' endpoints.yaml
 yq eval -i '.title = env(API_TITLE)' endpoints.yaml

--- a/scripts/deploy_gke.sh
+++ b/scripts/deploy_gke.sh
@@ -84,7 +84,7 @@ kubectl apply -f kustomize-build.yaml
 
 # Deploy Cloud Endpoints
 cp $ROOT/esp/endpoints.yaml.tmpl endpoints.yaml
-sed -i -e "s/<DOMAIN>/"$DOMAIN"/g" endpoints.yaml
+sed -i -e "s/<DOMAIN>/$DOMAIN/g" endpoints.yaml
 yq eval -i '.name = env(DOMAIN)' endpoints.yaml
 yq eval -i '.title = env(API_TITLE)' endpoints.yaml
 yq eval -i '.apis[0].name = env(API)' endpoints.yaml

--- a/scripts/deploy_gke.sh
+++ b/scripts/deploy_gke.sh
@@ -84,6 +84,8 @@ kubectl apply -f kustomize-build.yaml
 
 # Deploy Cloud Endpoints
 cp $ROOT/esp/endpoints.yaml.tmpl endpoints.yaml
+echo $DOMAIN
+sed -i -e "s/<DOMAIN>/"$DOMAIN"/g" endpoints.yaml
 yq eval -i '.name = env(DOMAIN)' endpoints.yaml
 yq eval -i '.title = env(API_TITLE)' endpoints.yaml
 yq eval -i '.apis[0].name = env(API)' endpoints.yaml


### PR DESCRIPTION
From https://cloud.google.com/endpoints/docs/grpc/grpc-service-config#rules_and_selectors, wildcard "*" can only be in the last part of a selector.

Updated to replace the domain in deploy_gke.sh