### PR TITLE
Revive Minikube for local mixer development

### DIFF
--- a/deploy/local/custom_bigtable_info.yaml
+++ b/deploy/local/custom_bigtable_info.yaml
@@ -1,0 +1,5 @@
+project: <project_id>
+instance: <instance_id>
+tables:
+  - <table1>
+  - <table2>

--- a/deploy/local/deployment.yaml
+++ b/deploy/local/deployment.yaml
@@ -1,0 +1,173 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Mixer Kubernetes Deployment config. (https://kubernetes.io/docs/concepts/workloads/controllers/deployment/)
+# This is to be extended by the dev/autopush/staging/prod overlay.
+# The deployment contains grpc mixer container and esp container that transcodes grpc to JSON.
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mixer
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mixer-service
+spec:
+  type: NodePort
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8081
+      protocol: TCP
+  selector:
+    app: mixer-grpc
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mixer-grpc
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mixer-grpc
+  template:
+    metadata:
+      labels:
+        app: mixer-grpc
+    spec:
+      volumes:
+        - name: schema-mapping
+          configMap:
+            name: schema-mapping
+        - name: mixer-grpc-json
+          emptyDir: {}
+      containers:
+        - name: mixer
+          image: datacommons/mixer
+          imagePullPolicy: Never
+          resources:
+            limits:
+              memory: "8G"
+            requests:
+              memory: "8G"
+          args:
+            - --base_bigtable_info=$(BASE_BIGTABLE_INFO)
+            - --custom_bigtable_info=$(CUSTOM_BIGTABLE_INFO)
+            - --mixer_project=$(MIXER_PROJECT)
+            - --bq_dataset=$(BIG_QUERY)
+            - --schema_path=/datacommons/mapping
+          volumeMounts:
+            - name: schema-mapping
+              mountPath: /datacommons/mapping
+          env:
+            - name: MIXER_PROJECT
+              valueFrom:
+                configMapKeyRef:
+                  name: mixer-configmap
+                  key: mixerProject
+            - name: BIG_QUERY
+              valueFrom:
+                configMapKeyRef:
+                  name: store-configmap
+                  key: bigquery.version
+            - name: BASE_BIGTABLE_INFO
+              valueFrom:
+                configMapKeyRef:
+                  name: store-configmap
+                  key: base_bigtable_info.yaml
+            - name: CUSTOM_BIGTABLE_INFO
+              valueFrom:
+                configMapKeyRef:
+                  name: store-configmap
+                  key: custom_bigtable_info.yaml
+          ports:
+            - containerPort: 12345
+          readinessProbe:
+            exec:
+              command: ["/bin/grpc_health_probe", "-addr=:12345"]
+            periodSeconds: 10
+          livenessProbe:
+            exec:
+              command: ["/bin/grpc_health_probe", "-addr=:12345"]
+            failureThreshold: 1
+            periodSeconds: 10
+          startupProbe:
+            exec:
+              command: ["/bin/grpc_health_probe", "-addr=:12345"]
+            periodSeconds: 10
+            failureThreshold: 30
+        - name: esp
+          image: gcr.io/endpoints-release/endpoints-runtime:1
+          args:
+            - --service_json_path=/esp/mixer-grpc.json
+            - --http_port=8081
+            - --backend=grpc://127.0.0.1:12345
+            - --cors_preset=basic
+            - --rollout_strategy=managed
+            - --healthz=healthz
+            - --non_gcp
+          volumeMounts:
+            - mountPath: /esp
+              name: mixer-grpc-json
+          env:
+            - name: SERVICE_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: mixer-configmap
+                  key: serviceName
+          resources:
+            limits:
+              memory: "1G"
+            requests:
+              memory: "1G"
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            periodSeconds: 5
+            initialDelaySeconds: 10
+          ports:
+            - containerPort: 8081
+        - name: api-compiler
+          image: datacommons/api-compiler
+          imagePullPolicy: Never
+          command: ["/bin/sh"]
+          args:
+            - "-c"
+            - >
+              cp /output/mixer-grpc.json /esp/ &&
+              while true; do
+                echo "api-compiler running"
+                sleep 3600;
+              done
+          resources:
+            limits:
+              memory: "0.1G"
+            requests:
+              memory: "0.1G"
+          volumeMounts:
+            - name: mixer-grpc-json
+              mountPath: /esp
+          readinessProbe:
+            exec:
+              command: ["ls", "/esp/mixer-grpc.json"]
+            periodSeconds: 1

--- a/deploy/local/kustomization.yaml
+++ b/deploy/local/kustomization.yaml
@@ -1,0 +1,46 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Kustomization for local mixer in local Minikube environment.
+# - Adds "local" suffix to all the resources
+# - Use "serviceaccount.yaml" to create service account explicitly.
+#   Note the GKE cluster service account is created once at cluster creation time.
+# - Patch deployment with "api-compiler" image that can updates the gRPC config on code change.
+# - Update the esp startup options for local container.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: mixer
+
+bases:
+  - ../mapping
+  - ../storage
+
+resources:
+  - deployment.yaml
+
+configMapGenerator:
+  - name: mixer-configmap
+    behavior: create
+    literals:
+      - mixerProject=datcom-mixer-dev-316822
+      - serviceName=
+  - behavior: merge
+    name: store-configmap
+    files:
+      - custom_bigtable_info.yaml
+
+generatorOptions:
+  disableNameSuffixHash: true

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -235,6 +235,10 @@ which is compiled using [API Compiler](https://github.com/googleapis/api-compile
 
 ### Start mixer in minikube
 
+Mixer in Minikube (local Kubernetes) brings up mixer with REST endpoints through
+ESP. This requires docker and minikube to be installed in local environment. To
+start Mixer in Minikube, run:
+
 ```bash
 minikube start
 minikube addons enable gcp-auth
@@ -248,10 +252,17 @@ This exposes the local mixer service at `localhost:8081`.
 To verify the server serving request:
 
 ```bash
-curl http://localhost:8081/node/property-labels?dcids=Class
+curl http://localhost:8081/v1/bulk/observations/series?entities=geoId/06025&variables=Count_Person
 ```
 
-After code edit, the container images are automatically rebuilt and re-deployed to the local cluster.
+After code edit, the container images are automatically rebuilt and re-deployed
+to the local cluster.
+
+Starting Mixer and ESP locally allows development that relies on a custom mixer.
+For example, Data Commons website local development may need a mixer with custom
+Bigtables. To do this, update
+[deploy/local/custom_bigtable_info.yaml](../deploy/local/custom_bigtable_info.yaml)
+and the local mixer would be able to serve the custom Bigtable.
 
 ### Run Tests
 

--- a/esp/Dockerfile
+++ b/esp/Dockerfile
@@ -17,11 +17,19 @@
 # by local ESP container. These two containers share the same volume that holds
 # the mixer-grpc.json.
 
-FROM golang:1.15 AS base
+FROM golang:1.19 AS base
 
+WORKDIR /workspace
+
+# Install protoc
 RUN apt-get update && \
-    apt-get install -y protobuf-compiler && \
-    apt-get install -y git
+    apt-get upgrade -y && \
+    apt-get install -y unzip
+
+RUN curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v3.19.4/protoc-3.19.4-linux-x86_64.zip
+RUN unzip protoc-3.19.4-linux-x86_64.zip
+RUN chmod +x /workspace/bin/protoc
+ENV PATH="${PATH}:/workspace/bin/"
 
 # Install protobuf go plugin
 ENV GO111MODULE=on

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -25,23 +25,23 @@ metadata:
   name: mixer
 build:
   artifacts:
-  - image: datacommons/mixer
-    context: .
-    docker:
-      dockerfile: build/Dockerfile
-      target: server
-  - image: datacommons/api-compiler
-    context: .
-    docker:
-      dockerfile: esp/Dockerfile
+    - image: datacommons/mixer
+      context: .
+      docker:
+        dockerfile: build/Dockerfile
+        target: server
+    - image: datacommons/api-compiler
+      context: .
+      docker:
+        dockerfile: esp/Dockerfile
 deploy:
   kubeContext: minikube
   kustomize:
     paths:
-    - deploy/overlays/local
+      - deploy/local
 portForward:
-- resourceType: service
-  resourceName: mixer-service-local
-  namespace: mixer
-  port: 80
-  localPort: 8081
+  - resourceType: service
+    resourceName: mixer-service
+    namespace: mixer
+    port: 80
+    localPort: 8081


### PR DESCRIPTION
Mixer GKE deployment has migrated to Helm from Kustomize. 

As the original minikube setup is based on Kustomize, I forked a deployment file under `local` folder. Since the mixer deployment config rarely changes, this fork is okay to maintain.