### PR TITLE
Make endpoint group for observations API

### DIFF
--- a/deploy/helm_charts/envs/mixer_autopush.yaml
+++ b/deploy/helm_charts/envs/mixer_autopush.yaml
@@ -11,16 +11,16 @@ ingress:
     }
 
 serviceGroups:
-  - mixer-svg-service:
+  - svg:
       urlPaths:
         - "/place/stat-var-group/*"
         - "/stat-var/*"
         - "/v1/info/variable/group/*"
         - "/v1/variable/*"
       replicas:
-        default: 2
-        min: 2
-        max: 8
+        default: 5
+        min: 5
+        max: 10
       resources:
         memoryRequest: "8G"
         memoryLimit: "8G"
@@ -34,7 +34,7 @@ serviceGroups:
       resources:
         memoryRequest: "400M"
         memoryLimit: "400M"
-  - mixer-default-service:
+  - observation:
       urlPaths:
         - "/v1/observations/*"
         - "/v1/bulk/observations/*"
@@ -45,7 +45,7 @@ serviceGroups:
       resources:
         memoryRequest: "4G"
         memoryLimit: "4G"
-  - mixer-default-service:
+  - default:
       urlPaths:
         - "/*"
       replicas:

--- a/deploy/helm_charts/envs/mixer_autopush.yaml
+++ b/deploy/helm_charts/envs/mixer_autopush.yaml
@@ -36,6 +36,17 @@ serviceGroups:
         memoryLimit: "400M"
   - mixer-default-service:
       urlPaths:
+        - "/v1/observations/*"
+        - "/v1/bulk/observations/*"
+      replicas:
+        default: 10
+        min: 10
+        max: 20
+      resources:
+        memoryRequest: "4G"
+        memoryLimit: "4G"
+  - mixer-default-service:
+      urlPaths:
         - "/*"
       replicas:
         default: 10

--- a/deploy/helm_charts/envs/mixer_encode.yaml
+++ b/deploy/helm_charts/envs/mixer_encode.yaml
@@ -11,7 +11,7 @@ ingress:
 
 # Encode instance only services SPARQL
 serviceGroups:
-  - mixer-sparql-service:
+  - sparql:
       urlPaths:
         - "/v1/query"
       replicas:

--- a/deploy/helm_charts/envs/mixer_prod.yaml
+++ b/deploy/helm_charts/envs/mixer_prod.yaml
@@ -11,16 +11,16 @@ ingress:
     }
 
 serviceGroups:
-  - mixer-svg-service:
+  - svg:
       urlPaths:
         - "/place/stat-var-group/*"
         - "/stat-var/*"
         - "/v1/info/variable/group/*"
         - "/v1/variable/*"
       replicas:
-        default: 30
-        min: 30
-        max: 50
+        default: 10
+        min: 10
+        max: 20
       resources:
         memoryRequest: "8G"
         memoryLimit: "8G"
@@ -34,16 +34,27 @@ serviceGroups:
       resources:
         memoryRequest: "400M"
         memoryLimit: "400M"
-  - mixer-default-service:
+  - observation:
+      urlPaths:
+        - "/v1/observations/*"
+        - "/v1/bulk/observations/*"
+      replicas:
+        default: 20
+        min: 20
+        max: 40
+      resources:
+        memoryRequest: "4G"
+        memoryLimit: "4G"
+  - default:
       urlPaths:
         - "/*"
       replicas:
-        default: 80
-        min: 80
-        max: 120
+        default: 40
+        min: 40
+        max: 80
       resources:
-        memoryRequest: "2G"
-        memoryLimit: "2G"
+        memoryRequest: "3G"
+        memoryLimit: "3G"
 
 # GCP level config
 ip: 35.244.133.155

--- a/deploy/helm_charts/envs/mixer_staging.yaml
+++ b/deploy/helm_charts/envs/mixer_staging.yaml
@@ -11,7 +11,7 @@ ingress:
     }
 
 serviceGroups:
-  - mixer-svg-service:
+  - svg:
       urlPaths:
         - "/place/stat-var-group/*"
         - "/stat-var/*"
@@ -28,19 +28,30 @@ serviceGroups:
       urlPaths:
         - "/v1/recon/*"
       replicas:
-        default: 30
-        min: 30
-        max: 40
+        default: 10
+        min: 10
+        max: 20
       resources:
         memoryRequest: "400M"
         memoryLimit: "400M"
-  - mixer-default-service:
+  - observation:
+      urlPaths:
+        - "/v1/observations/*"
+        - "/v1/bulk/observations/*"
+      replicas:
+        default: 10
+        min: 10
+        max: 20
+      resources:
+        memoryRequest: "4G"
+        memoryLimit: "4G"
+  - default:
       urlPaths:
         - "/*"
       replicas:
-        default: 15
-        min: 15
-        max: 30
+        default: 10
+        min: 10
+        max: 20
       resources:
         memoryRequest: "3G"
         memoryLimit: "3G"

--- a/deploy/helm_charts/mixer/values.yaml
+++ b/deploy/helm_charts/mixer/values.yaml
@@ -120,7 +120,7 @@ serviceGroups:
       resources:
         memoryRequest: "400M"
         memoryLimit: "400M"
-  - mixer-default-service:
+  - observation:
       urlPaths:
         - "/v1/observations/*"
         - "/v1/bulk/observations/*"

--- a/deploy/helm_charts/mixer/values.yaml
+++ b/deploy/helm_charts/mixer/values.yaml
@@ -120,6 +120,17 @@ serviceGroups:
       resources:
         memoryRequest: "400M"
         memoryLimit: "400M"
+  - mixer-default-service:
+      urlPaths:
+        - "/v1/observations/*"
+        - "/v1/bulk/observations/*"
+      replicas:
+        default: 2
+        min: 2
+        max: 24
+      resources:
+        memoryRequest: "4G"
+        memoryLimit: "4G"
   - default:
       urlPaths:
         - "/*"


### PR DESCRIPTION
There have been a lot of webdriver tests failure, which could be due to resource issue in autopush mixer. Create a new group for observations API to narrow down / fix the issue.