### PR TITLE
Mixer API split - part 3: Add env speicific values yaml files

### DIFF
--- a/deploy/charts/envs/mixer_autopush.yaml
+++ b/deploy/charts/envs/mixer_autopush.yaml
@@ -1,0 +1,16 @@
+# Helm config
+mixer:
+  gcpProjectID: datcom-mixer-autopush
+  serviceName: autopush.api.datacommons.org
+
+ingress:
+  annotations: {
+    ingress.gcp.kubernetes.io/pre-shared-cert: "mixer-certificate,multi-domain-2022"
+  }
+
+# GCP level config
+ip: 34.117.145.125
+region: us-central1
+api_title: DataCommons API (Autopush)
+api: datacommons.Mixer
+nodes: 4

--- a/deploy/charts/envs/mixer_encode.yaml
+++ b/deploy/charts/envs/mixer_encode.yaml
@@ -1,0 +1,27 @@
+# Helm config
+mixer:
+  gcpProjectID: datcom-mixer-encode
+  serviceName: encode.api.datacommons.org
+
+  bigqueryOnly: true
+  bigqueryTableRef: google.com:datcom-store-dev.dc_v3_encode_clustered
+
+# Encode instance only services SPARQL
+serviceGroups:
+  - mixer-sparql-service:
+      urlPaths:
+        - "/v1/query"
+      replicas:
+        default: 12
+        min: 12
+        max: 24
+      resources:
+        memoryRequest: "2G"
+        memoryLimit: "2G"
+
+# GCP level config
+ip: 34.107.228.109
+region: us-central1
+api_title: DataCommons API (Encode)
+api: datacommons.Mixer
+nodes: 1

--- a/deploy/charts/envs/mixer_private.yaml
+++ b/deploy/charts/envs/mixer_private.yaml
@@ -1,0 +1,122 @@
+# Helm config
+mixer:
+  gcpProjectID: datcom-mixer-statvar
+  serviceName: mixer.endpoints.datcom-mixer-statvar.cloud.goog
+
+  useTMCFCSVData: true
+  tmcfCSVBucket: datcom-public
+  tmcfCSVFolder: food
+
+memdbJSON: |
+  {
+    "importName": "Feeding America",
+    "provenanceUrl": "https://www.feedingamerica.org/",
+    "dataDownloadUrl": "https://www.feedingamerica.org/",
+    "rootSvg": "g/Feeding_America",
+    "statVarGroups": {
+      "g/Feeding_America": {
+        "childStatVarGroups": [
+          {
+            "id": "g/Child_FoodInsecure",
+            "specializedEntity": "Food Insecure Children"
+          },
+          {
+            "id": "g/Person_FoodInsecure",
+            "specializedEntity": "Food Insecure People"
+          }
+        ],
+        "childStatVars": [
+          {
+            "id": "Annual_FoodBudgetShortfall",
+            "searchNames": ["Annual Food Budget Shortfall"],
+            "displayName": "Annual Food Budget Shortfall"
+          },
+          {
+            "id": "Mean_MealCost_Person_FoodSecure",
+            "searchNames": ["Food Secure Person Mean Meal Cost"],
+            "displayName": "Average Meal Cost for Food Secure Persons"
+          }
+        ]
+      },
+      "g/Child_FoodInsecure": {
+        "childStatVarGroups": [
+          {
+            "id": "g/Child_FoodInsecure_ChildNutritionBenefits",
+            "specializedEntity": "Child Nutrition Benefits"
+          }
+        ],
+        "childStatVars": [
+          {
+            "id": "Count_Child_FoodInsecure",
+            "searchNames": ["Count of Food Insecure Child"],
+            "displayName": "Population"
+          }
+        ]
+      },
+      "g/Child_FoodInsecure_ChildNutritionBenefits": {
+        "childStatVars": [
+          {
+            "id": "Count_Child_FoodInsecure_EligibleForManyChildNutritionBenefits",
+            "searchNames": [
+              "Count of Child Food Insecure Eligible for Many Child Nutrition Benefits"
+            ],
+            "displayName": "Eligible"
+          },
+          {
+            "id": "Count_Child_FoodInsecure_IneligibleForChildNutritionBenefits",
+            "searchNames": [
+              "Count of Child Food Insecure Ineligible for Many Child Nutrition Benefits"
+            ],
+            "displayName": "Ineligible"
+          }
+        ]
+      },
+      "g/Person_FoodInsecure": {
+        "childStatVarGroups": [
+          {
+            "id": "g/Person_FoodInsecure_FederalBenefits",
+            "specializedEntity": "Federal Benefits"
+          }
+        ],
+        "childStatVars": [
+          {
+            "id": "Count_Person_FoodInsecure",
+            "searchNames": ["Count of Person Food Insecure"],
+            "displayName": "Population"
+          }
+        ]
+      },
+      "g/Person_FoodInsecure_FederalBenefits": {
+        "childStatVars": [
+          {
+            "id": "Count_Person_FoodInsecure_EligibleForAllFederalBenefits",
+            "searchNames": [
+              "Count of Person with Food Insecure Eligible for All Federal Benefits"
+            ],
+            "displayName": "Eligible for All Federal Benefits"
+          },
+          {
+            "id": "Count_Person_FoodInsecure_EligibleForSomeFederalBenefits",
+            "searchNames": [
+              "Count of Person with Food Insecure Eligible for Some Federal Benefits"
+            ],
+            "displayName": "Eligible for Some Federal Benefits"
+          },
+          {
+            "id": "Count_Person_FoodInsecure_IneligibleForFederalBenefits",
+            "searchNames": [
+              "Count of Person with Food Insecure Ineligible for Federal Benefits"
+            ],
+            "displayName": "Ineligible for Federal Benefits"
+          }
+        ]
+      }
+    }
+  }
+
+# GCP level config
+ip: 35.244.175.66
+region: us-central1
+api_title: DataCommons API (Private)
+api: datacommons.Mixer
+nodes: 1

