### PR TITLE
Mixer API split - part 5 : Switch over to helm in deploy_gke.sh

### DIFF
--- a/build/ci/cloudbuild.push.yaml
+++ b/build/ci/cloudbuild.push.yaml
@@ -46,6 +46,7 @@ steps:
           -t gcr.io/datcom-ci/datacommons-mixer:latest \
           .
         docker push gcr.io/datcom-ci/datacommons-mixer:$SHORT_SHA
+        docker push gcr.io/datcom-ci/datacommons-mixer:latest
 
   # Push the grpc descriptor to gcs.
   - id: push-grpc-descriptor
@@ -58,6 +59,7 @@ steps:
         gsutil cp mixer-grpc.$SHORT_SHA.pb gs://datcom-mixer-grpc/mixer-grpc/mixer-grpc.$SHORT_SHA.pb
         gsutil cp mixer-grpc.$SHORT_SHA.pb gs://datcom-mixer-grpc/mixer-grpc/mixer-grpc.latest.pb
         gsutil acl ch -u AllUsers:R gs://datcom-mixer-grpc/mixer-grpc/mixer-grpc.$SHORT_SHA.pb
+        gsutil acl ch -u AllUsers:R gs://datcom-mixer-grpc/mixer-grpc/mixer-grpc.latest.pb
 
   # Update autopush version in the GCP repo "deployment".
   - id: update-autopush-version

--- a/build/ci/cloudbuild.push.yaml
+++ b/build/ci/cloudbuild.push.yaml
@@ -46,7 +46,6 @@ steps:
           -t gcr.io/datcom-ci/datacommons-mixer:latest \
           .
         docker push gcr.io/datcom-ci/datacommons-mixer:$SHORT_SHA
-        docker push gcr.io/datcom-ci/datacommons-mixer:latest
 
   # Push the grpc descriptor to gcs.
   - id: push-grpc-descriptor
@@ -59,16 +58,19 @@ steps:
         gsutil cp mixer-grpc.$SHORT_SHA.pb gs://datcom-mixer-grpc/mixer-grpc/mixer-grpc.$SHORT_SHA.pb
         gsutil cp mixer-grpc.$SHORT_SHA.pb gs://datcom-mixer-grpc/mixer-grpc/mixer-grpc.latest.pb
         gsutil acl ch -u AllUsers:R gs://datcom-mixer-grpc/mixer-grpc/mixer-grpc.$SHORT_SHA.pb
-        gsutil acl ch -u AllUsers:R gs://datcom-mixer-grpc/mixer-grpc/mixer-grpc.latest.pb
 
-  # Update all the versions.
-  - id: update-version
+  # Update autopush version in the GCP repo "deployment".
+  - id: update-autopush-version
     name: "gcr.io/cloud-builders/git"
     entrypoint: /bin/bash
     args:
       - -c
       - |
+        if [ "$_SKIP_AUTOPUSH_UPDATE" == "true" ] ; then exit 0 ; fi
         ./scripts/update_autopush_version.sh $SHORT_SHA
+
+substitutions:
+    _SKIP_AUTOPUSH_UPDATE: "true"
 
 options:
   volumes:

--- a/deploy/helm_charts/mixer/templates/service.yaml
+++ b/deploy/helm_charts/mixer/templates/service.yaml
@@ -31,7 +31,7 @@ metadata:
     {{- include "mixer.labels" $ | nindent 4 }}
   annotations:
     # This is to get longer timeout for the Cloud Load Balancer.
-    cloud.google.com/backend-config: '{"ports": {"8081":"backendconfig"}}'
+    cloud.google.com/backend-config: '{"ports": {"8081":"{{ include "mixer.fullname" $ }}-backendconfig"}}'
 spec:
   type: NodePort
   ports:
@@ -50,8 +50,7 @@ spec:
 apiVersion: cloud.google.com/v1
 kind: BackendConfig
 metadata:
-  # TODO(alexyfchen): Change name to {{ include "mixer.fullname" . }}
-  name: backendconfig
+  name: {{ include "mixer.fullname" . }}-backendconfig
   namespace: {{ .Values.namespace.name }}
 spec:
   timeoutSec: 600

