### PR TITLE
Fix golden-diff

### DIFF
--- a/build/ci/cloudbuild.goldendiff.yaml
+++ b/build/ci/cloudbuild.goldendiff.yaml
@@ -21,9 +21,9 @@ steps:
     args:
       - "-c"
       - |
-        touch /tmp/base_bigtable_info.yaml
         yq eval -i 'del(.tables)' deploy/storage/base_bigtable_info.yaml
         yq eval -i '.tables = []' deploy/storage/base_bigtable_info.yaml
+        cp deploy/storage/base_bigtable_info.yaml /tmp/base_bigtable_info.yaml
         for src in $(gsutil ls gs://datcom-control/autopush/*_latest_base_cache_version.txt); do
           echo "Copying $src"
           export TABLE="$(gsutil cat $src)"


### PR DESCRIPTION
Copy over base_bigtable_info with tables deleted instead of creating starting from empty file which causes missing information.