--- a/deploy/charts/envs/mixer_prod.yaml
+++ b/deploy/charts/envs/mixer_prod.yaml
@@ -1,0 +1,42 @@
+# Helm config
+mixer:
+  gcpProjectID: datcom-mixer
+  serviceName: api.datacommons.org
+
+ingress:
+  annotations: {
+    ingress.gcp.kubernetes.io/pre-shared-cert: "mixer-certificate,multi-domain-2022"
+  }
+
+serviceGroups:
+  - mixer-svg-service: 
+      urlPaths:
+        - "/place/stat-var-group/*"
+        - "/stat-var/*"
+        - "/v1/info/variable/group/*"
+        - "/v1/variable/*"
+        - "/variable/ancestors/*"
+      replicas:
+        default: 10
+        min: 10
+        max: 40
+      resources:
+        memoryRequest: "8G"
+        memoryLimit: "8G"
+  - mixer-default-service:
+      urlPaths:
+        - "/*"
+      replicas:
+        default: 20
+        min: 20
+        max: 40
+      resources:
+        memoryRequest: "2G"
+        memoryLimit: "2G"
+
+# GCP level config
+ip: 35.244.133.155
+region: us-central1
+api_title: DataCommons API
+api: datacommons.Mixer
+nodes: 6

--- a/deploy/charts/envs/mixer_staging.yaml
+++ b/deploy/charts/envs/mixer_staging.yaml
@@ -1,0 +1,16 @@
+# Helm config
+mixer:
+  gcpProjectID: datcom-mixer-staging
+  serviceName: staging.api.datacommons.org
+
+ingress:
+  annotations: {
+    ingress.gcp.kubernetes.io/pre-shared-cert: "mixer-certificate,multi-domain-2022"
+  }
+
+# GCP level config
+ip: 34.107.161.252
+region: us-central1
+api_title: DataCommons API (Staging)
+api: datacommons.Mixer
+nodes: 2


### PR DESCRIPTION
This is a follow up from [part 1](https://github.com/datacommonsorg/mixer/pull/902).

This PR migrates [overlaps](https://github.com/datacommonsorg/website/tree/master/deploy/overlays) to value yaml files used by the Helm chart.

- local instance is excluded.
- recon instances are excluded because they are marked to be deleted.
- custom folder is excluded because it is a template.
