### PR TITLE
Mixer API split - part 2: Add helm to deploy tool image

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -13,15 +13,18 @@
 # limitations under the License.
 
 # Build docker image used in Cloud Build for deployment.
-# This image contains "gcloud", "kubectl", "yq", "kustomize"
+# This image contains "gcloud", "kubectl", "yq", "kustomize", "helm"
 
 FROM google/cloud-sdk:slim
 
-RUN apt-get install wget
-RUN apt-get install kubectl
-
-RUN curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
-RUN mv kustomize /bin/
-
-RUN wget https://github.com/mikefarah/yq/releases/download/v4.12.1/yq_linux_386 -O /usr/bin/yq &&\
-    chmod +x /usr/bin/yq
+RUN \
+    apt-get install kubectl && \
+    curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash && \
+    mv kustomize /bin/ && \
+    curl https://github.com/mikefarah/yq/releases/download/v4.12.1/yq_linux_386 -o /usr/bin/yq && \
+    chmod +x /usr/bin/yq && \
+    curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && \
+    chmod 700 get_helm.sh && \
+    ./get_helm.sh && \
+    mv /usr/local/bin/helm /usr/bin/helm && \
+    chmod +x /usr/bin/helm

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -21,7 +21,7 @@ RUN \
     apt-get install kubectl && \
     curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash && \
     mv kustomize /bin/ && \
-    curl https://github.com/mikefarah/yq/releases/download/v4.12.1/yq_linux_386 -o /usr/bin/yq && \
+    curl -L https://github.com/mikefarah/yq/releases/download/v4.27.3/yq_linux_386 -o /usr/bin/yq && \
     chmod +x /usr/bin/yq && \
     curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && \
     chmod 700 get_helm.sh && \

--- a/deploy/cloudbuild.yaml
+++ b/deploy/cloudbuild.yaml
@@ -1,0 +1,5 @@
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args: [ 'build', '-t', 'gcr.io/datcom-ci/deploy-tool:latest', '.' ]
+images:
+- 'gcr.io/datcom-ci/deploy-tool:latest'

--- a/deploy/cloudbuild.yaml
+++ b/deploy/cloudbuild.yaml
@@ -1,5 +1,7 @@
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  args: [ 'build', '-t', 'gcr.io/datcom-ci/deploy-tool:latest', '.' ]
+  args: [ 'build', '-t', 'gcr.io/datcom-ci/deploy-tool:${_TAG}', '.' ]
 images:
-- 'gcr.io/datcom-ci/deploy-tool:latest'
+- 'gcr.io/datcom-ci/deploy-tool:${_TAG}'
+substitutions:
+    _TAG: "latest"

--- a/deploy/push_deploy_tool_image.sh
+++ b/deploy/push_deploy_tool_image.sh
@@ -24,5 +24,6 @@ ROOT="$(dirname "$DIR")"
 
 cd "$ROOT"
 
-docker build -t gcr.io/datcom-ci/deploy-tool:latest -f deploy/Dockerfile .
-docker push gcr.io/datcom-ci/deploy-tool:latest
+gcloud builds submit ./deploy \
+    --project=datcom-ci \
+    --config=deploy/cloudbuild.yaml

--- a/deploy/push_deploy_tool_image.sh
+++ b/deploy/push_deploy_tool_image.sh
@@ -24,6 +24,13 @@ ROOT="$(dirname "$DIR")"
 
 cd "$ROOT"
 
+TAG="latest"
+if [[ $1 != "" ]]; then
+  TAG=$1
+fi
+echo "Using tag=$TAG for the deploy-tool image."
+
 gcloud builds submit ./deploy \
     --project=datcom-ci \
+    --substitutions=_TAG="$TAG" \
     --config=deploy/cloudbuild.yaml


### PR DESCRIPTION
Add helm to deploy tool so that deploy_gke.sh can use it in automation. Also change docker build -> cloud build for the deployer image.