### PR TITLE
Remove configmap suffix for kustomize files referenced by website kustomize files.

### DIFF
--- a/deploy/mapping/kustomization.yaml
+++ b/deploy/mapping/kustomization.yaml
@@ -20,3 +20,6 @@ configMapGenerator:
     files:
       - base.mcf
       - encode.mcf
+
+generatorOptions:
+ disableNameSuffixHash: true

--- a/deploy/storage/kustomization.yaml
+++ b/deploy/storage/kustomization.yaml
@@ -24,3 +24,6 @@ configMapGenerator:
     files:
       - bigquery.version
       - base_bigtable_info.yaml
+
+generatorOptions:
+ disableNameSuffixHash: true


### PR DESCRIPTION
We removed kustomize for mixer, but some are still kept because they're used by https://github.com/datacommonsorg/website/blob/master/deploy/base/kustomization.yaml#L24