### PR TITLE
Add merging for resolve results for V2 API.

### DIFF
--- a/internal/merger/merger.go
+++ b/internal/merger/merger.go
@@ -21,7 +21,7 @@ import (
 	pbv2 "github.com/datacommonsorg/mixer/internal/proto/v2"
 )
 
-// MergeObservation merges two V2 resolve responses.
+// MergeResolve merges two V2 resolve responses.
 func MergeResolve(r1, r2 *pbv2.ResolveResponse) *pbv2.ResolveResponse {
 	// Maps are used to dedup.
 	nodeToResolvedIDSet := map[string]map[string]struct{}{}

--- a/internal/merger/merger.go
+++ b/internal/merger/merger.go
@@ -16,10 +16,56 @@
 package merger
 
 import (
+	"sort"
+
 	pbv2 "github.com/datacommonsorg/mixer/internal/proto/v2"
 )
 
-// MergeObservation merges two V2 observation response.
+// MergeObservation merges two V2 resolve responses.
+func MergeResolve(r1, r2 *pbv2.ResolveResponse) *pbv2.ResolveResponse {
+	// Maps are used to dedup.
+	nodeToResolvedIDSet := map[string]map[string]struct{}{}
+
+	collectEntities := func(r *pbv2.ResolveResponse) {
+		for _, e := range r.GetEntities() {
+			node := e.GetNode()
+			if _, ok := nodeToResolvedIDSet[node]; !ok {
+				nodeToResolvedIDSet[node] = map[string]struct{}{}
+			}
+			for _, id := range e.GetResolvedIds() {
+				nodeToResolvedIDSet[node][id] = struct{}{}
+			}
+		}
+	}
+
+	collectEntities(r1)
+	collectEntities(r2)
+
+	res := &pbv2.ResolveResponse{}
+	for node, resolvedIDSet := range nodeToResolvedIDSet {
+		var resolvedIDs []string
+		for id := range resolvedIDSet {
+			resolvedIDs = append(resolvedIDs, id)
+		}
+
+		// Sort to make result deterministic.
+		sort.Strings(resolvedIDs)
+
+		res.Entities = append(res.Entities, &pbv2.ResolveResponse_Entity{
+			Node:        node,
+			ResolvedIds: resolvedIDs,
+		})
+	}
+
+	// Sort to make result deterministic.
+	sort.Slice(res.Entities, func(i, j int) bool {
+		return res.Entities[i].Node < res.Entities[j].Node
+	})
+
+	return res
+}
+
+// MergeObservation merges two V2 observation responses.
 func MergeObservation(
 	o1, o2 *pbv2.ObservationResponse) *pbv2.ObservationResponse {
 	for v, vData := range o2.ByVariable {

--- a/internal/merger/merger_test.go
+++ b/internal/merger/merger_test.go
@@ -25,6 +25,58 @@ import (
 	"google.golang.org/protobuf/testing/protocmp"
 )
 
+func TestMergeResolve(t *testing.T) {
+	cmpOpts := cmp.Options{
+		protocmp.Transform(),
+	}
+
+	for _, c := range []struct {
+		r1   *pbv2.ResolveResponse
+		r2   *pbv2.ResolveResponse
+		want *pbv2.ResolveResponse
+	}{
+		{
+			&pbv2.ResolveResponse{
+				Entities: []*pbv2.ResolveResponse_Entity{
+					{
+						Node:        "node1",
+						ResolvedIds: []string{"id1.1", "id1.3"},
+					},
+				},
+			},
+			&pbv2.ResolveResponse{
+				Entities: []*pbv2.ResolveResponse_Entity{
+					{
+						Node:        "node1",
+						ResolvedIds: []string{"id1.2"},
+					},
+					{
+						Node:        "node2",
+						ResolvedIds: []string{"id2.1"},
+					},
+				},
+			},
+			&pbv2.ResolveResponse{
+				Entities: []*pbv2.ResolveResponse_Entity{
+					{
+						Node:        "node1",
+						ResolvedIds: []string{"id1.1", "id1.2", "id1.3"},
+					},
+					{
+						Node:        "node2",
+						ResolvedIds: []string{"id2.1"},
+					},
+				},
+			},
+		},
+	} {
+		got := MergeResolve(c.r1, c.r2)
+		if diff := cmp.Diff(got, c.want, cmpOpts); diff != "" {
+			t.Errorf("MergeResolve(%v, %v) got diff: %s", c.r1, c.r2, diff)
+		}
+	}
+}
+
 func TestMergeObservation(t *testing.T) {
 	cmpOpts := cmp.Options{
 		protocmp.Transform(),
@@ -130,8 +182,7 @@ func TestMergeObservation(t *testing.T) {
 	} {
 		got := MergeObservation(c.o1, c.o2)
 		if diff := cmp.Diff(got, c.want, cmpOpts); diff != "" {
-			t.Errorf("%+v", got)
-			// t.Errorf("MergeObservation(%v, %v) got diff: %s", c.o1, c.o2, diff)
+			t.Errorf("MergeObservation(%v, %v) got diff: %s", c.o1, c.o2, diff)
 		}
 	}
 }

--- a/internal/server/handler_core.go
+++ b/internal/server/handler_core.go
@@ -84,7 +84,7 @@ func V2ResolveCore(
 		outArc.SingleProp)
 }
 
-// V2ObservationBigtable fetches observation from Cloud Bigtable.
+// V2ObservationCore fetches observation from Cloud Bigtable.
 func V2ObservationCore(
 	ctx context.Context, store *store.Store, in *pbv2.ObservationRequest,
 ) (*pbv2.ObservationResponse, error) {

--- a/internal/server/handler_core.go
+++ b/internal/server/handler_core.go
@@ -21,13 +21,71 @@ import (
 	pbv2 "github.com/datacommonsorg/mixer/internal/proto/v2"
 	v2 "github.com/datacommonsorg/mixer/internal/server/v2"
 	v2observation "github.com/datacommonsorg/mixer/internal/server/v2/observation"
+	"github.com/datacommonsorg/mixer/internal/server/v2/resolve"
 	"github.com/datacommonsorg/mixer/internal/store"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"googlemaps.github.io/maps"
 )
 
-// V2ObservationBigtable fetches V2 observation from Cloud Bigtable.
-func V2ObservationBigtable(
+// V2ResolveCore gets resolve results from Cloud Bigtable and Maps API.
+func V2ResolveCore(
+	ctx context.Context,
+	store *store.Store,
+	mapsClient *maps.Client,
+	in *pbv2.ResolveRequest,
+) (*pbv2.ResolveResponse, error) {
+	arcs, err := v2.ParseProperty(in.GetProperty())
+	if err != nil {
+		return nil, err
+	}
+
+	if len(arcs) != 2 {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"invalid property for resolving: %s", in.GetProperty())
+	}
+
+	inArc := arcs[0]
+	outArc := arcs[1]
+	if inArc.Out || !outArc.Out {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"invalid property for resolving: %s", in.GetProperty())
+	}
+
+	if inArc.SingleProp == "geoCoordinate" && outArc.SingleProp == "dcid" {
+		// Coordinate to ID:
+		// Example:
+		//   <-geoCoordinate
+		return resolve.Coordinate(ctx, store, in.GetNodes())
+	}
+
+	if inArc.SingleProp == "description" && outArc.SingleProp == "dcid" {
+		// Description (name) to ID:
+		// Examples:
+		//   <-description
+		//   <-description{typeOf:City}
+		typeOf := inArc.Filter["typeOf"] // Could be empty.
+		return resolve.Description(
+			ctx,
+			store,
+			mapsClient,
+			in.GetNodes(),
+			typeOf)
+	}
+
+	// ID to ID:
+	// Example:
+	//   <-wikidataId->nutsCode
+	return resolve.ID(
+		ctx,
+		store,
+		in.GetNodes(),
+		inArc.SingleProp,
+		outArc.SingleProp)
+}
+
+// V2ObservationBigtable fetches observation from Cloud Bigtable.
+func V2ObservationCore(
 	ctx context.Context, store *store.Store, in *pbv2.ObservationRequest,
 ) (*pbv2.ObservationResponse, error) {
 	// (TODO): The routing logic here is very rough. This needs more work.


### PR DESCRIPTION
Also renamed handler_bigtable.go to handler_core.go, because for Resolve(), it's not just read from Bigtable, but also Maps API, and (in the future) NL APIs.