### PR TITLE
Fix bulk linked observation bug

### DIFF
--- a/internal/server/v1/observations/golden/bulk_point_linked/all_CA_County.json
+++ b/internal/server/v1/observations/golden/bulk_point_linked/all_CA_County.json
@@ -2809,6 +2809,185 @@
           ]
         }
       ]
+    },
+    {
+      "variable": "dummy",
+      "observations_by_entity": [
+        {
+          "entity": "geoId/06001"
+        },
+        {
+          "entity": "geoId/06003"
+        },
+        {
+          "entity": "geoId/06005"
+        },
+        {
+          "entity": "geoId/06007"
+        },
+        {
+          "entity": "geoId/06009"
+        },
+        {
+          "entity": "geoId/06011"
+        },
+        {
+          "entity": "geoId/06013"
+        },
+        {
+          "entity": "geoId/06015"
+        },
+        {
+          "entity": "geoId/06017"
+        },
+        {
+          "entity": "geoId/06019"
+        },
+        {
+          "entity": "geoId/06021"
+        },
+        {
+          "entity": "geoId/06023"
+        },
+        {
+          "entity": "geoId/06025"
+        },
+        {
+          "entity": "geoId/06027"
+        },
+        {
+          "entity": "geoId/06029"
+        },
+        {
+          "entity": "geoId/06031"
+        },
+        {
+          "entity": "geoId/06033"
+        },
+        {
+          "entity": "geoId/06035"
+        },
+        {
+          "entity": "geoId/06037"
+        },
+        {
+          "entity": "geoId/06039"
+        },
+        {
+          "entity": "geoId/06041"
+        },
+        {
+          "entity": "geoId/06043"
+        },
+        {
+          "entity": "geoId/06045"
+        },
+        {
+          "entity": "geoId/06047"
+        },
+        {
+          "entity": "geoId/06049"
+        },
+        {
+          "entity": "geoId/06051"
+        },
+        {
+          "entity": "geoId/06053"
+        },
+        {
+          "entity": "geoId/06055"
+        },
+        {
+          "entity": "geoId/06057"
+        },
+        {
+          "entity": "geoId/06059"
+        },
+        {
+          "entity": "geoId/06061"
+        },
+        {
+          "entity": "geoId/06063"
+        },
+        {
+          "entity": "geoId/06065"
+        },
+        {
+          "entity": "geoId/06067"
+        },
+        {
+          "entity": "geoId/06069"
+        },
+        {
+          "entity": "geoId/06071"
+        },
+        {
+          "entity": "geoId/06073"
+        },
+        {
+          "entity": "geoId/06075"
+        },
+        {
+          "entity": "geoId/06077"
+        },
+        {
+          "entity": "geoId/06079"
+        },
+        {
+          "entity": "geoId/06081"
+        },
+        {
+          "entity": "geoId/06083"
+        },
+        {
+          "entity": "geoId/06085"
+        },
+        {
+          "entity": "geoId/06087"
+        },
+        {
+          "entity": "geoId/06089"
+        },
+        {
+          "entity": "geoId/06091"
+        },
+        {
+          "entity": "geoId/06093"
+        },
+        {
+          "entity": "geoId/06095"
+        },
+        {
+          "entity": "geoId/06097"
+        },
+        {
+          "entity": "geoId/06099"
+        },
+        {
+          "entity": "geoId/06101"
+        },
+        {
+          "entity": "geoId/06103"
+        },
+        {
+          "entity": "geoId/06105"
+        },
+        {
+          "entity": "geoId/06107"
+        },
+        {
+          "entity": "geoId/06109"
+        },
+        {
+          "entity": "geoId/06111"
+        },
+        {
+          "entity": "geoId/06113"
+        },
+        {
+          "entity": "geoId/06115"
+        }
+      ]
     }
   ],
   "facets": {

--- a/internal/server/v1/observations/golden/bulk_point_linked/all_US_State.json
+++ b/internal/server/v1/observations/golden/bulk_point_linked/all_US_State.json
@@ -5957,6 +5957,524 @@
               "facet": "180485622"
             }
           ]
+        },
+        {
+          "entity": "geoId/72"
+        }
+      ]
+    },
+    {
+      "variable": "Count_Person_FoodInsecure",
+      "observations_by_entity": [
+        {
+          "entity": "geoId/01",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 788250,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/02",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 86970,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/04",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 918940,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/05",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 499950,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/06",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 4011960,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/08",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 566440,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/09",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 428800,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/10",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 114190,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/11",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 70480,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/12",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 2567300,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/13",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 1279310,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/15",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 162220,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/16",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 179580,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/17",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 1211410,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/18",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 834530,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/19",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 297800,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/20",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 351090,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/21",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 644540,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/22",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 718360,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/23",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 166910,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/24",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 640180,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/25",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 566930,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/26",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 1299020,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/27",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 432170,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/28",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 550370,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/29",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 809680,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/30",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 111080,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/31",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 225580,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/32",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 373370,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/33",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 119990,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/34",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 762530,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/35",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 298030,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/36",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 2090550,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/37",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 1417440,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/38",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 51380,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/39",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 1547110,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/40",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 583570,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/41",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 486200,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/42",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 1353730,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/44",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 101100,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/45",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 555630,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/46",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 91510,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/47",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 905090,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/48",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 4092850,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/49",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 355550,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/50",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 68590,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/51",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 799620,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/53",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 790050,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/54",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 242180,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/55",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 530500,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/56",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 67750,
+              "facet": "180485622"
+            }
+          ]
         }
       ]
     }

