### PR TITLE
[Custom DC] Fix custom SVG hierarchy

### DIFF
--- a/internal/server/statvar/statvar_group.go
+++ b/internal/server/statvar/statvar_group.go
@@ -132,12 +132,12 @@ func adjustDescendentStatVarCount(id2Node map[string]*pb.StatVarGroupNode, curID
 	return curNode.GetDescendentStatVarCount()
 }
 
-// mergeCustomSVGNode merges node2's svg and svs into node1.
+// mergeSVGNodes merges node2's svg and svs into node1.
 // Merge here refers to set operation.
 // Warning: node1's DescendentStatVarCount is unchanged.
 // Caller is responsible for calling fixCustomRootDescendentStatVarCount
 // at the end of all merges.
-func mergeCustomSVGNode(node1, node2 *pb.StatVarGroupNode) {
+func mergeSVGNodes(node1, node2 *pb.StatVarGroupNode) {
 	node1SVGs := map[string]bool{}
 	for _, childSVG := range node1.GetChildStatVarGroups() {
 		node1SVGs[childSVG.GetId()] = true
@@ -223,7 +223,7 @@ func GetStatVarGroup(
 						} else if strings.HasPrefix(k, customSVGPrefix) {
 							// For custom SVGs, merge all SVGs regardless of the import group rank.
 							// Custom DC assumes overlapping stat var groups.
-							mergeCustomSVGNode(result.StatVarGroups[k], v)
+							mergeSVGNodes(result.StatVarGroups[k], v)
 						}
 					}
 				}

--- a/internal/server/statvar/statvar_group_test.go
+++ b/internal/server/statvar/statvar_group_test.go
@@ -317,7 +317,7 @@ func TestMergeCustomSVG(t *testing.T) {
 				}
 			}
 		}
-		fixCustomRootDescendentStatVarCount(got.StatVarGroups, customSvgRoot)
+		adjustDescendentStatVarCount(got.StatVarGroups, customSvgRoot)
 
 		for k, svgWant := range c.want.GetStatVarGroups() {
 			svgGot, ok := got.StatVarGroups[k]

--- a/internal/server/statvar/statvar_group_test.go
+++ b/internal/server/statvar/statvar_group_test.go
@@ -182,3 +182,151 @@ func TestFilter(t *testing.T) {
 		}
 	}
 }
