### PR TITLE
Add quote to some helm templated values

### DIFF
--- a/deploy/helm_charts/mixer/templates/config_maps.yaml
+++ b/deploy/helm_charts/mixer/templates/config_maps.yaml
@@ -28,7 +28,7 @@ metadata:
   name: {{ include "mixer.fullname" . }}-githash
   namespace: {{ .Values.namespace.name }}
 data:
-  mixer_hash.txt: {{ required "mixer githash is required" .Values.mixer.githash }}
+  mixer_hash.txt: {{ required "mixer githash is required" .Values.mixer.githash | quote }}
 
 ---
 
@@ -41,7 +41,7 @@ data:
   bigquery.version: {{ required "kgStoreConfig.bigqueryVersion is required." .Values.kgStoreConfig.bigqueryVersion }}
   bigtable_import_groups.version: |
   {{-  required "bigtableImportGroupsVersion is required." .Values.kgStoreConfig.bigtableImportGroupsVersion | nindent 4 }}
-  store.project: {{ required "storeProjectID is required." .Values.kgStoreConfig.storeProjectID }}
+  store.project: {{ required "storeProjectID is required." .Values.kgStoreConfig.storeProjectID | quote }}
 
 ---
 
@@ -61,8 +61,8 @@ metadata:
   name: {{ include "mixer.fullname" . }}-mixer-config
   namespace: {{ .Values.namespace.name }}
 data:
-  mixerProject: {{ required "Mixer GCP project is required." .Values.mixer.gcpProjectID }}
-  serviceName:  {{ required "Mixer service name is required." .Values.mixer.serviceName }}
+  mixerProject: {{ required "Mixer GCP project is required." .Values.mixer.gcpProjectID | quote }}
+  serviceName:  {{ required "Mixer service name is required." .Values.mixer.serviceName | quote }}
 
 ---
 
@@ -74,5 +74,5 @@ metadata:
 data:
   {{- range $key, $val := .Values.mixer.schemaConfigs }}
   {{ $key }}: |
-    {{ $val | nindent 4 }}
+    {{ $val | nindent 4 | quote }}
   {{- end  }}


### PR DESCRIPTION
GKE fails to interpret some values due to type mismatches. This happened for example when the githash starts with a number "8734187", 


Failed run
https://pantheon.corp.google.com/cloud-build/builds;region=global/daac272b-a58f-47a8-be18-3f9c91ad4025?mods=-monitoring_api_staging&project=datcom-ci

Tested with manual run

export RELEASE=mixer-autopush
export ENV=mixer_autopush
export TAG=8734187

helm upgrade --install "$RELEASE" deploy/helm_charts/mixer   --atomic   --debug   -f "deploy/helm_charts/envs/$ENV.yaml"   --set mixer.image.tag="$TAG"   --set mixer.githash="$TAG"   --set-file mixer.schemaConfigs."base\.mcf"=deploy/mapping/base.mcf   --set-file mixer.schemaConfigs."encode\.mcf"=deploy/mapping/encode.mcf   --set-file mixer.schemaConfigs."dailyweather\.mcf"=deploy/mapping/dailyweather.mcf   --set-file mixer.schemaConfigs."monthlyweather\.mcf"=deploy/mapping/monthlyweather.mcf   --set-file kgStoreConfig.bigqueryVersion=deploy/storage/bigquery.version   --set-file kgStoreConfig.bigtableImportGroupsVersion=deploy/storage/bigtable_import_groups.version