--- a/internal/server/v1/observations/golden/bulk_point_linked/all_test.json
+++ b/internal/server/v1/observations/golden/bulk_point_linked/all_test.json
@@ -1,0 +1,2462 @@
+{
+  "observations_by_variable": [
+    {
+      "variable": "Count_Person",
+      "observations_by_entity": [
+        {
+          "entity": "geoId/0600562",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 76362,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0600674",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 19488,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0601640",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 21605,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0602252",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 114794,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0603092",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 6915,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0605108",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 27225,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0605164",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 2104,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0605290",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 26819,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0606000",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 117145,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0608142",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 64870,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0608310",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 4668,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0609066",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 30106,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0609892",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 5187,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0610345",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 42754,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0613882",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 10973,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0614190",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 8954,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0614736",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 1577,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0616000",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 124074,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0616462",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 10141,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0616560",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 7498,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0617610",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 58622,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0617918",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 101243,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0617988",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 43240,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0619402",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 18974,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0620018",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 71674,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0620956",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 28847,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0621796",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 25845,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0622594",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 12870,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0623168",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 7521,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0623182",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 119705,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0625338",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 32517,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0626000",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 227514,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0629504",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 58101,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0631708",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 11363,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0633000",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 159827,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0633056",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 11275,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0633308",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 26091,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0633798",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 11016,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0639122",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 25208,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0640438",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 12928,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0641992",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 86803,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0643280",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 30700,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0643294",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 8295,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0644112",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 32538,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0646114",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 36819,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0646870",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 32475,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0647486",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 22277,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0647710",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 14105,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0647766",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 79066,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0648956",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 3396,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0649187",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 16624,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0649194",
+          "points_by_facet": [
+            {
+              "date": "1999",
+              "value": 16927,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0649278",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 45342,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0649670",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 81516,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0650258",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 78818,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0650916",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 47434,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0652582",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 52708,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0653000",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 433823,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0653070",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 43771,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0654232",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 19483,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0654806",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 37099,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0655282",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 66680,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0656784",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 59403,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0656938",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 11107,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0657288",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 18821,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0657456",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 76544,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0657764",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 34304,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0657792",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 78252,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0658380",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 4289,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0660102",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 81643,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0660620",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 115639,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0660984",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 10217,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0662546",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 44411,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0662980",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 2327,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0664140",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 5386,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0664434",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 12693,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0665028",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 42275,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0665070",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 30034,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0667000",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 815201,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0668000",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 983489,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0668084",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 88868,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0668252",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 102200,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0668294",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 31773,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0668364",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 60769,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0668378",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 86947,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0669084",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 127151,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0670098",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 176938,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0670280",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 30163,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0670364",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 7199,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0670770",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 7448,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0672646",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 10644,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0673262",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 64251,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0675630",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 29165,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0677000",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 152258,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0678666",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 9052,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0681204",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 68681,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0681554",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 103078,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0681666",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 124886,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0683346",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 69695,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0685922",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 26039,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0686440",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 5131,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0686930",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 3360,
+              "facet": "2176550201"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "variable": "Count_CriminalActivities_LarcenyTheft",
+      "observations_by_entity": [
+        {
+          "entity": "geoId/0600135"
+        },
+        {
+          "entity": "geoId/0600562",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 1958,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0600618"
+        },
+        {
+          "entity": "geoId/0600674",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 534,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0600898"
+        },
+        {
+          "entity": "geoId/0600996"
+        },
+        {
+          "entity": "geoId/0601416"
+        },
+        {
+          "entity": "geoId/0601458"
+        },
+        {
+          "entity": "geoId/0601486"
+        },
+        {
+          "entity": "geoId/0601640",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 368,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0602168"
+        },
+        {
+          "entity": "geoId/0602252",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 2078,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0602980"
+        },
+        {
+          "entity": "geoId/0603036"
+        },
+        {
+          "entity": "geoId/0603092",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 74,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0604415"
+        },
+        {
+          "entity": "geoId/0604470"
+        },
+        {
+          "entity": "geoId/0605108",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 312,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0605164",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 13,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0605290",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 250,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0606000",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 4993,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0606210"
+        },
+        {
+          "entity": "geoId/0606928"
+        },
+        {
+          "entity": "geoId/0606982"
+        },
+        {
+          "entity": "geoId/0607036"
+        },
+        {
+          "entity": "geoId/0607246"
+        },
+        {
+          "entity": "geoId/0607260"
+        },
+        {
+          "entity": "geoId/0607316"
+        },
+        {
+          "entity": "geoId/0607848"
+        },
+        {
+          "entity": "geoId/0608142",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 1095,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0608310",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 52,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0608338"
+        },
+        {
+          "entity": "geoId/0608848"
+        },
+        {
+          "entity": "geoId/0608968"
+        },
+        {
+          "entity": "geoId/0609066",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 937,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0609346"
+        },
+        {
+          "entity": "geoId/0609892",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 54,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0610088"
+        },
+        {
+          "entity": "geoId/0610301"
+        },
+        {
+          "entity": "geoId/0610345",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 990,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0611376"
+        },
+        {
+          "entity": "geoId/0611915"
+        },
+        {
+          "entity": "geoId/0611964"
+        },
+        {
+          "entity": "geoId/0612146"
+        },
+        {
+          "entity": "geoId/0612902"
+        },
+        {
+          "entity": "geoId/0613882",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 137,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0614190",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 87,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0614232"
+        },
+        {
+          "entity": "geoId/0614736",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 263,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0616000",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 3512,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0616090"
+        },
+        {
+          "entity": "geoId/0616462"
+        },
+        {
+          "entity": "geoId/0616560",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 68,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0617274"
+        },
+        {
+          "entity": "geoId/0617610",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 803,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0617918",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 1517,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0617988",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 247,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0618324"
+        },
+        {
+          "entity": "geoId/0619150"
+        },
+        {
+          "entity": "geoId/0619262"
+        },
+        {
+          "entity": "geoId/0619339"
+        },
+        {
+          "entity": "geoId/0619402",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 284,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0620018",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 1052,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0620598"
+        },
+        {
+          "entity": "geoId/0620956",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 360,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0621061"
+        },
+        {
+          "entity": "geoId/0621796",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 1054,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0621894"
+        },
+        {
+          "entity": "geoId/0621936"
+        },
+        {
+          "entity": "geoId/0622146"
+        },
+        {
+          "entity": "geoId/0622454"
+        },
+        {
+          "entity": "geoId/0622510"
+        },
+        {
+          "entity": "geoId/0622587"
+        },
+        {
+          "entity": "geoId/0622594",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 2415,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0623168",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 77,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0623182",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 2780,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0623350"
+        },
+        {
+          "entity": "geoId/0623973"
+        },
+        {
+          "entity": "geoId/0624960"
+        },
+        {
+          "entity": "geoId/0625338",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 341,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0626000",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 3408,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0627080"
+        },
+        {
+          "entity": "geoId/0628014"
+        },
+        {
+          "entity": "geoId/0629420"
+        },
+        {
+          "entity": "geoId/0629504",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 1034,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0630028"
+        },
+        {
+          "entity": "geoId/0630812"
+        },
+        {
+          "entity": "geoId/0631099"
+        },
+        {
+          "entity": "geoId/0631470"
+        },
+        {
+          "entity": "geoId/0631708",
+          "points_by_facet": [
+            {
+              "date": "2010",
+              "value": 193,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0632340"
+        },
+        {
+          "entity": "geoId/0633000",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 3197,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0633056",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 142,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0633308",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 278,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0633633"
+        },
+        {
+          "entity": "geoId/0633798",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 49,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0634120",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 174,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0636616"
+        },
+        {
+          "entity": "geoId/0637274"
+        },
+        {
+          "entity": "geoId/0638086"
+        },
+        {
+          "entity": "geoId/0638114"
+        },
+        {
+          "entity": "geoId/0638156"
+        },
+        {
+          "entity": "geoId/0638772"
+        },
+        {
+          "entity": "geoId/0639094"
+        },
+        {
+          "entity": "geoId/0639122",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 286,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0639283"
+        },
+        {
+          "entity": "geoId/0639318"
+        },
+        {
+          "entity": "geoId/0640426"
+        },
+        {
+          "entity": "geoId/0640438"
+        },
+        {
+          "entity": "geoId/0641282"
+        },
+        {
+          "entity": "geoId/0641992",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 1279,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0642384"
+        },
+        {
+          "entity": "geoId/0643280",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 181,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0643294",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 38,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0644112",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 332,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0644378"
+        },
+        {
+          "entity": "geoId/0644399"
+        },
+        {
+          "entity": "geoId/0645820"
+        },
+        {
+          "entity": "geoId/0646010"
+        },
+        {
+          "entity": "geoId/0646114",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 386,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0646870",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 633,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0647486",
+          "points_by_facet": [
+            {
+              "date": "2011",
+              "value": 264,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0647710",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 177,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0647766",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 1791,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0648718"
+        },
+        {
+          "entity": "geoId/0648760"
+        },
+        {
+          "entity": "geoId/0648928"
+        },
+        {
+          "entity": "geoId/0648956",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 9,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0649187",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 79,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0649194"
+        },
+        {
+          "entity": "geoId/0649278",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 507,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0649432"
+        },
+        {
+          "entity": "geoId/0649446"
+        },
+        {
+          "entity": "geoId/0649651"
+        },
+        {
+          "entity": "geoId/0649670",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 2030,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0649950"
+        },
+        {
+          "entity": "geoId/0650258",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 847,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0650916",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 1090,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0651280"
+        },
+        {
+          "entity": "geoId/0651622"
+        },
+        {
+          "entity": "geoId/0651658"
+        },
+        {
+          "entity": "geoId/0651840"
+        },
+        {
+          "entity": "geoId/0651890"
+        },
+        {
+          "entity": "geoId/0652162"
+        },
+        {
+          "entity": "geoId/0652582",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 711,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0653000",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 20228,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0653070",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 336,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0653196"
+        },
+        {
+          "entity": "geoId/0653266"
+        },
+        {
+          "entity": "geoId/0654232",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 125,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0654764"
+        },
+        {
+          "entity": "geoId/0654806",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 408,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0655282",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 1722,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0656476"
+        },
+        {
+          "entity": "geoId/0656756"
+        },
+        {
+          "entity": "geoId/0656784",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 626,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0656938",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 162,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0657288",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 726,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0657456",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 983,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0657764",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 1276,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0657792",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 1386,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0657960"
+        },
+        {
+          "entity": "geoId/0658226"
+        },
+        {
+          "entity": "geoId/0658380"
+        },
+        {
+          "entity": "geoId/0660102",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 1014,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0660279"
+        },
+        {
+          "entity": "geoId/0660620",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 2480,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0660914"
+        },
+        {
+          "entity": "geoId/0660984",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 87,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0662490"
+        },
+        {
+          "entity": "geoId/0662546",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 615,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0662700"
+        },
+        {
+          "entity": "geoId/0662868"
+        },
+        {
+          "entity": "geoId/0662980",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 19,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0663400"
+        },
+        {
+          "entity": "geoId/0664140",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 43,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0664252"
+        },
+        {
+          "entity": "geoId/0664434",
+          "points_by_facet": [
+            {
+              "date": "2012",
+              "value": 110,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0665028",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 948,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0665070",
+          "points_by_facet": [
+            {
+              "date": "2009",
+              "value": 436,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0667000",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 39887,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0667070"
+        },
+        {
+          "entity": "geoId/0668000",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 14924,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0668014"
+        },
+        {
+          "entity": "geoId/0668084",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 2941,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0668112"
+        },
+        {
+          "entity": "geoId/0668122"
+        },
+        {
+          "entity": "geoId/0668238"
+        },
+        {
+          "entity": "geoId/0668252",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 1523,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0668263"
+        },
+        {
+          "entity": "geoId/0668294",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 589,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0668364",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 1173,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0668378",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 869,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0669084",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 4013,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0670098",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 2077,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0670154"
+        },
+        {
+          "entity": "geoId/0670266"
+        },
+        {
+          "entity": "geoId/0670280",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 122,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0670364",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 224,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0670712"
+        },
+        {
+          "entity": "geoId/0670770",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 110,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0671000"
+        },
+        {
+          "entity": "geoId/0671074"
+        },
+        {
+          "entity": "geoId/0671362"
+        },
+        {
+          "entity": "geoId/0671927"
+        },
+        {
+          "entity": "geoId/0672184"
+        },
+        {
+          "entity": "geoId/0672646",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 95,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0673262",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 1074,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0673906"
+        },
+        {
+          "entity": "geoId/0674172"
+        },
+        {
+          "entity": "geoId/0675315"
+        },
+        {
+          "entity": "geoId/0675630",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 479,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0677000",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 2598,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0677042"
+        },
+        {
+          "entity": "geoId/0677805"
+        },
+        {
+          "entity": "geoId/0677924"
+        },
+        {
+          "entity": "geoId/0678126"
+        },
+        {
+          "entity": "geoId/0678666",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 67,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0678715"
+        },
+        {
+          "entity": "geoId/0678890"
+        },
+        {
+          "entity": "geoId/0681204",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 1300,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0681554",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 2120,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0681666",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 1148,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0681778"
+        },
+        {
+          "entity": "geoId/0682842"
+        },
+        {
+          "entity": "geoId/0683215"
+        },
+        {
+          "entity": "geoId/0683346",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 2034,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0684536"
+        },
+        {
+          "entity": "geoId/0685922",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 212,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0686216"
+        },
+        {
+          "entity": "geoId/0686440"
+        },
+        {
+          "entity": "geoId/0686930",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 36,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "wikidataId/Q1267489"
+        },
+        {
+          "entity": "wikidataId/Q1863076"
+        },
+        {
+          "entity": "wikidataId/Q1911837"
+        },
+        {
+          "entity": "wikidataId/Q2036981"
+        },
+        {
+          "entity": "wikidataId/Q2208068"
+        },
+        {
+          "entity": "wikidataId/Q2214519"
+        },
+        {
+          "entity": "wikidataId/Q2586362"
+        },
+        {
+          "entity": "wikidataId/Q2620952"
+        },
+        {
+          "entity": "wikidataId/Q3470832"
+        },
+        {
+          "entity": "wikidataId/Q3476563"
+        },
+        {
+          "entity": "wikidataId/Q6041883"
+        }
+      ]
+    }
+  ],
+  "facets": {
+    "2176550201": {
+      "import_name": "USCensusPEP_Annual_Population",
+      "provenance_url": "https://www2.census.gov/programs-surveys/popest/tables",
+      "measurement_method": "CensusPEPSurvey",
+      "observation_period": "P1Y"
+    },
+    "4277990144": {
+      "import_name": "FBIGovCrime",
+      "provenance_url": "http://www.fbi.gov/services/cjis/ucr",
+      "observation_period": "P1Y"
+    }
+  }
+}

--- a/internal/server/v1/observations/golden/bulk_point_linked/preferred_CA_County.json
+++ b/internal/server/v1/observations/golden/bulk_point_linked/preferred_CA_County.json
@@ -1169,6 +1169,185 @@
           ]
         }
       ]
+    },
+    {
+      "variable": "dummy",
+      "observations_by_entity": [
+        {
+          "entity": "geoId/06001"
+        },
+        {
+          "entity": "geoId/06003"
+        },
+        {
+          "entity": "geoId/06005"
+        },
+        {
+          "entity": "geoId/06007"
+        },
+        {
+          "entity": "geoId/06009"
+        },
+        {
+          "entity": "geoId/06011"
+        },
+        {
+          "entity": "geoId/06013"
+        },
+        {
+          "entity": "geoId/06015"
+        },
+        {
+          "entity": "geoId/06017"
+        },
+        {
+          "entity": "geoId/06019"
+        },
+        {
+          "entity": "geoId/06021"
+        },
+        {
+          "entity": "geoId/06023"
+        },
+        {
+          "entity": "geoId/06025"
+        },
+        {
+          "entity": "geoId/06027"
+        },
+        {
+          "entity": "geoId/06029"
+        },
+        {
+          "entity": "geoId/06031"
+        },
+        {
+          "entity": "geoId/06033"
+        },
+        {
+          "entity": "geoId/06035"
+        },
+        {
+          "entity": "geoId/06037"
+        },
+        {
+          "entity": "geoId/06039"
+        },
+        {
+          "entity": "geoId/06041"
+        },
+        {
+          "entity": "geoId/06043"
+        },
+        {
+          "entity": "geoId/06045"
+        },
+        {
+          "entity": "geoId/06047"
+        },
+        {
+          "entity": "geoId/06049"
+        },
+        {
+          "entity": "geoId/06051"
+        },
+        {
+          "entity": "geoId/06053"
+        },
+        {
+          "entity": "geoId/06055"
+        },
+        {
+          "entity": "geoId/06057"
+        },
+        {
+          "entity": "geoId/06059"
+        },
+        {
+          "entity": "geoId/06061"
+        },
+        {
+          "entity": "geoId/06063"
+        },
+        {
+          "entity": "geoId/06065"
+        },
+        {
+          "entity": "geoId/06067"
+        },
+        {
+          "entity": "geoId/06069"
+        },
+        {
+          "entity": "geoId/06071"
+        },
+        {
+          "entity": "geoId/06073"
+        },
+        {
+          "entity": "geoId/06075"
+        },
+        {
+          "entity": "geoId/06077"
+        },
+        {
+          "entity": "geoId/06079"
+        },
+        {
+          "entity": "geoId/06081"
+        },
+        {
+          "entity": "geoId/06083"
+        },
+        {
+          "entity": "geoId/06085"
+        },
+        {
+          "entity": "geoId/06087"
+        },
+        {
+          "entity": "geoId/06089"
+        },
+        {
+          "entity": "geoId/06091"
+        },
+        {
+          "entity": "geoId/06093"
+        },
+        {
+          "entity": "geoId/06095"
+        },
+        {
+          "entity": "geoId/06097"
+        },
+        {
+          "entity": "geoId/06099"
+        },
+        {
+          "entity": "geoId/06101"
+        },
+        {
+          "entity": "geoId/06103"
+        },
+        {
+          "entity": "geoId/06105"
+        },
+        {
+          "entity": "geoId/06107"
+        },
+        {
+          "entity": "geoId/06109"
+        },
+        {
+          "entity": "geoId/06111"
+        },
+        {
+          "entity": "geoId/06113"
+        },
+        {
+          "entity": "geoId/06115"
+        }
+      ]
     }
   ],
   "facets": {

--- a/internal/server/v1/observations/golden/bulk_point_linked/preferred_USA_County.json
+++ b/internal/server/v1/observations/golden/bulk_point_linked/preferred_USA_County.json
@@ -95564,6 +95564,9692 @@
           ]
         }
       ]
+    },
+    {
+      "variable": "dummy",
+      "observations_by_entity": [
+        {
+          "entity": "geoId/01001"
+        },
+        {
+          "entity": "geoId/01003"
+        },
+        {
+          "entity": "geoId/01005"
+        },
+        {
+          "entity": "geoId/01007"
+        },
+        {
+          "entity": "geoId/01009"
+        },
+        {
+          "entity": "geoId/01011"
+        },
+        {
+          "entity": "geoId/01013"
+        },
+        {
+          "entity": "geoId/01015"
+        },
+        {
+          "entity": "geoId/01017"
+        },
+        {
+          "entity": "geoId/01019"
+        },
+        {
+          "entity": "geoId/01021"
+        },
+        {
+          "entity": "geoId/01023"
+        },
+        {
+          "entity": "geoId/01025"
+        },
+        {
+          "entity": "geoId/01027"
+        },
+        {
+          "entity": "geoId/01029"
+        },
+        {
+          "entity": "geoId/01031"
+        },
+        {
+          "entity": "geoId/01033"
+        },
+        {
+          "entity": "geoId/01035"
+        },
+        {
+          "entity": "geoId/01037"
+        },
+        {
+          "entity": "geoId/01039"
+        },
+        {
+          "entity": "geoId/01041"
+        },
+        {
+          "entity": "geoId/01043"
+        },
+        {
+          "entity": "geoId/01045"
+        },
+        {
+          "entity": "geoId/01047"
+        },
+        {
+          "entity": "geoId/01049"
+        },
+        {
+          "entity": "geoId/01051"
+        },
+        {
+          "entity": "geoId/01053"
+        },
+        {
+          "entity": "geoId/01055"
+        },
+        {
+          "entity": "geoId/01057"
+        },
+        {
+          "entity": "geoId/01059"
+        },
+        {
+          "entity": "geoId/01061"
+        },
+        {
+          "entity": "geoId/01063"
+        },
+        {
+          "entity": "geoId/01065"
+        },
+        {
+          "entity": "geoId/01067"
+        },
+        {
+          "entity": "geoId/01069"
+        },
+        {
+          "entity": "geoId/01071"
+        },
+        {
+          "entity": "geoId/01073"
+        },
+        {
+          "entity": "geoId/01075"
+        },
+        {
+          "entity": "geoId/01077"
+        },
+        {
+          "entity": "geoId/01079"
+        },
+        {
+          "entity": "geoId/01081"
+        },
+        {
+          "entity": "geoId/01083"
+        },
+        {
+          "entity": "geoId/01085"
+        },
+        {
+          "entity": "geoId/01087"
+        },
+        {
+          "entity": "geoId/01089"
+        },
+        {
+          "entity": "geoId/01091"
+        },
+        {
+          "entity": "geoId/01093"
+        },
+        {
+          "entity": "geoId/01095"
+        },
+        {
+          "entity": "geoId/01097"
+        },
+        {
+          "entity": "geoId/01099"
+        },
+        {
+          "entity": "geoId/01101"
+        },
+        {
+          "entity": "geoId/01103"
+        },
+        {
+          "entity": "geoId/01105"
+        },
+        {
+          "entity": "geoId/01107"
+        },
+        {
+          "entity": "geoId/01109"
+        },
+        {
+          "entity": "geoId/01111"
+        },
+        {
+          "entity": "geoId/01113"
+        },
+        {
+          "entity": "geoId/01115"
+        },
+        {
+          "entity": "geoId/01117"
+        },
+        {
+          "entity": "geoId/01119"
+        },
+        {
+          "entity": "geoId/01121"
+        },
+        {
+          "entity": "geoId/01123"
+        },
+        {
+          "entity": "geoId/01125"
+        },
+        {
+          "entity": "geoId/01127"
+        },
+        {
+          "entity": "geoId/01129"
+        },
+        {
+          "entity": "geoId/01131"
+        },
+        {
+          "entity": "geoId/01133"
+        },
+        {
+          "entity": "geoId/02013"
+        },
+        {
+          "entity": "geoId/02016"
+        },
+        {
+          "entity": "geoId/02020"
+        },
+        {
+          "entity": "geoId/02050"
+        },
+        {
+          "entity": "geoId/02060"
+        },
+        {
+          "entity": "geoId/02068"
+        },
+        {
+          "entity": "geoId/02070"
+        },
+        {
+          "entity": "geoId/02090"
+        },
+        {
+          "entity": "geoId/02100"
+        },
+        {
+          "entity": "geoId/02105"
+        },
+        {
+          "entity": "geoId/02110"
+        },
+        {
+          "entity": "geoId/02122"
+        },
+        {
+          "entity": "geoId/02130"
+        },
+        {
+          "entity": "geoId/02150"
+        },
+        {
+          "entity": "geoId/02158"
+        },
+        {
+          "entity": "geoId/02164"
+        },
+        {
+          "entity": "geoId/02170"
+        },
+        {
+          "entity": "geoId/02180"
+        },
+        {
+          "entity": "geoId/02185"
+        },
+        {
+          "entity": "geoId/02188"
+        },
+        {
+          "entity": "geoId/02195"
+        },
+        {
+          "entity": "geoId/02198"
+        },
+        {
+          "entity": "geoId/02220"
+        },
+        {
+          "entity": "geoId/02230"
+        },
+        {
+          "entity": "geoId/02240"
+        },
+        {
+          "entity": "geoId/02261"
+        },
+        {
+          "entity": "geoId/02275"
+        },
+        {
+          "entity": "geoId/02280"
+        },
+        {
+          "entity": "geoId/02282"
+        },
+        {
+          "entity": "geoId/02290"
+        },
+        {
+          "entity": "geoId/04001"
+        },
+        {
+          "entity": "geoId/04003"
+        },
+        {
+          "entity": "geoId/04005"
+        },
+        {
+          "entity": "geoId/04007"
+        },
+        {
+          "entity": "geoId/04009"
+        },
+        {
+          "entity": "geoId/04011"
+        },
+        {
+          "entity": "geoId/04012"
+        },
+        {
+          "entity": "geoId/04013"
+        },
+        {
+          "entity": "geoId/04015"
+        },
+        {
+          "entity": "geoId/04017"
+        },
+        {
+          "entity": "geoId/04019"
+        },
+        {
+          "entity": "geoId/04021"
+        },
+        {
+          "entity": "geoId/04023"
+        },
+        {
+          "entity": "geoId/04025"
+        },
+        {
+          "entity": "geoId/04027"
+        },
+        {
+          "entity": "geoId/05001"
+        },
+        {
+          "entity": "geoId/05003"
+        },
+        {
+          "entity": "geoId/05005"
+        },
+        {
+          "entity": "geoId/05007"
+        },
+        {
+          "entity": "geoId/05009"
+        },
+        {
+          "entity": "geoId/05011"
+        },
+        {
+          "entity": "geoId/05013"
+        },
+        {
+          "entity": "geoId/05015"
+        },
+        {
+          "entity": "geoId/05017"
+        },
+        {
+          "entity": "geoId/05019"
+        },
+        {
+          "entity": "geoId/05021"
+        },
+        {
+          "entity": "geoId/05023"
+        },
+        {
+          "entity": "geoId/05025"
+        },
+        {
+          "entity": "geoId/05027"
+        },
+        {
+          "entity": "geoId/05029"
+        },
+        {
+          "entity": "geoId/05031"
+        },
+        {
+          "entity": "geoId/05033"
+        },
+        {
+          "entity": "geoId/05035"
+        },
+        {
+          "entity": "geoId/05037"
+        },
+        {
+          "entity": "geoId/05039"
+        },
+        {
+          "entity": "geoId/05041"
+        },
+        {
+          "entity": "geoId/05043"
+        },
+        {
+          "entity": "geoId/05045"
+        },
+        {
+          "entity": "geoId/05047"
+        },
+        {
+          "entity": "geoId/05049"
+        },
+        {
+          "entity": "geoId/05051"
+        },
+        {
+          "entity": "geoId/05053"
+        },
+        {
+          "entity": "geoId/05055"
+        },
+        {
+          "entity": "geoId/05057"
+        },
+        {
+          "entity": "geoId/05059"
+        },
+        {
+          "entity": "geoId/05061"
+        },
+        {
+          "entity": "geoId/05063"
+        },
+        {
+          "entity": "geoId/05065"
+        },
+        {
+          "entity": "geoId/05067"
+        },
+        {
+          "entity": "geoId/05069"
+        },
+        {
+          "entity": "geoId/05071"
+        },
+        {
+          "entity": "geoId/05073"
+        },
+        {
+          "entity": "geoId/05075"
+        },
+        {
+          "entity": "geoId/05077"
+        },
+        {
+          "entity": "geoId/05079"
+        },
+        {
+          "entity": "geoId/05081"
+        },
+        {
+          "entity": "geoId/05083"
+        },
+        {
+          "entity": "geoId/05085"
+        },
+        {
+          "entity": "geoId/05087"
+        },
+        {
+          "entity": "geoId/05089"
+        },
+        {
+          "entity": "geoId/05091"
+        },
+        {
+          "entity": "geoId/05093"
+        },
+        {
+          "entity": "geoId/05095"
+        },
+        {
+          "entity": "geoId/05097"
+        },
+        {
+          "entity": "geoId/05099"
+        },
+        {
+          "entity": "geoId/05101"
+        },
+        {
+          "entity": "geoId/05103"
+        },
+        {
+          "entity": "geoId/05105"
+        },
+        {
+          "entity": "geoId/05107"
+        },
+        {
+          "entity": "geoId/05109"
+        },
+        {
+          "entity": "geoId/05111"
+        },
+        {
+          "entity": "geoId/05113"
+        },
+        {
+          "entity": "geoId/05115"
+        },
+        {
+          "entity": "geoId/05117"
+        },
+        {
+          "entity": "geoId/05119"
+        },
+        {
+          "entity": "geoId/05121"
+        },
+        {
+          "entity": "geoId/05123"
+        },
+        {
+          "entity": "geoId/05125"
+        },
+        {
+          "entity": "geoId/05127"
+        },
+        {
+          "entity": "geoId/05129"
+        },
+        {
+          "entity": "geoId/05131"
+        },
+        {
+          "entity": "geoId/05133"
+        },
+        {
+          "entity": "geoId/05135"
+        },
+        {
+          "entity": "geoId/05137"
+        },
+        {
+          "entity": "geoId/05139"
+        },
+        {
+          "entity": "geoId/05141"
+        },
+        {
+          "entity": "geoId/05143"
+        },
+        {
+          "entity": "geoId/05145"
+        },
+        {
+          "entity": "geoId/05147"
+        },
+        {
+          "entity": "geoId/05149"
+        },
+        {
+          "entity": "geoId/06001"
+        },
+        {
+          "entity": "geoId/06003"
+        },
+        {
+          "entity": "geoId/06005"
+        },
+        {
+          "entity": "geoId/06007"
+        },
+        {
+          "entity": "geoId/06009"
+        },
+        {
+          "entity": "geoId/06011"
+        },
+        {
+          "entity": "geoId/06013"
+        },
+        {
+          "entity": "geoId/06015"
+        },
+        {
+          "entity": "geoId/06017"
+        },
+        {
+          "entity": "geoId/06019"
+        },
+        {
+          "entity": "geoId/06021"
+        },
+        {
+          "entity": "geoId/06023"
+        },
+        {
+          "entity": "geoId/06025"
+        },
+        {
+          "entity": "geoId/06027"
+        },
+        {
+          "entity": "geoId/06029"
+        },
+        {
+          "entity": "geoId/06031"
+        },
+        {
+          "entity": "geoId/06033"
+        },
+        {
+          "entity": "geoId/06035"
+        },
+        {
+          "entity": "geoId/06037"
+        },
+        {
+          "entity": "geoId/06039"
+        },
+        {
+          "entity": "geoId/06041"
+        },
+        {
+          "entity": "geoId/06043"
+        },
+        {
+          "entity": "geoId/06045"
+        },
+        {
+          "entity": "geoId/06047"
+        },
+        {
+          "entity": "geoId/06049"
+        },
+        {
+          "entity": "geoId/06051"
+        },
+        {
+          "entity": "geoId/06053"
+        },
+        {
+          "entity": "geoId/06055"
+        },
+        {
+          "entity": "geoId/06057"
+        },
+        {
+          "entity": "geoId/06059"
+        },
+        {
+          "entity": "geoId/06061"
+        },
+        {
+          "entity": "geoId/06063"
+        },
+        {
+          "entity": "geoId/06065"
+        },
+        {
+          "entity": "geoId/06067"
+        },
+        {
+          "entity": "geoId/06069"
+        },
+        {
+          "entity": "geoId/06071"
+        },
+        {
+          "entity": "geoId/06073"
+        },
+        {
+          "entity": "geoId/06075"
+        },
+        {
+          "entity": "geoId/06077"
+        },
+        {
+          "entity": "geoId/06079"
+        },
+        {
+          "entity": "geoId/06081"
+        },
+        {
+          "entity": "geoId/06083"
+        },
+        {
+          "entity": "geoId/06085"
+        },
+        {
+          "entity": "geoId/06087"
+        },
+        {
+          "entity": "geoId/06089"
+        },
+        {
+          "entity": "geoId/06091"
+        },
+        {
+          "entity": "geoId/06093"
+        },
+        {
+          "entity": "geoId/06095"
+        },
+        {
+          "entity": "geoId/06097"
+        },
+        {
+          "entity": "geoId/06099"
+        },
+        {
+          "entity": "geoId/06101"
+        },
+        {
+          "entity": "geoId/06103"
+        },
+        {
+          "entity": "geoId/06105"
+        },
+        {
+          "entity": "geoId/06107"
+        },
+        {
+          "entity": "geoId/06109"
+        },
+        {
+          "entity": "geoId/06111"
+        },
+        {
+          "entity": "geoId/06113"
+        },
+        {
+          "entity": "geoId/06115"
+        },
+        {
+          "entity": "geoId/08001"
+        },
+        {
+          "entity": "geoId/08003"
+        },
+        {
+          "entity": "geoId/08005"
+        },
+        {
+          "entity": "geoId/08007"
+        },
+        {
+          "entity": "geoId/08009"
+        },
+        {
+          "entity": "geoId/08011"
+        },
+        {
+          "entity": "geoId/08013"
+        },
+        {
+          "entity": "geoId/08014"
+        },
+        {
+          "entity": "geoId/08015"
+        },
+        {
+          "entity": "geoId/08017"
+        },
+        {
+          "entity": "geoId/08019"
+        },
+        {
+          "entity": "geoId/08021"
+        },
+        {
+          "entity": "geoId/08023"
+        },
+        {
+          "entity": "geoId/08025"
+        },
+        {
+          "entity": "geoId/08027"
+        },
+        {
+          "entity": "geoId/08029"
+        },
+        {
+          "entity": "geoId/08031"
+        },
+        {
+          "entity": "geoId/08033"
+        },
+        {
+          "entity": "geoId/08035"
+        },
+        {
+          "entity": "geoId/08037"
+        },
+        {
+          "entity": "geoId/08039"
+        },
+        {
+          "entity": "geoId/08041"
+        },
+        {
+          "entity": "geoId/08043"
+        },
+        {
+          "entity": "geoId/08045"
+        },
+        {
+          "entity": "geoId/08047"
+        },
+        {
+          "entity": "geoId/08049"
+        },
+        {
+          "entity": "geoId/08051"
+        },
+        {
+          "entity": "geoId/08053"
+        },
+        {
+          "entity": "geoId/08055"
+        },
+        {
+          "entity": "geoId/08057"
+        },
+        {
+          "entity": "geoId/08059"
+        },
+        {
+          "entity": "geoId/08061"
+        },
+        {
+          "entity": "geoId/08063"
+        },
+        {
+          "entity": "geoId/08065"
+        },
+        {
+          "entity": "geoId/08067"
+        },
+        {
+          "entity": "geoId/08069"
+        },
+        {
+          "entity": "geoId/08071"
+        },
+        {
+          "entity": "geoId/08073"
+        },
+        {
+          "entity": "geoId/08075"
+        },
+        {
+          "entity": "geoId/08077"
+        },
+        {
+          "entity": "geoId/08079"
+        },
+        {
+          "entity": "geoId/08081"
+        },
+        {
+          "entity": "geoId/08083"
+        },
+        {
+          "entity": "geoId/08085"
+        },
+        {
+          "entity": "geoId/08087"
+        },
+        {
+          "entity": "geoId/08089"
+        },
+        {
+          "entity": "geoId/08091"
+        },
+        {
+          "entity": "geoId/08093"
+        },
+        {
+          "entity": "geoId/08095"
+        },
+        {
+          "entity": "geoId/08097"
+        },
+        {
+          "entity": "geoId/08099"
+        },
+        {
+          "entity": "geoId/08101"
+        },
+        {
+          "entity": "geoId/08103"
+        },
+        {
+          "entity": "geoId/08105"
+        },
+        {
+          "entity": "geoId/08107"
+        },
+        {
+          "entity": "geoId/08109"
+        },
+        {
+          "entity": "geoId/08111"
+        },
+        {
+          "entity": "geoId/08113"
+        },
+        {
+          "entity": "geoId/08115"
+        },
+        {
+          "entity": "geoId/08117"
+        },
+        {
+          "entity": "geoId/08119"
+        },
+        {
+          "entity": "geoId/08121"
+        },
+        {
+          "entity": "geoId/08123"
+        },
+        {
+          "entity": "geoId/08125"
+        },
+        {
+          "entity": "geoId/09001"
+        },
+        {
+          "entity": "geoId/09003"
+        },
+        {
+          "entity": "geoId/09005"
+        },
+        {
+          "entity": "geoId/09007"
+        },
+        {
+          "entity": "geoId/09009"
+        },
+        {
+          "entity": "geoId/09011"
+        },
+        {
+          "entity": "geoId/09013"
+        },
+        {
+          "entity": "geoId/09015"
+        },
+        {
+          "entity": "geoId/10001"
+        },
+        {
+          "entity": "geoId/10003"
+        },
+        {
+          "entity": "geoId/10005"
+        },
+        {
+          "entity": "geoId/11001"
+        },
+        {
+          "entity": "geoId/12001"
+        },
+        {
+          "entity": "geoId/12003"
+        },
+        {
+          "entity": "geoId/12005"
+        },
+        {
+          "entity": "geoId/12007"
+        },
+        {
+          "entity": "geoId/12009"
+        },
+        {
+          "entity": "geoId/12011"
+        },
+        {
+          "entity": "geoId/12013"
+        },
+        {
+          "entity": "geoId/12015"
+        },
+        {
+          "entity": "geoId/12017"
+        },
+        {
+          "entity": "geoId/12019"
+        },
+        {
+          "entity": "geoId/12021"
+        },
+        {
+          "entity": "geoId/12023"
+        },
+        {
+          "entity": "geoId/12027"
+        },
+        {
+          "entity": "geoId/12029"
+        },
+        {
+          "entity": "geoId/12031"
+        },
+        {
+          "entity": "geoId/12033"
+        },
+        {
+          "entity": "geoId/12035"
+        },
+        {
+          "entity": "geoId/12037"
+        },
+        {
+          "entity": "geoId/12039"
+        },
+        {
+          "entity": "geoId/12041"
+        },
+        {
+          "entity": "geoId/12043"
+        },
+        {
+          "entity": "geoId/12045"
+        },
+        {
+          "entity": "geoId/12047"
+        },
+        {
+          "entity": "geoId/12049"
+        },
+        {
+          "entity": "geoId/12051"
+        },
+        {
+          "entity": "geoId/12053"
+        },
+        {
+          "entity": "geoId/12055"
+        },
+        {
+          "entity": "geoId/12057"
+        },
+        {
+          "entity": "geoId/12059"
+        },
+        {
+          "entity": "geoId/12061"
+        },
+        {
+          "entity": "geoId/12063"
+        },
+        {
+          "entity": "geoId/12065"
+        },
+        {
+          "entity": "geoId/12067"
+        },
+        {
+          "entity": "geoId/12069"
+        },
+        {
+          "entity": "geoId/12071"
+        },
+        {
+          "entity": "geoId/12073"
+        },
+        {
+          "entity": "geoId/12075"
+        },
+        {
+          "entity": "geoId/12077"
+        },
+        {
+          "entity": "geoId/12079"
+        },
+        {
+          "entity": "geoId/12081"
+        },
+        {
+          "entity": "geoId/12083"
+        },
+        {
+          "entity": "geoId/12085"
+        },
+        {
+          "entity": "geoId/12086"
+        },
+        {
+          "entity": "geoId/12087"
+        },
+        {
+          "entity": "geoId/12089"
+        },
+        {
+          "entity": "geoId/12091"
+        },
+        {
+          "entity": "geoId/12093"
+        },
+        {
+          "entity": "geoId/12095"
+        },
+        {
+          "entity": "geoId/12097"
+        },
+        {
+          "entity": "geoId/12099"
+        },
+        {
+          "entity": "geoId/12101"
+        },
+        {
+          "entity": "geoId/12103"
+        },
+        {
+          "entity": "geoId/12105"
+        },
+        {
+          "entity": "geoId/12107"
+        },
+        {
+          "entity": "geoId/12109"
+        },
+        {
+          "entity": "geoId/12111"
+        },
+        {
+          "entity": "geoId/12113"
+        },
+        {
+          "entity": "geoId/12115"
+        },
+        {
+          "entity": "geoId/12117"
+        },
+        {
+          "entity": "geoId/12119"
+        },
+        {
+          "entity": "geoId/12121"
+        },
+        {
+          "entity": "geoId/12123"
+        },
+        {
+          "entity": "geoId/12125"
+        },
+        {
+          "entity": "geoId/12127"
+        },
+        {
+          "entity": "geoId/12129"
+        },
+        {
+          "entity": "geoId/12131"
+        },
+        {
+          "entity": "geoId/12133"
+        },
+        {
+          "entity": "geoId/13001"
+        },
+        {
+          "entity": "geoId/13003"
+        },
+        {
+          "entity": "geoId/13005"
+        },
+        {
+          "entity": "geoId/13007"
+        },
+        {
+          "entity": "geoId/13009"
+        },
+        {
+          "entity": "geoId/13011"
+        },
+        {
+          "entity": "geoId/13013"
+        },
+        {
+          "entity": "geoId/13015"
+        },
+        {
+          "entity": "geoId/13017"
+        },
+        {
+          "entity": "geoId/13019"
+        },
+        {
+          "entity": "geoId/13021"
+        },
+        {
+          "entity": "geoId/13023"
+        },
+        {
+          "entity": "geoId/13025"
+        },
+        {
+          "entity": "geoId/13027"
+        },
+        {
+          "entity": "geoId/13029"
+        },
+        {
+          "entity": "geoId/13031"
+        },
+        {
+          "entity": "geoId/13033"
+        },
+        {
+          "entity": "geoId/13035"
+        },
+        {
+          "entity": "geoId/13037"
+        },
+        {
+          "entity": "geoId/13039"
+        },
+        {
+          "entity": "geoId/13043"
+        },
+        {
+          "entity": "geoId/13045"
+        },
+        {
+          "entity": "geoId/13047"
+        },
+        {
+          "entity": "geoId/13049"
+        },
+        {
+          "entity": "geoId/13051"
+        },
+        {
+          "entity": "geoId/13053"
+        },
+        {
+          "entity": "geoId/13055"
+        },
+        {
+          "entity": "geoId/13057"
+        },
+        {
+          "entity": "geoId/13059"
+        },
+        {
+          "entity": "geoId/13061"
+        },
+        {
+          "entity": "geoId/13063"
+        },
+        {
+          "entity": "geoId/13065"
+        },
+        {
+          "entity": "geoId/13067"
+        },
+        {
+          "entity": "geoId/13069"
+        },
+        {
+          "entity": "geoId/13071"
+        },
+        {
+          "entity": "geoId/13073"
+        },
+        {
+          "entity": "geoId/13075"
+        },
+        {
+          "entity": "geoId/13077"
+        },
+        {
+          "entity": "geoId/13079"
+        },
+        {
+          "entity": "geoId/13081"
+        },
+        {
+          "entity": "geoId/13083"
+        },
+        {
+          "entity": "geoId/13085"
+        },
+        {
+          "entity": "geoId/13087"
+        },
+        {
+          "entity": "geoId/13089"
+        },
+        {
+          "entity": "geoId/13091"
+        },
+        {
+          "entity": "geoId/13093"
+        },
+        {
+          "entity": "geoId/13095"
+        },
+        {
+          "entity": "geoId/13097"
+        },
+        {
+          "entity": "geoId/13099"
+        },
+        {
+          "entity": "geoId/13101"
+        },
+        {
+          "entity": "geoId/13103"
+        },
+        {
+          "entity": "geoId/13105"
+        },
+        {
+          "entity": "geoId/13107"
+        },
+        {
+          "entity": "geoId/13109"
+        },
+        {
+          "entity": "geoId/13111"
+        },
+        {
+          "entity": "geoId/13113"
+        },
+        {
+          "entity": "geoId/13115"
+        },
+        {
+          "entity": "geoId/13117"
+        },
+        {
+          "entity": "geoId/13119"
+        },
+        {
+          "entity": "geoId/13121"
+        },
+        {
+          "entity": "geoId/13123"
+        },
+        {
+          "entity": "geoId/13125"
+        },
+        {
+          "entity": "geoId/13127"
+        },
+        {
+          "entity": "geoId/13129"
+        },
+        {
+          "entity": "geoId/13131"
+        },
+        {
+          "entity": "geoId/13133"
+        },
+        {
+          "entity": "geoId/13135"
+        },
+        {
+          "entity": "geoId/13137"
+        },
+        {
+          "entity": "geoId/13139"
+        },
+        {
+          "entity": "geoId/13141"
+        },
+        {
+          "entity": "geoId/13143"
+        },
+        {
+          "entity": "geoId/13145"
+        },
+        {
+          "entity": "geoId/13147"
+        },
+        {
+          "entity": "geoId/13149"
+        },
+        {
+          "entity": "geoId/13151"
+        },
+        {
+          "entity": "geoId/13153"
+        },
+        {
+          "entity": "geoId/13155"
+        },
+        {
+          "entity": "geoId/13157"
+        },
+        {
+          "entity": "geoId/13159"
+        },
+        {
+          "entity": "geoId/13161"
+        },
+        {
+          "entity": "geoId/13163"
+        },
+        {
+          "entity": "geoId/13165"
+        },
+        {
+          "entity": "geoId/13167"
+        },
+        {
+          "entity": "geoId/13169"
+        },
+        {
+          "entity": "geoId/13171"
+        },
+        {
+          "entity": "geoId/13173"
+        },
+        {
+          "entity": "geoId/13175"
+        },
+        {
+          "entity": "geoId/13177"
+        },
+        {
+          "entity": "geoId/13179"
+        },
+        {
+          "entity": "geoId/13181"
+        },
+        {
+          "entity": "geoId/13183"
+        },
+        {
+          "entity": "geoId/13185"
+        },
+        {
+          "entity": "geoId/13187"
+        },
+        {
+          "entity": "geoId/13189"
+        },
+        {
+          "entity": "geoId/13191"
+        },
+        {
+          "entity": "geoId/13193"
+        },
+        {
+          "entity": "geoId/13195"
+        },
+        {
+          "entity": "geoId/13197"
+        },
+        {
+          "entity": "geoId/13199"
+        },
+        {
+          "entity": "geoId/13201"
+        },
+        {
+          "entity": "geoId/13205"
+        },
+        {
+          "entity": "geoId/13207"
+        },
+        {
+          "entity": "geoId/13209"
+        },
+        {
+          "entity": "geoId/13211"
+        },
+        {
+          "entity": "geoId/13213"
+        },
+        {
+          "entity": "geoId/13215"
+        },
+        {
+          "entity": "geoId/13217"
+        },
+        {
+          "entity": "geoId/13219"
+        },
+        {
+          "entity": "geoId/13221"
+        },
+        {
+          "entity": "geoId/13223"
+        },
+        {
+          "entity": "geoId/13225"
+        },
+        {
+          "entity": "geoId/13227"
+        },
+        {
+          "entity": "geoId/13229"
+        },
+        {
+          "entity": "geoId/13231"
+        },
+        {
+          "entity": "geoId/13233"
+        },
+        {
+          "entity": "geoId/13235"
+        },
+        {
+          "entity": "geoId/13237"
+        },
+        {
+          "entity": "geoId/13239"
+        },
+        {
+          "entity": "geoId/13241"
+        },
+        {
+          "entity": "geoId/13243"
+        },
+        {
+          "entity": "geoId/13245"
+        },
+        {
+          "entity": "geoId/13247"
+        },
+        {
+          "entity": "geoId/13249"
+        },
+        {
+          "entity": "geoId/13251"
+        },
+        {
+          "entity": "geoId/13253"
+        },
+        {
+          "entity": "geoId/13255"
+        },
+        {
+          "entity": "geoId/13257"
+        },
+        {
+          "entity": "geoId/13259"
+        },
+        {
+          "entity": "geoId/13261"
+        },
+        {
+          "entity": "geoId/13263"
+        },
+        {
+          "entity": "geoId/13265"
+        },
+        {
+          "entity": "geoId/13267"
+        },
+        {
+          "entity": "geoId/13269"
+        },
+        {
+          "entity": "geoId/13271"
+        },
+        {
+          "entity": "geoId/13273"
+        },
+        {
+          "entity": "geoId/13275"
+        },
+        {
+          "entity": "geoId/13277"
+        },
+        {
+          "entity": "geoId/13279"
+        },
+        {
+          "entity": "geoId/13281"
+        },
+        {
+          "entity": "geoId/13283"
+        },
+        {
+          "entity": "geoId/13285"
+        },
+        {
+          "entity": "geoId/13287"
+        },
+        {
+          "entity": "geoId/13289"
+        },
+        {
+          "entity": "geoId/13291"
+        },
+        {
+          "entity": "geoId/13293"
+        },
+        {
+          "entity": "geoId/13295"
+        },
+        {
+          "entity": "geoId/13297"
+        },
+        {
+          "entity": "geoId/13299"
+        },
+        {
+          "entity": "geoId/13301"
+        },
+        {
+          "entity": "geoId/13303"
+        },
+        {
+          "entity": "geoId/13305"
+        },
+        {
+          "entity": "geoId/13307"
+        },
+        {
+          "entity": "geoId/13309"
+        },
+        {
+          "entity": "geoId/13311"
+        },
+        {
+          "entity": "geoId/13313"
+        },
+        {
+          "entity": "geoId/13315"
+        },
+        {
+          "entity": "geoId/13317"
+        },
+        {
+          "entity": "geoId/13319"
+        },
+        {
+          "entity": "geoId/13321"
+        },
+        {
+          "entity": "geoId/15001"
+        },
+        {
+          "entity": "geoId/15003"
+        },
+        {
+          "entity": "geoId/15005"
+        },
+        {
+          "entity": "geoId/15007"
+        },
+        {
+          "entity": "geoId/15009"
+        },
+        {
+          "entity": "geoId/16001"
+        },
+        {
+          "entity": "geoId/16003"
+        },
+        {
+          "entity": "geoId/16005"
+        },
+        {
+          "entity": "geoId/16007"
+        },
+        {
+          "entity": "geoId/16009"
+        },
+        {
+          "entity": "geoId/16011"
+        },
+        {
+          "entity": "geoId/16013"
+        },
+        {
+          "entity": "geoId/16015"
+        },
+        {
+          "entity": "geoId/16017"
+        },
+        {
+          "entity": "geoId/16019"
+        },
+        {
+          "entity": "geoId/16021"
+        },
+        {
+          "entity": "geoId/16023"
+        },
+        {
+          "entity": "geoId/16025"
+        },
+        {
+          "entity": "geoId/16027"
+        },
+        {
+          "entity": "geoId/16029"
+        },
+        {
+          "entity": "geoId/16031"
+        },
+        {
+          "entity": "geoId/16033"
+        },
+        {
+          "entity": "geoId/16035"
+        },
+        {
+          "entity": "geoId/16037"
+        },
+        {
+          "entity": "geoId/16039"
+        },
+        {
+          "entity": "geoId/16041"
+        },
+        {
+          "entity": "geoId/16043"
+        },
+        {
+          "entity": "geoId/16045"
+        },
+        {
+          "entity": "geoId/16047"
+        },
+        {
+          "entity": "geoId/16049"
+        },
+        {
+          "entity": "geoId/16051"
+        },
+        {
+          "entity": "geoId/16053"
+        },
+        {
+          "entity": "geoId/16055"
+        },
+        {
+          "entity": "geoId/16057"
+        },
+        {
+          "entity": "geoId/16059"
+        },
+        {
+          "entity": "geoId/16061"
+        },
+        {
+          "entity": "geoId/16063"
+        },
+        {
+          "entity": "geoId/16065"
+        },
+        {
+          "entity": "geoId/16067"
+        },
+        {
+          "entity": "geoId/16069"
+        },
+        {
+          "entity": "geoId/16071"
+        },
+        {
+          "entity": "geoId/16073"
+        },
+        {
+          "entity": "geoId/16075"
+        },
+        {
+          "entity": "geoId/16077"
+        },
+        {
+          "entity": "geoId/16079"
+        },
+        {
+          "entity": "geoId/16081"
+        },
+        {
+          "entity": "geoId/16083"
+        },
+        {
+          "entity": "geoId/16085"
+        },
+        {
+          "entity": "geoId/16087"
+        },
+        {
+          "entity": "geoId/17001"
+        },
+        {
+          "entity": "geoId/17003"
+        },
+        {
+          "entity": "geoId/17005"
+        },
+        {
+          "entity": "geoId/17007"
+        },
+        {
+          "entity": "geoId/17009"
+        },
+        {
+          "entity": "geoId/17011"
+        },
+        {
+          "entity": "geoId/17013"
+        },
+        {
+          "entity": "geoId/17015"
+        },
+        {
+          "entity": "geoId/17017"
+        },
+        {
+          "entity": "geoId/17019"
+        },
+        {
+          "entity": "geoId/17021"
+        },
+        {
+          "entity": "geoId/17023"
+        },
+        {
+          "entity": "geoId/17025"
+        },
+        {
+          "entity": "geoId/17027"
+        },
+        {
+          "entity": "geoId/17029"
+        },
+        {
+          "entity": "geoId/17031"
+        },
+        {
+          "entity": "geoId/17033"
+        },
+        {
+          "entity": "geoId/17035"
+        },
+        {
+          "entity": "geoId/17037"
+        },
+        {
+          "entity": "geoId/17039"
+        },
+        {
+          "entity": "geoId/17041"
+        },
+        {
+          "entity": "geoId/17043"
+        },
+        {
+          "entity": "geoId/17045"
+        },
+        {
+          "entity": "geoId/17047"
+        },
+        {
+          "entity": "geoId/17049"
+        },
+        {
+          "entity": "geoId/17051"
+        },
+        {
+          "entity": "geoId/17053"
+        },
+        {
+          "entity": "geoId/17055"
+        },
+        {
+          "entity": "geoId/17057"
+        },
+        {
+          "entity": "geoId/17059"
+        },
+        {
+          "entity": "geoId/17061"
+        },
+        {
+          "entity": "geoId/17063"
+        },
+        {
+          "entity": "geoId/17065"
+        },
+        {
+          "entity": "geoId/17067"
+        },
+        {
+          "entity": "geoId/17069"
+        },
+        {
+          "entity": "geoId/17071"
+        },
+        {
+          "entity": "geoId/17073"
+        },
+        {
+          "entity": "geoId/17075"
+        },
+        {
+          "entity": "geoId/17077"
+        },
+        {
+          "entity": "geoId/17079"
+        },
+        {
+          "entity": "geoId/17081"
+        },
+        {
+          "entity": "geoId/17083"
+        },
+        {
+          "entity": "geoId/17085"
+        },
+        {
+          "entity": "geoId/17087"
+        },
+        {
+          "entity": "geoId/17089"
+        },
+        {
+          "entity": "geoId/17091"
+        },
+        {
+          "entity": "geoId/17093"
+        },
+        {
+          "entity": "geoId/17095"
+        },
+        {
+          "entity": "geoId/17097"
+        },
+        {
+          "entity": "geoId/17099"
+        },
+        {
+          "entity": "geoId/17101"
+        },
+        {
+          "entity": "geoId/17103"
+        },
+        {
+          "entity": "geoId/17105"
+        },
+        {
+          "entity": "geoId/17107"
+        },
+        {
+          "entity": "geoId/17109"
+        },
+        {
+          "entity": "geoId/17111"
+        },
+        {
+          "entity": "geoId/17113"
+        },
+        {
+          "entity": "geoId/17115"
+        },
+        {
+          "entity": "geoId/17117"
+        },
+        {
+          "entity": "geoId/17119"
+        },
+        {
+          "entity": "geoId/17121"
+        },
+        {
+          "entity": "geoId/17123"
+        },
+        {
+          "entity": "geoId/17125"
+        },
+        {
+          "entity": "geoId/17127"
+        },
+        {
+          "entity": "geoId/17129"
+        },
+        {
+          "entity": "geoId/17131"
+        },
+        {
+          "entity": "geoId/17133"
+        },
+        {
+          "entity": "geoId/17135"
+        },
+        {
+          "entity": "geoId/17137"
+        },
+        {
+          "entity": "geoId/17139"
+        },
+        {
+          "entity": "geoId/17141"
+        },
+        {
+          "entity": "geoId/17143"
+        },
+        {
+          "entity": "geoId/17145"
+        },
+        {
+          "entity": "geoId/17147"
+        },
+        {
+          "entity": "geoId/17149"
+        },
+        {
+          "entity": "geoId/17151"
+        },
+        {
+          "entity": "geoId/17153"
+        },
+        {
+          "entity": "geoId/17155"
+        },
+        {
+          "entity": "geoId/17157"
+        },
+        {
+          "entity": "geoId/17159"
+        },
+        {
+          "entity": "geoId/17161"
+        },
+        {
+          "entity": "geoId/17163"
+        },
+        {
+          "entity": "geoId/17165"
+        },
+        {
+          "entity": "geoId/17167"
+        },
+        {
+          "entity": "geoId/17169"
+        },
+        {
+          "entity": "geoId/17171"
+        },
+        {
+          "entity": "geoId/17173"
+        },
+        {
+          "entity": "geoId/17175"
+        },
+        {
+          "entity": "geoId/17177"
+        },
+        {
+          "entity": "geoId/17179"
+        },
+        {
+          "entity": "geoId/17181"
+        },
+        {
+          "entity": "geoId/17183"
+        },
+        {
+          "entity": "geoId/17185"
+        },
+        {
+          "entity": "geoId/17187"
+        },
+        {
+          "entity": "geoId/17189"
+        },
+        {
+          "entity": "geoId/17191"
+        },
+        {
+          "entity": "geoId/17193"
+        },
+        {
+          "entity": "geoId/17195"
+        },
+        {
+          "entity": "geoId/17197"
+        },
+        {
+          "entity": "geoId/17199"
+        },
+        {
+          "entity": "geoId/17201"
+        },
+        {
+          "entity": "geoId/17203"
+        },
+        {
+          "entity": "geoId/18001"
+        },
+        {
+          "entity": "geoId/18003"
+        },
+        {
+          "entity": "geoId/18005"
+        },
+        {
+          "entity": "geoId/18007"
+        },
+        {
+          "entity": "geoId/18009"
+        },
+        {
+          "entity": "geoId/18011"
+        },
+        {
+          "entity": "geoId/18013"
+        },
+        {
+          "entity": "geoId/18015"
+        },
+        {
+          "entity": "geoId/18017"
+        },
+        {
+          "entity": "geoId/18019"
+        },
+        {
+          "entity": "geoId/18021"
+        },
+        {
+          "entity": "geoId/18023"
+        },
+        {
+          "entity": "geoId/18025"
+        },
+        {
+          "entity": "geoId/18027"
+        },
+        {
+          "entity": "geoId/18029"
+        },
+        {
+          "entity": "geoId/18031"
+        },
+        {
+          "entity": "geoId/18033"
+        },
+        {
+          "entity": "geoId/18035"
+        },
+        {
+          "entity": "geoId/18037"
+        },
+        {
+          "entity": "geoId/18039"
+        },
+        {
+          "entity": "geoId/18041"
+        },
+        {
+          "entity": "geoId/18043"
+        },
+        {
+          "entity": "geoId/18045"
+        },
+        {
+          "entity": "geoId/18047"
+        },
+        {
+          "entity": "geoId/18049"
+        },
+        {
+          "entity": "geoId/18051"
+        },
+        {
+          "entity": "geoId/18053"
+        },
+        {
+          "entity": "geoId/18055"
+        },
+        {
+          "entity": "geoId/18057"
+        },
+        {
+          "entity": "geoId/18059"
+        },
+        {
+          "entity": "geoId/18061"
+        },
+        {
+          "entity": "geoId/18063"
+        },
+        {
+          "entity": "geoId/18065"
+        },
+        {
+          "entity": "geoId/18067"
+        },
+        {
+          "entity": "geoId/18069"
+        },
+        {
+          "entity": "geoId/18071"
+        },
+        {
+          "entity": "geoId/18073"
+        },
+        {
+          "entity": "geoId/18075"
+        },
+        {
+          "entity": "geoId/18077"
+        },
+        {
+          "entity": "geoId/18079"
+        },
+        {
+          "entity": "geoId/18081"
+        },
+        {
+          "entity": "geoId/18083"
+        },
+        {
+          "entity": "geoId/18085"
+        },
+        {
+          "entity": "geoId/18087"
+        },
+        {
+          "entity": "geoId/18089"
+        },
+        {
+          "entity": "geoId/18091"
+        },
+        {
+          "entity": "geoId/18093"
+        },
+        {
+          "entity": "geoId/18095"
+        },
+        {
+          "entity": "geoId/18097"
+        },
+        {
+          "entity": "geoId/18099"
+        },
+        {
+          "entity": "geoId/18101"
+        },
+        {
+          "entity": "geoId/18103"
+        },
+        {
+          "entity": "geoId/18105"
+        },
+        {
+          "entity": "geoId/18107"
+        },
+        {
+          "entity": "geoId/18109"
+        },
+        {
+          "entity": "geoId/18111"
+        },
+        {
+          "entity": "geoId/18113"
+        },
+        {
+          "entity": "geoId/18115"
+        },
+        {
+          "entity": "geoId/18117"
+        },
+        {
+          "entity": "geoId/18119"
+        },
+        {
+          "entity": "geoId/18121"
+        },
+        {
+          "entity": "geoId/18123"
+        },
+        {
+          "entity": "geoId/18125"
+        },
+        {
+          "entity": "geoId/18127"
+        },
+        {
+          "entity": "geoId/18129"
+        },
+        {
+          "entity": "geoId/18131"
+        },
+        {
+          "entity": "geoId/18133"
+        },
+        {
+          "entity": "geoId/18135"
+        },
+        {
+          "entity": "geoId/18137"
+        },
+        {
+          "entity": "geoId/18139"
+        },
+        {
+          "entity": "geoId/18141"
+        },
+        {
+          "entity": "geoId/18143"
+        },
+        {
+          "entity": "geoId/18145"
+        },
+        {
+          "entity": "geoId/18147"
+        },
+        {
+          "entity": "geoId/18149"
+        },
+        {
+          "entity": "geoId/18151"
+        },
+        {
+          "entity": "geoId/18153"
+        },
+        {
+          "entity": "geoId/18155"
+        },
+        {
+          "entity": "geoId/18157"
+        },
+        {
+          "entity": "geoId/18159"
+        },
+        {
+          "entity": "geoId/18161"
+        },
+        {
+          "entity": "geoId/18163"
+        },
+        {
+          "entity": "geoId/18165"
+        },
+        {
+          "entity": "geoId/18167"
+        },
+        {
+          "entity": "geoId/18169"
+        },
+        {
+          "entity": "geoId/18171"
+        },
+        {
+          "entity": "geoId/18173"
+        },
+        {
+          "entity": "geoId/18175"
+        },
+        {
+          "entity": "geoId/18177"
+        },
+        {
+          "entity": "geoId/18179"
+        },
+        {
+          "entity": "geoId/18181"
+        },
+        {
+          "entity": "geoId/18183"
+        },
+        {
+          "entity": "geoId/19001"
+        },
+        {
+          "entity": "geoId/19003"
+        },
+        {
+          "entity": "geoId/19005"
+        },
+        {
+          "entity": "geoId/19007"
+        },
+        {
+          "entity": "geoId/19009"
+        },
+        {
+          "entity": "geoId/19011"
+        },
+        {
+          "entity": "geoId/19013"
+        },
+        {
+          "entity": "geoId/19015"
+        },
+        {
+          "entity": "geoId/19017"
+        },
+        {
+          "entity": "geoId/19019"
+        },
+        {
+          "entity": "geoId/19021"
+        },
+        {
+          "entity": "geoId/19023"
+        },
+        {
+          "entity": "geoId/19025"
+        },
+        {
+          "entity": "geoId/19027"
+        },
+        {
+          "entity": "geoId/19029"
+        },
+        {
+          "entity": "geoId/19031"
+        },
+        {
+          "entity": "geoId/19033"
+        },
+        {
+          "entity": "geoId/19035"
+        },
+        {
+          "entity": "geoId/19037"
+        },
+        {
+          "entity": "geoId/19039"
+        },
+        {
+          "entity": "geoId/19041"
+        },
+        {
+          "entity": "geoId/19043"
+        },
+        {
+          "entity": "geoId/19045"
+        },
+        {
+          "entity": "geoId/19047"
+        },
+        {
+          "entity": "geoId/19049"
+        },
+        {
+          "entity": "geoId/19051"
+        },
+        {
+          "entity": "geoId/19053"
+        },
+        {
+          "entity": "geoId/19055"
+        },
+        {
+          "entity": "geoId/19057"
+        },
+        {
+          "entity": "geoId/19059"
+        },
+        {
+          "entity": "geoId/19061"
+        },
+        {
+          "entity": "geoId/19063"
+        },
+        {
+          "entity": "geoId/19065"
+        },
+        {
+          "entity": "geoId/19067"
+        },
+        {
+          "entity": "geoId/19069"
+        },
+        {
+          "entity": "geoId/19071"
+        },
+        {
+          "entity": "geoId/19073"
+        },
+        {
+          "entity": "geoId/19075"
+        },
+        {
+          "entity": "geoId/19077"
+        },
+        {
+          "entity": "geoId/19079"
+        },
+        {
+          "entity": "geoId/19081"
+        },
+        {
+          "entity": "geoId/19083"
+        },
+        {
+          "entity": "geoId/19085"
+        },
+        {
+          "entity": "geoId/19087"
+        },
+        {
+          "entity": "geoId/19089"
+        },
+        {
+          "entity": "geoId/19091"
+        },
+        {
+          "entity": "geoId/19093"
+        },
+        {
+          "entity": "geoId/19095"
+        },
+        {
+          "entity": "geoId/19097"
+        },
+        {
+          "entity": "geoId/19099"
+        },
+        {
+          "entity": "geoId/19101"
+        },
+        {
+          "entity": "geoId/19103"
+        },
+        {
+          "entity": "geoId/19105"
+        },
+        {
+          "entity": "geoId/19107"
+        },
+        {
+          "entity": "geoId/19109"
+        },
+        {
+          "entity": "geoId/19111"
+        },
+        {
+          "entity": "geoId/19113"
+        },
+        {
+          "entity": "geoId/19115"
+        },
+        {
+          "entity": "geoId/19117"
+        },
+        {
+          "entity": "geoId/19119"
+        },
+        {
+          "entity": "geoId/19121"
+        },
+        {
+          "entity": "geoId/19123"
+        },
+        {
+          "entity": "geoId/19125"
+        },
+        {
+          "entity": "geoId/19127"
+        },
+        {
+          "entity": "geoId/19129"
+        },
+        {
+          "entity": "geoId/19131"
+        },
+        {
+          "entity": "geoId/19133"
+        },
+        {
+          "entity": "geoId/19135"
+        },
+        {
+          "entity": "geoId/19137"
+        },
+        {
+          "entity": "geoId/19139"
+        },
+        {
+          "entity": "geoId/19141"
+        },
+        {
+          "entity": "geoId/19143"
+        },
+        {
+          "entity": "geoId/19145"
+        },
+        {
+          "entity": "geoId/19147"
+        },
+        {
+          "entity": "geoId/19149"
+        },
+        {
+          "entity": "geoId/19151"
+        },
+        {
+          "entity": "geoId/19153"
+        },
+        {
+          "entity": "geoId/19155"
+        },
+        {
+          "entity": "geoId/19157"
+        },
+        {
+          "entity": "geoId/19159"
+        },
+        {
+          "entity": "geoId/19161"
+        },
+        {
+          "entity": "geoId/19163"
+        },
+        {
+          "entity": "geoId/19165"
+        },
+        {
+          "entity": "geoId/19167"
+        },
+        {
+          "entity": "geoId/19169"
+        },
+        {
+          "entity": "geoId/19171"
+        },
+        {
+          "entity": "geoId/19173"
+        },
+        {
+          "entity": "geoId/19175"
+        },
+        {
+          "entity": "geoId/19177"
+        },
+        {
+          "entity": "geoId/19179"
+        },
+        {
+          "entity": "geoId/19181"
+        },
+        {
+          "entity": "geoId/19183"
+        },
+        {
+          "entity": "geoId/19185"
+        },
+        {
+          "entity": "geoId/19187"
+        },
+        {
+          "entity": "geoId/19189"
+        },
+        {
+          "entity": "geoId/19191"
+        },
+        {
+          "entity": "geoId/19193"
+        },
+        {
+          "entity": "geoId/19195"
+        },
+        {
+          "entity": "geoId/19197"
+        },
+        {
+          "entity": "geoId/20001"
+        },
+        {
+          "entity": "geoId/20003"
+        },
+        {
+          "entity": "geoId/20005"
+        },
+        {
+          "entity": "geoId/20007"
+        },
+        {
+          "entity": "geoId/20009"
+        },
+        {
+          "entity": "geoId/20011"
+        },
+        {
+          "entity": "geoId/20013"
+        },
+        {
+          "entity": "geoId/20015"
+        },
+        {
+          "entity": "geoId/20017"
+        },
+        {
+          "entity": "geoId/20019"
+        },
+        {
+          "entity": "geoId/20021"
+        },
+        {
+          "entity": "geoId/20023"
+        },
+        {
+          "entity": "geoId/20025"
+        },
+        {
+          "entity": "geoId/20027"
+        },
+        {
+          "entity": "geoId/20029"
+        },
+        {
+          "entity": "geoId/20031"
+        },
+        {
+          "entity": "geoId/20033"
+        },
+        {
+          "entity": "geoId/20035"
+        },
+        {
+          "entity": "geoId/20037"
+        },
+        {
+          "entity": "geoId/20039"
+        },
+        {
+          "entity": "geoId/20041"
+        },
+        {
+          "entity": "geoId/20043"
+        },
+        {
+          "entity": "geoId/20045"
+        },
+        {
+          "entity": "geoId/20047"
+        },
+        {
+          "entity": "geoId/20049"
+        },
+        {
+          "entity": "geoId/20051"
+        },
+        {
+          "entity": "geoId/20053"
+        },
+        {
+          "entity": "geoId/20055"
+        },
+        {
+          "entity": "geoId/20057"
+        },
+        {
+          "entity": "geoId/20059"
+        },
+        {
+          "entity": "geoId/20061"
+        },
+        {
+          "entity": "geoId/20063"
+        },
+        {
+          "entity": "geoId/20065"
+        },
+        {
+          "entity": "geoId/20067"
+        },
+        {
+          "entity": "geoId/20069"
+        },
+        {
+          "entity": "geoId/20071"
+        },
+        {
+          "entity": "geoId/20073"
+        },
+        {
+          "entity": "geoId/20075"
+        },
+        {
+          "entity": "geoId/20077"
+        },
+        {
+          "entity": "geoId/20079"
+        },
+        {
+          "entity": "geoId/20081"
+        },
+        {
+          "entity": "geoId/20083"
+        },
+        {
+          "entity": "geoId/20085"
+        },
+        {
+          "entity": "geoId/20087"
+        },
+        {
+          "entity": "geoId/20089"
+        },
+        {
+          "entity": "geoId/20091"
+        },
+        {
+          "entity": "geoId/20093"
+        },
+        {
+          "entity": "geoId/20095"
+        },
+        {
+          "entity": "geoId/20097"
+        },
+        {
+          "entity": "geoId/20099"
+        },
+        {
+          "entity": "geoId/20101"
+        },
+        {
+          "entity": "geoId/20103"
+        },
+        {
+          "entity": "geoId/20105"
+        },
+        {
+          "entity": "geoId/20107"
+        },
+        {
+          "entity": "geoId/20109"
+        },
+        {
+          "entity": "geoId/20111"
+        },
+        {
+          "entity": "geoId/20113"
+        },
+        {
+          "entity": "geoId/20115"
+        },
+        {
+          "entity": "geoId/20117"
+        },
+        {
+          "entity": "geoId/20119"
+        },
+        {
+          "entity": "geoId/20121"
+        },
+        {
+          "entity": "geoId/20123"
+        },
+        {
+          "entity": "geoId/20125"
+        },
+        {
+          "entity": "geoId/20127"
+        },
+        {
+          "entity": "geoId/20129"
+        },
+        {
+          "entity": "geoId/20131"
+        },
+        {
+          "entity": "geoId/20133"
+        },
+        {
+          "entity": "geoId/20135"
+        },
+        {
+          "entity": "geoId/20137"
+        },
+        {
+          "entity": "geoId/20139"
+        },
+        {
+          "entity": "geoId/20141"
+        },
+        {
+          "entity": "geoId/20143"
+        },
+        {
+          "entity": "geoId/20145"
+        },
+        {
+          "entity": "geoId/20147"
+        },
+        {
+          "entity": "geoId/20149"
+        },
+        {
+          "entity": "geoId/20151"
+        },
+        {
+          "entity": "geoId/20153"
+        },
+        {
+          "entity": "geoId/20155"
+        },
+        {
+          "entity": "geoId/20157"
+        },
+        {
+          "entity": "geoId/20159"
+        },
+        {
+          "entity": "geoId/20161"
+        },
+        {
+          "entity": "geoId/20163"
+        },
+        {
+          "entity": "geoId/20165"
+        },
+        {
+          "entity": "geoId/20167"
+        },
+        {
+          "entity": "geoId/20169"
+        },
+        {
+          "entity": "geoId/20171"
+        },
+        {
+          "entity": "geoId/20173"
+        },
+        {
+          "entity": "geoId/20175"
+        },
+        {
+          "entity": "geoId/20177"
+        },
+        {
+          "entity": "geoId/20179"
+        },
+        {
+          "entity": "geoId/20181"
+        },
+        {
+          "entity": "geoId/20183"
+        },
+        {
+          "entity": "geoId/20185"
+        },
+        {
+          "entity": "geoId/20187"
+        },
+        {
+          "entity": "geoId/20189"
+        },
+        {
+          "entity": "geoId/20191"
+        },
+        {
+          "entity": "geoId/20193"
+        },
+        {
+          "entity": "geoId/20195"
+        },
+        {
+          "entity": "geoId/20197"
+        },
+        {
+          "entity": "geoId/20199"
+        },
+        {
+          "entity": "geoId/20201"
+        },
+        {
+          "entity": "geoId/20203"
+        },
+        {
+          "entity": "geoId/20205"
+        },
+        {
+          "entity": "geoId/20207"
+        },
+        {
+          "entity": "geoId/20209"
+        },
+        {
+          "entity": "geoId/21001"
+        },
+        {
+          "entity": "geoId/21003"
+        },
+        {
+          "entity": "geoId/21005"
+        },
+        {
+          "entity": "geoId/21007"
+        },
+        {
+          "entity": "geoId/21009"
+        },
+        {
+          "entity": "geoId/21011"
+        },
+        {
+          "entity": "geoId/21013"
+        },
+        {
+          "entity": "geoId/21015"
+        },
+        {
+          "entity": "geoId/21017"
+        },
+        {
+          "entity": "geoId/21019"
+        },
+        {
+          "entity": "geoId/21021"
+        },
+        {
+          "entity": "geoId/21023"
+        },
+        {
+          "entity": "geoId/21025"
+        },
+        {
+          "entity": "geoId/21027"
+        },
+        {
+          "entity": "geoId/21029"
+        },
+        {
+          "entity": "geoId/21031"
+        },
+        {
+          "entity": "geoId/21033"
+        },
+        {
+          "entity": "geoId/21035"
+        },
+        {
+          "entity": "geoId/21037"
+        },
+        {
+          "entity": "geoId/21039"
+        },
+        {
+          "entity": "geoId/21041"
+        },
+        {
+          "entity": "geoId/21043"
+        },
+        {
+          "entity": "geoId/21045"
+        },
+        {
+          "entity": "geoId/21047"
+        },
+        {
+          "entity": "geoId/21049"
+        },
+        {
+          "entity": "geoId/21051"
+        },
+        {
+          "entity": "geoId/21053"
+        },
+        {
+          "entity": "geoId/21055"
+        },
+        {
+          "entity": "geoId/21057"
+        },
+        {
+          "entity": "geoId/21059"
+        },
+        {
+          "entity": "geoId/21061"
+        },
+        {
+          "entity": "geoId/21063"
+        },
+        {
+          "entity": "geoId/21065"
+        },
+        {
+          "entity": "geoId/21067"
+        },
+        {
+          "entity": "geoId/21069"
+        },
+        {
+          "entity": "geoId/21071"
+        },
+        {
+          "entity": "geoId/21073"
+        },
+        {
+          "entity": "geoId/21075"
+        },
+        {
+          "entity": "geoId/21077"
+        },
+        {
+          "entity": "geoId/21079"
+        },
+        {
+          "entity": "geoId/21081"
+        },
+        {
+          "entity": "geoId/21083"
+        },
+        {
+          "entity": "geoId/21085"
+        },
+        {
+          "entity": "geoId/21087"
+        },
+        {
+          "entity": "geoId/21089"
+        },
+        {
+          "entity": "geoId/21091"
+        },
+        {
+          "entity": "geoId/21093"
+        },
+        {
+          "entity": "geoId/21095"
+        },
+        {
+          "entity": "geoId/21097"
+        },
+        {
+          "entity": "geoId/21099"
+        },
+        {
+          "entity": "geoId/21101"
+        },
+        {
+          "entity": "geoId/21103"
+        },
+        {
+          "entity": "geoId/21105"
+        },
+        {
+          "entity": "geoId/21107"
+        },
+        {
+          "entity": "geoId/21109"
+        },
+        {
+          "entity": "geoId/21111"
+        },
+        {
+          "entity": "geoId/21113"
+        },
+        {
+          "entity": "geoId/21115"
+        },
+        {
+          "entity": "geoId/21117"
+        },
+        {
+          "entity": "geoId/21119"
+        },
+        {
+          "entity": "geoId/21121"
+        },
+        {
+          "entity": "geoId/21123"
+        },
+        {
+          "entity": "geoId/21125"
+        },
+        {
+          "entity": "geoId/21127"
+        },
+        {
+          "entity": "geoId/21129"
+        },
+        {
+          "entity": "geoId/21131"
+        },
+        {
+          "entity": "geoId/21133"
+        },
+        {
+          "entity": "geoId/21135"
+        },
+        {
+          "entity": "geoId/21137"
+        },
+        {
+          "entity": "geoId/21139"
+        },
+        {
+          "entity": "geoId/21141"
+        },
+        {
+          "entity": "geoId/21143"
+        },
+        {
+          "entity": "geoId/21145"
+        },
+        {
+          "entity": "geoId/21147"
+        },
+        {
+          "entity": "geoId/21149"
+        },
+        {
+          "entity": "geoId/21151"
+        },
+        {
+          "entity": "geoId/21153"
+        },
+        {
+          "entity": "geoId/21155"
+        },
+        {
+          "entity": "geoId/21157"
+        },
+        {
+          "entity": "geoId/21159"
+        },
+        {
+          "entity": "geoId/21161"
+        },
+        {
+          "entity": "geoId/21163"
+        },
+        {
+          "entity": "geoId/21165"
+        },
+        {
+          "entity": "geoId/21167"
+        },
+        {
+          "entity": "geoId/21169"
+        },
+        {
+          "entity": "geoId/21171"
+        },
+        {
+          "entity": "geoId/21173"
+        },
+        {
+          "entity": "geoId/21175"
+        },
+        {
+          "entity": "geoId/21177"
+        },
+        {
+          "entity": "geoId/21179"
+        },
+        {
+          "entity": "geoId/21181"
+        },
+        {
+          "entity": "geoId/21183"
+        },
+        {
+          "entity": "geoId/21185"
+        },
+        {
+          "entity": "geoId/21187"
+        },
+        {
+          "entity": "geoId/21189"
+        },
+        {
+          "entity": "geoId/21191"
+        },
+        {
+          "entity": "geoId/21193"
+        },
+        {
+          "entity": "geoId/21195"
+        },
+        {
+          "entity": "geoId/21197"
+        },
+        {
+          "entity": "geoId/21199"
+        },
+        {
+          "entity": "geoId/21201"
+        },
+        {
+          "entity": "geoId/21203"
+        },
+        {
+          "entity": "geoId/21205"
+        },
+        {
+          "entity": "geoId/21207"
+        },
+        {
+          "entity": "geoId/21209"
+        },
+        {
+          "entity": "geoId/21211"
+        },
+        {
+          "entity": "geoId/21213"
+        },
+        {
+          "entity": "geoId/21215"
+        },
+        {
+          "entity": "geoId/21217"
+        },
+        {
+          "entity": "geoId/21219"
+        },
+        {
+          "entity": "geoId/21221"
+        },
+        {
+          "entity": "geoId/21223"
+        },
+        {
+          "entity": "geoId/21225"
+        },
+        {
+          "entity": "geoId/21227"
+        },
+        {
+          "entity": "geoId/21229"
+        },
+        {
+          "entity": "geoId/21231"
+        },
+        {
+          "entity": "geoId/21233"
+        },
+        {
+          "entity": "geoId/21235"
+        },
+        {
+          "entity": "geoId/21237"
+        },
+        {
+          "entity": "geoId/21239"
+        },
+        {
+          "entity": "geoId/22001"
+        },
+        {
+          "entity": "geoId/22003"
+        },
+        {
+          "entity": "geoId/22005"
+        },
+        {
+          "entity": "geoId/22007"
+        },
+        {
+          "entity": "geoId/22009"
+        },
+        {
+          "entity": "geoId/22011"
+        },
+        {
+          "entity": "geoId/22013"
+        },
+        {
+          "entity": "geoId/22015"
+        },
+        {
+          "entity": "geoId/22017"
+        },
+        {
+          "entity": "geoId/22019"
+        },
+        {
+          "entity": "geoId/22021"
+        },
+        {
+          "entity": "geoId/22023"
+        },
+        {
+          "entity": "geoId/22025"
+        },
+        {
+          "entity": "geoId/22027"
+        },
+        {
+          "entity": "geoId/22029"
+        },
+        {
+          "entity": "geoId/22031"
+        },
+        {
+          "entity": "geoId/22033"
+        },
+        {
+          "entity": "geoId/22035"
+        },
+        {
+          "entity": "geoId/22037"
+        },
+        {
+          "entity": "geoId/22039"
+        },
+        {
+          "entity": "geoId/22041"
+        },
+        {
+          "entity": "geoId/22043"
+        },
+        {
+          "entity": "geoId/22045"
+        },
+        {
+          "entity": "geoId/22047"
+        },
+        {
+          "entity": "geoId/22049"
+        },
+        {
+          "entity": "geoId/22051"
+        },
+        {
+          "entity": "geoId/22053"
+        },
+        {
+          "entity": "geoId/22055"
+        },
+        {
+          "entity": "geoId/22057"
+        },
+        {
+          "entity": "geoId/22059"
+        },
+        {
+          "entity": "geoId/22061"
+        },
+        {
+          "entity": "geoId/22063"
+        },
+        {
+          "entity": "geoId/22065"
+        },
+        {
+          "entity": "geoId/22067"
+        },
+        {
+          "entity": "geoId/22069"
+        },
+        {
+          "entity": "geoId/22071"
+        },
+        {
+          "entity": "geoId/22073"
+        },
+        {
+          "entity": "geoId/22075"
+        },
+        {
+          "entity": "geoId/22077"
+        },
+        {
+          "entity": "geoId/22079"
+        },
+        {
+          "entity": "geoId/22081"
+        },
+        {
+          "entity": "geoId/22083"
+        },
+        {
+          "entity": "geoId/22085"
+        },
+        {
+          "entity": "geoId/22087"
+        },
+        {
+          "entity": "geoId/22089"
+        },
+        {
+          "entity": "geoId/22091"
+        },
+        {
+          "entity": "geoId/22093"
+        },
+        {
+          "entity": "geoId/22095"
+        },
+        {
+          "entity": "geoId/22097"
+        },
+        {
+          "entity": "geoId/22099"
+        },
+        {
+          "entity": "geoId/22101"
+        },
+        {
+          "entity": "geoId/22103"
+        },
+        {
+          "entity": "geoId/22105"
+        },
+        {
+          "entity": "geoId/22107"
+        },
+        {
+          "entity": "geoId/22109"
+        },
+        {
+          "entity": "geoId/22111"
+        },
+        {
+          "entity": "geoId/22113"
+        },
+        {
+          "entity": "geoId/22115"
+        },
+        {
+          "entity": "geoId/22117"
+        },
+        {
+          "entity": "geoId/22119"
+        },
+        {
+          "entity": "geoId/22121"
+        },
+        {
+          "entity": "geoId/22123"
+        },
+        {
+          "entity": "geoId/22125"
+        },
+        {
+          "entity": "geoId/22127"
+        },
+        {
+          "entity": "geoId/23001"
+        },
+        {
+          "entity": "geoId/23003"
+        },
+        {
+          "entity": "geoId/23005"
+        },
+        {
+          "entity": "geoId/23007"
+        },
+        {
+          "entity": "geoId/23009"
+        },
+        {
+          "entity": "geoId/23011"
+        },
+        {
+          "entity": "geoId/23013"
+        },
+        {
+          "entity": "geoId/23015"
+        },
+        {
+          "entity": "geoId/23017"
+        },
+        {
+          "entity": "geoId/23019"
+        },
+        {
+          "entity": "geoId/23021"
+        },
+        {
+          "entity": "geoId/23023"
+        },
+        {
+          "entity": "geoId/23025"
+        },
+        {
+          "entity": "geoId/23027"
+        },
+        {
+          "entity": "geoId/23029"
+        },
+        {
+          "entity": "geoId/23031"
+        },
+        {
+          "entity": "geoId/24001"
+        },
+        {
+          "entity": "geoId/24003"
+        },
+        {
+          "entity": "geoId/24005"
+        },
+        {
+          "entity": "geoId/24009"
+        },
+        {
+          "entity": "geoId/24011"
+        },
+        {
+          "entity": "geoId/24013"
+        },
+        {
+          "entity": "geoId/24015"
+        },
+        {
+          "entity": "geoId/24017"
+        },
+        {
+          "entity": "geoId/24019"
+        },
+        {
+          "entity": "geoId/24021"
+        },
+        {
+          "entity": "geoId/24023"
+        },
+        {
+          "entity": "geoId/24025"
+        },
+        {
+          "entity": "geoId/24027"
+        },
+        {
+          "entity": "geoId/24029"
+        },
+        {
+          "entity": "geoId/24031"
+        },
+        {
+          "entity": "geoId/24033"
+        },
+        {
+          "entity": "geoId/24035"
+        },
+        {
+          "entity": "geoId/24037"
+        },
+        {
+          "entity": "geoId/24039"
+        },
+        {
+          "entity": "geoId/24041"
+        },
+        {
+          "entity": "geoId/24043"
+        },
+        {
+          "entity": "geoId/24045"
+        },
+        {
+          "entity": "geoId/24047"
+        },
+        {
+          "entity": "geoId/24510"
+        },
+        {
+          "entity": "geoId/25001"
+        },
+        {
+          "entity": "geoId/25003"
+        },
+        {
+          "entity": "geoId/25005"
+        },
+        {
+          "entity": "geoId/25007"
+        },
+        {
+          "entity": "geoId/25009"
+        },
+        {
+          "entity": "geoId/25011"
+        },
+        {
+          "entity": "geoId/25013"
+        },
+        {
+          "entity": "geoId/25015"
+        },
+        {
+          "entity": "geoId/25017"
+        },
+        {
+          "entity": "geoId/25019"
+        },
+        {
+          "entity": "geoId/25021"
+        },
+        {
+          "entity": "geoId/25023"
+        },
+        {
+          "entity": "geoId/25025"
+        },
+        {
+          "entity": "geoId/25027"
+        },
+        {
+          "entity": "geoId/26001"
+        },
+        {
+          "entity": "geoId/26003"
+        },
+        {
+          "entity": "geoId/26005"
+        },
+        {
+          "entity": "geoId/26007"
+        },
+        {
+          "entity": "geoId/26009"
+        },
+        {
+          "entity": "geoId/26011"
+        },
+        {
+          "entity": "geoId/26013"
+        },
+        {
+          "entity": "geoId/26015"
+        },
+        {
+          "entity": "geoId/26017"
+        },
+        {
+          "entity": "geoId/26019"
+        },
+        {
+          "entity": "geoId/26021"
+        },
+        {
+          "entity": "geoId/26023"
+        },
+        {
+          "entity": "geoId/26025"
+        },
+        {
+          "entity": "geoId/26027"
+        },
+        {
+          "entity": "geoId/26029"
+        },
+        {
+          "entity": "geoId/26031"
+        },
+        {
+          "entity": "geoId/26033"
+        },
+        {
+          "entity": "geoId/26035"
+        },
+        {
+          "entity": "geoId/26037"
+        },
+        {
+          "entity": "geoId/26039"
+        },
+        {
+          "entity": "geoId/26041"
+        },
+        {
+          "entity": "geoId/26043"
+        },
+        {
+          "entity": "geoId/26045"
+        },
+        {
+          "entity": "geoId/26047"
+        },
+        {
+          "entity": "geoId/26049"
+        },
+        {
+          "entity": "geoId/26051"
+        },
+        {
+          "entity": "geoId/26053"
+        },
+        {
+          "entity": "geoId/26055"
+        },
+        {
+          "entity": "geoId/26057"
+        },
+        {
+          "entity": "geoId/26059"
+        },
+        {
+          "entity": "geoId/26061"
+        },
+        {
+          "entity": "geoId/26063"
+        },
+        {
+          "entity": "geoId/26065"
+        },
+        {
+          "entity": "geoId/26067"
+        },
+        {
+          "entity": "geoId/26069"
+        },
+        {
+          "entity": "geoId/26071"
+        },
+        {
+          "entity": "geoId/26073"
+        },
+        {
+          "entity": "geoId/26075"
+        },
+        {
+          "entity": "geoId/26077"
+        },
+        {
+          "entity": "geoId/26079"
+        },
+        {
+          "entity": "geoId/26081"
+        },
+        {
+          "entity": "geoId/26083"
+        },
+        {
+          "entity": "geoId/26085"
+        },
+        {
+          "entity": "geoId/26087"
+        },
+        {
+          "entity": "geoId/26089"
+        },
+        {
+          "entity": "geoId/26091"
+        },
+        {
+          "entity": "geoId/26093"
+        },
+        {
+          "entity": "geoId/26095"
+        },
+        {
+          "entity": "geoId/26097"
+        },
+        {
+          "entity": "geoId/26099"
+        },
+        {
+          "entity": "geoId/26101"
+        },
+        {
+          "entity": "geoId/26103"
+        },
+        {
+          "entity": "geoId/26105"
+        },
+        {
+          "entity": "geoId/26107"
+        },
+        {
+          "entity": "geoId/26109"
+        },
+        {
+          "entity": "geoId/26111"
+        },
+        {
+          "entity": "geoId/26113"
+        },
+        {
+          "entity": "geoId/26115"
+        },
+        {
+          "entity": "geoId/26117"
+        },
+        {
+          "entity": "geoId/26119"
+        },
+        {
+          "entity": "geoId/26121"
+        },
+        {
+          "entity": "geoId/26123"
+        },
+        {
+          "entity": "geoId/26125"
+        },
+        {
+          "entity": "geoId/26127"
+        },
+        {
+          "entity": "geoId/26129"
+        },
+        {
+          "entity": "geoId/26131"
+        },
+        {
+          "entity": "geoId/26133"
+        },
+        {
+          "entity": "geoId/26135"
+        },
+        {
+          "entity": "geoId/26137"
+        },
+        {
+          "entity": "geoId/26139"
+        },
+        {
+          "entity": "geoId/26141"
+        },
+        {
+          "entity": "geoId/26143"
+        },
+        {
+          "entity": "geoId/26145"
+        },
+        {
+          "entity": "geoId/26147"
+        },
+        {
+          "entity": "geoId/26149"
+        },
+        {
+          "entity": "geoId/26151"
+        },
+        {
+          "entity": "geoId/26153"
+        },
+        {
+          "entity": "geoId/26155"
+        },
+        {
+          "entity": "geoId/26157"
+        },
+        {
+          "entity": "geoId/26159"
+        },
+        {
+          "entity": "geoId/26161"
+        },
+        {
+          "entity": "geoId/26163"
+        },
+        {
+          "entity": "geoId/26165"
+        },
+        {
+          "entity": "geoId/27001"
+        },
+        {
+          "entity": "geoId/27003"
+        },
+        {
+          "entity": "geoId/27005"
+        },
+        {
+          "entity": "geoId/27007"
+        },
+        {
+          "entity": "geoId/27009"
+        },
+        {
+          "entity": "geoId/27011"
+        },
+        {
+          "entity": "geoId/27013"
+        },
+        {
+          "entity": "geoId/27015"
+        },
+        {
+          "entity": "geoId/27017"
+        },
+        {
+          "entity": "geoId/27019"
+        },
+        {
+          "entity": "geoId/27021"
+        },
+        {
+          "entity": "geoId/27023"
+        },
+        {
+          "entity": "geoId/27025"
+        },
+        {
+          "entity": "geoId/27027"
+        },
+        {
+          "entity": "geoId/27029"
+        },
+        {
+          "entity": "geoId/27031"
+        },
+        {
+          "entity": "geoId/27033"
+        },
+        {
+          "entity": "geoId/27035"
+        },
+        {
+          "entity": "geoId/27037"
+        },
+        {
+          "entity": "geoId/27039"
+        },
+        {
+          "entity": "geoId/27041"
+        },
+        {
+          "entity": "geoId/27043"
+        },
+        {
+          "entity": "geoId/27045"
+        },
+        {
+          "entity": "geoId/27047"
+        },
+        {
+          "entity": "geoId/27049"
+        },
+        {
+          "entity": "geoId/27051"
+        },
+        {
+          "entity": "geoId/27053"
+        },
+        {
+          "entity": "geoId/27055"
+        },
+        {
+          "entity": "geoId/27057"
+        },
+        {
+          "entity": "geoId/27059"
+        },
+        {
+          "entity": "geoId/27061"
+        },
+        {
+          "entity": "geoId/27063"
+        },
+        {
+          "entity": "geoId/27065"
+        },
+        {
+          "entity": "geoId/27067"
+        },
+        {
+          "entity": "geoId/27069"
+        },
+        {
+          "entity": "geoId/27071"
+        },
+        {
+          "entity": "geoId/27073"
+        },
+        {
+          "entity": "geoId/27075"
+        },
+        {
+          "entity": "geoId/27077"
+        },
+        {
+          "entity": "geoId/27079"
+        },
+        {
+          "entity": "geoId/27081"
+        },
+        {
+          "entity": "geoId/27083"
+        },
+        {
+          "entity": "geoId/27085"
+        },
+        {
+          "entity": "geoId/27087"
+        },
+        {
+          "entity": "geoId/27089"
+        },
+        {
+          "entity": "geoId/27091"
+        },
+        {
+          "entity": "geoId/27093"
+        },
+        {
+          "entity": "geoId/27095"
+        },
+        {
+          "entity": "geoId/27097"
+        },
+        {
+          "entity": "geoId/27099"
+        },
+        {
+          "entity": "geoId/27101"
+        },
+        {
+          "entity": "geoId/27103"
+        },
+        {
+          "entity": "geoId/27105"
+        },
+        {
+          "entity": "geoId/27107"
+        },
+        {
+          "entity": "geoId/27109"
+        },
+        {
+          "entity": "geoId/27111"
+        },
+        {
+          "entity": "geoId/27113"
+        },
+        {
+          "entity": "geoId/27115"
+        },
+        {
+          "entity": "geoId/27117"
+        },
+        {
+          "entity": "geoId/27119"
+        },
+        {
+          "entity": "geoId/27121"
+        },
+        {
+          "entity": "geoId/27123"
+        },
+        {
+          "entity": "geoId/27125"
+        },
+        {
+          "entity": "geoId/27127"
+        },
+        {
+          "entity": "geoId/27129"
+        },
+        {
+          "entity": "geoId/27131"
+        },
+        {
+          "entity": "geoId/27133"
+        },
+        {
+          "entity": "geoId/27135"
+        },
+        {
+          "entity": "geoId/27137"
+        },
+        {
+          "entity": "geoId/27139"
+        },
+        {
+          "entity": "geoId/27141"
+        },
+        {
+          "entity": "geoId/27143"
+        },
+        {
+          "entity": "geoId/27145"
+        },
+        {
+          "entity": "geoId/27147"
+        },
+        {
+          "entity": "geoId/27149"
+        },
+        {
+          "entity": "geoId/27151"
+        },
+        {
+          "entity": "geoId/27153"
+        },
+        {
+          "entity": "geoId/27155"
+        },
+        {
+          "entity": "geoId/27157"
+        },
+        {
+          "entity": "geoId/27159"
+        },
+        {
+          "entity": "geoId/27161"
+        },
+        {
+          "entity": "geoId/27163"
+        },
+        {
+          "entity": "geoId/27165"
+        },
+        {
+          "entity": "geoId/27167"
+        },
+        {
+          "entity": "geoId/27169"
+        },
+        {
+          "entity": "geoId/27171"
+        },
+        {
+          "entity": "geoId/27173"
+        },
+        {
+          "entity": "geoId/28001"
+        },
+        {
+          "entity": "geoId/28003"
+        },
+        {
+          "entity": "geoId/28005"
+        },
+        {
+          "entity": "geoId/28007"
+        },
+        {
+          "entity": "geoId/28009"
+        },
+        {
+          "entity": "geoId/28011"
+        },
+        {
+          "entity": "geoId/28013"
+        },
+        {
+          "entity": "geoId/28015"
+        },
+        {
+          "entity": "geoId/28017"
+        },
+        {
+          "entity": "geoId/28019"
+        },
+        {
+          "entity": "geoId/28021"
+        },
+        {
+          "entity": "geoId/28023"
+        },
+        {
+          "entity": "geoId/28025"
+        },
+        {
+          "entity": "geoId/28027"
+        },
+        {
+          "entity": "geoId/28029"
+        },
+        {
+          "entity": "geoId/28031"
+        },
+        {
+          "entity": "geoId/28033"
+        },
+        {
+          "entity": "geoId/28035"
+        },
+        {
+          "entity": "geoId/28037"
+        },
+        {
+          "entity": "geoId/28039"
+        },
+        {
+          "entity": "geoId/28041"
+        },
+        {
+          "entity": "geoId/28043"
+        },
+        {
+          "entity": "geoId/28045"
+        },
+        {
+          "entity": "geoId/28047"
+        },
+        {
+          "entity": "geoId/28049"
+        },
+        {
+          "entity": "geoId/28051"
+        },
+        {
+          "entity": "geoId/28053"
+        },
+        {
+          "entity": "geoId/28055"
+        },
+        {
+          "entity": "geoId/28057"
+        },
+        {
+          "entity": "geoId/28059"
+        },
+        {
+          "entity": "geoId/28061"
+        },
+        {
+          "entity": "geoId/28063"
+        },
+        {
+          "entity": "geoId/28065"
+        },
+        {
+          "entity": "geoId/28067"
+        },
+        {
+          "entity": "geoId/28069"
+        },
+        {
+          "entity": "geoId/28071"
+        },
+        {
+          "entity": "geoId/28073"
+        },
+        {
+          "entity": "geoId/28075"
+        },
+        {
+          "entity": "geoId/28077"
+        },
+        {
+          "entity": "geoId/28079"
+        },
+        {
+          "entity": "geoId/28081"
+        },
+        {
+          "entity": "geoId/28083"
+        },
+        {
+          "entity": "geoId/28085"
+        },
+        {
+          "entity": "geoId/28087"
+        },
+        {
+          "entity": "geoId/28089"
+        },
+        {
+          "entity": "geoId/28091"
+        },
+        {
+          "entity": "geoId/28093"
+        },
+        {
+          "entity": "geoId/28095"
+        },
+        {
+          "entity": "geoId/28097"
+        },
+        {
+          "entity": "geoId/28099"
+        },
+        {
+          "entity": "geoId/28101"
+        },
+        {
+          "entity": "geoId/28103"
+        },
+        {
+          "entity": "geoId/28105"
+        },
+        {
+          "entity": "geoId/28107"
+        },
+        {
+          "entity": "geoId/28109"
+        },
+        {
+          "entity": "geoId/28111"
+        },
+        {
+          "entity": "geoId/28113"
+        },
+        {
+          "entity": "geoId/28115"
+        },
+        {
+          "entity": "geoId/28117"
+        },
+        {
+          "entity": "geoId/28119"
+        },
+        {
+          "entity": "geoId/28121"
+        },
+        {
+          "entity": "geoId/28123"
+        },
+        {
+          "entity": "geoId/28125"
+        },
+        {
+          "entity": "geoId/28127"
+        },
+        {
+          "entity": "geoId/28129"
+        },
+        {
+          "entity": "geoId/28131"
+        },
+        {
+          "entity": "geoId/28133"
+        },
+        {
+          "entity": "geoId/28135"
+        },
+        {
+          "entity": "geoId/28137"
+        },
+        {
+          "entity": "geoId/28139"
+        },
+        {
+          "entity": "geoId/28141"
+        },
+        {
+          "entity": "geoId/28143"
+        },
+        {
+          "entity": "geoId/28145"
+        },
+        {
+          "entity": "geoId/28147"
+        },
+        {
+          "entity": "geoId/28149"
+        },
+        {
+          "entity": "geoId/28151"
+        },
+        {
+          "entity": "geoId/28153"
+        },
+        {
+          "entity": "geoId/28155"
+        },
+        {
+          "entity": "geoId/28157"
+        },
+        {
+          "entity": "geoId/28159"
+        },
+        {
+          "entity": "geoId/28161"
+        },
+        {
+          "entity": "geoId/28163"
+        },
+        {
+          "entity": "geoId/29001"
+        },
+        {
+          "entity": "geoId/29003"
+        },
+        {
+          "entity": "geoId/29005"
+        },
+        {
+          "entity": "geoId/29007"
+        },
+        {
+          "entity": "geoId/29009"
+        },
+        {
+          "entity": "geoId/29011"
+        },
+        {
+          "entity": "geoId/29013"
+        },
+        {
+          "entity": "geoId/29015"
+        },
+        {
+          "entity": "geoId/29017"
+        },
+        {
+          "entity": "geoId/29019"
+        },
+        {
+          "entity": "geoId/29021"
+        },
+        {
+          "entity": "geoId/29023"
+        },
+        {
+          "entity": "geoId/29025"
+        },
+        {
+          "entity": "geoId/29027"
+        },
+        {
+          "entity": "geoId/29029"
+        },
+        {
+          "entity": "geoId/29031"
+        },
+        {
+          "entity": "geoId/29033"
+        },
+        {
+          "entity": "geoId/29035"
+        },
+        {
+          "entity": "geoId/29037"
+        },
+        {
+          "entity": "geoId/29039"
+        },
+        {
+          "entity": "geoId/29041"
+        },
+        {
+          "entity": "geoId/29043"
+        },
+        {
+          "entity": "geoId/29045"
+        },
+        {
+          "entity": "geoId/29047"
+        },
+        {
+          "entity": "geoId/29049"
+        },
+        {
+          "entity": "geoId/29051"
+        },
+        {
+          "entity": "geoId/29053"
+        },
+        {
+          "entity": "geoId/29055"
+        },
+        {
+          "entity": "geoId/29057"
+        },
+        {
+          "entity": "geoId/29059"
+        },
+        {
+          "entity": "geoId/29061"
+        },
+        {
+          "entity": "geoId/29063"
+        },
+        {
+          "entity": "geoId/29065"
+        },
+        {
+          "entity": "geoId/29067"
+        },
+        {
+          "entity": "geoId/29069"
+        },
+        {
+          "entity": "geoId/29071"
+        },
+        {
+          "entity": "geoId/29073"
+        },
+        {
+          "entity": "geoId/29075"
+        },
+        {
+          "entity": "geoId/29077"
+        },
+        {
+          "entity": "geoId/29079"
+        },
+        {
+          "entity": "geoId/29081"
+        },
+        {
+          "entity": "geoId/29083"
+        },
+        {
+          "entity": "geoId/29085"
+        },
+        {
+          "entity": "geoId/29087"
+        },
+        {
+          "entity": "geoId/29089"
+        },
+        {
+          "entity": "geoId/29091"
+        },
+        {
+          "entity": "geoId/29093"
+        },
+        {
+          "entity": "geoId/29095"
+        },
+        {
+          "entity": "geoId/29097"
+        },
+        {
+          "entity": "geoId/29099"
+        },
+        {
+          "entity": "geoId/29101"
+        },
+        {
+          "entity": "geoId/29103"
+        },
+        {
+          "entity": "geoId/29105"
+        },
+        {
+          "entity": "geoId/29107"
+        },
+        {
+          "entity": "geoId/29109"
+        },
+        {
+          "entity": "geoId/29111"
+        },
+        {
+          "entity": "geoId/29113"
+        },
+        {
+          "entity": "geoId/29115"
+        },
+        {
+          "entity": "geoId/29117"
+        },
+        {
+          "entity": "geoId/29119"
+        },
+        {
+          "entity": "geoId/29121"
+        },
+        {
+          "entity": "geoId/29123"
+        },
+        {
+          "entity": "geoId/29125"
+        },
+        {
+          "entity": "geoId/29127"
+        },
+        {
+          "entity": "geoId/29129"
+        },
+        {
+          "entity": "geoId/29131"
+        },
+        {
+          "entity": "geoId/29133"
+        },
+        {
+          "entity": "geoId/29135"
+        },
+        {
+          "entity": "geoId/29137"
+        },
+        {
+          "entity": "geoId/29139"
+        },
+        {
+          "entity": "geoId/29141"
+        },
+        {
+          "entity": "geoId/29143"
+        },
+        {
+          "entity": "geoId/29145"
+        },
+        {
+          "entity": "geoId/29147"
+        },
+        {
+          "entity": "geoId/29149"
+        },
+        {
+          "entity": "geoId/29151"
+        },
+        {
+          "entity": "geoId/29153"
+        },
+        {
+          "entity": "geoId/29155"
+        },
+        {
+          "entity": "geoId/29157"
+        },
+        {
+          "entity": "geoId/29159"
+        },
+        {
+          "entity": "geoId/29161"
+        },
+        {
+          "entity": "geoId/29163"
+        },
+        {
+          "entity": "geoId/29165"
+        },
+        {
+          "entity": "geoId/29167"
+        },
+        {
+          "entity": "geoId/29169"
+        },
+        {
+          "entity": "geoId/29171"
+        },
+        {
+          "entity": "geoId/29173"
+        },
+        {
+          "entity": "geoId/29175"
+        },
+        {
+          "entity": "geoId/29177"
+        },
+        {
+          "entity": "geoId/29179"
+        },
+        {
+          "entity": "geoId/29181"
+        },
+        {
+          "entity": "geoId/29183"
+        },
+        {
+          "entity": "geoId/29185"
+        },
+        {
+          "entity": "geoId/29186"
+        },
+        {
+          "entity": "geoId/29187"
+        },
+        {
+          "entity": "geoId/29189"
+        },
+        {
+          "entity": "geoId/29195"
+        },
+        {
+          "entity": "geoId/29197"
+        },
+        {
+          "entity": "geoId/29199"
+        },
+        {
+          "entity": "geoId/29201"
+        },
+        {
+          "entity": "geoId/29203"
+        },
+        {
+          "entity": "geoId/29205"
+        },
+        {
+          "entity": "geoId/29207"
+        },
+        {
+          "entity": "geoId/29209"
+        },
+        {
+          "entity": "geoId/29211"
+        },
+        {
+          "entity": "geoId/29213"
+        },
+        {
+          "entity": "geoId/29215"
+        },
+        {
+          "entity": "geoId/29217"
+        },
+        {
+          "entity": "geoId/29219"
+        },
+        {
+          "entity": "geoId/29221"
+        },
+        {
+          "entity": "geoId/29223"
+        },
+        {
+          "entity": "geoId/29225"
+        },
+        {
+          "entity": "geoId/29227"
+        },
+        {
+          "entity": "geoId/29229"
+        },
+        {
+          "entity": "geoId/29510"
+        },
+        {
+          "entity": "geoId/30001"
+        },
+        {
+          "entity": "geoId/30003"
+        },
+        {
+          "entity": "geoId/30005"
+        },
+        {
+          "entity": "geoId/30007"
+        },
+        {
+          "entity": "geoId/30009"
+        },
+        {
+          "entity": "geoId/30011"
+        },
+        {
+          "entity": "geoId/30013"
+        },
+        {
+          "entity": "geoId/30015"
+        },
+        {
+          "entity": "geoId/30017"
+        },
+        {
+          "entity": "geoId/30019"
+        },
+        {
+          "entity": "geoId/30021"
+        },
+        {
+          "entity": "geoId/30023"
+        },
+        {
+          "entity": "geoId/30025"
+        },
+        {
+          "entity": "geoId/30027"
+        },
+        {
+          "entity": "geoId/30029"
+        },
+        {
+          "entity": "geoId/30031"
+        },
+        {
+          "entity": "geoId/30033"
+        },
+        {
+          "entity": "geoId/30035"
+        },
+        {
+          "entity": "geoId/30037"
+        },
+        {
+          "entity": "geoId/30039"
+        },
+        {
+          "entity": "geoId/30041"
+        },
+        {
+          "entity": "geoId/30043"
+        },
+        {
+          "entity": "geoId/30045"
+        },
+        {
+          "entity": "geoId/30047"
+        },
+        {
+          "entity": "geoId/30049"
+        },
+        {
+          "entity": "geoId/30051"
+        },
+        {
+          "entity": "geoId/30053"
+        },
+        {
+          "entity": "geoId/30055"
+        },
+        {
+          "entity": "geoId/30057"
+        },
+        {
+          "entity": "geoId/30059"
+        },
+        {
+          "entity": "geoId/30061"
+        },
+        {
+          "entity": "geoId/30063"
+        },
+        {
+          "entity": "geoId/30065"
+        },
+        {
+          "entity": "geoId/30067"
+        },
+        {
+          "entity": "geoId/30069"
+        },
+        {
+          "entity": "geoId/30071"
+        },
+        {
+          "entity": "geoId/30073"
+        },
+        {
+          "entity": "geoId/30075"
+        },
+        {
+          "entity": "geoId/30077"
+        },
+        {
+          "entity": "geoId/30079"
+        },
+        {
+          "entity": "geoId/30081"
+        },
+        {
+          "entity": "geoId/30083"
+        },
+        {
+          "entity": "geoId/30085"
+        },
+        {
+          "entity": "geoId/30087"
+        },
+        {
+          "entity": "geoId/30089"
+        },
+        {
+          "entity": "geoId/30091"
+        },
+        {
+          "entity": "geoId/30093"
+        },
+        {
+          "entity": "geoId/30095"
+        },
+        {
+          "entity": "geoId/30097"
+        },
+        {
+          "entity": "geoId/30099"
+        },
+        {
+          "entity": "geoId/30101"
+        },
+        {
+          "entity": "geoId/30103"
+        },
+        {
+          "entity": "geoId/30105"
+        },
+        {
+          "entity": "geoId/30107"
+        },
+        {
+          "entity": "geoId/30109"
+        },
+        {
+          "entity": "geoId/30111"
+        },
+        {
+          "entity": "geoId/31001"
+        },
+        {
+          "entity": "geoId/31003"
+        },
+        {
+          "entity": "geoId/31005"
+        },
+        {
+          "entity": "geoId/31007"
+        },
+        {
+          "entity": "geoId/31009"
+        },
+        {
+          "entity": "geoId/31011"
+        },
+        {
+          "entity": "geoId/31013"
+        },
+        {
+          "entity": "geoId/31015"
+        },
+        {
+          "entity": "geoId/31017"
+        },
+        {
+          "entity": "geoId/31019"
+        },
+        {
+          "entity": "geoId/31021"
+        },
+        {
+          "entity": "geoId/31023"
+        },
+        {
+          "entity": "geoId/31025"
+        },
+        {
+          "entity": "geoId/31027"
+        },
+        {
+          "entity": "geoId/31029"
+        },
+        {
+          "entity": "geoId/31031"
+        },
+        {
+          "entity": "geoId/31033"
+        },
+        {
+          "entity": "geoId/31035"
+        },
+        {
+          "entity": "geoId/31037"
+        },
+        {
+          "entity": "geoId/31039"
+        },
+        {
+          "entity": "geoId/31041"
+        },
+        {
+          "entity": "geoId/31043"
+        },
+        {
+          "entity": "geoId/31045"
+        },
+        {
+          "entity": "geoId/31047"
+        },
+        {
+          "entity": "geoId/31049"
+        },
+        {
+          "entity": "geoId/31051"
+        },
+        {
+          "entity": "geoId/31053"
+        },
+        {
+          "entity": "geoId/31055"
+        },
+        {
+          "entity": "geoId/31057"
+        },
+        {
+          "entity": "geoId/31059"
+        },
+        {
+          "entity": "geoId/31061"
+        },
+        {
+          "entity": "geoId/31063"
+        },
+        {
+          "entity": "geoId/31065"
+        },
+        {
+          "entity": "geoId/31067"
+        },
+        {
+          "entity": "geoId/31069"
+        },
+        {
+          "entity": "geoId/31071"
+        },
+        {
+          "entity": "geoId/31073"
+        },
+        {
+          "entity": "geoId/31075"
+        },
+        {
+          "entity": "geoId/31077"
+        },
+        {
+          "entity": "geoId/31079"
+        },
+        {
+          "entity": "geoId/31081"
+        },
+        {
+          "entity": "geoId/31083"
+        },
+        {
+          "entity": "geoId/31085"
+        },
+        {
+          "entity": "geoId/31087"
+        },
+        {
+          "entity": "geoId/31089"
+        },
+        {
+          "entity": "geoId/31091"
+        },
+        {
+          "entity": "geoId/31093"
+        },
+        {
+          "entity": "geoId/31095"
+        },
+        {
+          "entity": "geoId/31097"
+        },
+        {
+          "entity": "geoId/31099"
+        },
+        {
+          "entity": "geoId/31101"
+        },
+        {
+          "entity": "geoId/31103"
+        },
+        {
+          "entity": "geoId/31105"
+        },
+        {
+          "entity": "geoId/31107"
+        },
+        {
+          "entity": "geoId/31109"
+        },
+        {
+          "entity": "geoId/31111"
+        },
+        {
+          "entity": "geoId/31113"
+        },
+        {
+          "entity": "geoId/31115"
+        },
+        {
+          "entity": "geoId/31117"
+        },
+        {
+          "entity": "geoId/31119"
+        },
+        {
+          "entity": "geoId/31121"
+        },
+        {
+          "entity": "geoId/31123"
+        },
+        {
+          "entity": "geoId/31125"
+        },
+        {
+          "entity": "geoId/31127"
+        },
+        {
+          "entity": "geoId/31129"
+        },
+        {
+          "entity": "geoId/31131"
+        },
+        {
+          "entity": "geoId/31133"
+        },
+        {
+          "entity": "geoId/31135"
+        },
+        {
+          "entity": "geoId/31137"
+        },
+        {
+          "entity": "geoId/31139"
+        },
+        {
+          "entity": "geoId/31141"
+        },
+        {
+          "entity": "geoId/31143"
+        },
+        {
+          "entity": "geoId/31145"
+        },
+        {
+          "entity": "geoId/31147"
+        },
+        {
+          "entity": "geoId/31149"
+        },
+        {
+          "entity": "geoId/31151"
+        },
+        {
+          "entity": "geoId/31153"
+        },
+        {
+          "entity": "geoId/31155"
+        },
+        {
+          "entity": "geoId/31157"
+        },
+        {
+          "entity": "geoId/31159"
+        },
+        {
+          "entity": "geoId/31161"
+        },
+        {
+          "entity": "geoId/31163"
+        },
+        {
+          "entity": "geoId/31165"
+        },
+        {
+          "entity": "geoId/31167"
+        },
+        {
+          "entity": "geoId/31169"
+        },
+        {
+          "entity": "geoId/31171"
+        },
+        {
+          "entity": "geoId/31173"
+        },
+        {
+          "entity": "geoId/31175"
+        },
+        {
+          "entity": "geoId/31177"
+        },
+        {
+          "entity": "geoId/31179"
+        },
+        {
+          "entity": "geoId/31181"
+        },
+        {
+          "entity": "geoId/31183"
+        },
+        {
+          "entity": "geoId/31185"
+        },
+        {
+          "entity": "geoId/32001"
+        },
+        {
+          "entity": "geoId/32003"
+        },
+        {
+          "entity": "geoId/32005"
+        },
+        {
+          "entity": "geoId/32007"
+        },
+        {
+          "entity": "geoId/32009"
+        },
+        {
+          "entity": "geoId/32011"
+        },
+        {
+          "entity": "geoId/32013"
+        },
+        {
+          "entity": "geoId/32015"
+        },
+        {
+          "entity": "geoId/32017"
+        },
+        {
+          "entity": "geoId/32019"
+        },
+        {
+          "entity": "geoId/32021"
+        },
+        {
+          "entity": "geoId/32023"
+        },
+        {
+          "entity": "geoId/32027"
+        },
+        {
+          "entity": "geoId/32029"
+        },
+        {
+          "entity": "geoId/32031"
+        },
+        {
+          "entity": "geoId/32033"
+        },
+        {
+          "entity": "geoId/32510"
+        },
+        {
+          "entity": "geoId/33001"
+        },
+        {
+          "entity": "geoId/33003"
+        },
+        {
+          "entity": "geoId/33005"
+        },
+        {
+          "entity": "geoId/33007"
+        },
+        {
+          "entity": "geoId/33009"
+        },
+        {
+          "entity": "geoId/33011"
+        },
+        {
+          "entity": "geoId/33013"
+        },
+        {
+          "entity": "geoId/33015"
+        },
+        {
+          "entity": "geoId/33017"
+        },
+        {
+          "entity": "geoId/33019"
+        },
+        {
+          "entity": "geoId/34001"
+        },
+        {
+          "entity": "geoId/34003"
+        },
+        {
+          "entity": "geoId/34005"
+        },
+        {
+          "entity": "geoId/34007"
+        },
+        {
+          "entity": "geoId/34009"
+        },
+        {
+          "entity": "geoId/34011"
+        },
+        {
+          "entity": "geoId/34013"
+        },
+        {
+          "entity": "geoId/34015"
+        },
+        {
+          "entity": "geoId/34017"
+        },
+        {
+          "entity": "geoId/34019"
+        },
+        {
+          "entity": "geoId/34021"
+        },
+        {
+          "entity": "geoId/34023"
+        },
+        {
+          "entity": "geoId/34025"
+        },
+        {
+          "entity": "geoId/34027"
+        },
+        {
+          "entity": "geoId/34029"
+        },
+        {
+          "entity": "geoId/34031"
+        },
+        {
+          "entity": "geoId/34033"
+        },
+        {
+          "entity": "geoId/34035"
+        },
+        {
+          "entity": "geoId/34037"
+        },
+        {
+          "entity": "geoId/34039"
+        },
+        {
+          "entity": "geoId/34041"
+        },
+        {
+          "entity": "geoId/35001"
+        },
+        {
+          "entity": "geoId/35003"
+        },
+        {
+          "entity": "geoId/35005"
+        },
+        {
+          "entity": "geoId/35006"
+        },
+        {
+          "entity": "geoId/35007"
+        },
+        {
+          "entity": "geoId/35009"
+        },
+        {
+          "entity": "geoId/35011"
+        },
+        {
+          "entity": "geoId/35013"
+        },
+        {
+          "entity": "geoId/35015"
+        },
+        {
+          "entity": "geoId/35017"
+        },
+        {
+          "entity": "geoId/35019"
+        },
+        {
+          "entity": "geoId/35021"
+        },
+        {
+          "entity": "geoId/35023"
+        },
+        {
+          "entity": "geoId/35025"
+        },
+        {
+          "entity": "geoId/35027"
+        },
+        {
+          "entity": "geoId/35028"
+        },
+        {
+          "entity": "geoId/35029"
+        },
+        {
+          "entity": "geoId/35031"
+        },
+        {
+          "entity": "geoId/35033"
+        },
+        {
+          "entity": "geoId/35035"
+        },
+        {
+          "entity": "geoId/35037"
+        },
+        {
+          "entity": "geoId/35039"
+        },
+        {
+          "entity": "geoId/35041"
+        },
+        {
+          "entity": "geoId/35043"
+        },
+        {
+          "entity": "geoId/35045"
+        },
+        {
+          "entity": "geoId/35047"
+        },
+        {
+          "entity": "geoId/35049"
+        },
+        {
+          "entity": "geoId/35051"
+        },
+        {
+          "entity": "geoId/35053"
+        },
+        {
+          "entity": "geoId/35055"
+        },
+        {
+          "entity": "geoId/35057"
+        },
+        {
+          "entity": "geoId/35059"
+        },
+        {
+          "entity": "geoId/35061"
+        },
+        {
+          "entity": "geoId/36001"
+        },
+        {
+          "entity": "geoId/36003"
+        },
+        {
+          "entity": "geoId/36005"
+        },
+        {
+          "entity": "geoId/36007"
+        },
+        {
+          "entity": "geoId/36009"
+        },
+        {
+          "entity": "geoId/36011"
+        },
+        {
+          "entity": "geoId/36013"
+        },
+        {
+          "entity": "geoId/36015"
+        },
+        {
+          "entity": "geoId/36017"
+        },
+        {
+          "entity": "geoId/36019"
+        },
+        {
+          "entity": "geoId/36021"
+        },
+        {
+          "entity": "geoId/36023"
+        },
+        {
+          "entity": "geoId/36025"
+        },
+        {
+          "entity": "geoId/36027"
+        },
+        {
+          "entity": "geoId/36029"
+        },
+        {
+          "entity": "geoId/36031"
+        },
+        {
+          "entity": "geoId/36033"
+        },
+        {
+          "entity": "geoId/36035"
+        },
+        {
+          "entity": "geoId/36037"
+        },
+        {
+          "entity": "geoId/36039"
+        },
+        {
+          "entity": "geoId/36041"
+        },
+        {
+          "entity": "geoId/36043"
+        },
+        {
+          "entity": "geoId/36045"
+        },
+        {
+          "entity": "geoId/36047"
+        },
+        {
+          "entity": "geoId/36049"
+        },
+        {
+          "entity": "geoId/36051"
+        },
+        {
+          "entity": "geoId/36053"
+        },
+        {
+          "entity": "geoId/36055"
+        },
+        {
+          "entity": "geoId/36057"
+        },
+        {
+          "entity": "geoId/36059"
+        },
+        {
+          "entity": "geoId/36061"
+        },
+        {
+          "entity": "geoId/36063"
+        },
+        {
+          "entity": "geoId/36065"
+        },
+        {
+          "entity": "geoId/36067"
+        },
+        {
+          "entity": "geoId/36069"
+        },
+        {
+          "entity": "geoId/36071"
+        },
+        {
+          "entity": "geoId/36073"
+        },
+        {
+          "entity": "geoId/36075"
+        },
+        {
+          "entity": "geoId/36077"
+        },
+        {
+          "entity": "geoId/36079"
+        },
+        {
+          "entity": "geoId/36081"
+        },
+        {
+          "entity": "geoId/36083"
+        },
+        {
+          "entity": "geoId/36085"
+        },
+        {
+          "entity": "geoId/36087"
+        },
+        {
+          "entity": "geoId/36089"
+        },
+        {
+          "entity": "geoId/36091"
+        },
+        {
+          "entity": "geoId/36093"
+        },
+        {
+          "entity": "geoId/36095"
+        },
+        {
+          "entity": "geoId/36097"
+        },
+        {
+          "entity": "geoId/36099"
+        },
+        {
+          "entity": "geoId/36101"
+        },
+        {
+          "entity": "geoId/36103"
+        },
+        {
+          "entity": "geoId/36105"
+        },
+        {
+          "entity": "geoId/36107"
+        },
+        {
+          "entity": "geoId/36109"
+        },
+        {
+          "entity": "geoId/36111"
+        },
+        {
+          "entity": "geoId/36113"
+        },
+        {
+          "entity": "geoId/36115"
+        },
+        {
+          "entity": "geoId/36117"
+        },
+        {
+          "entity": "geoId/36119"
+        },
+        {
+          "entity": "geoId/36121"
+        },
+        {
+          "entity": "geoId/36123"
+        },
+        {
+          "entity": "geoId/37001"
+        },
+        {
+          "entity": "geoId/37003"
+        },
+        {
+          "entity": "geoId/37005"
+        },
+        {
+          "entity": "geoId/37007"
+        },
+        {
+          "entity": "geoId/37009"
+        },
+        {
+          "entity": "geoId/37011"
+        },
+        {
+          "entity": "geoId/37013"
+        },
+        {
+          "entity": "geoId/37015"
+        },
+        {
+          "entity": "geoId/37017"
+        },
+        {
+          "entity": "geoId/37019"
+        },
+        {
+          "entity": "geoId/37021"
+        },
+        {
+          "entity": "geoId/37023"
+        },
+        {
+          "entity": "geoId/37025"
+        },
+        {
+          "entity": "geoId/37027"
+        },
+        {
+          "entity": "geoId/37029"
+        },
+        {
+          "entity": "geoId/37031"
+        },
+        {
+          "entity": "geoId/37033"
+        },
+        {
+          "entity": "geoId/37035"
+        },
+        {
+          "entity": "geoId/37037"
+        },
+        {
+          "entity": "geoId/37039"
+        },
+        {
+          "entity": "geoId/37041"
+        },
+        {
+          "entity": "geoId/37043"
+        },
+        {
+          "entity": "geoId/37045"
+        },
+        {
+          "entity": "geoId/37047"
+        },
+        {
+          "entity": "geoId/37049"
+        },
+        {
+          "entity": "geoId/37051"
+        },
+        {
+          "entity": "geoId/37053"
+        },
+        {
+          "entity": "geoId/37055"
+        },
+        {
+          "entity": "geoId/37057"
+        },
+        {
+          "entity": "geoId/37059"
+        },
+        {
+          "entity": "geoId/37061"
+        },
+        {
+          "entity": "geoId/37063"
+        },
+        {
+          "entity": "geoId/37065"
+        },
+        {
+          "entity": "geoId/37067"
+        },
+        {
+          "entity": "geoId/37069"
+        },
+        {
+          "entity": "geoId/37071"
+        },
+        {
+          "entity": "geoId/37073"
+        },
+        {
+          "entity": "geoId/37075"
+        },
+        {
+          "entity": "geoId/37077"
+        },
+        {
+          "entity": "geoId/37079"
+        },
+        {
+          "entity": "geoId/37081"
+        },
+        {
+          "entity": "geoId/37083"
+        },
+        {
+          "entity": "geoId/37085"
+        },
+        {
+          "entity": "geoId/37087"
+        },
+        {
+          "entity": "geoId/37089"
+        },
+        {
+          "entity": "geoId/37091"
+        },
+        {
+          "entity": "geoId/37093"
+        },
+        {
+          "entity": "geoId/37095"
+        },
+        {
+          "entity": "geoId/37097"
+        },
+        {
+          "entity": "geoId/37099"
+        },
+        {
+          "entity": "geoId/37101"
+        },
+        {
+          "entity": "geoId/37103"
+        },
+        {
+          "entity": "geoId/37105"
+        },
+        {
+          "entity": "geoId/37107"
+        },
+        {
+          "entity": "geoId/37109"
+        },
+        {
+          "entity": "geoId/37111"
+        },
+        {
+          "entity": "geoId/37113"
+        },
+        {
+          "entity": "geoId/37115"
+        },
+        {
+          "entity": "geoId/37117"
+        },
+        {
+          "entity": "geoId/37119"
+        },
+        {
+          "entity": "geoId/37121"
+        },
+        {
+          "entity": "geoId/37123"
+        },
+        {
+          "entity": "geoId/37125"
+        },
+        {
+          "entity": "geoId/37127"
+        },
+        {
+          "entity": "geoId/37129"
+        },
+        {
+          "entity": "geoId/37131"
+        },
+        {
+          "entity": "geoId/37133"
+        },
+        {
+          "entity": "geoId/37135"
+        },
+        {
+          "entity": "geoId/37137"
+        },
+        {
+          "entity": "geoId/37139"
+        },
+        {
+          "entity": "geoId/37141"
+        },
+        {
+          "entity": "geoId/37143"
+        },
+        {
+          "entity": "geoId/37145"
+        },
+        {
+          "entity": "geoId/37147"
+        },
+        {
+          "entity": "geoId/37149"
+        },
+        {
+          "entity": "geoId/37151"
+        },
+        {
+          "entity": "geoId/37153"
+        },
+        {
+          "entity": "geoId/37155"
+        },
+        {
+          "entity": "geoId/37157"
+        },
+        {
+          "entity": "geoId/37159"
+        },
+        {
+          "entity": "geoId/37161"
+        },
+        {
+          "entity": "geoId/37163"
+        },
+        {
+          "entity": "geoId/37165"
+        },
+        {
+          "entity": "geoId/37167"
+        },
+        {
+          "entity": "geoId/37169"
+        },
+        {
+          "entity": "geoId/37171"
+        },
+        {
+          "entity": "geoId/37173"
+        },
+        {
+          "entity": "geoId/37175"
+        },
+        {
+          "entity": "geoId/37177"
+        },
+        {
+          "entity": "geoId/37179"
+        },
+        {
+          "entity": "geoId/37181"
+        },
+        {
+          "entity": "geoId/37183"
+        },
+        {
+          "entity": "geoId/37185"
+        },
+        {
+          "entity": "geoId/37187"
+        },
+        {
+          "entity": "geoId/37189"
+        },
+        {
+          "entity": "geoId/37191"
+        },
+        {
+          "entity": "geoId/37193"
+        },
+        {
+          "entity": "geoId/37195"
+        },
+        {
+          "entity": "geoId/37197"
+        },
+        {
+          "entity": "geoId/37199"
+        },
+        {
+          "entity": "geoId/38001"
+        },
+        {
+          "entity": "geoId/38003"
+        },
+        {
+          "entity": "geoId/38005"
+        },
+        {
+          "entity": "geoId/38007"
+        },
+        {
+          "entity": "geoId/38009"
+        },
+        {
+          "entity": "geoId/38011"
+        },
+        {
+          "entity": "geoId/38013"
+        },
+        {
+          "entity": "geoId/38015"
+        },
+        {
+          "entity": "geoId/38017"
+        },
+        {
+          "entity": "geoId/38019"
+        },
+        {
+          "entity": "geoId/38021"
+        },
+        {
+          "entity": "geoId/38023"
+        },
+        {
+          "entity": "geoId/38025"
+        },
+        {
+          "entity": "geoId/38027"
+        },
+        {
+          "entity": "geoId/38029"
+        },
+        {
+          "entity": "geoId/38031"
+        },
+        {
+          "entity": "geoId/38033"
+        },
+        {
+          "entity": "geoId/38035"
+        },
+        {
+          "entity": "geoId/38037"
+        },
+        {
+          "entity": "geoId/38039"
+        },
+        {
+          "entity": "geoId/38041"
+        },
+        {
+          "entity": "geoId/38043"
+        },
+        {
+          "entity": "geoId/38045"
+        },
+        {
+          "entity": "geoId/38047"
+        },
+        {
+          "entity": "geoId/38049"
+        },
+        {
+          "entity": "geoId/38051"
+        },
+        {
+          "entity": "geoId/38053"
+        },
+        {
+          "entity": "geoId/38055"
+        },
+        {
+          "entity": "geoId/38057"
+        },
+        {
+          "entity": "geoId/38059"
+        },
+        {
+          "entity": "geoId/38061"
+        },
+        {
+          "entity": "geoId/38063"
+        },
+        {
+          "entity": "geoId/38065"
+        },
+        {
+          "entity": "geoId/38067"
+        },
+        {
+          "entity": "geoId/38069"
+        },
+        {
+          "entity": "geoId/38071"
+        },
+        {
+          "entity": "geoId/38073"
+        },
+        {
+          "entity": "geoId/38075"
+        },
+        {
+          "entity": "geoId/38077"
+        },
+        {
+          "entity": "geoId/38079"
+        },
+        {
+          "entity": "geoId/38081"
+        },
+        {
+          "entity": "geoId/38083"
+        },
+        {
+          "entity": "geoId/38085"
+        },
+        {
+          "entity": "geoId/38087"
+        },
+        {
+          "entity": "geoId/38089"
+        },
+        {
+          "entity": "geoId/38091"
+        },
+        {
+          "entity": "geoId/38093"
+        },
+        {
+          "entity": "geoId/38095"
+        },
+        {
+          "entity": "geoId/38097"
+        },
+        {
+          "entity": "geoId/38099"
+        },
+        {
+          "entity": "geoId/38101"
+        },
+        {
+          "entity": "geoId/38103"
+        },
+        {
+          "entity": "geoId/38105"
+        },
+        {
+          "entity": "geoId/39001"
+        },
+        {
+          "entity": "geoId/39003"
+        },
+        {
+          "entity": "geoId/39005"
+        },
+        {
+          "entity": "geoId/39007"
+        },
+        {
+          "entity": "geoId/39009"
+        },
+        {
+          "entity": "geoId/39011"
+        },
+        {
+          "entity": "geoId/39013"
+        },
+        {
+          "entity": "geoId/39015"
+        },
+        {
+          "entity": "geoId/39017"
+        },
+        {
+          "entity": "geoId/39019"
+        },
+        {
+          "entity": "geoId/39021"
+        },
+        {
+          "entity": "geoId/39023"
+        },
+        {
+          "entity": "geoId/39025"
+        },
+        {
+          "entity": "geoId/39027"
+        },
+        {
+          "entity": "geoId/39029"
+        },
+        {
+          "entity": "geoId/39031"
+        },
+        {
+          "entity": "geoId/39033"
+        },
+        {
+          "entity": "geoId/39035"
+        },
+        {
+          "entity": "geoId/39037"
+        },
+        {
+          "entity": "geoId/39039"
+        },
+        {
+          "entity": "geoId/39041"
+        },
+        {
+          "entity": "geoId/39043"
+        },
+        {
+          "entity": "geoId/39045"
+        },
+        {
+          "entity": "geoId/39047"
+        },
+        {
+          "entity": "geoId/39049"
+        },
+        {
+          "entity": "geoId/39051"
+        },
+        {
+          "entity": "geoId/39053"
+        },
+        {
+          "entity": "geoId/39055"
+        },
+        {
+          "entity": "geoId/39057"
+        },
+        {
+          "entity": "geoId/39059"
+        },
+        {
+          "entity": "geoId/39061"
+        },
+        {
+          "entity": "geoId/39063"
+        },
+        {
+          "entity": "geoId/39065"
+        },
+        {
+          "entity": "geoId/39067"
+        },
+        {
+          "entity": "geoId/39069"
+        },
+        {
+          "entity": "geoId/39071"
+        },
+        {
+          "entity": "geoId/39073"
+        },
+        {
+          "entity": "geoId/39075"
+        },
+        {
+          "entity": "geoId/39077"
+        },
+        {
+          "entity": "geoId/39079"
+        },
+        {
+          "entity": "geoId/39081"
+        },
+        {
+          "entity": "geoId/39083"
+        },
+        {
+          "entity": "geoId/39085"
+        },
+        {
+          "entity": "geoId/39087"
+        },
+        {
+          "entity": "geoId/39089"
+        },
+        {
+          "entity": "geoId/39091"
+        },
+        {
+          "entity": "geoId/39093"
+        },
+        {
+          "entity": "geoId/39095"
+        },
+        {
+          "entity": "geoId/39097"
+        },
+        {
+          "entity": "geoId/39099"
+        },
+        {
+          "entity": "geoId/39101"
+        },
+        {
+          "entity": "geoId/39103"
+        },
+        {
+          "entity": "geoId/39105"
+        },
+        {
+          "entity": "geoId/39107"
+        },
+        {
+          "entity": "geoId/39109"
+        },
+        {
+          "entity": "geoId/39111"
+        },
+        {
+          "entity": "geoId/39113"
+        },
+        {
+          "entity": "geoId/39115"
+        },
+        {
+          "entity": "geoId/39117"
+        },
+        {
+          "entity": "geoId/39119"
+        },
+        {
+          "entity": "geoId/39121"
+        },
+        {
+          "entity": "geoId/39123"
+        },
+        {
+          "entity": "geoId/39125"
+        },
+        {
+          "entity": "geoId/39127"
+        },
+        {
+          "entity": "geoId/39129"
+        },
+        {
+          "entity": "geoId/39131"
+        },
+        {
+          "entity": "geoId/39133"
+        },
+        {
+          "entity": "geoId/39135"
+        },
+        {
+          "entity": "geoId/39137"
+        },
+        {
+          "entity": "geoId/39139"
+        },
+        {
+          "entity": "geoId/39141"
+        },
+        {
+          "entity": "geoId/39143"
+        },
+        {
+          "entity": "geoId/39145"
+        },
+        {
+          "entity": "geoId/39147"
+        },
+        {
+          "entity": "geoId/39149"
+        },
+        {
+          "entity": "geoId/39151"
+        },
+        {
+          "entity": "geoId/39153"
+        },
+        {
+          "entity": "geoId/39155"
+        },
+        {
+          "entity": "geoId/39157"
+        },
+        {
+          "entity": "geoId/39159"
+        },
+        {
+          "entity": "geoId/39161"
+        },
+        {
+          "entity": "geoId/39163"
+        },
+        {
+          "entity": "geoId/39165"
+        },
+        {
+          "entity": "geoId/39167"
+        },
+        {
+          "entity": "geoId/39169"
+        },
+        {
+          "entity": "geoId/39171"
+        },
+        {
+          "entity": "geoId/39173"
+        },
+        {
+          "entity": "geoId/39175"
+        },
+        {
+          "entity": "geoId/40001"
+        },
+        {
+          "entity": "geoId/40003"
+        },
+        {
+          "entity": "geoId/40005"
+        },
+        {
+          "entity": "geoId/40007"
+        },
+        {
+          "entity": "geoId/40009"
+        },
+        {
+          "entity": "geoId/40011"
+        },
+        {
+          "entity": "geoId/40013"
+        },
+        {
+          "entity": "geoId/40015"
+        },
+        {
+          "entity": "geoId/40017"
+        },
+        {
+          "entity": "geoId/40019"
+        },
+        {
+          "entity": "geoId/40021"
+        },
+        {
+          "entity": "geoId/40023"
+        },
+        {
+          "entity": "geoId/40025"
+        },
+        {
+          "entity": "geoId/40027"
+        },
+        {
+          "entity": "geoId/40029"
+        },
+        {
+          "entity": "geoId/40031"
+        },
+        {
+          "entity": "geoId/40033"
+        },
+        {
+          "entity": "geoId/40035"
+        },
+        {
+          "entity": "geoId/40037"
+        },
+        {
+          "entity": "geoId/40039"
+        },
+        {
+          "entity": "geoId/40041"
+        },
+        {
+          "entity": "geoId/40043"
+        },
+        {
+          "entity": "geoId/40045"
+        },
+        {
+          "entity": "geoId/40047"
+        },
+        {
+          "entity": "geoId/40049"
+        },
+        {
+          "entity": "geoId/40051"
+        },
+        {
+          "entity": "geoId/40053"
+        },
+        {
+          "entity": "geoId/40055"
+        },
+        {
+          "entity": "geoId/40057"
+        },
+        {
+          "entity": "geoId/40059"
+        },
+        {
+          "entity": "geoId/40061"
+        },
+        {
+          "entity": "geoId/40063"
+        },
+        {
+          "entity": "geoId/40065"
+        },
+        {
+          "entity": "geoId/40067"
+        },
+        {
+          "entity": "geoId/40069"
+        },
+        {
+          "entity": "geoId/40071"
+        },
+        {
+          "entity": "geoId/40073"
+        },
+        {
+          "entity": "geoId/40075"
+        },
+        {
+          "entity": "geoId/40077"
+        },
+        {
+          "entity": "geoId/40079"
+        },
+        {
+          "entity": "geoId/40081"
+        },
+        {
+          "entity": "geoId/40083"
+        },
+        {
+          "entity": "geoId/40085"
+        },
+        {
+          "entity": "geoId/40087"
+        },
+        {
+          "entity": "geoId/40089"
+        },
+        {
+          "entity": "geoId/40091"
+        },
+        {
+          "entity": "geoId/40093"
+        },
+        {
+          "entity": "geoId/40095"
+        },
+        {
+          "entity": "geoId/40097"
+        },
+        {
+          "entity": "geoId/40099"
+        },
+        {
+          "entity": "geoId/40101"
+        },
+        {
+          "entity": "geoId/40103"
+        },
+        {
+          "entity": "geoId/40105"
+        },
+        {
+          "entity": "geoId/40107"
+        },
+        {
+          "entity": "geoId/40109"
+        },
+        {
+          "entity": "geoId/40111"
+        },
+        {
+          "entity": "geoId/40113"
+        },
+        {
+          "entity": "geoId/40115"
+        },
+        {
+          "entity": "geoId/40117"
+        },
+        {
+          "entity": "geoId/40119"
+        },
+        {
+          "entity": "geoId/40121"
+        },
+        {
+          "entity": "geoId/40123"
+        },
+        {
+          "entity": "geoId/40125"
+        },
+        {
+          "entity": "geoId/40127"
+        },
+        {
+          "entity": "geoId/40129"
+        },
+        {
+          "entity": "geoId/40131"
+        },
+        {
+          "entity": "geoId/40133"
+        },
+        {
+          "entity": "geoId/40135"
+        },
+        {
+          "entity": "geoId/40137"
+        },
+        {
+          "entity": "geoId/40139"
+        },
+        {
+          "entity": "geoId/40141"
+        },
+        {
+          "entity": "geoId/40143"
+        },
+        {
+          "entity": "geoId/40145"
+        },
+        {
+          "entity": "geoId/40147"
+        },
+        {
+          "entity": "geoId/40149"
+        },
+        {
+          "entity": "geoId/40151"
+        },
+        {
+          "entity": "geoId/40153"
+        },
+        {
+          "entity": "geoId/41001"
+        },
+        {
+          "entity": "geoId/41003"
+        },
+        {
+          "entity": "geoId/41005"
+        },
+        {
+          "entity": "geoId/41007"
+        },
+        {
+          "entity": "geoId/41009"
+        },
+        {
+          "entity": "geoId/41011"
+        },
+        {
+          "entity": "geoId/41013"
+        },
+        {
+          "entity": "geoId/41015"
+        },
+        {
+          "entity": "geoId/41017"
+        },
+        {
+          "entity": "geoId/41019"
+        },
+        {
+          "entity": "geoId/41021"
+        },
+        {
+          "entity": "geoId/41023"
+        },
+        {
+          "entity": "geoId/41025"
+        },
+        {
+          "entity": "geoId/41027"
+        },
+        {
+          "entity": "geoId/41029"
+        },
+        {
+          "entity": "geoId/41031"
+        },
+        {
+          "entity": "geoId/41033"
+        },
+        {
+          "entity": "geoId/41035"
+        },
+        {
+          "entity": "geoId/41037"
+        },
+        {
+          "entity": "geoId/41039"
+        },
+        {
+          "entity": "geoId/41041"
+        },
+        {
+          "entity": "geoId/41043"
+        },
+        {
+          "entity": "geoId/41045"
+        },
+        {
+          "entity": "geoId/41047"
+        },
+        {
+          "entity": "geoId/41049"
+        },
+        {
+          "entity": "geoId/41051"
+        },
+        {
+          "entity": "geoId/41053"
+        },
+        {
+          "entity": "geoId/41055"
+        },
+        {
+          "entity": "geoId/41057"
+        },
+        {
+          "entity": "geoId/41059"
+        },
+        {
+          "entity": "geoId/41061"
+        },
+        {
+          "entity": "geoId/41063"
+        },
+        {
+          "entity": "geoId/41065"
+        },
+        {
+          "entity": "geoId/41067"
+        },
+        {
+          "entity": "geoId/41069"
+        },
+        {
+          "entity": "geoId/41071"
+        },
+        {
+          "entity": "geoId/42001"
+        },
+        {
+          "entity": "geoId/42003"
+        },
+        {
+          "entity": "geoId/42005"
+        },
+        {
+          "entity": "geoId/42007"
+        },
+        {
+          "entity": "geoId/42009"
+        },
+        {
+          "entity": "geoId/42011"
+        },
+        {
+          "entity": "geoId/42013"
+        },
+        {
+          "entity": "geoId/42015"
+        },
+        {
+          "entity": "geoId/42017"
+        },
+        {
+          "entity": "geoId/42019"
+        },
+        {
+          "entity": "geoId/42021"
+        },
+        {
+          "entity": "geoId/42023"
+        },
+        {
+          "entity": "geoId/42025"
+        },
+        {
+          "entity": "geoId/42027"
+        },
+        {
+          "entity": "geoId/42029"
+        },
+        {
+          "entity": "geoId/42031"
+        },
+        {
+          "entity": "geoId/42033"
+        },
+        {
+          "entity": "geoId/42035"
+        },
+        {
+          "entity": "geoId/42037"
+        },
+        {
+          "entity": "geoId/42039"
+        },
+        {
+          "entity": "geoId/42041"
+        },
+        {
+          "entity": "geoId/42043"
+        },
+        {
+          "entity": "geoId/42045"
+        },
+        {
+          "entity": "geoId/42047"
+        },
+        {
+          "entity": "geoId/42049"
+        },
+        {
+          "entity": "geoId/42051"
+        },
+        {
+          "entity": "geoId/42053"
+        },
+        {
+          "entity": "geoId/42055"
+        },
+        {
+          "entity": "geoId/42057"
+        },
+        {
+          "entity": "geoId/42059"
+        },
+        {
+          "entity": "geoId/42061"
+        },
+        {
+          "entity": "geoId/42063"
+        },
+        {
+          "entity": "geoId/42065"
+        },
+        {
+          "entity": "geoId/42067"
+        },
+        {
+          "entity": "geoId/42069"
+        },
+        {
+          "entity": "geoId/42071"
+        },
+        {
+          "entity": "geoId/42073"
+        },
+        {
+          "entity": "geoId/42075"
+        },
+        {
+          "entity": "geoId/42077"
+        },
+        {
+          "entity": "geoId/42079"
+        },
+        {
+          "entity": "geoId/42081"
+        },
+        {
+          "entity": "geoId/42083"
+        },
+        {
+          "entity": "geoId/42085"
+        },
+        {
+          "entity": "geoId/42087"
+        },
+        {
+          "entity": "geoId/42089"
+        },
+        {
+          "entity": "geoId/42091"
+        },
+        {
+          "entity": "geoId/42093"
+        },
+        {
+          "entity": "geoId/42095"
+        },
+        {
+          "entity": "geoId/42097"
+        },
+        {
+          "entity": "geoId/42099"
+        },
+        {
+          "entity": "geoId/42101"
+        },
+        {
+          "entity": "geoId/42103"
+        },
+        {
+          "entity": "geoId/42105"
+        },
+        {
+          "entity": "geoId/42107"
+        },
+        {
+          "entity": "geoId/42109"
+        },
+        {
+          "entity": "geoId/42111"
+        },
+        {
+          "entity": "geoId/42113"
+        },
+        {
+          "entity": "geoId/42115"
+        },
+        {
+          "entity": "geoId/42117"
+        },
+        {
+          "entity": "geoId/42119"
+        },
+        {
+          "entity": "geoId/42121"
+        },
+        {
+          "entity": "geoId/42123"
+        },
+        {
+          "entity": "geoId/42125"
+        },
+        {
+          "entity": "geoId/42127"
+        },
+        {
+          "entity": "geoId/42129"
+        },
+        {
+          "entity": "geoId/42131"
+        },
+        {
+          "entity": "geoId/42133"
+        },
+        {
+          "entity": "geoId/44001"
+        },
+        {
+          "entity": "geoId/44003"
+        },
+        {
+          "entity": "geoId/44005"
+        },
+        {
+          "entity": "geoId/44007"
+        },
+        {
+          "entity": "geoId/44009"
+        },
+        {
+          "entity": "geoId/45001"
+        },
+        {
+          "entity": "geoId/45003"
+        },
+        {
+          "entity": "geoId/45005"
+        },
+        {
+          "entity": "geoId/45007"
+        },
+        {
+          "entity": "geoId/45009"
+        },
+        {
+          "entity": "geoId/45011"
+        },
+        {
+          "entity": "geoId/45013"
+        },
+        {
+          "entity": "geoId/45015"
+        },
+        {
+          "entity": "geoId/45017"
+        },
+        {
+          "entity": "geoId/45019"
+        },
+        {
+          "entity": "geoId/45021"
+        },
+        {
+          "entity": "geoId/45023"
+        },
+        {
+          "entity": "geoId/45025"
+        },
+        {
+          "entity": "geoId/45027"
+        },
+        {
+          "entity": "geoId/45029"
+        },
+        {
+          "entity": "geoId/45031"
+        },
+        {
+          "entity": "geoId/45033"
+        },
+        {
+          "entity": "geoId/45035"
+        },
+        {
+          "entity": "geoId/45037"
+        },
+        {
+          "entity": "geoId/45039"
+        },
+        {
+          "entity": "geoId/45041"
+        },
+        {
+          "entity": "geoId/45043"
+        },
+        {
+          "entity": "geoId/45045"
+        },
+        {
+          "entity": "geoId/45047"
+        },
+        {
+          "entity": "geoId/45049"
+        },
+        {
+          "entity": "geoId/45051"
+        },
+        {
+          "entity": "geoId/45053"
+        },
+        {
+          "entity": "geoId/45055"
+        },
+        {
+          "entity": "geoId/45057"
+        },
+        {
+          "entity": "geoId/45059"
+        },
+        {
+          "entity": "geoId/45061"
+        },
+        {
+          "entity": "geoId/45063"
+        },
+        {
+          "entity": "geoId/45065"
+        },
+        {
+          "entity": "geoId/45067"
+        },
+        {
+          "entity": "geoId/45069"
+        },
+        {
+          "entity": "geoId/45071"
+        },
+        {
+          "entity": "geoId/45073"
+        },
+        {
+          "entity": "geoId/45075"
+        },
+        {
+          "entity": "geoId/45077"
+        },
+        {
+          "entity": "geoId/45079"
+        },
+        {
+          "entity": "geoId/45081"
+        },
+        {
+          "entity": "geoId/45083"
+        },
+        {
+          "entity": "geoId/45085"
+        },
+        {
+          "entity": "geoId/45087"
+        },
+        {
+          "entity": "geoId/45089"
+        },
+        {
+          "entity": "geoId/45091"
+        },
+        {
+          "entity": "geoId/46003"
+        },
+        {
+          "entity": "geoId/46005"
+        },
+        {
+          "entity": "geoId/46007"
+        },
+        {
+          "entity": "geoId/46009"
+        },
+        {
+          "entity": "geoId/46011"
+        },
+        {
+          "entity": "geoId/46013"
+        },
+        {
+          "entity": "geoId/46015"
+        },
+        {
+          "entity": "geoId/46017"
+        },
+        {
+          "entity": "geoId/46019"
+        },
+        {
+          "entity": "geoId/46021"
+        },
+        {
+          "entity": "geoId/46023"
+        },
+        {
+          "entity": "geoId/46025"
+        },
+        {
+          "entity": "geoId/46027"
+        },
+        {
+          "entity": "geoId/46029"
+        },
+        {
+          "entity": "geoId/46031"
+        },
+        {
+          "entity": "geoId/46033"
+        },
+        {
+          "entity": "geoId/46035"
+        },
+        {
+          "entity": "geoId/46037"
+        },
+        {
+          "entity": "geoId/46039"
+        },
+        {
+          "entity": "geoId/46041"
+        },
+        {
+          "entity": "geoId/46043"
+        },
+        {
+          "entity": "geoId/46045"
+        },
+        {
+          "entity": "geoId/46047"
+        },
+        {
+          "entity": "geoId/46049"
+        },
+        {
+          "entity": "geoId/46051"
+        },
+        {
+          "entity": "geoId/46053"
+        },
+        {
+          "entity": "geoId/46055"
+        },
+        {
+          "entity": "geoId/46057"
+        },
+        {
+          "entity": "geoId/46059"
+        },
+        {
+          "entity": "geoId/46061"
+        },
+        {
+          "entity": "geoId/46063"
+        },
+        {
+          "entity": "geoId/46065"
+        },
+        {
+          "entity": "geoId/46067"
+        },
+        {
+          "entity": "geoId/46069"
+        },
+        {
+          "entity": "geoId/46071"
+        },
+        {
+          "entity": "geoId/46073"
+        },
+        {
+          "entity": "geoId/46075"
+        },
+        {
+          "entity": "geoId/46077"
+        },
+        {
+          "entity": "geoId/46079"
+        },
+        {
+          "entity": "geoId/46081"
+        },
+        {
+          "entity": "geoId/46083"
+        },
+        {
+          "entity": "geoId/46085"
+        },
+        {
+          "entity": "geoId/46087"
+        },
+        {
+          "entity": "geoId/46089"
+        },
+        {
+          "entity": "geoId/46091"
+        },
+        {
+          "entity": "geoId/46093"
+        },
+        {
+          "entity": "geoId/46095"
+        },
+        {
+          "entity": "geoId/46097"
+        },
+        {
+          "entity": "geoId/46099"
+        },
+        {
+          "entity": "geoId/46101"
+        },
+        {
+          "entity": "geoId/46102"
+        },
+        {
+          "entity": "geoId/46103"
+        },
+        {
+          "entity": "geoId/46105"
+        },
+        {
+          "entity": "geoId/46107"
+        },
+        {
+          "entity": "geoId/46109"
+        },
+        {
+          "entity": "geoId/46111"
+        },
+        {
+          "entity": "geoId/46113"
+        },
+        {
+          "entity": "geoId/46115"
+        },
+        {
+          "entity": "geoId/46117"
+        },
+        {
+          "entity": "geoId/46119"
+        },
+        {
+          "entity": "geoId/46121"
+        },
+        {
+          "entity": "geoId/46123"
+        },
+        {
+          "entity": "geoId/46125"
+        },
+        {
+          "entity": "geoId/46127"
+        },
+        {
+          "entity": "geoId/46129"
+        },
+        {
+          "entity": "geoId/46135"
+        },
+        {
+          "entity": "geoId/46137"
+        },
+        {
+          "entity": "geoId/47001"
+        },
+        {
+          "entity": "geoId/47003"
+        },
+        {
+          "entity": "geoId/47005"
+        },
+        {
+          "entity": "geoId/47007"
+        },
+        {
+          "entity": "geoId/47009"
+        },
+        {
+          "entity": "geoId/47011"
+        },
+        {
+          "entity": "geoId/47013"
+        },
+        {
+          "entity": "geoId/47015"
+        },
+        {
+          "entity": "geoId/47017"
+        },
+        {
+          "entity": "geoId/47019"
+        },
+        {
+          "entity": "geoId/47021"
+        },
+        {
+          "entity": "geoId/47023"
+        },
+        {
+          "entity": "geoId/47025"
+        },
+        {
+          "entity": "geoId/47027"
+        },
+        {
+          "entity": "geoId/47029"
+        },
+        {
+          "entity": "geoId/47031"
+        },
+        {
+          "entity": "geoId/47033"
+        },
+        {
+          "entity": "geoId/47035"
+        },
+        {
+          "entity": "geoId/47037"
+        },
+        {
+          "entity": "geoId/47039"
+        },
+        {
+          "entity": "geoId/47041"
+        },
+        {
+          "entity": "geoId/47043"
+        },
+        {
+          "entity": "geoId/47045"
+        },
+        {
+          "entity": "geoId/47047"
+        },
+        {
+          "entity": "geoId/47049"
+        },
+        {
+          "entity": "geoId/47051"
+        },
+        {
+          "entity": "geoId/47053"
+        },
+        {
+          "entity": "geoId/47055"
+        },
+        {
+          "entity": "geoId/47057"
+        },
+        {
+          "entity": "geoId/47059"
+        },
+        {
+          "entity": "geoId/47061"
+        },
+        {
+          "entity": "geoId/47063"
+        },
+        {
+          "entity": "geoId/47065"
+        },
+        {
+          "entity": "geoId/47067"
+        },
+        {
+          "entity": "geoId/47069"
+        },
+        {
+          "entity": "geoId/47071"
+        },
+        {
+          "entity": "geoId/47073"
+        },
+        {
+          "entity": "geoId/47075"
+        },
+        {
+          "entity": "geoId/47077"
+        },
+        {
+          "entity": "geoId/47079"
+        },
+        {
+          "entity": "geoId/47081"
+        },
+        {
+          "entity": "geoId/47083"
+        },
+        {
+          "entity": "geoId/47085"
+        },
+        {
+          "entity": "geoId/47087"
+        },
+        {
+          "entity": "geoId/47089"
+        },
+        {
+          "entity": "geoId/47091"
+        },
+        {
+          "entity": "geoId/47093"
+        },
+        {
+          "entity": "geoId/47095"
+        },
+        {
+          "entity": "geoId/47097"
+        },
+        {
+          "entity": "geoId/47099"
+        },
+        {
+          "entity": "geoId/47101"
+        },
+        {
+          "entity": "geoId/47103"
+        },
+        {
+          "entity": "geoId/47105"
+        },
+        {
+          "entity": "geoId/47107"
+        },
+        {
+          "entity": "geoId/47109"
+        },
+        {
+          "entity": "geoId/47111"
+        },
+        {
+          "entity": "geoId/47113"
+        },
+        {
+          "entity": "geoId/47115"
+        },
+        {
+          "entity": "geoId/47117"
+        },
+        {
+          "entity": "geoId/47119"
+        },
+        {
+          "entity": "geoId/47121"
+        },
+        {
+          "entity": "geoId/47123"
+        },
+        {
+          "entity": "geoId/47125"
+        },
+        {
+          "entity": "geoId/47127"
+        },
+        {
+          "entity": "geoId/47129"
+        },
+        {
+          "entity": "geoId/47131"
+        },
+        {
+          "entity": "geoId/47133"
+        },
+        {
+          "entity": "geoId/47135"
+        },
+        {
+          "entity": "geoId/47137"
+        },
+        {
+          "entity": "geoId/47139"
+        },
+        {
+          "entity": "geoId/47141"
+        },
+        {
+          "entity": "geoId/47143"
+        },
+        {
+          "entity": "geoId/47145"
+        },
+        {
+          "entity": "geoId/47147"
+        },
+        {
+          "entity": "geoId/47149"
+        },
+        {
+          "entity": "geoId/47151"
+        },
+        {
+          "entity": "geoId/47153"
+        },
+        {
+          "entity": "geoId/47155"
+        },
+        {
+          "entity": "geoId/47157"
+        },
+        {
+          "entity": "geoId/47159"
+        },
+        {
+          "entity": "geoId/47161"
+        },
+        {
+          "entity": "geoId/47163"
+        },
+        {
+          "entity": "geoId/47165"
+        },
+        {
+          "entity": "geoId/47167"
+        },
+        {
+          "entity": "geoId/47169"
+        },
+        {
+          "entity": "geoId/47171"
+        },
+        {
+          "entity": "geoId/47173"
+        },
+        {
+          "entity": "geoId/47175"
+        },
+        {
+          "entity": "geoId/47177"
+        },
+        {
+          "entity": "geoId/47179"
+        },
+        {
+          "entity": "geoId/47181"
+        },
+        {
+          "entity": "geoId/47183"
+        },
+        {
+          "entity": "geoId/47185"
+        },
+        {
+          "entity": "geoId/47187"
+        },
+        {
+          "entity": "geoId/47189"
+        },
+        {
+          "entity": "geoId/48001"
+        },
+        {
+          "entity": "geoId/48003"
+        },
+        {
+          "entity": "geoId/48005"
+        },
+        {
+          "entity": "geoId/48007"
+        },
+        {
+          "entity": "geoId/48009"
+        },
+        {
+          "entity": "geoId/48011"
+        },
+        {
+          "entity": "geoId/48013"
+        },
+        {
+          "entity": "geoId/48015"
+        },
+        {
+          "entity": "geoId/48017"
+        },
+        {
+          "entity": "geoId/48019"
+        },
+        {
+          "entity": "geoId/48021"
+        },
+        {
+          "entity": "geoId/48023"
+        },
+        {
+          "entity": "geoId/48025"
+        },
+        {
+          "entity": "geoId/48027"
+        },
+        {
+          "entity": "geoId/48029"
+        },
+        {
+          "entity": "geoId/48031"
+        },
+        {
+          "entity": "geoId/48033"
+        },
+        {
+          "entity": "geoId/48035"
+        },
+        {
+          "entity": "geoId/48037"
+        },
+        {
+          "entity": "geoId/48039"
+        },
+        {
+          "entity": "geoId/48041"
+        },
+        {
+          "entity": "geoId/48043"
+        },
+        {
+          "entity": "geoId/48045"
+        },
+        {
+          "entity": "geoId/48047"
+        },
+        {
+          "entity": "geoId/48049"
+        },
+        {
+          "entity": "geoId/48051"
+        },
+        {
+          "entity": "geoId/48053"
+        },
+        {
+          "entity": "geoId/48055"
+        },
+        {
+          "entity": "geoId/48057"
+        },
+        {
+          "entity": "geoId/48059"
+        },
+        {
+          "entity": "geoId/48061"
+        },
+        {
+          "entity": "geoId/48063"
+        },
+        {
+          "entity": "geoId/48065"
+        },
+        {
+          "entity": "geoId/48067"
+        },
+        {
+          "entity": "geoId/48069"
+        },
+        {
+          "entity": "geoId/48071"
+        },
+        {
+          "entity": "geoId/48073"
+        },
+        {
+          "entity": "geoId/48075"
+        },
+        {
+          "entity": "geoId/48077"
+        },
+        {
+          "entity": "geoId/48079"
+        },
+        {
+          "entity": "geoId/48081"
+        },
+        {
+          "entity": "geoId/48083"
+        },
+        {
+          "entity": "geoId/48085"
+        },
+        {
+          "entity": "geoId/48087"
+        },
+        {
+          "entity": "geoId/48089"
+        },
+        {
+          "entity": "geoId/48091"
+        },
+        {
+          "entity": "geoId/48093"
+        },
+        {
+          "entity": "geoId/48095"
+        },
+        {
+          "entity": "geoId/48097"
+        },
+        {
+          "entity": "geoId/48099"
+        },
+        {
+          "entity": "geoId/48101"
+        },
+        {
+          "entity": "geoId/48103"
+        },
+        {
+          "entity": "geoId/48105"
+        },
+        {
+          "entity": "geoId/48107"
+        },
+        {
+          "entity": "geoId/48109"
+        },
+        {
+          "entity": "geoId/48111"
+        },
+        {
+          "entity": "geoId/48113"
+        },
+        {
+          "entity": "geoId/48115"
+        },
+        {
+          "entity": "geoId/48117"
+        },
+        {
+          "entity": "geoId/48119"
+        },
+        {
+          "entity": "geoId/48121"
+        },
+        {
+          "entity": "geoId/48123"
+        },
+        {
+          "entity": "geoId/48125"
+        },
+        {
+          "entity": "geoId/48127"
+        },
+        {
+          "entity": "geoId/48129"
+        },
+        {
+          "entity": "geoId/48131"
+        },
+        {
+          "entity": "geoId/48133"
+        },
+        {
+          "entity": "geoId/48135"
+        },
+        {
+          "entity": "geoId/48137"
+        },
+        {
+          "entity": "geoId/48139"
+        },
+        {
+          "entity": "geoId/48141"
+        },
+        {
+          "entity": "geoId/48143"
+        },
+        {
+          "entity": "geoId/48145"
+        },
+        {
+          "entity": "geoId/48147"
+        },
+        {
+          "entity": "geoId/48149"
+        },
+        {
+          "entity": "geoId/48151"
+        },
+        {
+          "entity": "geoId/48153"
+        },
+        {
+          "entity": "geoId/48155"
+        },
+        {
+          "entity": "geoId/48157"
+        },
+        {
+          "entity": "geoId/48159"
+        },
+        {
+          "entity": "geoId/48161"
+        },
+        {
+          "entity": "geoId/48163"
+        },
+        {
+          "entity": "geoId/48165"
+        },
+        {
+          "entity": "geoId/48167"
+        },
+        {
+          "entity": "geoId/48169"
+        },
+        {
+          "entity": "geoId/48171"
+        },
+        {
+          "entity": "geoId/48173"
+        },
+        {
+          "entity": "geoId/48175"
+        },
+        {
+          "entity": "geoId/48177"
+        },
+        {
+          "entity": "geoId/48179"
+        },
+        {
+          "entity": "geoId/48181"
+        },
+        {
+          "entity": "geoId/48183"
+        },
+        {
+          "entity": "geoId/48185"
+        },
+        {
+          "entity": "geoId/48187"
+        },
+        {
+          "entity": "geoId/48189"
+        },
+        {
+          "entity": "geoId/48191"
+        },
+        {
+          "entity": "geoId/48193"
+        },
+        {
+          "entity": "geoId/48195"
+        },
+        {
+          "entity": "geoId/48197"
+        },
+        {
+          "entity": "geoId/48199"
+        },
+        {
+          "entity": "geoId/48201"
+        },
+        {
+          "entity": "geoId/48203"
+        },
+        {
+          "entity": "geoId/48205"
+        },
+        {
+          "entity": "geoId/48207"
+        },
+        {
+          "entity": "geoId/48209"
+        },
+        {
+          "entity": "geoId/48211"
+        },
+        {
+          "entity": "geoId/48213"
+        },
+        {
+          "entity": "geoId/48215"
+        },
+        {
+          "entity": "geoId/48217"
+        },
+        {
+          "entity": "geoId/48219"
+        },
+        {
+          "entity": "geoId/48221"
+        },
+        {
+          "entity": "geoId/48223"
+        },
+        {
+          "entity": "geoId/48225"
+        },
+        {
+          "entity": "geoId/48227"
+        },
+        {
+          "entity": "geoId/48229"
+        },
+        {
+          "entity": "geoId/48231"
+        },
+        {
+          "entity": "geoId/48233"
+        },
+        {
+          "entity": "geoId/48235"
+        },
+        {
+          "entity": "geoId/48237"
+        },
+        {
+          "entity": "geoId/48239"
+        },
+        {
+          "entity": "geoId/48241"
+        },
+        {
+          "entity": "geoId/48243"
+        },
+        {
+          "entity": "geoId/48245"
+        },
+        {
+          "entity": "geoId/48247"
+        },
+        {
+          "entity": "geoId/48249"
+        },
+        {
+          "entity": "geoId/48251"
+        },
+        {
+          "entity": "geoId/48253"
+        },
+        {
+          "entity": "geoId/48255"
+        },
+        {
+          "entity": "geoId/48257"
+        },
+        {
+          "entity": "geoId/48259"
+        },
+        {
+          "entity": "geoId/48261"
+        },
+        {
+          "entity": "geoId/48263"
+        },
+        {
+          "entity": "geoId/48265"
+        },
+        {
+          "entity": "geoId/48267"
+        },
+        {
+          "entity": "geoId/48269"
+        },
+        {
+          "entity": "geoId/48271"
+        },
+        {
+          "entity": "geoId/48273"
+        },
+        {
+          "entity": "geoId/48275"
+        },
+        {
+          "entity": "geoId/48277"
+        },
+        {
+          "entity": "geoId/48279"
+        },
+        {
+          "entity": "geoId/48281"
+        },
+        {
+          "entity": "geoId/48283"
+        },
+        {
+          "entity": "geoId/48285"
+        },
+        {
+          "entity": "geoId/48287"
+        },
+        {
+          "entity": "geoId/48289"
+        },
+        {
+          "entity": "geoId/48291"
+        },
+        {
+          "entity": "geoId/48293"
+        },
+        {
+          "entity": "geoId/48295"
+        },
+        {
+          "entity": "geoId/48297"
+        },
+        {
+          "entity": "geoId/48299"
+        },
+        {
+          "entity": "geoId/48301"
+        },
+        {
+          "entity": "geoId/48303"
+        },
+        {
+          "entity": "geoId/48305"
+        },
+        {
+          "entity": "geoId/48307"
+        },
+        {
+          "entity": "geoId/48309"
+        },
+        {
+          "entity": "geoId/48311"
+        },
+        {
+          "entity": "geoId/48313"
+        },
+        {
+          "entity": "geoId/48315"
+        },
+        {
+          "entity": "geoId/48317"
+        },
+        {
+          "entity": "geoId/48319"
+        },
+        {
+          "entity": "geoId/48321"
+        },
+        {
+          "entity": "geoId/48323"
+        },
+        {
+          "entity": "geoId/48325"
+        },
+        {
+          "entity": "geoId/48327"
+        },
+        {
+          "entity": "geoId/48329"
+        },
+        {
+          "entity": "geoId/48331"
+        },
+        {
+          "entity": "geoId/48333"
+        },
+        {
+          "entity": "geoId/48335"
+        },
+        {
+          "entity": "geoId/48337"
+        },
+        {
+          "entity": "geoId/48339"
+        },
+        {
+          "entity": "geoId/48341"
+        },
+        {
+          "entity": "geoId/48343"
+        },
+        {
+          "entity": "geoId/48345"
+        },
+        {
+          "entity": "geoId/48347"
+        },
+        {
+          "entity": "geoId/48349"
+        },
+        {
+          "entity": "geoId/48351"
+        },
+        {
+          "entity": "geoId/48353"
+        },
+        {
+          "entity": "geoId/48355"
+        },
+        {
+          "entity": "geoId/48357"
+        },
+        {
+          "entity": "geoId/48359"
+        },
+        {
+          "entity": "geoId/48361"
+        },
+        {
+          "entity": "geoId/48363"
+        },
+        {
+          "entity": "geoId/48365"
+        },
+        {
+          "entity": "geoId/48367"
+        },
+        {
+          "entity": "geoId/48369"
+        },
+        {
+          "entity": "geoId/48371"
+        },
+        {
+          "entity": "geoId/48373"
+        },
+        {
+          "entity": "geoId/48375"
+        },
+        {
+          "entity": "geoId/48377"
+        },
+        {
+          "entity": "geoId/48379"
+        },
+        {
+          "entity": "geoId/48381"
+        },
+        {
+          "entity": "geoId/48383"
+        },
+        {
+          "entity": "geoId/48385"
+        },
+        {
+          "entity": "geoId/48387"
+        },
+        {
+          "entity": "geoId/48389"
+        },
+        {
+          "entity": "geoId/48391"
+        },
+        {
+          "entity": "geoId/48393"
+        },
+        {
+          "entity": "geoId/48395"
+        },
+        {
+          "entity": "geoId/48397"
+        },
+        {
+          "entity": "geoId/48399"
+        },
+        {
+          "entity": "geoId/48401"
+        },
+        {
+          "entity": "geoId/48403"
+        },
+        {
+          "entity": "geoId/48405"
+        },
+        {
+          "entity": "geoId/48407"
+        },
+        {
+          "entity": "geoId/48409"
+        },
+        {
+          "entity": "geoId/48411"
+        },
+        {
+          "entity": "geoId/48413"
+        },
+        {
+          "entity": "geoId/48415"
+        },
+        {
+          "entity": "geoId/48417"
+        },
+        {
+          "entity": "geoId/48419"
+        },
+        {
+          "entity": "geoId/48421"
+        },
+        {
+          "entity": "geoId/48423"
+        },
+        {
+          "entity": "geoId/48425"
+        },
+        {
+          "entity": "geoId/48427"
+        },
+        {
+          "entity": "geoId/48429"
+        },
+        {
+          "entity": "geoId/48431"
+        },
+        {
+          "entity": "geoId/48433"
+        },
+        {
+          "entity": "geoId/48435"
+        },
+        {
+          "entity": "geoId/48437"
+        },
+        {
+          "entity": "geoId/48439"
+        },
+        {
+          "entity": "geoId/48441"
+        },
+        {
+          "entity": "geoId/48443"
+        },
+        {
+          "entity": "geoId/48445"
+        },
+        {
+          "entity": "geoId/48447"
+        },
+        {
+          "entity": "geoId/48449"
+        },
+        {
+          "entity": "geoId/48451"
+        },
+        {
+          "entity": "geoId/48453"
+        },
+        {
+          "entity": "geoId/48455"
+        },
+        {
+          "entity": "geoId/48457"
+        },
+        {
+          "entity": "geoId/48459"
+        },
+        {
+          "entity": "geoId/48461"
+        },
+        {
+          "entity": "geoId/48463"
+        },
+        {
+          "entity": "geoId/48465"
+        },
+        {
+          "entity": "geoId/48467"
+        },
+        {
+          "entity": "geoId/48469"
+        },
+        {
+          "entity": "geoId/48471"
+        },
+        {
+          "entity": "geoId/48473"
+        },
+        {
+          "entity": "geoId/48475"
+        },
+        {
+          "entity": "geoId/48477"
+        },
+        {
+          "entity": "geoId/48479"
+        },
+        {
+          "entity": "geoId/48481"
+        },
+        {
+          "entity": "geoId/48483"
+        },
+        {
+          "entity": "geoId/48485"
+        },
+        {
+          "entity": "geoId/48487"
+        },
+        {
+          "entity": "geoId/48489"
+        },
+        {
+          "entity": "geoId/48491"
+        },
+        {
+          "entity": "geoId/48493"
+        },
+        {
+          "entity": "geoId/48495"
+        },
+        {
+          "entity": "geoId/48497"
+        },
+        {
+          "entity": "geoId/48499"
+        },
+        {
+          "entity": "geoId/48501"
+        },
+        {
+          "entity": "geoId/48503"
+        },
+        {
+          "entity": "geoId/48505"
+        },
+        {
+          "entity": "geoId/48507"
+        },
+        {
+          "entity": "geoId/49001"
+        },
+        {
+          "entity": "geoId/49003"
+        },
+        {
+          "entity": "geoId/49005"
+        },
+        {
+          "entity": "geoId/49007"
+        },
+        {
+          "entity": "geoId/49009"
+        },
+        {
+          "entity": "geoId/49011"
+        },
+        {
+          "entity": "geoId/49013"
+        },
+        {
+          "entity": "geoId/49015"
+        },
+        {
+          "entity": "geoId/49017"
+        },
+        {
+          "entity": "geoId/49019"
+        },
+        {
+          "entity": "geoId/49021"
+        },
+        {
+          "entity": "geoId/49023"
+        },
+        {
+          "entity": "geoId/49025"
+        },
+        {
+          "entity": "geoId/49027"
+        },
+        {
+          "entity": "geoId/49029"
+        },
+        {
+          "entity": "geoId/49031"
+        },
+        {
+          "entity": "geoId/49033"
+        },
+        {
+          "entity": "geoId/49035"
+        },
+        {
+          "entity": "geoId/49037"
+        },
+        {
+          "entity": "geoId/49039"
+        },
+        {
+          "entity": "geoId/49041"
+        },
+        {
+          "entity": "geoId/49043"
+        },
+        {
+          "entity": "geoId/49045"
+        },
+        {
+          "entity": "geoId/49047"
+        },
+        {
+          "entity": "geoId/49049"
+        },
+        {
+          "entity": "geoId/49051"
+        },
+        {
+          "entity": "geoId/49053"
+        },
+        {
+          "entity": "geoId/49055"
+        },
+        {
+          "entity": "geoId/49057"
+        },
+        {
+          "entity": "geoId/50001"
+        },
+        {
+          "entity": "geoId/50003"
+        },
+        {
+          "entity": "geoId/50005"
+        },
+        {
+          "entity": "geoId/50007"
+        },
+        {
+          "entity": "geoId/50009"
+        },
+        {
+          "entity": "geoId/50011"
+        },
+        {
+          "entity": "geoId/50013"
+        },
+        {
+          "entity": "geoId/50015"
+        },
+        {
+          "entity": "geoId/50017"
+        },
+        {
+          "entity": "geoId/50019"
+        },
+        {
+          "entity": "geoId/50021"
+        },
+        {
+          "entity": "geoId/50023"
+        },
+        {
+          "entity": "geoId/50025"
+        },
+        {
+          "entity": "geoId/50027"
+        },
+        {
+          "entity": "geoId/51001"
+        },
+        {
+          "entity": "geoId/51003"
+        },
+        {
+          "entity": "geoId/51005"
+        },
+        {
+          "entity": "geoId/51007"
+        },
+        {
+          "entity": "geoId/51009"
+        },
+        {
+          "entity": "geoId/51011"
+        },
+        {
+          "entity": "geoId/51013"
+        },
+        {
+          "entity": "geoId/51015"
+        },
+        {
+          "entity": "geoId/51017"
+        },
+        {
+          "entity": "geoId/51019"
+        },
+        {
+          "entity": "geoId/51021"
+        },
+        {
+          "entity": "geoId/51023"
+        },
+        {
+          "entity": "geoId/51025"
+        },
+        {
+          "entity": "geoId/51027"
+        },
+        {
+          "entity": "geoId/51029"
+        },
+        {
+          "entity": "geoId/51031"
+        },
+        {
+          "entity": "geoId/51033"
+        },
+        {
+          "entity": "geoId/51035"
+        },
+        {
+          "entity": "geoId/51036"
+        },
+        {
+          "entity": "geoId/51037"
+        },
+        {
+          "entity": "geoId/51041"
+        },
+        {
+          "entity": "geoId/51043"
+        },
+        {
+          "entity": "geoId/51045"
+        },
+        {
+          "entity": "geoId/51047"
+        },
+        {
+          "entity": "geoId/51049"
+        },
+        {
+          "entity": "geoId/51051"
+        },
+        {
+          "entity": "geoId/51053"
+        },
+        {
+          "entity": "geoId/51057"
+        },
+        {
+          "entity": "geoId/51059"
+        },
+        {
+          "entity": "geoId/51061"
+        },
+        {
+          "entity": "geoId/51063"
+        },
+        {
+          "entity": "geoId/51065"
+        },
+        {
+          "entity": "geoId/51067"
+        },
+        {
+          "entity": "geoId/51069"
+        },
+        {
+          "entity": "geoId/51071"
+        },
+        {
+          "entity": "geoId/51073"
+        },
+        {
+          "entity": "geoId/51075"
+        },
+        {
+          "entity": "geoId/51077"
+        },
+        {
+          "entity": "geoId/51079"
+        },
+        {
+          "entity": "geoId/51081"
+        },
+        {
+          "entity": "geoId/51083"
+        },
+        {
+          "entity": "geoId/51085"
+        },
+        {
+          "entity": "geoId/51087"
+        },
+        {
+          "entity": "geoId/51089"
+        },
+        {
+          "entity": "geoId/51091"
+        },
+        {
+          "entity": "geoId/51093"
+        },
+        {
+          "entity": "geoId/51095"
+        },
+        {
+          "entity": "geoId/51097"
+        },
+        {
+          "entity": "geoId/51099"
+        },
+        {
+          "entity": "geoId/51101"
+        },
+        {
+          "entity": "geoId/51103"
+        },
+        {
+          "entity": "geoId/51105"
+        },
+        {
+          "entity": "geoId/51107"
+        },
+        {
+          "entity": "geoId/51109"
+        },
+        {
+          "entity": "geoId/51111"
+        },
+        {
+          "entity": "geoId/51113"
+        },
+        {
+          "entity": "geoId/51115"
+        },
+        {
+          "entity": "geoId/51117"
+        },
+        {
+          "entity": "geoId/51119"
+        },
+        {
+          "entity": "geoId/51121"
+        },
+        {
+          "entity": "geoId/51125"
+        },
+        {
+          "entity": "geoId/51127"
+        },
+        {
+          "entity": "geoId/51131"
+        },
+        {
+          "entity": "geoId/51133"
+        },
+        {
+          "entity": "geoId/51135"
+        },
+        {
+          "entity": "geoId/51137"
+        },
+        {
+          "entity": "geoId/51139"
+        },
+        {
+          "entity": "geoId/51141"
+        },
+        {
+          "entity": "geoId/51143"
+        },
+        {
+          "entity": "geoId/51145"
+        },
+        {
+          "entity": "geoId/51147"
+        },
+        {
+          "entity": "geoId/51149"
+        },
+        {
+          "entity": "geoId/51153"
+        },
+        {
+          "entity": "geoId/51155"
+        },
+        {
+          "entity": "geoId/51157"
+        },
+        {
+          "entity": "geoId/51159"
+        },
+        {
+          "entity": "geoId/51161"
+        },
+        {
+          "entity": "geoId/51163"
+        },
+        {
+          "entity": "geoId/51165"
+        },
+        {
+          "entity": "geoId/51167"
+        },
+        {
+          "entity": "geoId/51169"
+        },
+        {
+          "entity": "geoId/51171"
+        },
+        {
+          "entity": "geoId/51173"
+        },
+        {
+          "entity": "geoId/51175"
+        },
+        {
+          "entity": "geoId/51177"
+        },
+        {
+          "entity": "geoId/51179"
+        },
+        {
+          "entity": "geoId/51181"
+        },
+        {
+          "entity": "geoId/51183"
+        },
+        {
+          "entity": "geoId/51185"
+        },
+        {
+          "entity": "geoId/51187"
+        },
+        {
+          "entity": "geoId/51191"
+        },
+        {
+          "entity": "geoId/51193"
+        },
+        {
+          "entity": "geoId/51195"
+        },
+        {
+          "entity": "geoId/51197"
+        },
+        {
+          "entity": "geoId/51199"
+        },
+        {
+          "entity": "geoId/51510"
+        },
+        {
+          "entity": "geoId/51520"
+        },
+        {
+          "entity": "geoId/51530"
+        },
+        {
+          "entity": "geoId/51540"
+        },
+        {
+          "entity": "geoId/51550"
+        },
+        {
+          "entity": "geoId/51570"
+        },
+        {
+          "entity": "geoId/51580"
+        },
+        {
+          "entity": "geoId/51590"
+        },
+        {
+          "entity": "geoId/51595"
+        },
+        {
+          "entity": "geoId/51600"
+        },
+        {
+          "entity": "geoId/51610"
+        },
+        {
+          "entity": "geoId/51620"
+        },
+        {
+          "entity": "geoId/51630"
+        },
+        {
+          "entity": "geoId/51640"
+        },
+        {
+          "entity": "geoId/51650"
+        },
+        {
+          "entity": "geoId/51660"
+        },
+        {
+          "entity": "geoId/51670"
+        },
+        {
+          "entity": "geoId/51678"
+        },
+        {
+          "entity": "geoId/51680"
+        },
+        {
+          "entity": "geoId/51683"
+        },
+        {
+          "entity": "geoId/51685"
+        },
+        {
+          "entity": "geoId/51690"
+        },
+        {
+          "entity": "geoId/51700"
+        },
+        {
+          "entity": "geoId/51710"
+        },
+        {
+          "entity": "geoId/51720"
+        },
+        {
+          "entity": "geoId/51730"
+        },
+        {
+          "entity": "geoId/51735"
+        },
+        {
+          "entity": "geoId/51740"
+        },
+        {
+          "entity": "geoId/51750"
+        },
+        {
+          "entity": "geoId/51760"
+        },
+        {
+          "entity": "geoId/51770"
+        },
+        {
+          "entity": "geoId/51775"
+        },
+        {
+          "entity": "geoId/51790"
+        },
+        {
+          "entity": "geoId/51800"
+        },
+        {
+          "entity": "geoId/51810"
+        },
+        {
+          "entity": "geoId/51820"
+        },
+        {
+          "entity": "geoId/51830"
+        },
+        {
+          "entity": "geoId/51840"
+        },
+        {
+          "entity": "geoId/53001"
+        },
+        {
+          "entity": "geoId/53003"
+        },
+        {
+          "entity": "geoId/53005"
+        },
+        {
+          "entity": "geoId/53007"
+        },
+        {
+          "entity": "geoId/53009"
+        },
+        {
+          "entity": "geoId/53011"
+        },
+        {
+          "entity": "geoId/53013"
+        },
+        {
+          "entity": "geoId/53015"
+        },
+        {
+          "entity": "geoId/53017"
+        },
+        {
+          "entity": "geoId/53019"
+        },
+        {
+          "entity": "geoId/53021"
+        },
+        {
+          "entity": "geoId/53023"
+        },
+        {
+          "entity": "geoId/53025"
+        },
+        {
+          "entity": "geoId/53027"
+        },
+        {
+          "entity": "geoId/53029"
+        },
+        {
+          "entity": "geoId/53031"
+        },
+        {
+          "entity": "geoId/53033"
+        },
+        {
+          "entity": "geoId/53035"
+        },
+        {
+          "entity": "geoId/53037"
+        },
+        {
+          "entity": "geoId/53039"
+        },
+        {
+          "entity": "geoId/53041"
+        },
+        {
+          "entity": "geoId/53043"
+        },
+        {
+          "entity": "geoId/53045"
+        },
+        {
+          "entity": "geoId/53047"
+        },
+        {
+          "entity": "geoId/53049"
+        },
+        {
+          "entity": "geoId/53051"
+        },
+        {
+          "entity": "geoId/53053"
+        },
+        {
+          "entity": "geoId/53055"
+        },
+        {
+          "entity": "geoId/53057"
+        },
+        {
+          "entity": "geoId/53059"
+        },
+        {
+          "entity": "geoId/53061"
+        },
+        {
+          "entity": "geoId/53063"
+        },
+        {
+          "entity": "geoId/53065"
+        },
+        {
+          "entity": "geoId/53067"
+        },
+        {
+          "entity": "geoId/53069"
+        },
+        {
+          "entity": "geoId/53071"
+        },
+        {
+          "entity": "geoId/53073"
+        },
+        {
+          "entity": "geoId/53075"
+        },
+        {
+          "entity": "geoId/53077"
+        },
+        {
+          "entity": "geoId/54001"
+        },
+        {
+          "entity": "geoId/54003"
+        },
+        {
+          "entity": "geoId/54005"
+        },
+        {
+          "entity": "geoId/54007"
+        },
+        {
+          "entity": "geoId/54009"
+        },
+        {
+          "entity": "geoId/54011"
+        },
+        {
+          "entity": "geoId/54013"
+        },
+        {
+          "entity": "geoId/54015"
+        },
+        {
+          "entity": "geoId/54017"
+        },
+        {
+          "entity": "geoId/54019"
+        },
+        {
+          "entity": "geoId/54021"
+        },
+        {
+          "entity": "geoId/54023"
+        },
+        {
+          "entity": "geoId/54025"
+        },
+        {
+          "entity": "geoId/54027"
+        },
+        {
+          "entity": "geoId/54029"
+        },
+        {
+          "entity": "geoId/54031"
+        },
+        {
+          "entity": "geoId/54033"
+        },
+        {
+          "entity": "geoId/54035"
+        },
+        {
+          "entity": "geoId/54037"
+        },
+        {
+          "entity": "geoId/54039"
+        },
+        {
+          "entity": "geoId/54041"
+        },
+        {
+          "entity": "geoId/54043"
+        },
+        {
+          "entity": "geoId/54045"
+        },
+        {
+          "entity": "geoId/54047"
+        },
+        {
+          "entity": "geoId/54049"
+        },
+        {
+          "entity": "geoId/54051"
+        },
+        {
+          "entity": "geoId/54053"
+        },
+        {
+          "entity": "geoId/54055"
+        },
+        {
+          "entity": "geoId/54057"
+        },
+        {
+          "entity": "geoId/54059"
+        },
+        {
+          "entity": "geoId/54061"
+        },
+        {
+          "entity": "geoId/54063"
+        },
+        {
+          "entity": "geoId/54065"
+        },
+        {
+          "entity": "geoId/54067"
+        },
+        {
+          "entity": "geoId/54069"
+        },
+        {
+          "entity": "geoId/54071"
+        },
+        {
+          "entity": "geoId/54073"
+        },
+        {
+          "entity": "geoId/54075"
+        },
+        {
+          "entity": "geoId/54077"
+        },
+        {
+          "entity": "geoId/54079"
+        },
+        {
+          "entity": "geoId/54081"
+        },
+        {
+          "entity": "geoId/54083"
+        },
+        {
+          "entity": "geoId/54085"
+        },
+        {
+          "entity": "geoId/54087"
+        },
+        {
+          "entity": "geoId/54089"
+        },
+        {
+          "entity": "geoId/54091"
+        },
+        {
+          "entity": "geoId/54093"
+        },
+        {
+          "entity": "geoId/54095"
+        },
+        {
+          "entity": "geoId/54097"
+        },
+        {
+          "entity": "geoId/54099"
+        },
+        {
+          "entity": "geoId/54101"
+        },
+        {
+          "entity": "geoId/54103"
+        },
+        {
+          "entity": "geoId/54105"
+        },
+        {
+          "entity": "geoId/54107"
+        },
+        {
+          "entity": "geoId/54109"
+        },
+        {
+          "entity": "geoId/55001"
+        },
+        {
+          "entity": "geoId/55003"
+        },
+        {
+          "entity": "geoId/55005"
+        },
+        {
+          "entity": "geoId/55007"
+        },
+        {
+          "entity": "geoId/55009"
+        },
+        {
+          "entity": "geoId/55011"
+        },
+        {
+          "entity": "geoId/55013"
+        },
+        {
+          "entity": "geoId/55015"
+        },
+        {
+          "entity": "geoId/55017"
+        },
+        {
+          "entity": "geoId/55019"
+        },
+        {
+          "entity": "geoId/55021"
+        },
+        {
+          "entity": "geoId/55023"
+        },
+        {
+          "entity": "geoId/55025"
+        },
+        {
+          "entity": "geoId/55027"
+        },
+        {
+          "entity": "geoId/55029"
+        },
+        {
+          "entity": "geoId/55031"
+        },
+        {
+          "entity": "geoId/55033"
+        },
+        {
+          "entity": "geoId/55035"
+        },
+        {
+          "entity": "geoId/55037"
+        },
+        {
+          "entity": "geoId/55039"
+        },
+        {
+          "entity": "geoId/55041"
+        },
+        {
+          "entity": "geoId/55043"
+        },
+        {
+          "entity": "geoId/55045"
+        },
+        {
+          "entity": "geoId/55047"
+        },
+        {
+          "entity": "geoId/55049"
+        },
+        {
+          "entity": "geoId/55051"
+        },
+        {
+          "entity": "geoId/55053"
+        },
+        {
+          "entity": "geoId/55055"
+        },
+        {
+          "entity": "geoId/55057"
+        },
+        {
+          "entity": "geoId/55059"
+        },
+        {
+          "entity": "geoId/55061"
+        },
+        {
+          "entity": "geoId/55063"
+        },
+        {
+          "entity": "geoId/55065"
+        },
+        {
+          "entity": "geoId/55067"
+        },
+        {
+          "entity": "geoId/55069"
+        },
+        {
+          "entity": "geoId/55071"
+        },
+        {
+          "entity": "geoId/55073"
+        },
+        {
+          "entity": "geoId/55075"
+        },
+        {
+          "entity": "geoId/55077"
+        },
+        {
+          "entity": "geoId/55078"
+        },
+        {
+          "entity": "geoId/55079"
+        },
+        {
+          "entity": "geoId/55081"
+        },
+        {
+          "entity": "geoId/55083"
+        },
+        {
+          "entity": "geoId/55085"
+        },
+        {
+          "entity": "geoId/55087"
+        },
+        {
+          "entity": "geoId/55089"
+        },
+        {
+          "entity": "geoId/55091"
+        },
+        {
+          "entity": "geoId/55093"
+        },
+        {
+          "entity": "geoId/55095"
+        },
+        {
+          "entity": "geoId/55097"
+        },
+        {
+          "entity": "geoId/55099"
+        },
+        {
+          "entity": "geoId/55101"
+        },
+        {
+          "entity": "geoId/55103"
+        },
+        {
+          "entity": "geoId/55105"
+        },
+        {
+          "entity": "geoId/55107"
+        },
+        {
+          "entity": "geoId/55109"
+        },
+        {
+          "entity": "geoId/55111"
+        },
+        {
+          "entity": "geoId/55113"
+        },
+        {
+          "entity": "geoId/55115"
+        },
+        {
+          "entity": "geoId/55117"
+        },
+        {
+          "entity": "geoId/55119"
+        },
+        {
+          "entity": "geoId/55121"
+        },
+        {
+          "entity": "geoId/55123"
+        },
+        {
+          "entity": "geoId/55125"
+        },
+        {
+          "entity": "geoId/55127"
+        },
+        {
+          "entity": "geoId/55129"
+        },
+        {
+          "entity": "geoId/55131"
+        },
+        {
+          "entity": "geoId/55133"
+        },
+        {
+          "entity": "geoId/55135"
+        },
+        {
+          "entity": "geoId/55137"
+        },
+        {
+          "entity": "geoId/55139"
+        },
+        {
+          "entity": "geoId/55141"
+        },
+        {
+          "entity": "geoId/56001"
+        },
+        {
+          "entity": "geoId/56003"
+        },
+        {
+          "entity": "geoId/56005"
+        },
+        {
+          "entity": "geoId/56007"
+        },
+        {
+          "entity": "geoId/56009"
+        },
+        {
+          "entity": "geoId/56011"
+        },
+        {
+          "entity": "geoId/56013"
+        },
+        {
+          "entity": "geoId/56015"
+        },
+        {
+          "entity": "geoId/56017"
+        },
+        {
+          "entity": "geoId/56019"
+        },
+        {
+          "entity": "geoId/56021"
+        },
+        {
+          "entity": "geoId/56023"
+        },
+        {
+          "entity": "geoId/56025"
+        },
+        {
+          "entity": "geoId/56027"
+        },
+        {
+          "entity": "geoId/56029"
+        },
+        {
+          "entity": "geoId/56031"
+        },
+        {
+          "entity": "geoId/56033"
+        },
+        {
+          "entity": "geoId/56035"
+        },
+        {
+          "entity": "geoId/56037"
+        },
+        {
+          "entity": "geoId/56039"
+        },
+        {
+          "entity": "geoId/56041"
+        },
+        {
+          "entity": "geoId/56043"
+        },
+        {
+          "entity": "geoId/56045"
+        },
+        {
+          "entity": "geoId/60010"
+        },
+        {
+          "entity": "geoId/60020"
+        },
+        {
+          "entity": "geoId/60030"
+        },
+        {
+          "entity": "geoId/60040"
+        },
+        {
+          "entity": "geoId/60050"
+        },
+        {
+          "entity": "geoId/72001"
+        },
+        {
+          "entity": "geoId/72003"
+        },
+        {
+          "entity": "geoId/72005"
+        },
+        {
+          "entity": "geoId/72007"
+        },
+        {
+          "entity": "geoId/72009"
+        },
+        {
+          "entity": "geoId/72011"
+        },
+        {
+          "entity": "geoId/72013"
+        },
+        {
+          "entity": "geoId/72015"
+        },
+        {
+          "entity": "geoId/72017"
+        },
+        {
+          "entity": "geoId/72019"
+        },
+        {
+          "entity": "geoId/72021"
+        },
+        {
+          "entity": "geoId/72023"
+        },
+        {
+          "entity": "geoId/72025"
+        },
+        {
+          "entity": "geoId/72027"
+        },
+        {
+          "entity": "geoId/72029"
+        },
+        {
+          "entity": "geoId/72031"
+        },
+        {
+          "entity": "geoId/72033"
+        },
+        {
+          "entity": "geoId/72035"
+        },
+        {
+          "entity": "geoId/72037"
+        },
+        {
+          "entity": "geoId/72039"
+        },
+        {
+          "entity": "geoId/72041"
+        },
+        {
+          "entity": "geoId/72043"
+        },
+        {
+          "entity": "geoId/72045"
+        },
+        {
+          "entity": "geoId/72047"
+        },
+        {
+          "entity": "geoId/72049"
+        },
+        {
+          "entity": "geoId/72051"
+        },
+        {
+          "entity": "geoId/72053"
+        },
+        {
+          "entity": "geoId/72054"
+        },
+        {
+          "entity": "geoId/72055"
+        },
+        {
+          "entity": "geoId/72057"
+        },
+        {
+          "entity": "geoId/72059"
+        },
+        {
+          "entity": "geoId/72061"
+        },
+        {
+          "entity": "geoId/72063"
+        },
+        {
+          "entity": "geoId/72065"
+        },
+        {
+          "entity": "geoId/72067"
+        },
+        {
+          "entity": "geoId/72069"
+        },
+        {
+          "entity": "geoId/72071"
+        },
+        {
+          "entity": "geoId/72073"
+        },
+        {
+          "entity": "geoId/72075"
+        },
+        {
+          "entity": "geoId/72077"
+        },
+        {
+          "entity": "geoId/72079"
+        },
+        {
+          "entity": "geoId/72081"
+        },
+        {
+          "entity": "geoId/72083"
+        },
+        {
+          "entity": "geoId/72085"
+        },
+        {
+          "entity": "geoId/72087"
+        },
+        {
+          "entity": "geoId/72089"
+        },
+        {
+          "entity": "geoId/72091"
+        },
+        {
+          "entity": "geoId/72093"
+        },
+        {
+          "entity": "geoId/72095"
+        },
+        {
+          "entity": "geoId/72097"
+        },
+        {
+          "entity": "geoId/72099"
+        },
+        {
+          "entity": "geoId/72101"
+        },
+        {
+          "entity": "geoId/72103"
+        },
+        {
+          "entity": "geoId/72105"
+        },
+        {
+          "entity": "geoId/72107"
+        },
+        {
+          "entity": "geoId/72109"
+        },
+        {
+          "entity": "geoId/72111"
+        },
+        {
+          "entity": "geoId/72113"
+        },
+        {
+          "entity": "geoId/72115"
+        },
+        {
+          "entity": "geoId/72117"
+        },
+        {
+          "entity": "geoId/72119"
+        },
+        {
+          "entity": "geoId/72121"
+        },
+        {
+          "entity": "geoId/72123"
+        },
+        {
+          "entity": "geoId/72125"
+        },
+        {
+          "entity": "geoId/72127"
+        },
+        {
+          "entity": "geoId/72129"
+        },
+        {
+          "entity": "geoId/72131"
+        },
+        {
+          "entity": "geoId/72133"
+        },
+        {
+          "entity": "geoId/72135"
+        },
+        {
+          "entity": "geoId/72137"
+        },
+        {
+          "entity": "geoId/72139"
+        },
+        {
+          "entity": "geoId/72141"
+        },
+        {
+          "entity": "geoId/72143"
+        },
+        {
+          "entity": "geoId/72145"
+        },
+        {
+          "entity": "geoId/72147"
+        },
+        {
+          "entity": "geoId/72149"
+        },
+        {
+          "entity": "geoId/72151"
+        },
+        {
+          "entity": "geoId/72153"
+        }
+      ]
     }
   ],
   "facets": {

--- a/internal/server/v1/observations/golden/bulk_point_linked/preferred_US_State.json
+++ b/internal/server/v1/observations/golden/bulk_point_linked/preferred_US_State.json
@@ -2602,6 +2602,524 @@
               "facet": "180485622"
             }
           ]
+        },
+        {
+          "entity": "geoId/72"
+        }
+      ]
+    },
+    {
+      "variable": "Count_Person_FoodInsecure",
+      "observations_by_entity": [
+        {
+          "entity": "geoId/01",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 788250,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/02",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 86970,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/04",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 918940,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/05",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 499950,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/06",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 4011960,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/08",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 566440,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/09",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 428800,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/10",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 114190,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/11",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 70480,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/12",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 2567300,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/13",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 1279310,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/15",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 162220,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/16",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 179580,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/17",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 1211410,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/18",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 834530,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/19",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 297800,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/20",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 351090,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/21",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 644540,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/22",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 718360,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/23",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 166910,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/24",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 640180,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/25",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 566930,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/26",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 1299020,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/27",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 432170,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/28",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 550370,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/29",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 809680,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/30",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 111080,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/31",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 225580,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/32",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 373370,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/33",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 119990,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/34",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 762530,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/35",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 298030,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/36",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 2090550,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/37",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 1417440,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/38",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 51380,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/39",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 1547110,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/40",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 583570,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/41",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 486200,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/42",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 1353730,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/44",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 101100,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/45",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 555630,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/46",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 91510,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/47",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 905090,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/48",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 4092850,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/49",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 355550,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/50",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 68590,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/51",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 799620,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/53",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 790050,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/54",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 242180,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/55",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 530500,
+              "facet": "180485622"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/56",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 67750,
+              "facet": "180485622"
+            }
+          ]
         }
       ]
     }