--- a/deploy/overlays/README.md
+++ b/deploy/overlays/README.md
@@ -1,0 +1,3 @@
+# Deprecated
+
+Files here are no longer used (to be deleted soon). Please make changes to deploy/helm_charts/envs/<env>.yaml instead.

--- a/scripts/deploy_gke.sh
+++ b/scripts/deploy_gke.sh
@@ -80,14 +80,14 @@ gcloud container clusters get-credentials $CLUSTER_NAME --region $REGION
 RELEASE=${ENV//_/-}
 
 # Create a release specific image for the deployment.
-./scripts/push_binary.sh $TAG
+./scripts/push_binary.sh "$TAG"
 
 # Upgrade or install Mixer helm chart into the cluster
-helm upgrade --install $RELEASE deploy/helm_charts/mixer \
+helm upgrade --install "$RELEASE" deploy/helm_charts/mixer \
   --atomic \
-  -f deploy/helm_charts/envs/$ENV.yaml \
-  --set mixer.image.tag=$TAG \
-  --set mixer.githash=$TAG \
+  -f "deploy/helm_charts/envs/$ENV.yaml" \
+  --set mixer.image.tag="$TAG" \
+  --set mixer.githash="$TAG" \
   --set-file mixer.schemaConfigs."base\.mcf"=deploy/mapping/base.mcf \
   --set-file mixer.schemaConfigs."encode\.mcf"=deploy/mapping/encode.mcf \
   --set-file mixer.schemaConfigs."dailyweather\.mcf"=deploy/mapping/dailyweather.mcf \

--- a/scripts/deploy_gke.sh
+++ b/scripts/deploy_gke.sh
@@ -79,8 +79,9 @@ gcloud container clusters get-credentials $CLUSTER_NAME --region $REGION
 # Change "mixer_prod" for example, to "mixer-prod"
 RELEASE=${ENV//_/-}
 
-# Create a release specific image for the deployment.
-./scripts/push_binary.sh "$TAG"
+# Create a release specific image for the deployment, if it does not exist.
+IMAGE_ERR=$(gcloud container images describe gcr.io/datcom-ci/datacommons-mixer:"$TAG" > /dev/null ; echo $?)
+if [[ "$IMAGE_ERR" == "1" ]];  then ./scripts/push_binary.sh "$TAG"; fi
 
 # Upgrade or install Mixer helm chart into the cluster
 helm upgrade --install "$RELEASE" deploy/helm_charts/mixer \

--- a/scripts/deploy_gke.sh
+++ b/scripts/deploy_gke.sh
@@ -33,8 +33,8 @@ set -e
 
 ENV=$1
 
-if [[ $ENV != "staging" && $ENV != "prod" && $ENV != "autopush" && $ENV != "encode" && $ENV != "dev" && $ENV != "private" && $ENV != "recon-prod" && $ENV != "recon-staging" && $ENV != "recon-autopush" ]]; then
-  echo "First argument should be 'staging' or 'prod' or 'autopush' or 'encode' or 'dev' or 'recon-prod' or 'recon-staging' or 'recon-autopush'"
+if [[ $ENV != "mixer_staging" && $ENV != "mixer_prod" && $ENV != "mixer_autopush" && $ENV != "mixer_encode" && $ENV != "mixer_dev" && $ENV != "mixer_private" ]]; then
+  echo "First argument should be 'mixer_staging' or 'mixer_prod' or 'mixer_autopush' or 'mixer_encode' or 'mixer_dev' or 'mixer_private'"
   exit
 fi
 
@@ -54,7 +54,7 @@ echo -n "$TAG" > mixer_hash.txt
 
 cd $ROOT
 
-if [[ $ENV == "autopush" ]]; then
+if [[ $ENV == "mixer_autopush" ]]; then
   # Update bigquery version
   gsutil cp gs://datcom-control/latest_base_bigquery_version.txt deploy/storage/bigquery.version
   # Import group
@@ -64,23 +64,36 @@ if [[ $ENV == "autopush" ]]; then
     echo $(gsutil cat "$src") >> deploy/storage/bigtable_import_groups.version
   done
 fi
-export PROJECT_ID=$(yq eval '.project' deploy/gke/$ENV.yaml)
-export REGION=$(yq eval '.region' deploy/gke/$ENV.yaml)
-export IP=$(yq eval '.ip' deploy/gke/$ENV.yaml)
-export DOMAIN=$(yq eval '.domain' deploy/gke/$ENV.yaml)
-export API_TITLE=$(yq eval '.api_title' deploy/gke/$ENV.yaml)
-export API=$(yq eval '.api' deploy/gke/$ENV.yaml)
+export PROJECT_ID=$(yq eval '.mixer.gcpProjectID' deploy/helm_charts/envs/$ENV.yaml)
+export REGION=$(yq eval '.region' deploy/helm_charts/envs/$ENV.yaml)
+export IP=$(yq eval '.ip' deploy/helm_charts/envs/$ENV.yaml)
+export DOMAIN=$(yq eval '.mixer.serviceName' deploy/helm_charts/envs/$ENV.yaml)
+export API_TITLE=$(yq eval '.api_title' deploy/helm_charts/envs/$ENV.yaml)
+export API=$(yq eval '.api' deploy/helm_charts/envs/$ENV.yaml)
 export CLUSTER_NAME=mixer-$REGION
 
-cd $ROOT/deploy/overlays/$ENV
-
 # Deploy to GKE
-kustomize edit set image gcr.io/datcom-ci/datacommons-mixer=gcr.io/datcom-ci/datacommons-mixer:$TAG
-kustomize build > kustomize-build.yaml
-cp kustomization.yaml kustomize-deployed.yaml
 gcloud config set project $PROJECT_ID
 gcloud container clusters get-credentials $CLUSTER_NAME --region $REGION
-kubectl apply -f kustomize-build.yaml
+
+# Change "mixer_prod" for example, to "mixer-prod"
+RELEASE=${ENV//_/-}
+
+# Create a release specific image for the deployment.
+./scripts/push_binary.sh $TAG
+
+# Upgrade or install Mixer helm chart into the cluster
+helm upgrade --install $RELEASE deploy/helm_charts/mixer \
+  --atomic \
+  -f deploy/helm_charts/envs/$ENV.yaml \
+  --set mixer.image.tag=$TAG \
+  --set mixer.githash=$TAG \
+  --set-file mixer.schemaConfigs."base\.mcf"=deploy/mapping/base.mcf \
+  --set-file mixer.schemaConfigs."encode\.mcf"=deploy/mapping/encode.mcf \
+  --set-file mixer.schemaConfigs."dailyweather\.mcf"=deploy/mapping/dailyweather.mcf \
+  --set-file mixer.schemaConfigs."monthlyweather\.mcf"=deploy/mapping/monthlyweather.mcf \
+  --set-file kgStoreConfig.bigqueryVersion=deploy/storage/bigquery.version \
+  --set-file kgStoreConfig.bigtableImportGroupsVersion=deploy/storage/bigtable_import_groups.version
 
 # Deploy Cloud Endpoints
 cp $ROOT/esp/endpoints.yaml.tmpl endpoints.yaml
@@ -94,6 +107,5 @@ gcloud endpoints services deploy mixer-grpc.$TAG.pb endpoints.yaml --project $PR
 
 
 # Reset changed file
-git checkout HEAD -- kustomization.yaml
 cd $ROOT
 git checkout HEAD -- deploy/git/mixer_hash.txt

--- a/scripts/push_binary.sh
+++ b/scripts/push_binary.sh
@@ -22,6 +22,10 @@ ROOT="$(dirname "$DIR")"
 cd "$ROOT"
 
 TAG=$(git rev-parse --short=7 HEAD)
+if [[ $1 != "" ]]; then
+  TAG=$1
+  git checkout "$TAG"
+fi
 
 gcloud builds submit \
     --project=datcom-ci \


### PR DESCRIPTION
Switch over from kustomize to helm.

Changes:
- Change kustomize commands to helm commands in deploy_gke.sh. After this PR is merged, changes to the clusters will be based on deploy/helm_charts/envs/<env file>.yaml rather than overlays.
- Create a binary before each deployment, and bind the created image to what is deployed ass opposed to always using latest. Tags are easily overwritten and fixing tags to releases stabilizes this.
- Small fix on backend config template: make it release specific.

Tested:
./scripts/deploy_gke.sh mixer_dev 
./scripts/deploy_gke.sh mixer_autopush