### PR TITLE
Mixer API split - part 4 : Add a recon service group

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -118,13 +118,6 @@ func main() {
 	// Create grpc server.
 	srv := grpc.NewServer(opts...)
 
-	// Metadata.
-	metadata, err := server.NewMetadata(
-		*bqDataset, *storeProject, branchBtInstance, *schemaPath)
-	if err != nil {
-		log.Fatalf("Failed to create metadata: %v", err)
-	}
-
 	branchCachePubsubTopic := "proto-branch-cache-reload"
 	branchCacheVersionFile := "latest_proto_branch_cache_version.txt"
 
@@ -196,6 +189,13 @@ func main() {
 			if err != nil {
 				log.Fatalf("Failed to create cache: %v", err)
 			}
+		}
+
+		// Metadata.
+		metadata, err := server.NewMetadata(
+			*bqDataset, *storeProject, branchBtInstance, *schemaPath)
+		if err != nil {
+			log.Fatalf("Failed to create metadata: %v", err)
 		}
 
 		// Create server object

--- a/deploy/helm_charts/envs/mixer_prod.yaml
+++ b/deploy/helm_charts/envs/mixer_prod.yaml
@@ -23,6 +23,18 @@ serviceGroups:
       resources:
         memoryRequest: "8G"
         memoryLimit: "8G"
+  - recon: 
+      urlPaths:
+        - "/entity/*"
+        - "/coordinate/*"
+        - "/id/*"
+      replicas:
+        default: 4
+        min: 4
+        max: 8
+      resources:
+        memoryRequest: "3G"
+        memoryLimit: "3G"
   - mixer-default-service:
       urlPaths:
         - "/*"

--- a/deploy/helm_charts/mixer/templates/deployment.yaml
+++ b/deploy/helm_charts/mixer/templates/deployment.yaml
@@ -71,13 +71,18 @@ spec:
             requests:
               memory:  {{ .resources.memoryRequest }}
           args:
+            # Import group tables are need for both Mixer and Recon services.
+            - --import_group_tables=$(IMPORT_GROUP_TABLES)
+            {{- if eq $serviceName "recon"}}
+            - --serve_recon_service=true
+            - --serve_mixer_service=false
+            {{ else }}
             - --mixer_project=$(MIXER_PROJECT)
             - --store_project=$(STORE_PROJECT)
             - --bq_dataset=$(BIG_QUERY)
-            - --serve_recon_service=true
             - --schema_path=/datacommons/mapping
-            - --import_group_tables=$(IMPORT_GROUP_TABLES)
             - --memdb_path=/datacommons/memdb
+            {{- end }}
             {{- if eq $.Values.mixer.bigqueryOnly true }}
             - --bigquery_only=true
             {{- end }}

--- a/deploy/helm_charts/mixer/templates/deployment.yaml
+++ b/deploy/helm_charts/mixer/templates/deployment.yaml
@@ -71,14 +71,20 @@ spec:
             requests:
               memory:  {{ .resources.memoryRequest }}
           args:
-            # Import group tables are need for both Mixer and Recon services.
+            # Common arguments both Mixer and Recon services.
             - --import_group_tables=$(IMPORT_GROUP_TABLES)
+            - --store_project=$(STORE_PROJECT)
             {{- if eq $serviceName "recon"}}
             - --serve_recon_service=true
             - --serve_mixer_service=false
             {{ else }}
+            - --serve_recon_service=false
+            - --serve_mixer_service=true
+            {{- end }}
+            # Eveyrthing below are Mixer specific arguments.
+            # Note: all non-recon services are mixer services.
+            {{- if ne $serviceName "recon" }}
             - --mixer_project=$(MIXER_PROJECT)
-            - --store_project=$(STORE_PROJECT)
             - --bq_dataset=$(BIG_QUERY)
             - --schema_path=/datacommons/mapping
             - --memdb_path=/datacommons/memdb

--- a/deploy/helm_charts/mixer/values.yaml
+++ b/deploy/helm_charts/mixer/values.yaml
@@ -91,6 +91,9 @@ kgStoreConfig:
 
 memdbJSON: ""
 
+# To overwrite any portion of serviceGroups, please copy and paste 
+# the entire serviceGroups below into the custom values yaml file,
+# and make changes to it.
 serviceGroups:
   - svg: 
       urlPaths:
@@ -106,6 +109,18 @@ serviceGroups:
       resources:
         memoryRequest: "8G"
         memoryLimit: "8G"
+  - recon: 
+      urlPaths:
+        - "/entity/*"
+        - "/coordinate/*"
+        - "/id/*"
+      replicas:
+        default: 1
+        min: 1
+        max: 4
+      resources:
+        memoryRequest: "3G"
+        memoryLimit: "3G"
   - default:
       urlPaths:
         - "/*"

--- a/deploy/helm_charts/mixer/values.yaml
+++ b/deploy/helm_charts/mixer/values.yaml
@@ -109,6 +109,8 @@ serviceGroups:
       resources:
         memoryRequest: "8G"
         memoryLimit: "8G"
+    # If the name of the recon service is changed here,
+    # please also change the name in the deployment.yaml template.
   - recon: 
       urlPaths:
         - "/entity/*"


### PR DESCRIPTION
Add a recon service group which will only serve Recon services (currently all service groups serve recon services).

Tested on dev instance

```
helm upgrade --install mixer-dev deploy/helm_charts/mixer \
  --atomic \
  -f deploy/helm_charts/envs/mixer_Dev.yaml \
  --set mixer.image.tag=45bd8bb \
  --set mixer.githash=45bd8bb \
  --set-file mixer.schemaConfigs."base\.mcf"=deploy/mapping/base.mcf \
  --set-file mixer.schemaConfigs."encode\.mcf"=deploy/mapping/encode.mcf \
  --set-file mixer.schemaConfigs."dailyweather\.mcf"=deploy/mapping/dailyweather.mcf \
  --set-file mixer.schemaConfigs."monthlyweather\.mcf"=deploy/mapping/monthlyweather.mcf \
  --set-file kgStoreConfig.bigqueryVersion=deploy/storage/bigquery.version \
  --set-file kgStoreConfig.bigtableImportGroupsVersion=deploy/storage/bigtable_import_groups.version
```

All deployments were successful

https://pantheon.corp.google.com/kubernetes/workload/overview?mods=-monitoring_api_staging&project=datcom-mixer-dev-316822