+
+func TestMergeCustomSVG(t *testing.T) {
+	for _, c := range []struct {
+		input []*pb.StatVarGroups
+		want  *pb.StatVarGroups
+	}{
+		{
+			// input
+			[]*pb.StatVarGroups{
+				// Sample svg groups from cache 1
+				{
+					StatVarGroups: map[string]*pb.StatVarGroupNode{
+						"dc/g/Custom_Root": {
+							ChildStatVars: []*pb.StatVarGroupNode_ChildSV{},
+							ChildStatVarGroups: []*pb.StatVarGroupNode_ChildSVG{
+								{Id: "dc/g/Custom_Environment", DescendentStatVarCount: 0},
+								{Id: "dc/g/Custom_Energy", DescendentStatVarCount: 2},
+							},
+							DescendentStatVarCount: 2,
+						},
+						"dc/g/Custom_Environment": {
+							ChildStatVars:          []*pb.StatVarGroupNode_ChildSV{},
+							ChildStatVarGroups:     []*pb.StatVarGroupNode_ChildSVG{},
+							DescendentStatVarCount: 0,
+						},
+						"dc/g/Custom_Energy": {
+							ChildStatVars: []*pb.StatVarGroupNode_ChildSV{},
+							ChildStatVarGroups: []*pb.StatVarGroupNode_ChildSVG{
+								{Id: "dc/g/Custom_DeepSolar", DescendentStatVarCount: 2},
+							},
+							DescendentStatVarCount: 2,
+						},
+						"dc/g/Custom_DeepSolar": {
+							ChildStatVars: []*pb.StatVarGroupNode_ChildSV{
+								{Id: "Count_SolarInstallation_Commercial"},
+								{Id: "Mean_CoverageArea_SolarInstallation_Commercial"},
+							},
+							ChildStatVarGroups:     []*pb.StatVarGroupNode_ChildSVG{},
+							DescendentStatVarCount: 2,
+						},
+					},
+				},
+				// Sample svg groups from cache 2
+				{
+					StatVarGroups: map[string]*pb.StatVarGroupNode{
+						"dc/g/Custom_Root": {
+							ChildStatVars: []*pb.StatVarGroupNode_ChildSV{},
+							ChildStatVarGroups: []*pb.StatVarGroupNode_ChildSVG{
+								{Id: "dc/g/Custom_Environment", DescendentStatVarCount: 3},
+								{Id: "dc/g/Custom_Energy", DescendentStatVarCount: 0},
+							},
+							DescendentStatVarCount: 3,
+						},
+						"dc/g/Custom_Environment": {
+							ChildStatVars: []*pb.StatVarGroupNode_ChildSV{},
+							ChildStatVarGroups: []*pb.StatVarGroupNode_ChildSVG{
+								{Id: "dc/g/Custom_Atmosphere", DescendentStatVarCount: 3},
+							},
+							DescendentStatVarCount: 3,
+						},
+						"dc/g/Custom_Energy": {
+							ChildStatVars:          []*pb.StatVarGroupNode_ChildSV{},
+							ChildStatVarGroups:     []*pb.StatVarGroupNode_ChildSVG{},
+							DescendentStatVarCount: 0,
+						},
+						"dc/g/Custom_Atmosphere": {
+							ChildStatVars: []*pb.StatVarGroupNode_ChildSV{
+								{Id: "Max_Concentration_AirPollutant_Ozone"},
+								{Id: "Median_Concentration_AirPollutant_Ozone"},
+								{Id: "Min_Concentration_AirPollutant_Ozone"},
+							},
+							ChildStatVarGroups:     []*pb.StatVarGroupNode_ChildSVG{},
+							DescendentStatVarCount: 3,
+						},
+					},
+				},
+			},
+			// want
+			&pb.StatVarGroups{
+				// merged svg groups
+				StatVarGroups: map[string]*pb.StatVarGroupNode{
+					"dc/g/Custom_Root": {
+						ChildStatVars: []*pb.StatVarGroupNode_ChildSV{},
+						ChildStatVarGroups: []*pb.StatVarGroupNode_ChildSVG{
+							{Id: "dc/g/Custom_Environment", DescendentStatVarCount: 3},
+							{Id: "dc/g/Custom_Energy", DescendentStatVarCount: 2},
+						},
+						DescendentStatVarCount: 5,
+					},
+					"dc/g/Custom_Environment": {
+						ChildStatVars: []*pb.StatVarGroupNode_ChildSV{},
+						ChildStatVarGroups: []*pb.StatVarGroupNode_ChildSVG{
+							{Id: "dc/g/Custom_Atmosphere", DescendentStatVarCount: 3},
+						},
+						DescendentStatVarCount: 3,
+					},
+					"dc/g/Custom_Energy": {
+						ChildStatVars: []*pb.StatVarGroupNode_ChildSV{},
+						ChildStatVarGroups: []*pb.StatVarGroupNode_ChildSVG{
+							{Id: "dc/g/Custom_DeepSolar", DescendentStatVarCount: 2},
+						},
+						DescendentStatVarCount: 2,
+					},
+					"dc/g/Custom_DeepSolar": {
+						ChildStatVars: []*pb.StatVarGroupNode_ChildSV{
+							{Id: "Count_SolarInstallation_Commercial"},
+							{Id: "Mean_CoverageArea_SolarInstallation_Commercial"},
+						},
+						ChildStatVarGroups:     []*pb.StatVarGroupNode_ChildSVG{},
+						DescendentStatVarCount: 2,
+					},
+					"dc/g/Custom_Atmosphere": {
+						ChildStatVars: []*pb.StatVarGroupNode_ChildSV{
+							{Id: "Max_Concentration_AirPollutant_Ozone"},
+							{Id: "Median_Concentration_AirPollutant_Ozone"},
+							{Id: "Min_Concentration_AirPollutant_Ozone"},
+						},
+						ChildStatVarGroups:     []*pb.StatVarGroupNode_ChildSVG{},
+						DescendentStatVarCount: 3,
+					},
+				},
+			},
+		},
+	} {
+		// Mimick the logic in GetStatVarGroup.
+		got := &pb.StatVarGroups{StatVarGroups: map[string]*pb.StatVarGroupNode{}}
+		for _, importGroupSVGs := range c.input {
+			for k, v := range importGroupSVGs.GetStatVarGroups() {
+				if _, ok := got.StatVarGroups[k]; !ok {
+					got.StatVarGroups[k] = v
+				} else {
+					mergeCustomSVGNode(got.StatVarGroups[k], v)
+				}
+			}
+		}
+		fixCustomRootDescendentStatVarCount(got.StatVarGroups, customSvgRoot)
+
+		for k, svgWant := range c.want.GetStatVarGroups() {
+			svgGot, ok := got.StatVarGroups[k]
+			if !ok {
+				t.Errorf("MergeCustomSVG result missing svg %s", k)
+			}
+			if diff := cmp.Diff(svgGot, svgWant, protocmp.Transform()); diff != "" {
+				t.Errorf("MergeCustomSVG result[%s] got diff %v", k, diff)
+			}
+		}
+	}
+}

--- a/internal/server/statvar/statvar_group_test.go
+++ b/internal/server/statvar/statvar_group_test.go
@@ -313,7 +313,7 @@ func TestMergeCustomSVG(t *testing.T) {
 				if _, ok := got.StatVarGroups[k]; !ok {
 					got.StatVarGroups[k] = v
 				} else {
-					mergeCustomSVGNode(got.StatVarGroups[k], v)
+					mergeSVGNodes(got.StatVarGroups[k], v)
 				}
 			}
 		}


### PR DESCRIPTION
Currently, if multiple import groups have overlapping schemas, the hierarchy is not merged correctly. 
In addition, even when there is only 1 custom import group, the hierarchy is wrong (See [current stanford instance](https://screenshot.googleplex.com/9EGZoY9CTbhTG3p)).

I can't seem to figure out what determines when a svg shows up in cache (ex: dc/g/Custom_COVID-19_Incidence shows up in deepsolar import?), so a fix for this involves in merging all overlapping stat-vars and child svgs for a particular node, and then recounting all the nodes top down starting from the custom root. 

This fixes current Stanford instance's problem for multiple import groups.

TESTED=[local website, local mixer on envoy](https://screenshot.googleplex.com/3ShFhyPUdPpEM8W)