### PR TITLE
Property Values nodes merge: prefer highest ranked import group for duplicated nodes

### DIFF
--- a/internal/server/v1/propertyvalues/golden/bulk_property_values_in/containedIn1.json
+++ b/internal/server/v1/propertyvalues/golden/bulk_property_values_in/containedIn1.json
@@ -54119,12 +54119,12 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Lucerne Valley Unified School District",
+          "name": "Lucerne Valley Unified",
           "types": [
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0600015",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Upland Unified",
@@ -54143,12 +54143,12 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Mountain Valley Unified School District",
+          "name": "Mountain Valley Unified",
           "types": [
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0600018",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Dublin Unified",
@@ -54167,12 +54167,12 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Sunol Glen Unified School District",
+          "name": "Sunol Glen Unified",
           "types": [
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0600021",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Mendota Unified",
@@ -54191,12 +54191,12 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "El Tejon Unified School District",
+          "name": "El Tejon Unified",
           "types": [
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0600026",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Lake Elsinore Unified",
@@ -54215,12 +54215,12 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Murrieta Valley Unified School District",
+          "name": "Murrieta Valley Unified",
           "types": [
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0600029",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Big Sur Unified",
@@ -54239,12 +54239,12 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Dos Palos-Oro Loma Joint Unified School District",
+          "name": "Dos Palos Oro Loma Joint Unified",
           "types": [
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0600033",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Windsor Unified",
@@ -54263,12 +54263,12 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Natomas Unified School District",
+          "name": "Natomas Unified",
           "types": [
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0600036",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Ferndale Unified",
@@ -54287,12 +54287,12 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Delhi Unified School District",
+          "name": "Delhi Unified",
           "types": [
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0600039",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Riverdale Joint Unified",
@@ -54311,12 +54311,12 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Scotts Valley Unified School District",
+          "name": "Scotts Valley Unified",
           "types": [
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0600043",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Healdsburg Unified",
@@ -54335,12 +54335,12 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Gonzales Unified School District",
+          "name": "Gonzales Unified",
           "types": [
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0600046",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Tracy Joint Unified",
@@ -54359,12 +54359,12 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Coast Unified School District",
+          "name": "Coast Unified",
           "types": [
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0600049",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Cea Amador Co",
@@ -54431,12 +54431,12 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Oakdale Joint Unified School District",
+          "name": "Oakdale Joint Unified",
           "types": [
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0600062",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Waterford Unified",
@@ -54455,12 +54455,12 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Dinuba Unified School District",
+          "name": "Dinuba Unified",
           "types": [
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0600065",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Cea Ventura Co",
@@ -54487,12 +54487,12 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Valley Center-Pauma Unified School District",
+          "name": "Valley Center-Pauma Unified",
           "types": [
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0600069",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Sbe - Ridgecrest Charter",
@@ -55159,12 +55159,12 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Yosemite Unified School District",
+          "name": "Yosemite Unified",
           "types": [
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0600160",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Sbc - High Tech High",
@@ -55247,12 +55247,12 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Twin Rivers Unified School District",
+          "name": "Twin Rivers Unified",
           "types": [
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0601332",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Sbe - Doris Topsy-Elvord Academy",
@@ -55943,13 +55943,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Fortuna Elementary School District",
+          "name": "Fortuna Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0601420",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Santa Paula Unified",
@@ -56009,12 +56009,12 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Wiseburn Unified School District",
+          "name": "Wiseburn Unified",
           "types": [
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0601428",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Sbe - Thrive Public",
@@ -58091,13 +58091,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Adelanto Elementary School District",
+          "name": "Adelanto Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0601710",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Alexander Valley Union Elementary",
@@ -58118,13 +58118,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Allensworth Elementary School District",
+          "name": "Allensworth Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0601980",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Alpine Union Elementary",
@@ -58145,13 +58145,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Alta Vista Elementary School District",
+          "name": "Alta Vista Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0602220",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Alta-Dutch Flat Union Elementary",
@@ -58172,13 +58172,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Alview-Dairyland Union Elementary School District",
+          "name": "Alview-Dairyland Union Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0602360",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Alvina Elementary",
@@ -58208,13 +58208,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "West Sonoma County Union High School District",
+          "name": "West Sonoma County Union High",
           "types": [
             "HighSchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0602670",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Anderson Union High",
@@ -58226,13 +58226,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Antelope Elementary School District",
+          "name": "Antelope Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0602760",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Antelope Valley Union High",
@@ -58253,13 +58253,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Northern Humboldt Union High School District",
+          "name": "Northern Humboldt Union High",
           "types": [
             "HighSchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0603030",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Arcohe Union Elementary",
@@ -58271,12 +58271,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Arena Union Elementary School District",
+          "name": "Arena Union Elementary",
           "types": [
-            "ElementarySchoolDistrict"
+            "ElementarySchoolDistrict",
+            "SchoolDistrict"
           ],
           "dcid": "geoId/sch0603090",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Armona Union Elementary",
@@ -58297,13 +58298,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Atwater Elementary School District",
+          "name": "Atwater Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0603420",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Auburn Union Elementary",
@@ -58324,13 +58325,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Ballard Elementary School District",
+          "name": "Ballard Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0603720",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Ballico-Cressey Elementary",
@@ -58351,13 +58352,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Banta Elementary School District",
+          "name": "Banta Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0603870",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Bass Lake Joint Union Elementary",
@@ -58378,13 +58379,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Beardsley Elementary School District",
+          "name": "Beardsley Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0604260",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Bella Vista Elementary",
@@ -58405,13 +58406,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Belleview Elementary School District",
+          "name": "Belleview Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0604500",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Belmont-Redwood Shores Elementary",
@@ -58432,13 +58433,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Bennett Valley Union Elementary School District",
+          "name": "Bennett Valley Union Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0604650",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Berryessa Union Elementary",
@@ -58459,13 +58460,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Big Lagoon Union Elementary School District",
+          "name": "Big Lagoon Union Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0604890",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Big Springs Union Elementary",
@@ -58486,13 +58487,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Black Butte Union Elementary School District",
+          "name": "Black Butte Union Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0605220",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Blake Elementary",
@@ -58513,13 +58514,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Blue Lake Union Elementary School District",
+          "name": "Blue Lake Union Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0605400",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Bogus Elementary",
@@ -58540,13 +58541,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Santa Maria-Bonita Elementary School District",
+          "name": "Santa Maria-Bonita",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0605580",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Bonny Doon Union Elementary",
@@ -58567,13 +58568,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Brawley Elementary School District",
+          "name": "Brawley Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0605790",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Brawley Union High",
@@ -58740,13 +58741,13 @@
           "provenanceId": "dc/sm3m2w3"
         },
         {
-          "name": "Briggs Elementary School District",
+          "name": "Briggs Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0606030",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Tracy Unified School District (9-12)",
@@ -58807,13 +58808,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Browns Elementary School District",
+          "name": "Browns Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0606100",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Porterville Unified School District (9-12)",
@@ -58842,13 +58843,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Buena Park Elementary School District",
+          "name": "Buena Park Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0606360",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Panama-Buena Vista School District",
@@ -58869,13 +58870,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Burlingame Elementary School District",
+          "name": "Burlingame Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0606480",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Burnt Ranch Elementary",
@@ -58896,13 +58897,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Burton Elementary School District",
+          "name": "Burton Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0606570",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Butteville Union Elementary",
@@ -58923,13 +58924,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Byron Union Elementary School District",
+          "name": "Byron Union Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0606750",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Cajon Valley Union",
@@ -58950,13 +58951,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Cambrian Elementary School District",
+          "name": "Cambrian",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0607140",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Camino Union Elementary",
@@ -58986,13 +58987,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Camptonville Elementary School District",
+          "name": "Camptonville Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0607260",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Canyon Elementary",
@@ -59013,13 +59014,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Cardiff Elementary School District",
+          "name": "Cardiff Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0607470",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Cascade Union Elementary",
@@ -59040,13 +59041,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Castle Rock Union Elementary School District",
+          "name": "Castle Rock Union Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0607770",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Cayucos Elementary",
@@ -59076,22 +59077,22 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Central Union Elementary School District",
+          "name": "Central Union Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0607980",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Central Union High School District",
+          "name": "Central Union High",
           "types": [
             "HighSchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0608010",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Centralia Elementary",
@@ -59121,13 +59122,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Chicago Park Elementary School District",
+          "name": "Chicago Park Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0608340",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Chowchilla Elementary",
@@ -59157,13 +59158,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Chula Vista Elementary School District",
+          "name": "Chula Vista Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0608610",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Cienega Union Elementary",
@@ -59184,13 +59185,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Clay Joint Elementary School District",
+          "name": "Clay Joint Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0608850",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Clear Creek Elementary",
@@ -59211,13 +59212,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Cold Spring Elementary School District",
+          "name": "Cold Spring Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0609270",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Colfax Elementary",
@@ -59238,13 +59239,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Columbia Elementary School District",
+          "name": "Columbia Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0609450",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Columbia Union",
@@ -59265,22 +59266,22 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Corning Union Elementary School District",
+          "name": "Corning Union Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0609780",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Corning Union High School District",
+          "name": "Corning Union High",
           "types": [
             "HighSchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0609810",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Cottonwood Union Elementary",
@@ -59301,13 +59302,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Cupertino Union Elementary School District",
+          "name": "Cupertino Union",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0610290",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Curtis Creek Elementary",
@@ -59328,13 +59329,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Cypress Elementary School District",
+          "name": "Cypress Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0610440",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Dehesa Elementary",
@@ -59364,13 +59365,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Delano Union Elementary School District",
+          "name": "Delano Union Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0610890",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Delphic Elementary",
@@ -59397,7 +59398,7 @@
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0611220",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Douglas City Elementary",
@@ -59418,13 +59419,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Ducor Union Elementary School District",
+          "name": "Ducor Union Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0611550",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Dunham Elementary",
@@ -59454,22 +59455,22 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Earlimart Elementary School District",
+          "name": "Earlimart Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0611760",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "East Nicolaus Joint Union High School District",
+          "name": "East Nicolaus Joint Union High",
           "types": [
             "HighSchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0611780",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "East Side Union High",
@@ -59499,13 +59500,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Edison Elementary School District",
+          "name": "Edison Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0611940",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "El Centro Elementary",
@@ -59535,22 +59536,22 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "El Monte Union High School District",
+          "name": "El Monte Union High",
           "types": [
             "HighSchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0612120",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "El Nido Elementary School District",
+          "name": "El Nido Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0612150",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Elk Hills Elementary",
@@ -59571,13 +59572,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Elverta Joint Elementary School District",
+          "name": "Elverta Joint Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0612600",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Empire Union Elementary",
@@ -59598,13 +59599,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Enterprise Elementary School District",
+          "name": "Enterprise Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0612810",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Escondido Union",
@@ -59634,13 +59635,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Eureka Union Elementary School District",
+          "name": "Eureka Union",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0613080",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Evergreen Elementary",
@@ -59661,13 +59662,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Fairfax Elementary School District",
+          "name": "Fairfax Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0613290",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Fallbrook Union Elementary",
@@ -59697,13 +59698,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Fieldbrook Elementary School District",
+          "name": "Fieldbrook Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0613740",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Flournoy Union Elementary",
@@ -59724,13 +59725,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Forestville Union Elementary School District",
+          "name": "Forestville Union Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0614010",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Forks Of Salmon Elementary",
@@ -59751,22 +59752,22 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Fortuna Union High School District",
+          "name": "Fortuna Union High",
           "types": [
             "HighSchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0614190",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Fountain Valley Elementary School District",
+          "name": "Fountain Valley Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0614220",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Franklin Elementary",
@@ -59796,13 +59797,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "French Gulch-Whiskeytown Elementary School District",
+          "name": "French Gulch-Whiskeytown Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0614490",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Freshwater Elementary",
@@ -59823,13 +59824,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Fullerton Elementary School District",
+          "name": "Fullerton Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0614730",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Fullerton Joint Union High",
@@ -59850,13 +59851,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Galt Joint Union High School District",
+          "name": "Galt Joint Union High",
           "types": [
             "HighSchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0614820",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Garfield Elementary",
@@ -59868,13 +59869,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Garvey Elementary School District",
+          "name": "Garvey Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0614940",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Gazelle Union Elementary",
@@ -59895,13 +59896,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Gerber Union Elementary School District",
+          "name": "Gerber Union Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0615090",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Gold Oak Union Elementary",
@@ -59922,13 +59923,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Golden Feather Union Elementary School District",
+          "name": "Golden Feather Union Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0615480",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Goleta Union Elementary",
@@ -59949,13 +59950,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Grant Elementary School District",
+          "name": "Grant Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0615690",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Grass Valley Elementary",
@@ -59976,13 +59977,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Gravenstein Union Elementary School District",
+          "name": "Gravenstein Union Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0615840",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Graves Elementary",
@@ -60003,13 +60004,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Greenfield Union School District",
+          "name": "Greenfield Union",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0616050",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Greenfield Union Elementary",
@@ -60039,13 +60040,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Guadalupe Union Elementary School District",
+          "name": "Guadalupe Union Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0616260",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Cucamonga Elementary",
@@ -60066,13 +60067,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Hanford Elementary School District",
+          "name": "Hanford Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0616470",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Hanford Joint Union High",
@@ -60102,13 +60103,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Happy Valley Union Elementary School District",
+          "name": "Happy Valley Union Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0616570",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Harmony Union Elementary",
@@ -60129,13 +60130,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Hawthorne Elementary School District",
+          "name": "Hawthorne",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0616680",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Heber Elementary",
@@ -60156,13 +60157,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Hermosa Beach City Elementary School District",
+          "name": "Hermosa Beach City Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0617040",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Hickman Community Charter",
@@ -60183,13 +60184,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Hollister School District",
+          "name": "Hollister",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0617340",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Hope Elementary",
@@ -60210,13 +60211,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Horicon Elementary School District",
+          "name": "Horicon Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0617580",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Hornbrook Elementary",
@@ -60237,13 +60238,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Howell Mountain Elementary School District",
+          "name": "Howell Mountain Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0617760",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Hueneme Elementary",
@@ -60264,22 +60265,22 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Huntington Beach City Elementary School District",
+          "name": "Huntington Beach City Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0618030",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Huntington Beach Union High School District",
+          "name": "Huntington Beach Union High",
           "types": [
             "HighSchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0618060",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Hydesville Elementary",
@@ -60300,13 +60301,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Indian Diggings Elementary School District",
+          "name": "Indian Diggings Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0618240",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Indian Springs Elementary",
@@ -60327,12 +60328,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Jacoby Creek Elementary School District",
+          "name": "Jacoby Creek Elementary",
           "types": [
-            "ElementarySchoolDistrict"
+            "ElementarySchoolDistrict",
+            "SchoolDistrict"
           ],
           "dcid": "geoId/sch0618660",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Jamestown Elementary",
@@ -60353,13 +60355,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Janesville Union Elementary School District",
+          "name": "Janesville Union Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0618780",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Jefferson Elementary",
@@ -60380,13 +60382,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Jefferson Elementary School District",
+          "name": "Jefferson Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0618870",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Jefferson Union High",
@@ -60425,13 +60427,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Junction City Elementary School District",
+          "name": "Junction City Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0619170",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Junction Elementary",
@@ -60452,13 +60454,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Kentfield Elementary School District",
+          "name": "Kentfield Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0619380",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Kenwood",
@@ -60479,22 +60481,22 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Kern High School District",
+          "name": "Kern High",
           "types": [
             "HighSchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0619540",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Kernville Union Elementary School District",
+          "name": "Kernville Union Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0619590",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Keyes Union",
@@ -60524,13 +60526,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Kings River Union Elementary School District",
+          "name": "Kings River Union Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0619740",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Kings River-Hardwick Union Elementary",
@@ -60560,13 +60562,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Kirkwood Elementary School District",
+          "name": "Kirkwood Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0619860",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Kit Carson Union Elementary",
@@ -60587,13 +60589,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Kneeland Elementary School District",
+          "name": "Kneeland Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0619980",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Knights Ferry Elementary",
@@ -60614,13 +60616,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "La Habra City Elementary School District",
+          "name": "La Habra City Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0620190",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "La Mesa-Spring Valley",
@@ -60641,13 +60643,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Laguna Joint Elementary School District",
+          "name": "Laguna Joint Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0620430",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Pacifica",
@@ -60668,13 +60670,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Lagunitas Elementary School District",
+          "name": "Lagunitas Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0620520",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Lake Elementary",
@@ -60695,13 +60697,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Lakeside Union School District",
+          "name": "Lakeside Union",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0620730",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Lakeside Union Elementary",
@@ -60722,13 +60724,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Lamont Elementary School District",
+          "name": "Lamont Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0620850",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Lancaster Elementary",
@@ -60749,22 +60751,22 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Lassen Union High School District",
+          "name": "Lassen Union High",
           "types": [
             "HighSchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0621060",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Lassen View Union Elementary School District",
+          "name": "Lassen View Union Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0621090",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Latrobe",
@@ -60785,13 +60787,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Le Grand Union Elementary School District",
+          "name": "Le Grand Union Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0621240",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Le Grand Union High",
@@ -60830,13 +60832,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Lennox Elementary School District",
+          "name": "Lennox",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0621420",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Richland Union Elementary",
@@ -60857,13 +60859,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Liberty Elementary School District",
+          "name": "Liberty Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0621540",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Liberty Elementary",
@@ -60875,13 +60877,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Liberty Union High School District",
+          "name": "Liberty Union High",
           "types": [
             "HighSchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0621600",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Lincoln Elementary",
@@ -60893,13 +60895,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Linns Valley-Poso Flat Union School District",
+          "name": "Linns Valley-Poso Flat Union",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0621900",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Little Lake City Elementary",
@@ -60920,13 +60922,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Live Oak Elementary School District",
+          "name": "Live Oak Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0621990",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Livingston Union",
@@ -60947,13 +60949,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Loma Prieta Joint Union Elementary School District",
+          "name": "Loma Prieta Joint Union Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0622350",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Las Lomitas Elementary",
@@ -60974,13 +60976,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Los Altos Elementary School District",
+          "name": "Los Altos Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0622650",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Los Gatos-Saratoga Joint Union School District",
@@ -61010,13 +61012,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Los Olivos Elementary School District",
+          "name": "Los Olivos Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0622920",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Lost Hills Union Elementary",
@@ -61037,13 +61039,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Lucerne Elementary School District",
+          "name": "Lucerne Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0623040",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Luther Burbank",
@@ -61064,12 +61066,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Magnolia Union Elementary School District",
+          "name": "Magnolia Union Elementary",
           "types": [
-            "ElementarySchoolDistrict"
+            "ElementarySchoolDistrict",
+            "SchoolDistrict"
           ],
           "dcid": "geoId/sch0623460",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Manchester Union Elementary",
@@ -61090,13 +61093,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Maple Creek Elementary School District",
+          "name": "Maple Creek Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0623730",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Maple Elementary",
@@ -61117,13 +61120,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Mark Twain Union Elementary School District",
+          "name": "Mark Twain Union Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0623970",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Mark West Union Elementary",
@@ -61150,7 +61153,7 @@
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0624210",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "McKinleyville Union Elementary School District",
@@ -61177,7 +61180,7 @@
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0624360",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Meadows Union Elementary",
@@ -61198,13 +61201,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Menlo Park City Elementary School District",
+          "name": "Menlo Park City Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0624570",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Merced City Elementary",
@@ -61234,13 +61237,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Meridian Elementary School District",
+          "name": "Meridian Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0624690",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Mesa Union Elementary",
@@ -61261,13 +61264,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Mill Valley Elementary School District",
+          "name": "Mill Valley Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0624870",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Millbrae Elementary",
@@ -61288,13 +61291,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Mission Union Elementary School District",
+          "name": "Mission Union Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0625110",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Modesto City Elementary",
@@ -61306,13 +61309,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Modesto City High School District",
+          "name": "Modesto City High",
           "types": [
             "HighSchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0625150",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Monroe Elementary",
@@ -61324,13 +61327,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Monson-Sultana Joint Union Elementary School District",
+          "name": "Monson-Sultana Joint Union Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0625350",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Montague Elementary",
@@ -61351,13 +61354,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Montecito Union Elementary School District",
+          "name": "Montecito Union Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0625500",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Montgomery Elementary",
@@ -61378,13 +61381,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Moreland School District",
+          "name": "Moreland",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0625770",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Mother Lode Union Elementary",
@@ -61405,13 +61408,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Mountain Elementary School District",
+          "name": "Mountain Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0626070",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Mountain House Elementary",
@@ -61432,13 +61435,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Mountain View Elementary School District",
+          "name": "Mountain View Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0626220",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Mountain View Whisman",
@@ -61468,13 +61471,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Mount Pleasant Elementary School District",
+          "name": "Mount Pleasant Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0626400",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Mulberry Elementary",
@@ -61495,13 +61498,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "National Elementary School District",
+          "name": "National Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0626670",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Nevada City Elementary",
@@ -61531,13 +61534,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "New Jerusalem Elementary School District",
+          "name": "New Jerusalem Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0627030",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Mountain Union Elementary",
@@ -61558,13 +61561,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Newhall Elementary School District",
+          "name": "Newhall",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0627180",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Nicasio",
@@ -61585,13 +61588,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "North County Joint Union Elementary School District",
+          "name": "North County Joint Union Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0627480",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "North Cow Creek Elementary",
@@ -61612,13 +61615,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Nuview Union Elementary School District",
+          "name": "Nuview Union",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0627780",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Oak Grove Elementary",
@@ -61639,13 +61642,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Oak Run Elementary School District",
+          "name": "Oak Run Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0627870",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Oak Valley Union Elementary",
@@ -61666,13 +61669,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Oakley Union Elementary School District",
+          "name": "Oakley Union Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0628080",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Ocean View",
@@ -61693,13 +61696,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Old Adobe Union Elementary School District",
+          "name": "Old Adobe Union",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0628320",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Ontario-Montclair",
@@ -61720,13 +61723,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Orchard Elementary School District",
+          "name": "Orchard Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0628680",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Orcutt Union Elementary",
@@ -61747,13 +61750,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Orinda Union Elementary School District",
+          "name": "Orinda Union Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0628860",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Oro Grande",
@@ -61774,22 +61777,22 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Oroville Union High School District",
+          "name": "Oroville Union High",
           "types": [
             "HighSchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0629130",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Outside Creek Elementary School District",
+          "name": "Outside Creek Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0629160",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Oxnard",
@@ -61819,13 +61822,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Pacific Elementary School District",
+          "name": "Pacific Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0629340",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Pacific Union Elementary",
@@ -61846,12 +61849,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Palermo Union Elementary School District",
+          "name": "Palermo Union Elementary",
           "types": [
-            "ElementarySchoolDistrict"
+            "ElementarySchoolDistrict",
+            "SchoolDistrict"
           ],
           "dcid": "geoId/sch0629540",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Palmdale Elementary",
@@ -61872,13 +61876,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Panoche Elementary School District",
+          "name": "Panoche Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0629770",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Paradise Elementary",
@@ -61899,13 +61903,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Perris Elementary School District",
+          "name": "Perris Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0630180",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Perris Union High",
@@ -61926,12 +61930,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Petaluma Joint Union High School District",
+          "name": "Petaluma Joint Union High",
           "types": [
-            "HighSchoolDistrict"
+            "HighSchoolDistrict",
+            "SchoolDistrict"
           ],
           "dcid": "geoId/sch0630250",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Pine Ridge Elementary",
@@ -61943,13 +61948,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Piner-Olivet Union Elementary School District",
+          "name": "Piner-Olivet Union Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0630450",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Pioneer Union Elementary",
@@ -61970,12 +61975,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Pioneer Union Elementary School District",
+          "name": "Pioneer Union Elementary",
           "types": [
-            "ElementarySchoolDistrict"
+            "ElementarySchoolDistrict",
+            "SchoolDistrict"
           ],
           "dcid": "geoId/sch0630520",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Pixley Union Elementary",
@@ -62005,13 +62011,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Placerville Union Elementary School District",
+          "name": "Placerville Union Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0630780",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Plainsburg Union Elementary",
@@ -62032,13 +62038,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Plaza Elementary School District",
+          "name": "Plaza Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0630870",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Pleasant Grove Joint Union",
@@ -62059,13 +62065,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Pleasant Valley Elementary School District",
+          "name": "Pleasant Valley",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0630990",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Pleasant Valley Joint Union Elementary",
@@ -62086,13 +62092,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Plumas Lake Elementary School District",
+          "name": "Plumas Lake Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0631180",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Point Arena Joint Union High",
@@ -62122,13 +62128,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Pope Valley Union Elementary School District",
+          "name": "Pope Valley Union Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0631380",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Portola Valley Elementary",
@@ -62149,13 +62155,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Rancho Santa Fe Elementary School District",
+          "name": "Rancho Santa Fe Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0631740",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Ravendale-Termo Elementary",
@@ -62176,13 +62182,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Raymond-Knowles Union Elementary School District",
+          "name": "Raymond-Knowles Union Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0631920",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Red Bluff Union Elementary",
@@ -62194,13 +62200,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Red Bluff Joint Union High School District",
+          "name": "Red Bluff Joint Union High",
           "types": [
             "HighSchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0632010",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Redding Elementary",
@@ -62212,13 +62218,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Redwood City Elementary School District",
+          "name": "Redwood City Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0632130",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Reed Union Elementary",
@@ -62239,13 +62245,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Rescue Union Elementary School District",
+          "name": "Rescue Union Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0632310",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Kashia Elementary",
@@ -62266,13 +62272,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Richgrove Elementary School District",
+          "name": "Richgrove Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0632430",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Richmond Elementary",
@@ -62293,13 +62299,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Rio Bravo-Greeley Union Elementary School District",
+          "name": "Rio Bravo-Greeley Union Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0632710",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Rio Dell Elementary",
@@ -62320,13 +62326,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Roberts Ferry Union Elementary School District",
+          "name": "Roberts Ferry Union Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0633210",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Robla Elementary",
@@ -62347,13 +62353,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Romoland Elementary School District",
+          "name": "Romoland Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0633390",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Rosedale Union Elementary",
@@ -62374,13 +62380,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Rosemead Elementary School District",
+          "name": "Rosemead Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0633570",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Roseville City Elementary",
@@ -62410,13 +62416,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Round Valley Joint Elementary School District",
+          "name": "Round Valley Joint Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0633690",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Salida Union Elementary",
@@ -62446,13 +62452,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "San Antonio Union Elementary School District",
+          "name": "San Antonio Union Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0634050",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "San Ardo Union Elementary",
@@ -62464,13 +62470,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "San Benito High School District",
+          "name": "San Benito High",
           "types": [
             "HighSchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0634140",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "San Bruno Park Elementary",
@@ -62482,13 +62488,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "San Carlos Elementary School District",
+          "name": "San Carlos Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0634290",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "San Dieguito Union High",
@@ -62527,12 +62533,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "San Miguel Joint Union Elementary School District",
+          "name": "San Miguel Joint Union",
           "types": [
-            "ElementarySchoolDistrict"
+            "ElementarySchoolDistrict",
+            "SchoolDistrict"
           ],
           "dcid": "geoId/sch0635010",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "San Pasqual Union Elementary",
@@ -62553,22 +62560,22 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "San Rafael City High School District",
+          "name": "San Rafael City High",
           "types": [
             "HighSchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0635110",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "San Ysidro Elementary School District",
+          "name": "San Ysidro Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0635220",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Santa Clara Elementary",
@@ -62607,13 +62614,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Santa Rita Union Elementary School District",
+          "name": "Santa Rita Union Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0635790",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Santa Rosa Elementary",
@@ -62631,7 +62638,7 @@
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0635830",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Santa Ynez Valley Union High",
@@ -62652,13 +62659,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Saratoga Union Elementary School District",
+          "name": "Saratoga Union Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0635910",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Saucelito Elementary",
@@ -62685,7 +62692,7 @@
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0636000",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Savanna Elementary",
@@ -62706,13 +62713,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Sebastopol Union Elementary School District",
+          "name": "Sebastopol Union Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0636180",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Seeley Union Elementary",
@@ -62733,13 +62740,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Semitropic Elementary School District",
+          "name": "Semitropic Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0636330",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Sequoia Union Elementary",
@@ -62769,22 +62776,22 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Shasta Union Elementary School District",
+          "name": "Shasta Union Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0636570",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Shasta Union High School District",
+          "name": "Shasta Union High",
           "types": [
             "HighSchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0636600",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Shiloh Elementary",
@@ -62814,13 +62821,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Snelling-Merced Falls Union Elementary School District",
+          "name": "Snelling-Merced Falls Union Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0636960",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Victor Valley Union High",
@@ -62850,13 +62857,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Somis Union Elementary School District",
+          "name": "Somis Union",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0637140",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Sonora Elementary",
@@ -62868,13 +62875,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Sonora Union High School District",
+          "name": "Sonora Union High",
           "types": [
             "HighSchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0637260",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Soquel Elementary School District",
@@ -62886,13 +62893,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Soulsbyville Elementary School District",
+          "name": "Soulsbyville Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0637320",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "South Bay Union Elementary",
@@ -62913,13 +62920,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "South Fork Union School District",
+          "name": "South Fork Union",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0637470",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "South Whittier Elementary",
@@ -62940,13 +62947,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Spencer Valley Elementary School District",
+          "name": "Spencer Valley Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0637680",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Spreckels Union Elementary",
@@ -62967,13 +62974,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Standard Elementary School District",
+          "name": "Standard Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0637890",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Stanislaus Union Elementary",
@@ -62994,13 +63001,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Strathmore Union Elementary School District",
+          "name": "Strathmore Union Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0638130",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Sulphur Springs Union",
@@ -63030,13 +63037,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Sundale Union Elementary School District",
+          "name": "Sundale Union Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0638340",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Sunnyside Union Elementary",
@@ -63057,13 +63064,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Susanville Elementary School District",
+          "name": "Susanville Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0638550",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Sutter Union High",
@@ -63075,13 +63082,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Sweetwater Union High School District",
+          "name": "Sweetwater Union High",
           "types": [
             "HighSchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0638640",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Sylvan Union Elementary",
@@ -63120,13 +63127,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Terra Bella Union Elementary School District",
+          "name": "Terra Bella Union Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0639060",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Thermalito Union Elementary",
@@ -63147,13 +63154,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Tipton Elementary School District",
+          "name": "Tipton Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0639300",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Traver Joint Elementary",
@@ -63174,13 +63181,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Trinidad Union Elementary School District",
+          "name": "Trinidad Union Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0639720",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Trinity Center Elementary",
@@ -63201,22 +63208,22 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Tulare Joint Union High School District",
+          "name": "Tulare Joint Union High",
           "types": [
             "HighSchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0639930",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Twain Harte School District",
+          "name": "Twain Harte",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0640200",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Twin Hills Union Elementary",
@@ -63237,13 +63244,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Union Elementary School District",
+          "name": "Union Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0640320",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Union Hill Elementary",
@@ -63264,13 +63271,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Vallecito Union Elementary School District",
+          "name": "Vallecito Union",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0640680",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Vallecitos Elementary",
@@ -63291,13 +63298,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Victor Elementary School District",
+          "name": "Victor Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0641040",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Vineland Elementary",
@@ -63318,13 +63325,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Walnut Creek Elementary School District",
+          "name": "Walnut Creek Elementary",
           "types": [
             "ElementarySchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0641250",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "Wasco Union Elementary",
@@ -63363,13 +63370,13 @@
           "provenanceId": "dc/91s0hm"
         },
         {
-          "name": "Whittier Union High School District",
+          "name": "Whittier Union High",
           "types": [
             "HighSchoolDistrict",
             "SchoolDistrict"
           ],
           "dcid": "geoId/sch0642480",
-          "provenanceId": "dc/sm3m2w3"
+          "provenanceId": "dc/91s0hm"
         },
         {
           "name": "William S. Hart Union High",

--- a/internal/server/v1/propertyvalues/golden/property_values_in/containedIn1.json
+++ b/internal/server/v1/propertyvalues/golden/property_values_in/containedIn1.json
@@ -21475,12 +21475,12 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Lucerne Valley Unified School District",
+      "name": "Lucerne Valley Unified",
       "types": [
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0600015",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Upland Unified",
@@ -21499,12 +21499,12 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Mountain Valley Unified School District",
+      "name": "Mountain Valley Unified",
       "types": [
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0600018",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Dublin Unified",
@@ -21523,12 +21523,12 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Sunol Glen Unified School District",
+      "name": "Sunol Glen Unified",
       "types": [
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0600021",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Mendota Unified",
@@ -21547,12 +21547,12 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "El Tejon Unified School District",
+      "name": "El Tejon Unified",
       "types": [
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0600026",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Lake Elsinore Unified",
@@ -21571,12 +21571,12 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Murrieta Valley Unified School District",
+      "name": "Murrieta Valley Unified",
       "types": [
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0600029",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Big Sur Unified",
@@ -21595,12 +21595,12 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Dos Palos-Oro Loma Joint Unified School District",
+      "name": "Dos Palos Oro Loma Joint Unified",
       "types": [
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0600033",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Windsor Unified",
@@ -21619,12 +21619,12 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Natomas Unified School District",
+      "name": "Natomas Unified",
       "types": [
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0600036",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Ferndale Unified",
@@ -21643,12 +21643,12 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Delhi Unified School District",
+      "name": "Delhi Unified",
       "types": [
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0600039",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Riverdale Joint Unified",
@@ -21667,12 +21667,12 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Scotts Valley Unified School District",
+      "name": "Scotts Valley Unified",
       "types": [
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0600043",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Healdsburg Unified",
@@ -21691,12 +21691,12 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Gonzales Unified School District",
+      "name": "Gonzales Unified",
       "types": [
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0600046",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Tracy Joint Unified",
@@ -21715,12 +21715,12 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Coast Unified School District",
+      "name": "Coast Unified",
       "types": [
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0600049",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Cea Amador Co",
@@ -21787,12 +21787,12 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Oakdale Joint Unified School District",
+      "name": "Oakdale Joint Unified",
       "types": [
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0600062",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Waterford Unified",
@@ -21811,12 +21811,12 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Dinuba Unified School District",
+      "name": "Dinuba Unified",
       "types": [
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0600065",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Cea Ventura Co",
@@ -21843,12 +21843,12 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Valley Center-Pauma Unified School District",
+      "name": "Valley Center-Pauma Unified",
       "types": [
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0600069",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Sbe - Ridgecrest Charter",
@@ -22515,12 +22515,12 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Yosemite Unified School District",
+      "name": "Yosemite Unified",
       "types": [
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0600160",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Sbc - High Tech High",
@@ -22603,12 +22603,12 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Twin Rivers Unified School District",
+      "name": "Twin Rivers Unified",
       "types": [
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0601332",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Sbe - Doris Topsy-Elvord Academy",
@@ -23299,13 +23299,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Fortuna Elementary School District",
+      "name": "Fortuna Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0601420",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Santa Paula Unified",
@@ -23365,12 +23365,12 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Wiseburn Unified School District",
+      "name": "Wiseburn Unified",
       "types": [
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0601428",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Sbe - Thrive Public",
@@ -25447,13 +25447,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Adelanto Elementary School District",
+      "name": "Adelanto Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0601710",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Alexander Valley Union Elementary",
@@ -25474,13 +25474,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Allensworth Elementary School District",
+      "name": "Allensworth Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0601980",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Alpine Union Elementary",
@@ -25501,13 +25501,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Alta Vista Elementary School District",
+      "name": "Alta Vista Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0602220",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Alta-Dutch Flat Union Elementary",
@@ -25528,13 +25528,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Alview-Dairyland Union Elementary School District",
+      "name": "Alview-Dairyland Union Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0602360",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Alvina Elementary",
@@ -25564,13 +25564,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "West Sonoma County Union High School District",
+      "name": "West Sonoma County Union High",
       "types": [
         "HighSchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0602670",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Anderson Union High",
@@ -25582,13 +25582,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Antelope Elementary School District",
+      "name": "Antelope Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0602760",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Antelope Valley Union High",
@@ -25609,13 +25609,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Northern Humboldt Union High School District",
+      "name": "Northern Humboldt Union High",
       "types": [
         "HighSchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0603030",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Arcohe Union Elementary",
@@ -25627,12 +25627,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Arena Union Elementary School District",
+      "name": "Arena Union Elementary",
       "types": [
-        "ElementarySchoolDistrict"
+        "ElementarySchoolDistrict",
+        "SchoolDistrict"
       ],
       "dcid": "geoId/sch0603090",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Armona Union Elementary",
@@ -25653,13 +25654,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Atwater Elementary School District",
+      "name": "Atwater Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0603420",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Auburn Union Elementary",
@@ -25680,13 +25681,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Ballard Elementary School District",
+      "name": "Ballard Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0603720",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Ballico-Cressey Elementary",
@@ -25707,13 +25708,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Banta Elementary School District",
+      "name": "Banta Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0603870",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Bass Lake Joint Union Elementary",
@@ -25734,13 +25735,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Beardsley Elementary School District",
+      "name": "Beardsley Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0604260",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Bella Vista Elementary",
@@ -25761,13 +25762,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Belleview Elementary School District",
+      "name": "Belleview Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0604500",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Belmont-Redwood Shores Elementary",
@@ -25788,13 +25789,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Bennett Valley Union Elementary School District",
+      "name": "Bennett Valley Union Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0604650",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Berryessa Union Elementary",
@@ -25815,13 +25816,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Big Lagoon Union Elementary School District",
+      "name": "Big Lagoon Union Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0604890",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Big Springs Union Elementary",
@@ -25842,13 +25843,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Black Butte Union Elementary School District",
+      "name": "Black Butte Union Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0605220",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Blake Elementary",
@@ -25869,13 +25870,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Blue Lake Union Elementary School District",
+      "name": "Blue Lake Union Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0605400",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Bogus Elementary",
@@ -25896,13 +25897,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Santa Maria-Bonita Elementary School District",
+      "name": "Santa Maria-Bonita",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0605580",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Bonny Doon Union Elementary",
@@ -25923,13 +25924,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Brawley Elementary School District",
+      "name": "Brawley Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0605790",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Brawley Union High",
@@ -26096,13 +26097,13 @@
       "provenanceId": "dc/sm3m2w3"
     },
     {
-      "name": "Briggs Elementary School District",
+      "name": "Briggs Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0606030",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Tracy Unified School District (9-12)",
@@ -26163,13 +26164,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Browns Elementary School District",
+      "name": "Browns Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0606100",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Porterville Unified School District (9-12)",
@@ -26198,13 +26199,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Buena Park Elementary School District",
+      "name": "Buena Park Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0606360",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Panama-Buena Vista School District",
@@ -26225,13 +26226,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Burlingame Elementary School District",
+      "name": "Burlingame Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0606480",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Burnt Ranch Elementary",
@@ -26252,13 +26253,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Burton Elementary School District",
+      "name": "Burton Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0606570",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Butteville Union Elementary",
@@ -26279,13 +26280,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Byron Union Elementary School District",
+      "name": "Byron Union Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0606750",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Cajon Valley Union",
@@ -26306,13 +26307,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Cambrian Elementary School District",
+      "name": "Cambrian",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0607140",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Camino Union Elementary",
@@ -26342,13 +26343,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Camptonville Elementary School District",
+      "name": "Camptonville Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0607260",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Canyon Elementary",
@@ -26369,13 +26370,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Cardiff Elementary School District",
+      "name": "Cardiff Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0607470",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Cascade Union Elementary",
@@ -26396,13 +26397,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Castle Rock Union Elementary School District",
+      "name": "Castle Rock Union Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0607770",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Cayucos Elementary",
@@ -26432,22 +26433,22 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Central Union Elementary School District",
+      "name": "Central Union Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0607980",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Central Union High School District",
+      "name": "Central Union High",
       "types": [
         "HighSchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0608010",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Centralia Elementary",
@@ -26477,13 +26478,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Chicago Park Elementary School District",
+      "name": "Chicago Park Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0608340",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Chowchilla Elementary",
@@ -26513,13 +26514,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Chula Vista Elementary School District",
+      "name": "Chula Vista Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0608610",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Cienega Union Elementary",
@@ -26540,13 +26541,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Clay Joint Elementary School District",
+      "name": "Clay Joint Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0608850",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Clear Creek Elementary",
@@ -26567,13 +26568,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Cold Spring Elementary School District",
+      "name": "Cold Spring Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0609270",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Colfax Elementary",
@@ -26594,13 +26595,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Columbia Elementary School District",
+      "name": "Columbia Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0609450",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Columbia Union",
@@ -26621,22 +26622,22 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Corning Union Elementary School District",
+      "name": "Corning Union Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0609780",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Corning Union High School District",
+      "name": "Corning Union High",
       "types": [
         "HighSchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0609810",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Cottonwood Union Elementary",
@@ -26657,13 +26658,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Cupertino Union Elementary School District",
+      "name": "Cupertino Union",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0610290",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Curtis Creek Elementary",
@@ -26684,13 +26685,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Cypress Elementary School District",
+      "name": "Cypress Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0610440",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Dehesa Elementary",
@@ -26720,13 +26721,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Delano Union Elementary School District",
+      "name": "Delano Union Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0610890",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Delphic Elementary",
@@ -26753,7 +26754,7 @@
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0611220",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Douglas City Elementary",
@@ -26774,13 +26775,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Ducor Union Elementary School District",
+      "name": "Ducor Union Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0611550",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Dunham Elementary",
@@ -26810,22 +26811,22 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Earlimart Elementary School District",
+      "name": "Earlimart Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0611760",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "East Nicolaus Joint Union High School District",
+      "name": "East Nicolaus Joint Union High",
       "types": [
         "HighSchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0611780",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "East Side Union High",
@@ -26855,13 +26856,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Edison Elementary School District",
+      "name": "Edison Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0611940",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "El Centro Elementary",
@@ -26891,22 +26892,22 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "El Monte Union High School District",
+      "name": "El Monte Union High",
       "types": [
         "HighSchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0612120",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "El Nido Elementary School District",
+      "name": "El Nido Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0612150",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Elk Hills Elementary",
@@ -26927,13 +26928,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Elverta Joint Elementary School District",
+      "name": "Elverta Joint Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0612600",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Empire Union Elementary",
@@ -26954,13 +26955,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Enterprise Elementary School District",
+      "name": "Enterprise Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0612810",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Escondido Union",
@@ -26990,13 +26991,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Eureka Union Elementary School District",
+      "name": "Eureka Union",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0613080",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Evergreen Elementary",
@@ -27017,13 +27018,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Fairfax Elementary School District",
+      "name": "Fairfax Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0613290",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Fallbrook Union Elementary",
@@ -27053,13 +27054,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Fieldbrook Elementary School District",
+      "name": "Fieldbrook Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0613740",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Flournoy Union Elementary",
@@ -27080,13 +27081,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Forestville Union Elementary School District",
+      "name": "Forestville Union Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0614010",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Forks Of Salmon Elementary",
@@ -27107,22 +27108,22 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Fortuna Union High School District",
+      "name": "Fortuna Union High",
       "types": [
         "HighSchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0614190",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Fountain Valley Elementary School District",
+      "name": "Fountain Valley Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0614220",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Franklin Elementary",
@@ -27152,13 +27153,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "French Gulch-Whiskeytown Elementary School District",
+      "name": "French Gulch-Whiskeytown Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0614490",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Freshwater Elementary",
@@ -27179,13 +27180,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Fullerton Elementary School District",
+      "name": "Fullerton Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0614730",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Fullerton Joint Union High",
@@ -27206,13 +27207,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Galt Joint Union High School District",
+      "name": "Galt Joint Union High",
       "types": [
         "HighSchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0614820",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Garfield Elementary",
@@ -27224,13 +27225,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Garvey Elementary School District",
+      "name": "Garvey Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0614940",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Gazelle Union Elementary",
@@ -27251,13 +27252,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Gerber Union Elementary School District",
+      "name": "Gerber Union Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0615090",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Gold Oak Union Elementary",
@@ -27278,13 +27279,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Golden Feather Union Elementary School District",
+      "name": "Golden Feather Union Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0615480",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Goleta Union Elementary",
@@ -27305,13 +27306,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Grant Elementary School District",
+      "name": "Grant Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0615690",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Grass Valley Elementary",
@@ -27332,13 +27333,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Gravenstein Union Elementary School District",
+      "name": "Gravenstein Union Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0615840",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Graves Elementary",
@@ -27359,13 +27360,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Greenfield Union School District",
+      "name": "Greenfield Union",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0616050",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Greenfield Union Elementary",
@@ -27395,13 +27396,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Guadalupe Union Elementary School District",
+      "name": "Guadalupe Union Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0616260",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Cucamonga Elementary",
@@ -27422,13 +27423,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Hanford Elementary School District",
+      "name": "Hanford Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0616470",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Hanford Joint Union High",
@@ -27458,13 +27459,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Happy Valley Union Elementary School District",
+      "name": "Happy Valley Union Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0616570",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Harmony Union Elementary",
@@ -27485,13 +27486,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Hawthorne Elementary School District",
+      "name": "Hawthorne",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0616680",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Heber Elementary",
@@ -27512,13 +27513,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Hermosa Beach City Elementary School District",
+      "name": "Hermosa Beach City Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0617040",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Hickman Community Charter",
@@ -27539,13 +27540,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Hollister School District",
+      "name": "Hollister",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0617340",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Hope Elementary",
@@ -27566,13 +27567,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Horicon Elementary School District",
+      "name": "Horicon Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0617580",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Hornbrook Elementary",
@@ -27593,13 +27594,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Howell Mountain Elementary School District",
+      "name": "Howell Mountain Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0617760",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Hueneme Elementary",
@@ -27620,22 +27621,22 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Huntington Beach City Elementary School District",
+      "name": "Huntington Beach City Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0618030",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Huntington Beach Union High School District",
+      "name": "Huntington Beach Union High",
       "types": [
         "HighSchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0618060",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Hydesville Elementary",
@@ -27656,13 +27657,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Indian Diggings Elementary School District",
+      "name": "Indian Diggings Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0618240",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Indian Springs Elementary",
@@ -27683,12 +27684,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Jacoby Creek Elementary School District",
+      "name": "Jacoby Creek Elementary",
       "types": [
-        "ElementarySchoolDistrict"
+        "ElementarySchoolDistrict",
+        "SchoolDistrict"
       ],
       "dcid": "geoId/sch0618660",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Jamestown Elementary",
@@ -27709,13 +27711,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Janesville Union Elementary School District",
+      "name": "Janesville Union Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0618780",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Jefferson Elementary",
@@ -27736,13 +27738,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Jefferson Elementary School District",
+      "name": "Jefferson Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0618870",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Jefferson Union High",
@@ -27781,13 +27783,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Junction City Elementary School District",
+      "name": "Junction City Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0619170",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Junction Elementary",
@@ -27808,13 +27810,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Kentfield Elementary School District",
+      "name": "Kentfield Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0619380",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Kenwood",
@@ -27835,22 +27837,22 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Kern High School District",
+      "name": "Kern High",
       "types": [
         "HighSchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0619540",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Kernville Union Elementary School District",
+      "name": "Kernville Union Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0619590",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Keyes Union",
@@ -27880,13 +27882,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Kings River Union Elementary School District",
+      "name": "Kings River Union Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0619740",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Kings River-Hardwick Union Elementary",
@@ -27916,13 +27918,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Kirkwood Elementary School District",
+      "name": "Kirkwood Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0619860",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Kit Carson Union Elementary",
@@ -27943,13 +27945,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Kneeland Elementary School District",
+      "name": "Kneeland Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0619980",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Knights Ferry Elementary",
@@ -27970,13 +27972,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "La Habra City Elementary School District",
+      "name": "La Habra City Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0620190",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "La Mesa-Spring Valley",
@@ -27997,13 +27999,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Laguna Joint Elementary School District",
+      "name": "Laguna Joint Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0620430",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Pacifica",
@@ -28024,13 +28026,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Lagunitas Elementary School District",
+      "name": "Lagunitas Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0620520",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Lake Elementary",
@@ -28051,13 +28053,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Lakeside Union School District",
+      "name": "Lakeside Union",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0620730",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Lakeside Union Elementary",
@@ -28078,13 +28080,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Lamont Elementary School District",
+      "name": "Lamont Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0620850",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Lancaster Elementary",
@@ -28105,22 +28107,22 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Lassen Union High School District",
+      "name": "Lassen Union High",
       "types": [
         "HighSchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0621060",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Lassen View Union Elementary School District",
+      "name": "Lassen View Union Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0621090",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Latrobe",
@@ -28141,13 +28143,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Le Grand Union Elementary School District",
+      "name": "Le Grand Union Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0621240",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Le Grand Union High",
@@ -28186,13 +28188,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Lennox Elementary School District",
+      "name": "Lennox",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0621420",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Richland Union Elementary",
@@ -28213,13 +28215,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Liberty Elementary School District",
+      "name": "Liberty Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0621540",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Liberty Elementary",
@@ -28231,13 +28233,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Liberty Union High School District",
+      "name": "Liberty Union High",
       "types": [
         "HighSchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0621600",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Lincoln Elementary",
@@ -28249,13 +28251,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Linns Valley-Poso Flat Union School District",
+      "name": "Linns Valley-Poso Flat Union",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0621900",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Little Lake City Elementary",
@@ -28276,13 +28278,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Live Oak Elementary School District",
+      "name": "Live Oak Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0621990",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Livingston Union",
@@ -28303,13 +28305,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Loma Prieta Joint Union Elementary School District",
+      "name": "Loma Prieta Joint Union Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0622350",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Las Lomitas Elementary",
@@ -28330,13 +28332,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Los Altos Elementary School District",
+      "name": "Los Altos Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0622650",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Los Gatos-Saratoga Joint Union School District",
@@ -28366,13 +28368,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Los Olivos Elementary School District",
+      "name": "Los Olivos Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0622920",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Lost Hills Union Elementary",
@@ -28393,13 +28395,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Lucerne Elementary School District",
+      "name": "Lucerne Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0623040",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Luther Burbank",
@@ -28420,12 +28422,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Magnolia Union Elementary School District",
+      "name": "Magnolia Union Elementary",
       "types": [
-        "ElementarySchoolDistrict"
+        "ElementarySchoolDistrict",
+        "SchoolDistrict"
       ],
       "dcid": "geoId/sch0623460",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Manchester Union Elementary",
@@ -28446,13 +28449,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Maple Creek Elementary School District",
+      "name": "Maple Creek Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0623730",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Maple Elementary",
@@ -28473,13 +28476,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Mark Twain Union Elementary School District",
+      "name": "Mark Twain Union Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0623970",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Mark West Union Elementary",
@@ -28506,7 +28509,7 @@
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0624210",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "McKinleyville Union Elementary School District",
@@ -28533,7 +28536,7 @@
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0624360",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Meadows Union Elementary",
@@ -28554,13 +28557,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Menlo Park City Elementary School District",
+      "name": "Menlo Park City Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0624570",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Merced City Elementary",
@@ -28590,13 +28593,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Meridian Elementary School District",
+      "name": "Meridian Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0624690",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Mesa Union Elementary",
@@ -28617,13 +28620,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Mill Valley Elementary School District",
+      "name": "Mill Valley Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0624870",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Millbrae Elementary",
@@ -28644,13 +28647,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Mission Union Elementary School District",
+      "name": "Mission Union Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0625110",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Modesto City Elementary",
@@ -28662,13 +28665,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Modesto City High School District",
+      "name": "Modesto City High",
       "types": [
         "HighSchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0625150",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Monroe Elementary",
@@ -28680,13 +28683,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Monson-Sultana Joint Union Elementary School District",
+      "name": "Monson-Sultana Joint Union Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0625350",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Montague Elementary",
@@ -28707,13 +28710,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Montecito Union Elementary School District",
+      "name": "Montecito Union Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0625500",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Montgomery Elementary",
@@ -28734,13 +28737,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Moreland School District",
+      "name": "Moreland",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0625770",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Mother Lode Union Elementary",
@@ -28761,13 +28764,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Mountain Elementary School District",
+      "name": "Mountain Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0626070",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Mountain House Elementary",
@@ -28788,13 +28791,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Mountain View Elementary School District",
+      "name": "Mountain View Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0626220",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Mountain View Whisman",
@@ -28824,13 +28827,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Mount Pleasant Elementary School District",
+      "name": "Mount Pleasant Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0626400",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Mulberry Elementary",
@@ -28851,13 +28854,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "National Elementary School District",
+      "name": "National Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0626670",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Nevada City Elementary",
@@ -28887,13 +28890,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "New Jerusalem Elementary School District",
+      "name": "New Jerusalem Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0627030",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Mountain Union Elementary",
@@ -28914,13 +28917,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Newhall Elementary School District",
+      "name": "Newhall",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0627180",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Nicasio",
@@ -28941,13 +28944,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "North County Joint Union Elementary School District",
+      "name": "North County Joint Union Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0627480",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "North Cow Creek Elementary",
@@ -28968,13 +28971,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Nuview Union Elementary School District",
+      "name": "Nuview Union",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0627780",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Oak Grove Elementary",
@@ -28995,13 +28998,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Oak Run Elementary School District",
+      "name": "Oak Run Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0627870",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Oak Valley Union Elementary",
@@ -29022,13 +29025,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Oakley Union Elementary School District",
+      "name": "Oakley Union Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0628080",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Ocean View",
@@ -29049,13 +29052,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Old Adobe Union Elementary School District",
+      "name": "Old Adobe Union",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0628320",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Ontario-Montclair",
@@ -29076,13 +29079,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Orchard Elementary School District",
+      "name": "Orchard Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0628680",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Orcutt Union Elementary",
@@ -29103,13 +29106,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Orinda Union Elementary School District",
+      "name": "Orinda Union Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0628860",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Oro Grande",
@@ -29130,22 +29133,22 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Oroville Union High School District",
+      "name": "Oroville Union High",
       "types": [
         "HighSchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0629130",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Outside Creek Elementary School District",
+      "name": "Outside Creek Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0629160",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Oxnard",
@@ -29175,13 +29178,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Pacific Elementary School District",
+      "name": "Pacific Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0629340",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Pacific Union Elementary",
@@ -29202,12 +29205,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Palermo Union Elementary School District",
+      "name": "Palermo Union Elementary",
       "types": [
-        "ElementarySchoolDistrict"
+        "ElementarySchoolDistrict",
+        "SchoolDistrict"
       ],
       "dcid": "geoId/sch0629540",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Palmdale Elementary",
@@ -29228,13 +29232,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Panoche Elementary School District",
+      "name": "Panoche Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0629770",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Paradise Elementary",
@@ -29255,13 +29259,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Perris Elementary School District",
+      "name": "Perris Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0630180",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Perris Union High",
@@ -29282,12 +29286,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Petaluma Joint Union High School District",
+      "name": "Petaluma Joint Union High",
       "types": [
-        "HighSchoolDistrict"
+        "HighSchoolDistrict",
+        "SchoolDistrict"
       ],
       "dcid": "geoId/sch0630250",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Pine Ridge Elementary",
@@ -29299,13 +29304,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Piner-Olivet Union Elementary School District",
+      "name": "Piner-Olivet Union Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0630450",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Pioneer Union Elementary",
@@ -29326,12 +29331,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Pioneer Union Elementary School District",
+      "name": "Pioneer Union Elementary",
       "types": [
-        "ElementarySchoolDistrict"
+        "ElementarySchoolDistrict",
+        "SchoolDistrict"
       ],
       "dcid": "geoId/sch0630520",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Pixley Union Elementary",
@@ -29361,13 +29367,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Placerville Union Elementary School District",
+      "name": "Placerville Union Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0630780",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Plainsburg Union Elementary",
@@ -29388,13 +29394,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Plaza Elementary School District",
+      "name": "Plaza Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0630870",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Pleasant Grove Joint Union",
@@ -29415,13 +29421,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Pleasant Valley Elementary School District",
+      "name": "Pleasant Valley",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0630990",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Pleasant Valley Joint Union Elementary",
@@ -29442,13 +29448,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Plumas Lake Elementary School District",
+      "name": "Plumas Lake Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0631180",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Point Arena Joint Union High",
@@ -29478,13 +29484,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Pope Valley Union Elementary School District",
+      "name": "Pope Valley Union Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0631380",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Portola Valley Elementary",
@@ -29505,13 +29511,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Rancho Santa Fe Elementary School District",
+      "name": "Rancho Santa Fe Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0631740",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Ravendale-Termo Elementary",
@@ -29532,13 +29538,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Raymond-Knowles Union Elementary School District",
+      "name": "Raymond-Knowles Union Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0631920",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Red Bluff Union Elementary",
@@ -29550,13 +29556,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Red Bluff Joint Union High School District",
+      "name": "Red Bluff Joint Union High",
       "types": [
         "HighSchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0632010",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Redding Elementary",
@@ -29568,13 +29574,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Redwood City Elementary School District",
+      "name": "Redwood City Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0632130",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Reed Union Elementary",
@@ -29595,13 +29601,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Rescue Union Elementary School District",
+      "name": "Rescue Union Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0632310",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Kashia Elementary",
@@ -29622,13 +29628,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Richgrove Elementary School District",
+      "name": "Richgrove Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0632430",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Richmond Elementary",
@@ -29649,13 +29655,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Rio Bravo-Greeley Union Elementary School District",
+      "name": "Rio Bravo-Greeley Union Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0632710",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Rio Dell Elementary",
@@ -29676,13 +29682,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Roberts Ferry Union Elementary School District",
+      "name": "Roberts Ferry Union Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0633210",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Robla Elementary",
@@ -29703,13 +29709,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Romoland Elementary School District",
+      "name": "Romoland Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0633390",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Rosedale Union Elementary",
@@ -29730,13 +29736,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Rosemead Elementary School District",
+      "name": "Rosemead Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0633570",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Roseville City Elementary",
@@ -29766,13 +29772,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Round Valley Joint Elementary School District",
+      "name": "Round Valley Joint Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0633690",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Salida Union Elementary",
@@ -29802,13 +29808,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "San Antonio Union Elementary School District",
+      "name": "San Antonio Union Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0634050",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "San Ardo Union Elementary",
@@ -29820,13 +29826,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "San Benito High School District",
+      "name": "San Benito High",
       "types": [
         "HighSchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0634140",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "San Bruno Park Elementary",
@@ -29838,13 +29844,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "San Carlos Elementary School District",
+      "name": "San Carlos Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0634290",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "San Dieguito Union High",
@@ -29883,12 +29889,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "San Miguel Joint Union Elementary School District",
+      "name": "San Miguel Joint Union",
       "types": [
-        "ElementarySchoolDistrict"
+        "ElementarySchoolDistrict",
+        "SchoolDistrict"
       ],
       "dcid": "geoId/sch0635010",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "San Pasqual Union Elementary",
@@ -29909,22 +29916,22 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "San Rafael City High School District",
+      "name": "San Rafael City High",
       "types": [
         "HighSchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0635110",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "San Ysidro Elementary School District",
+      "name": "San Ysidro Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0635220",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Santa Clara Elementary",
@@ -29963,13 +29970,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Santa Rita Union Elementary School District",
+      "name": "Santa Rita Union Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0635790",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Santa Rosa Elementary",
@@ -29987,7 +29994,7 @@
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0635830",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Santa Ynez Valley Union High",
@@ -30008,13 +30015,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Saratoga Union Elementary School District",
+      "name": "Saratoga Union Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0635910",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Saucelito Elementary",
@@ -30041,7 +30048,7 @@
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0636000",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Savanna Elementary",
@@ -30062,13 +30069,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Sebastopol Union Elementary School District",
+      "name": "Sebastopol Union Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0636180",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Seeley Union Elementary",
@@ -30089,13 +30096,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Semitropic Elementary School District",
+      "name": "Semitropic Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0636330",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Sequoia Union Elementary",
@@ -30125,22 +30132,22 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Shasta Union Elementary School District",
+      "name": "Shasta Union Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0636570",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Shasta Union High School District",
+      "name": "Shasta Union High",
       "types": [
         "HighSchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0636600",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Shiloh Elementary",
@@ -30170,13 +30177,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Snelling-Merced Falls Union Elementary School District",
+      "name": "Snelling-Merced Falls Union Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0636960",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Victor Valley Union High",
@@ -30206,13 +30213,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Somis Union Elementary School District",
+      "name": "Somis Union",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0637140",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Sonora Elementary",
@@ -30224,13 +30231,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Sonora Union High School District",
+      "name": "Sonora Union High",
       "types": [
         "HighSchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0637260",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Soquel Elementary School District",
@@ -30242,13 +30249,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Soulsbyville Elementary School District",
+      "name": "Soulsbyville Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0637320",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "South Bay Union Elementary",
@@ -30269,13 +30276,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "South Fork Union School District",
+      "name": "South Fork Union",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0637470",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "South Whittier Elementary",
@@ -30296,13 +30303,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Spencer Valley Elementary School District",
+      "name": "Spencer Valley Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0637680",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Spreckels Union Elementary",
@@ -30323,13 +30330,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Standard Elementary School District",
+      "name": "Standard Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0637890",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Stanislaus Union Elementary",
@@ -30350,13 +30357,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Strathmore Union Elementary School District",
+      "name": "Strathmore Union Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0638130",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Sulphur Springs Union",
@@ -30386,13 +30393,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Sundale Union Elementary School District",
+      "name": "Sundale Union Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0638340",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Sunnyside Union Elementary",
@@ -30413,13 +30420,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Susanville Elementary School District",
+      "name": "Susanville Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0638550",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Sutter Union High",
@@ -30431,13 +30438,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Sweetwater Union High School District",
+      "name": "Sweetwater Union High",
       "types": [
         "HighSchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0638640",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Sylvan Union Elementary",
@@ -30476,13 +30483,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Terra Bella Union Elementary School District",
+      "name": "Terra Bella Union Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0639060",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Thermalito Union Elementary",
@@ -30503,13 +30510,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Tipton Elementary School District",
+      "name": "Tipton Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0639300",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Traver Joint Elementary",
@@ -30530,13 +30537,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Trinidad Union Elementary School District",
+      "name": "Trinidad Union Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0639720",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Trinity Center Elementary",
@@ -30557,22 +30564,22 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Tulare Joint Union High School District",
+      "name": "Tulare Joint Union High",
       "types": [
         "HighSchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0639930",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Twain Harte School District",
+      "name": "Twain Harte",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0640200",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Twin Hills Union Elementary",
@@ -30593,13 +30600,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Union Elementary School District",
+      "name": "Union Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0640320",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Union Hill Elementary",
@@ -30620,13 +30627,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Vallecito Union Elementary School District",
+      "name": "Vallecito Union",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0640680",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Vallecitos Elementary",
@@ -30647,13 +30654,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Victor Elementary School District",
+      "name": "Victor Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0641040",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Vineland Elementary",
@@ -30674,13 +30681,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Walnut Creek Elementary School District",
+      "name": "Walnut Creek Elementary",
       "types": [
         "ElementarySchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0641250",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "Wasco Union Elementary",
@@ -30719,13 +30726,13 @@
       "provenanceId": "dc/91s0hm"
     },
     {
-      "name": "Whittier Union High School District",
+      "name": "Whittier Union High",
       "types": [
         "HighSchoolDistrict",
         "SchoolDistrict"
       ],
       "dcid": "geoId/sch0642480",
-      "provenanceId": "dc/sm3m2w3"
+      "provenanceId": "dc/91s0hm"
     },
     {
       "name": "William S. Hart Union High",

--- a/internal/server/v1/propertyvalues/heap.go
+++ b/internal/server/v1/propertyvalues/heap.go
@@ -39,6 +39,9 @@ func (h nodeHeap) Less(i, j int) bool {
 	//     {entity_info.dcid(), entity_info.value(), entity_info.provenance_id()},
 	//      "!"});
 	// }
+	if di.Dcid+"!"+di.Value == dj.Dcid+"!"+dj.Value {
+		return h[i].ig < h[j].ig
+	}
 	return di.Dcid+"!"+di.Value < dj.Dcid+"!"+dj.Value
 }
 func (h nodeHeap) Swap(i, j int) { h[i], h[j] = h[j], h[i] }


### PR DESCRIPTION
The same node can appear in different import groups with different names. Should always prefer the highest ranked import group.