### PR TITLE
Add quote to memdbJSON

### DIFF
--- a/deploy/helm_charts/mixer/templates/config_maps.yaml
+++ b/deploy/helm_charts/mixer/templates/config_maps.yaml
@@ -51,7 +51,7 @@ metadata:
   name: {{ include "mixer.fullname" . }}-memdb-config
   namespace: {{ .Values.namespace.name }}
 data:
-  memdb.json: {{ .Values.memdbJSON }}
+  memdb.json: {{ .Values.memdbJSON | quote }}
 
 ---
 


### PR DESCRIPTION
memdbJSON has to be quoted, otherwise the value gets interpreted as nil and causes an error.

https://pantheon.corp.google.com/cloud-build/builds;region=global/6a5d538a-44a4-4e06-9d38-ff50ae6ae919;step=0?mods=-monitoring_api_staging&project=datcom-ci