--- a/internal/server/v1/observations/golden/bulk_point_linked/preferred_test.json
+++ b/internal/server/v1/observations/golden/bulk_point_linked/preferred_test.json
@@ -1,0 +1,2462 @@
+{
+  "observations_by_variable": [
+    {
+      "variable": "Count_Person",
+      "observations_by_entity": [
+        {
+          "entity": "geoId/0600562",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 76362,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0600674",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 19488,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0601640",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 21605,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0602252",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 114794,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0603092",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 6915,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0605108",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 27225,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0605164",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 2104,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0605290",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 26819,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0606000",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 117145,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0608142",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 64870,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0608310",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 4668,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0609066",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 30106,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0609892",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 5187,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0610345",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 42754,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0613882",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 10973,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0614190",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 8954,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0614736",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 1577,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0616000",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 124074,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0616462",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 10141,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0616560",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 7498,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0617610",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 58622,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0617918",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 101243,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0617988",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 43240,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0619402",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 18974,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0620018",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 71674,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0620956",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 28847,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0621796",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 25845,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0622594",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 12870,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0623168",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 7521,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0623182",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 119705,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0625338",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 32517,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0626000",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 227514,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0629504",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 58101,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0631708",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 11363,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0633000",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 159827,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0633056",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 11275,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0633308",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 26091,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0633798",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 11016,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0639122",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 25208,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0640438",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 12928,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0641992",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 86803,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0643280",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 30700,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0643294",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 8295,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0644112",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 32538,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0646114",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 36819,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0646870",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 32475,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0647486",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 22277,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0647710",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 14105,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0647766",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 79066,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0648956",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 3396,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0649187",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 16624,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0649194",
+          "points_by_facet": [
+            {
+              "date": "1999",
+              "value": 16927,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0649278",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 45342,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0649670",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 81516,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0650258",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 78818,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0650916",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 47434,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0652582",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 52708,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0653000",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 433823,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0653070",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 43771,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0654232",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 19483,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0654806",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 37099,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0655282",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 66680,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0656784",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 59403,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0656938",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 11107,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0657288",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 18821,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0657456",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 76544,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0657764",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 34304,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0657792",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 78252,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0658380",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 4289,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0660102",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 81643,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0660620",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 115639,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0660984",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 10217,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0662546",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 44411,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0662980",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 2327,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0664140",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 5386,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0664434",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 12693,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0665028",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 42275,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0665070",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 30034,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0667000",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 815201,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0668000",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 983489,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0668084",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 88868,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0668252",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 102200,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0668294",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 31773,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0668364",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 60769,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0668378",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 86947,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0669084",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 127151,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0670098",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 176938,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0670280",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 30163,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0670364",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 7199,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0670770",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 7448,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0672646",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 10644,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0673262",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 64251,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0675630",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 29165,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0677000",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 152258,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0678666",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 9052,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0681204",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 68681,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0681554",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 103078,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0681666",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 124886,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0683346",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 69695,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0685922",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 26039,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0686440",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 5131,
+              "facet": "2176550201"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0686930",
+          "points_by_facet": [
+            {
+              "date": "2021",
+              "value": 3360,
+              "facet": "2176550201"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "variable": "Count_CriminalActivities_LarcenyTheft",
+      "observations_by_entity": [
+        {
+          "entity": "geoId/0600135"
+        },
+        {
+          "entity": "geoId/0600562",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 1958,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0600618"
+        },
+        {
+          "entity": "geoId/0600674",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 534,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0600898"
+        },
+        {
+          "entity": "geoId/0600996"
+        },
+        {
+          "entity": "geoId/0601416"
+        },
+        {
+          "entity": "geoId/0601458"
+        },
+        {
+          "entity": "geoId/0601486"
+        },
+        {
+          "entity": "geoId/0601640",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 368,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0602168"
+        },
+        {
+          "entity": "geoId/0602252",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 2078,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0602980"
+        },
+        {
+          "entity": "geoId/0603036"
+        },
+        {
+          "entity": "geoId/0603092",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 74,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0604415"
+        },
+        {
+          "entity": "geoId/0604470"
+        },
+        {
+          "entity": "geoId/0605108",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 312,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0605164",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 13,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0605290",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 250,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0606000",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 4993,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0606210"
+        },
+        {
+          "entity": "geoId/0606928"
+        },
+        {
+          "entity": "geoId/0606982"
+        },
+        {
+          "entity": "geoId/0607036"
+        },
+        {
+          "entity": "geoId/0607246"
+        },
+        {
+          "entity": "geoId/0607260"
+        },
+        {
+          "entity": "geoId/0607316"
+        },
+        {
+          "entity": "geoId/0607848"
+        },
+        {
+          "entity": "geoId/0608142",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 1095,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0608310",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 52,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0608338"
+        },
+        {
+          "entity": "geoId/0608848"
+        },
+        {
+          "entity": "geoId/0608968"
+        },
+        {
+          "entity": "geoId/0609066",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 937,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0609346"
+        },
+        {
+          "entity": "geoId/0609892",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 54,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0610088"
+        },
+        {
+          "entity": "geoId/0610301"
+        },
+        {
+          "entity": "geoId/0610345",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 990,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0611376"
+        },
+        {
+          "entity": "geoId/0611915"
+        },
+        {
+          "entity": "geoId/0611964"
+        },
+        {
+          "entity": "geoId/0612146"
+        },
+        {
+          "entity": "geoId/0612902"
+        },
+        {
+          "entity": "geoId/0613882",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 137,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0614190",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 87,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0614232"
+        },
+        {
+          "entity": "geoId/0614736",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 263,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0616000",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 3512,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0616090"
+        },
+        {
+          "entity": "geoId/0616462"
+        },
+        {
+          "entity": "geoId/0616560",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 68,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0617274"
+        },
+        {
+          "entity": "geoId/0617610",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 803,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0617918",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 1517,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0617988",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 247,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0618324"
+        },
+        {
+          "entity": "geoId/0619150"
+        },
+        {
+          "entity": "geoId/0619262"
+        },
+        {
+          "entity": "geoId/0619339"
+        },
+        {
+          "entity": "geoId/0619402",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 284,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0620018",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 1052,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0620598"
+        },
+        {
+          "entity": "geoId/0620956",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 360,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0621061"
+        },
+        {
+          "entity": "geoId/0621796",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 1054,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0621894"
+        },
+        {
+          "entity": "geoId/0621936"
+        },
+        {
+          "entity": "geoId/0622146"
+        },
+        {
+          "entity": "geoId/0622454"
+        },
+        {
+          "entity": "geoId/0622510"
+        },
+        {
+          "entity": "geoId/0622587"
+        },
+        {
+          "entity": "geoId/0622594",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 2415,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0623168",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 77,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0623182",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 2780,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0623350"
+        },
+        {
+          "entity": "geoId/0623973"
+        },
+        {
+          "entity": "geoId/0624960"
+        },
+        {
+          "entity": "geoId/0625338",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 341,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0626000",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 3408,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0627080"
+        },
+        {
+          "entity": "geoId/0628014"
+        },
+        {
+          "entity": "geoId/0629420"
+        },
+        {
+          "entity": "geoId/0629504",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 1034,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0630028"
+        },
+        {
+          "entity": "geoId/0630812"
+        },
+        {
+          "entity": "geoId/0631099"
+        },
+        {
+          "entity": "geoId/0631470"
+        },
+        {
+          "entity": "geoId/0631708",
+          "points_by_facet": [
+            {
+              "date": "2010",
+              "value": 193,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0632340"
+        },
+        {
+          "entity": "geoId/0633000",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 3197,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0633056",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 142,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0633308",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 278,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0633633"
+        },
+        {
+          "entity": "geoId/0633798",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 49,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0634120",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 174,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0636616"
+        },
+        {
+          "entity": "geoId/0637274"
+        },
+        {
+          "entity": "geoId/0638086"
+        },
+        {
+          "entity": "geoId/0638114"
+        },
+        {
+          "entity": "geoId/0638156"
+        },
+        {
+          "entity": "geoId/0638772"
+        },
+        {
+          "entity": "geoId/0639094"
+        },
+        {
+          "entity": "geoId/0639122",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 286,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0639283"
+        },
+        {
+          "entity": "geoId/0639318"
+        },
+        {
+          "entity": "geoId/0640426"
+        },
+        {
+          "entity": "geoId/0640438"
+        },
+        {
+          "entity": "geoId/0641282"
+        },
+        {
+          "entity": "geoId/0641992",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 1279,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0642384"
+        },
+        {
+          "entity": "geoId/0643280",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 181,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0643294",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 38,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0644112",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 332,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0644378"
+        },
+        {
+          "entity": "geoId/0644399"
+        },
+        {
+          "entity": "geoId/0645820"
+        },
+        {
+          "entity": "geoId/0646010"
+        },
+        {
+          "entity": "geoId/0646114",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 386,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0646870",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 633,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0647486",
+          "points_by_facet": [
+            {
+              "date": "2011",
+              "value": 264,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0647710",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 177,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0647766",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 1791,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0648718"
+        },
+        {
+          "entity": "geoId/0648760"
+        },
+        {
+          "entity": "geoId/0648928"
+        },
+        {
+          "entity": "geoId/0648956",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 9,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0649187",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 79,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0649194"
+        },
+        {
+          "entity": "geoId/0649278",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 507,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0649432"
+        },
+        {
+          "entity": "geoId/0649446"
+        },
+        {
+          "entity": "geoId/0649651"
+        },
+        {
+          "entity": "geoId/0649670",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 2030,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0649950"
+        },
+        {
+          "entity": "geoId/0650258",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 847,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0650916",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 1090,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0651280"
+        },
+        {
+          "entity": "geoId/0651622"
+        },
+        {
+          "entity": "geoId/0651658"
+        },
+        {
+          "entity": "geoId/0651840"
+        },
+        {
+          "entity": "geoId/0651890"
+        },
+        {
+          "entity": "geoId/0652162"
+        },
+        {
+          "entity": "geoId/0652582",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 711,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0653000",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 20228,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0653070",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 336,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0653196"
+        },
+        {
+          "entity": "geoId/0653266"
+        },
+        {
+          "entity": "geoId/0654232",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 125,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0654764"
+        },
+        {
+          "entity": "geoId/0654806",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 408,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0655282",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 1722,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0656476"
+        },
+        {
+          "entity": "geoId/0656756"
+        },
+        {
+          "entity": "geoId/0656784",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 626,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0656938",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 162,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0657288",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 726,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0657456",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 983,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0657764",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 1276,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0657792",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 1386,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0657960"
+        },
+        {
+          "entity": "geoId/0658226"
+        },
+        {
+          "entity": "geoId/0658380"
+        },
+        {
+          "entity": "geoId/0660102",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 1014,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0660279"
+        },
+        {
+          "entity": "geoId/0660620",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 2480,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0660914"
+        },
+        {
+          "entity": "geoId/0660984",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 87,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0662490"
+        },
+        {
+          "entity": "geoId/0662546",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 615,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0662700"
+        },
+        {
+          "entity": "geoId/0662868"
+        },
+        {
+          "entity": "geoId/0662980",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 19,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0663400"
+        },
+        {
+          "entity": "geoId/0664140",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 43,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0664252"
+        },
+        {
+          "entity": "geoId/0664434",
+          "points_by_facet": [
+            {
+              "date": "2012",
+              "value": 110,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0665028",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 948,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0665070",
+          "points_by_facet": [
+            {
+              "date": "2009",
+              "value": 436,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0667000",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 39887,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0667070"
+        },
+        {
+          "entity": "geoId/0668000",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 14924,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0668014"
+        },
+        {
+          "entity": "geoId/0668084",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 2941,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0668112"
+        },
+        {
+          "entity": "geoId/0668122"
+        },
+        {
+          "entity": "geoId/0668238"
+        },
+        {
+          "entity": "geoId/0668252",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 1523,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0668263"
+        },
+        {
+          "entity": "geoId/0668294",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 589,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0668364",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 1173,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0668378",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 869,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0669084",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 4013,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0670098",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 2077,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0670154"
+        },
+        {
+          "entity": "geoId/0670266"
+        },
+        {
+          "entity": "geoId/0670280",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 122,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0670364",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 224,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0670712"
+        },
+        {
+          "entity": "geoId/0670770",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 110,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0671000"
+        },
+        {
+          "entity": "geoId/0671074"
+        },
+        {
+          "entity": "geoId/0671362"
+        },
+        {
+          "entity": "geoId/0671927"
+        },
+        {
+          "entity": "geoId/0672184"
+        },
+        {
+          "entity": "geoId/0672646",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 95,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0673262",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 1074,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0673906"
+        },
+        {
+          "entity": "geoId/0674172"
+        },
+        {
+          "entity": "geoId/0675315"
+        },
+        {
+          "entity": "geoId/0675630",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 479,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0677000",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 2598,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0677042"
+        },
+        {
+          "entity": "geoId/0677805"
+        },
+        {
+          "entity": "geoId/0677924"
+        },
+        {
+          "entity": "geoId/0678126"
+        },
+        {
+          "entity": "geoId/0678666",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 67,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0678715"
+        },
+        {
+          "entity": "geoId/0678890"
+        },
+        {
+          "entity": "geoId/0681204",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 1300,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0681554",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 2120,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0681666",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 1148,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0681778"
+        },
+        {
+          "entity": "geoId/0682842"
+        },
+        {
+          "entity": "geoId/0683215"
+        },
+        {
+          "entity": "geoId/0683346",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 2034,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0684536"
+        },
+        {
+          "entity": "geoId/0685922",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 212,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "geoId/0686216"
+        },
+        {
+          "entity": "geoId/0686440"
+        },
+        {
+          "entity": "geoId/0686930",
+          "points_by_facet": [
+            {
+              "date": "2019",
+              "value": 36,
+              "facet": "4277990144"
+            }
+          ]
+        },
+        {
+          "entity": "wikidataId/Q1267489"
+        },
+        {
+          "entity": "wikidataId/Q1863076"
+        },
+        {
+          "entity": "wikidataId/Q1911837"
+        },
+        {
+          "entity": "wikidataId/Q2036981"
+        },
+        {
+          "entity": "wikidataId/Q2208068"
+        },
+        {
+          "entity": "wikidataId/Q2214519"
+        },
+        {
+          "entity": "wikidataId/Q2586362"
+        },
+        {
+          "entity": "wikidataId/Q2620952"
+        },
+        {
+          "entity": "wikidataId/Q3470832"
+        },
+        {
+          "entity": "wikidataId/Q3476563"
+        },
+        {
+          "entity": "wikidataId/Q6041883"
+        }
+      ]
+    }
+  ],
+  "facets": {
+    "2176550201": {
+      "import_name": "USCensusPEP_Annual_Population",
+      "provenance_url": "https://www2.census.gov/programs-surveys/popest/tables",
+      "measurement_method": "CensusPEPSurvey",
+      "observation_period": "P1Y"
+    },
+    "4277990144": {
+      "import_name": "FBIGovCrime",
+      "provenance_url": "http://www.fbi.gov/services/cjis/ucr",
+      "observation_period": "P1Y"
+    }
+  }
+}


### PR DESCRIPTION
Make the code more robust by not relying on cache build behavior as different import groups (place, stat1, stat2) can use different data snapshot