### PR TITLE
Fix ingress name

### DIFF
--- a/build/ci/cloudbuild.push.yaml
+++ b/build/ci/cloudbuild.push.yaml
@@ -70,6 +70,8 @@ steps:
       - |
         if [ "$_SKIP_AUTOPUSH_UPDATE" == "true" ] ; then exit 0 ; fi
         ./scripts/update_autopush_version.sh $SHORT_SHA
+substitutions:
+    _SKIP_AUTOPUSH_UPDATE: "false"
 
 substitutions:
     _SKIP_AUTOPUSH_UPDATE: "true"

--- a/deploy/helm_charts/envs/mixer_autopush.yaml
+++ b/deploy/helm_charts/envs/mixer_autopush.yaml
@@ -4,6 +4,7 @@ mixer:
   serviceName: autopush.api.datacommons.org
 
 ingress:
+  name: mixer-ingress-autopush
   annotations: {
     ingress.gcp.kubernetes.io/pre-shared-cert: "mixer-certificate,multi-domain-2022"
   }

--- a/deploy/helm_charts/envs/mixer_encode.yaml
+++ b/deploy/helm_charts/envs/mixer_encode.yaml
@@ -6,6 +6,9 @@ mixer:
   bigqueryOnly: true
   bigqueryTableRef: google.com:datcom-store-dev.dc_v3_encode_clustered
 
+ingress:
+  name: mixer-ingress-encode
+
 # Encode instance only services SPARQL
 serviceGroups:
   - mixer-sparql-service:

--- a/deploy/helm_charts/envs/mixer_private.yaml
+++ b/deploy/helm_charts/envs/mixer_private.yaml
@@ -7,6 +7,9 @@ mixer:
   tmcfCSVBucket: datcom-public
   tmcfCSVFolder: food
 
+ingress:
+  name: mixer-ingress-private
+
 memdbJSON: |
   {
     "importName": "Feeding America",

--- a/deploy/helm_charts/envs/mixer_prod.yaml
+++ b/deploy/helm_charts/envs/mixer_prod.yaml
@@ -4,6 +4,7 @@ mixer:
   serviceName: api.datacommons.org
 
 ingress:
+  name: mixer-ingress-prod
   annotations: {
     ingress.gcp.kubernetes.io/pre-shared-cert: "mixer-certificate,multi-domain-2022"
   }

--- a/deploy/helm_charts/envs/mixer_staging.yaml
+++ b/deploy/helm_charts/envs/mixer_staging.yaml
@@ -4,6 +4,7 @@ mixer:
   serviceName: staging.api.datacommons.org
 
 ingress:
+  name: mixer-ingress-staging
   annotations: {
     ingress.gcp.kubernetes.io/pre-shared-cert: "mixer-certificate,multi-domain-2022"
   }

--- a/deploy/helm_charts/mixer/values.yaml
+++ b/deploy/helm_charts/mixer/values.yaml
@@ -77,7 +77,7 @@ serviceAccount:
   gsaName: mixer-robot
 
 ingress:
-  name: mixer-ingress
+  name:
   enabled: true
   annotations: {
     kubernetes.io/ingress.global-static-ip-name: mixer-ip,


### PR DESCRIPTION
Ingress name is incorrectly set to a fixed "mixer-ingress", causing new loadbalancers to be created instead of updating existing ones.