### PR TITLE
Fix autopush config, also add debug flag for helm

### DIFF
--- a/deploy/helm_charts/envs/mixer_autopush.yaml
+++ b/deploy/helm_charts/envs/mixer_autopush.yaml
@@ -28,9 +28,9 @@ serviceGroups:
       urlPaths:
         - "/v1/recon/*"
       replicas:
-        default: 4
-        min: 4
-        max: 8
+        default: 20
+        min: 20
+        max: 30
       resources:
         memoryRequest: "3G"
         memoryLimit: "3G"
@@ -38,9 +38,9 @@ serviceGroups:
       urlPaths:
         - "/*"
       replicas:
-        default: 15
-        min: 15
-        max: 30
+        default: 10
+        min: 10
+        max: 20
       resources:
         memoryRequest: "3G"
         memoryLimit: "3G"

--- a/scripts/deploy_gke.sh
+++ b/scripts/deploy_gke.sh
@@ -87,6 +87,7 @@ if [[ "$IMAGE_ERR" == "1" ]];  then ./scripts/push_binary.sh "$TAG"; fi
 # Upgrade or install Mixer helm chart into the cluster
 helm upgrade --install "$RELEASE" deploy/helm_charts/mixer \
   --atomic \
+  --debug \
   -f "deploy/helm_charts/envs/$ENV.yaml" \
   --set mixer.image.tag="$TAG" \
   --set mixer.githash="$TAG" \


### PR DESCRIPTION
This is a follow up for https://github.com/datacommonsorg/mixer/pull/925

Autopush had too much replicas, resulting in a scheduling failure. Add debug flag to helm to show the exact issues from now on.