### PR TITLE
[SVG Cache] Link custom root to dc/g/Root

### DIFF
--- a/internal/server/statvar/statvar_group.go
+++ b/internal/server/statvar/statvar_group.go
@@ -32,7 +32,7 @@ const (
 	// SvgRoot is the root stat var group of the hierarchy. It's a virtual entity
 	// that links to the top level category stat var groups.
 	SvgRoot       = "dc/g/Root"
-	CustomSvgRoot = "dc/g/Custom_Root"
+	customSvgRoot = "dc/g/Custom_Root"
 )
 
 // Note this function modifies validSVG inside.
@@ -167,7 +167,7 @@ func GetStatVarGroup(
 				svgData, ok := row.Data.(*pb.StatVarGroups)
 				if ok && len(svgData.StatVarGroups) > 0 {
 					for k, v := range svgData.StatVarGroups {
-						if k == CustomSvgRoot {
+						if k == customSvgRoot {
 							if customRootNode != nil {
 								continue
 							}
@@ -184,7 +184,7 @@ func GetStatVarGroup(
 			result.StatVarGroups[SvgRoot].ChildStatVarGroups = append(
 				result.StatVarGroups[SvgRoot].ChildStatVarGroups,
 				&pb.StatVarGroupNode_ChildSVG{
-					Id:                CustomSvgRoot,
+					Id:                customSvgRoot,
 					SpecializedEntity: customRootNode.AbsoluteName,
 				},
 			)

--- a/internal/server/statvar/statvar_group.go
+++ b/internal/server/statvar/statvar_group.go
@@ -181,14 +181,26 @@ func GetStatVarGroup(
 			}
 		}
 		if customRootNode != nil {
-			result.StatVarGroups[SvgRoot].ChildStatVarGroups = append(
-				result.StatVarGroups[SvgRoot].ChildStatVarGroups,
-				&pb.StatVarGroupNode_ChildSVG{
-					Id:                customSvgRoot,
-					SpecializedEntity: customRootNode.AbsoluteName,
-				},
-			)
-			result.StatVarGroups[SvgRoot].DescendentStatVarCount += customRootNode.DescendentStatVarCount
+			customRootExist := false
+			// If custom schema is built together with base schema, then it is
+			// already in the child stat var group of "dc/g/Root".
+			for _, x := range result.StatVarGroups[SvgRoot].ChildStatVarGroups {
+				if x.Id == customSvgRoot {
+					customRootExist = true
+					break
+				}
+			}
+			// Populate dc/g/Custom_Root as children of dc/g/Root
+			if !customRootExist {
+				result.StatVarGroups[SvgRoot].ChildStatVarGroups = append(
+					result.StatVarGroups[SvgRoot].ChildStatVarGroups,
+					&pb.StatVarGroupNode_ChildSVG{
+						Id:                customSvgRoot,
+						SpecializedEntity: customRootNode.AbsoluteName,
+					},
+				)
+				result.StatVarGroups[SvgRoot].DescendentStatVarCount += customRootNode.DescendentStatVarCount
+			}
 		}
 	} else {
 		result = &pb.StatVarGroups{StatVarGroups: cache.RawSvg}

--- a/test/custom_bigtable_info.yaml
+++ b/test/custom_bigtable_info.yaml
@@ -1,4 +1,6 @@
-project: datcom-ci
+project: datcom-magiceye-dev
 instance: dc-graph
 tables:
-  - private_2022_11_09_09_27_48
+  - cacheschema_2023_02_01_11_32_49
+  - cachesunroof_2023_02_01_10_36_39
+  - cacheeie_2023_01_31_20_31_08

--- a/test/custom_bigtable_info.yaml
+++ b/test/custom_bigtable_info.yaml
@@ -1,6 +1,4 @@
-project: datcom-magiceye-dev
+project: datcom-ci
 instance: dc-graph
 tables:
-  - cacheschema_2023_02_01_11_32_49
-  - cachesunroof_2023_02_01_10_36_39
-  - cacheeie_2023_01_31_20_31_08
+  - private_2022_11_09_09_27_48


### PR DESCRIPTION
Custom import group does not contains base schemas, so the SVG cache won't have "dc/g/Custom_Root" as child svg of "dc/g/Root".

Here explicitly add this link.