### PR TITLE
Fix failing recon API test

### DIFF
--- a/internal/server/recon/find_entities.go
+++ b/internal/server/recon/find_entities.go
@@ -170,7 +170,6 @@ func resolvePlaceIDs(
 					resolveResultChan <- resolveResult{
 						entityInfo: &entityInfo,
 						placeIDs:   []string{}}
-
 				} else {
 					// Only keep the first place ID, as the rest ones are usually much less accurate.
 					resolveResultChan <- resolveResult{

--- a/internal/server/recon/find_entities.go
+++ b/internal/server/recon/find_entities.go
@@ -89,7 +89,6 @@ func BulkFindEntities(
 			Type:        entityInfo.typ,
 		}
 
-		fmt.Print(entityInfoToPlaceIDs)
 		allDCIDs := []string{}
 		for _, placeID := range placeIDs {
 			if dcids, ok := placeIDToDCIDs[placeID]; ok {

--- a/internal/server/recon/find_entities.go
+++ b/internal/server/recon/find_entities.go
@@ -89,6 +89,7 @@ func BulkFindEntities(
 			Type:        entityInfo.typ,
 		}
 
+		fmt.Print(entityInfoToPlaceIDs)
 		allDCIDs := []string{}
 		for _, placeID := range placeIDs {
 			if dcids, ok := placeIDToDCIDs[placeID]; ok {
@@ -167,12 +168,16 @@ func resolvePlaceIDs(
 					return err
 				}
 				if len(placeIDs) == 0 {
-					continue
+					resolveResultChan <- resolveResult{
+						entityInfo: &entityInfo,
+						placeIDs:   []string{}}
+
+				} else {
+					// Only keep the first place ID, as the rest ones are usually much less accurate.
+					resolveResultChan <- resolveResult{
+						entityInfo: &entityInfo,
+						placeIDs:   []string{placeIDs[0]}}
 				}
-				// Only keep the first place ID, as the rest ones are usually much less accurate.
-				resolveResultChan <- resolveResult{
-					entityInfo: &entityInfo,
-					placeIDs:   []string{placeIDs[0]}}
 			}
 			return nil
 		}

--- a/internal/server/recon/find_entities.go
+++ b/internal/server/recon/find_entities.go
@@ -166,17 +166,14 @@ func resolvePlaceIDs(
 				if err != nil {
 					return err
 				}
-				if len(placeIDs) == 0 {
-					// If no results, set placeIDs to empty []string.
-					resolveResultChan <- resolveResult{
-						entityInfo: &entityInfo,
-						placeIDs:   []string{}}
-				} else {
+				usedPlaceIds := []string{}
+				if len(placeIDs) > 0 {
 					// Only keep the first place ID, as the rest ones are usually much less accurate.
-					resolveResultChan <- resolveResult{
-						entityInfo: &entityInfo,
-						placeIDs:   []string{placeIDs[0]}}
+					usedPlaceIds = []string{placeIDs[0]}
 				}
+				resolveResultChan <- resolveResult{
+					entityInfo: &entityInfo,
+					placeIDs:   usedPlaceIds}
 			}
 			return nil
 		}

--- a/internal/server/recon/find_entities.go
+++ b/internal/server/recon/find_entities.go
@@ -166,6 +166,9 @@ func resolvePlaceIDs(
 				if err != nil {
 					return err
 				}
+				if len(placeIDs) == 0 {
+					continue
+				}
 				// Only keep the first place ID, as the rest ones are usually much less accurate.
 				resolveResultChan <- resolveResult{
 					entityInfo: &entityInfo,

--- a/internal/server/recon/find_entities.go
+++ b/internal/server/recon/find_entities.go
@@ -167,6 +167,7 @@ func resolvePlaceIDs(
 					return err
 				}
 				if len(placeIDs) == 0 {
+					// If no results, set placeIDs to empty []string.
 					resolveResultChan <- resolveResult{
 						entityInfo: &entityInfo,
 						placeIDs:   []string{}}


### PR DESCRIPTION
This PR updates `resolvePlaceIDs()` so that `bulk_find_entities_test.go` passes.

With this change, descriptions that do not map to any dcids are still returned, just without matches (e.g. the "non-existing place wow" case in [/internal/server/recon/bulk_find_entities_test.go:51](https://github.com/datacommonsorg/mixer/blob/ade6e189a0ff2efb251dd32517208cfe5f73d123/internal/server/recon/golden/bulk_find_entities_test.go#L51)
 