### PR TITLE
Increase helm timeout from 5min to 10min

### DIFF
--- a/deploy/helm_charts/README.md
+++ b/deploy/helm_charts/README.md
@@ -6,12 +6,12 @@ A single helm chart organizes a collection of templatized k8s yaml files.
 
 ## Installing a Helm chart
 
-Installing a Helm chart means filling in the templates with a set of values and 
+Installing a Helm chart means filling in the templates with a set of values and
 applying the resources to a live cluster.
 
 Note: Helm uses [k8s config](https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl) for authentication. You can visit the GCP UI and click "CONNECT" on your cluster's page to get the command to configure the k8s config.
 
-![Alt text](images/gke_connect.png?raw=true "credentials")
+![Alt text](images/gke_connect.png?raw=true 'credentials')
 
 Check if the k8s config points to the right cluster with `kubectl config current-context`.
 
@@ -27,6 +27,7 @@ based on local change. Helm then deploys a release that refers to the newly crea
 
 helm upgrade --install mixer-dev deploy/helm_charts/mixer \
     --atomic \
+    --timeout 10m \
     -f deploy/helm_charts/envs/mixer_dev.yaml \
     --set mixer.githash=$(git rev-parse --short=7 HEAD) \
     --set-file mixer.schemaConfigs."base.mcf"=deploy/mapping/base.mcf \

--- a/scripts/deploy_gke.sh
+++ b/scripts/deploy_gke.sh
@@ -88,6 +88,7 @@ if [[ "$IMAGE_ERR" == "1" ]];  then ./scripts/push_binary.sh "$TAG"; fi
 helm upgrade --install "$RELEASE" deploy/helm_charts/mixer \
   --atomic \
   --debug \
+  --timeout 10m \
   -f "deploy/helm_charts/envs/$ENV.yaml" \
   --set mixer.image.tag="$TAG" \
   --set mixer.githash="$TAG" \


### PR DESCRIPTION
Some builds are timing out. Helm waits for a default of 5min. Immediate solution is to increase this.

Example 
https://pantheon.corp.google.com/cloud-build/builds;region=global/bdd7bfb9-d824-47f9-b7a8-a71c7b35e47c;step=0?mods=-monitoring_api_staging&project=datcom-ci


helm waits for all service groups in series, there's a way to change that.