### PR TITLE
Add mixer project to metadata and make variable names more precise

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -16,16 +16,16 @@ package main
 
 import (
 	"context"
-	"runtime"
-	"runtime/pprof"
-	"os"
 	"flag"
 	"fmt"
 	"log"
 	"net"
-	"path"
-	_ "net/http/pprof"
 	"net/http"
+	_ "net/http/pprof"
+	"os"
+	"path"
+	"runtime"
+	"runtime/pprof"
 
 	pb "github.com/datacommonsorg/mixer/internal/proto"
 	"github.com/datacommonsorg/mixer/internal/server"
@@ -193,7 +193,7 @@ func main() {
 
 		// Metadata.
 		metadata, err := server.NewMetadata(
-			*bqDataset, *storeProject, branchBtInstance, *schemaPath)
+			*mixerProject, *bqDataset, *storeProject, branchBtInstance, *schemaPath)
 		if err != nil {
 			log.Fatalf("Failed to create metadata: %v", err)
 		}
@@ -228,22 +228,22 @@ func main() {
 	if *startupMemoryProfile != "" {
 		// Code from https://pkg.go.dev/runtime/pprof README
 		f, err := os.Create(*startupMemoryProfile)
-        if err != nil {
-            log.Fatalf("could not create memory profile: %s", err)
-        }
-        defer f.Close()
+		if err != nil {
+			log.Fatalf("could not create memory profile: %s", err)
+		}
+		defer f.Close()
 		// explicitly trigger garbage collection to accurately understand memory
 		// still in use
-        runtime.GC()
-        if err := pprof.WriteHeapProfile(f); err != nil {
-            log.Fatalf("could not write memory profile: %s", err)
-        }
-		return;
+		runtime.GC()
+		if err := pprof.WriteHeapProfile(f); err != nil {
+			log.Fatalf("could not write memory profile: %s", err)
+		}
+		return
 	}
 
 	// Launch a goroutine that will serve memory requests using net/http/pprof
 	if *httpProfilePort != 0 {
-		go func(){
+		go func() {
 			// Code from https://pkg.go.dev/net/http/pprof README
 			httpProfileFrom := fmt.Sprintf("localhost:%d", *httpProfilePort)
 			log.Printf("Serving profile over HTTP on %v", httpProfileFrom)

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -334,7 +334,7 @@ func (s *Server) GetBioPageData(
 func (s *Server) Search(
 	ctx context.Context, in *pb.SearchRequest,
 ) (*pb.SearchResponse, error) {
-	return search.Search(ctx, in, s.store.BqClient, s.metadata.Bq)
+	return search.Search(ctx, in, s.store.BqClient, s.metadata.BigQueryDataset)
 }
 
 // GetVersion implements API for Mixer.GetVersion.
@@ -342,8 +342,8 @@ func (s *Server) GetVersion(
 	ctx context.Context, in *pb.GetVersionRequest,
 ) (*pb.GetVersionResponse, error) {
 	return &pb.GetVersionResponse{
-		Store:    s.metadata.BtProject,
-		BigQuery: s.metadata.Bq,
+		Store:    s.metadata.CoreBigtableProject,
+		BigQuery: s.metadata.BigQueryDataset,
 		Tables:   s.store.BtGroup.TableNames(),
 		GitHash:  os.Getenv("MIXER_HASH"),
 	}, nil

--- a/internal/server/resource/resource.go
+++ b/internal/server/resource/resource.go
@@ -50,13 +50,14 @@ type Cache struct {
 
 // Metadata represents the metadata used by the server.
 type Metadata struct {
-	Mappings         []*types.Mapping
-	OutArcInfo       map[string]map[string][]types.OutArcInfo
-	InArcInfo        map[string][]types.InArcInfo
-	SubTypeMap       map[string]string
-	Bq               string
-	BtProject        string
-	BranchBtInstance string
+	Mappings               []*types.Mapping
+	OutArcInfo             map[string]map[string][]types.OutArcInfo
+	InArcInfo              map[string][]types.InArcInfo
+	SubTypeMap             map[string]string
+	MixerProject           string
+	BigQueryDataset        string
+	CoreBigtableProject    string
+	BranchBigtableInstance string
 }
 
 // SearchIndex holds the index for searching stat var (group).

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -44,7 +44,7 @@ type Server struct {
 
 func (s *Server) updateBranchTable(ctx context.Context, branchTableName string) {
 	branchTable, err := bigtable.NewBtTable(
-		ctx, s.metadata.BtProject, s.metadata.BranchBtInstance, branchTableName)
+		ctx, s.metadata.CoreBigtableProject, s.metadata.BranchBigtableInstance, branchTableName)
 	if err != nil {
 		log.Printf("Failed to udpate branch cache Bigtable client: %v", err)
 		return
@@ -74,7 +74,12 @@ func ReadBranchTableName(
 
 // NewMetadata initialize the metadata for translator.
 func NewMetadata(
-	bqDataset, storeProject, branchInstance, schemaPath string) (*resource.Metadata, error) {
+	mixerProject,
+	bigQueryDataset,
+	storeProject,
+	branchBigtableInstance,
+	schemaPath string,
+) (*resource.Metadata, error) {
 	_, filename, _, _ := runtime.Caller(0)
 	subTypeMap, err := solver.GetSubTypeMap(
 		path.Join(path.Dir(filename), "../translator/table_types.json"))
@@ -92,7 +97,7 @@ func NewMetadata(
 			if err != nil {
 				return nil, err
 			}
-			mapping, err := mcf.ParseMapping(string(mappingStr), bqDataset)
+			mapping, err := mcf.ParseMapping(string(mappingStr), bigQueryDataset)
 			if err != nil {
 				return nil, err
 			}
@@ -102,13 +107,14 @@ func NewMetadata(
 	outArcInfo := map[string]map[string][]types.OutArcInfo{}
 	inArcInfo := map[string][]types.InArcInfo{}
 	return &resource.Metadata{
-			Mappings:         mappings,
-			OutArcInfo:       outArcInfo,
-			InArcInfo:        inArcInfo,
-			SubTypeMap:       subTypeMap,
-			Bq:               bqDataset,
-			BtProject:        storeProject,
-			BranchBtInstance: branchInstance,
+			Mappings:               mappings,
+			OutArcInfo:             outArcInfo,
+			InArcInfo:              inArcInfo,
+			SubTypeMap:             subTypeMap,
+			MixerProject:           mixerProject,
+			BigQueryDataset:        bigQueryDataset,
+			CoreBigtableProject:    storeProject,
+			BranchBigtableInstance: branchBigtableInstance,
 		},
 		nil
 }

--- a/test/setup.go
+++ b/test/setup.go
@@ -115,7 +115,7 @@ func setupInternal(
 		tables = append(tables, bigtable.NewTable(name, table))
 	}
 
-	metadata, err := server.NewMetadata(
+	metadata, err := server.NewMetadata("",
 		strings.TrimSpace(string(bqTableID)), storeProject, "", schemaPath)
 	if err != nil {
 		return nil, nil, err
@@ -158,6 +158,7 @@ func SetupBqOnly() (pb.MixerClient, pb.ReconClient, error) {
 		log.Fatalf("failed to create Bigquery client: %v", err)
 	}
 	metadata, err := server.NewMetadata(
+		"",
 		strings.TrimSpace(string(bqTableID)),
 		storeProject,
 		"",


### PR DESCRIPTION
mixer project will be used to add dynamic Bigtable instance for private DC. 

In a private website deployment, the user created private import cache is stored in the same project as the deployment.