### PR TITLE
Use non-local Cloud Build instead of Cloud Build Local for pushing mixer

### DIFF
--- a/scripts/push_binary.sh
+++ b/scripts/push_binary.sh
@@ -23,5 +23,8 @@ cd "$ROOT"
 
 TAG=$(git rev-parse --short=7 HEAD)
 
-cloud-build-local --config=build/ci/cloudbuild.push.yaml --dryrun=false \
---substitutions SHORT_SHA="$TAG" .
+gcloud builds submit \
+    --project=datcom-ci \
+    --config=build/ci/cloudbuild.push.yaml \
+    --substitutions SHORT_SHA="$TAG" \
+    .


### PR DESCRIPTION
Tested: called ./scripts/push_binary.sh (commenting out latest tag so it doesn't create a "latest" image, also commented out update_autopush_version.sh step)

Result

https://pantheon.corp.google.com/gcr/images/datcom-ci/global/datacommons-mixer@sha256:1af99c892362b88675b27d9ba0c56d23d091f6c1e0dc6c73b99eae0784e9edac/details?mods=-monitoring_api_staging&project=datcom-ci