### PR TITLE
Update mixer service group and resource management

### DIFF
--- a/deploy/helm_charts/envs/mixer_autopush.yaml
+++ b/deploy/helm_charts/envs/mixer_autopush.yaml
@@ -24,5 +24,7 @@ serviceGroups:
       replicas: 20
   observation:
       replicas: 20
-  default:
+  node:
       replicas: 20
+  default:
+      replicas: 10

--- a/deploy/helm_charts/envs/mixer_dev.yaml
+++ b/deploy/helm_charts/envs/mixer_dev.yaml
@@ -25,5 +25,7 @@ serviceGroups:
     replicas: 4
   observation:
     replicas: 4
-  default:
+  node:
     replicas: 4
+  default:
+    replicas: 2

--- a/deploy/helm_charts/envs/mixer_encode.yaml
+++ b/deploy/helm_charts/envs/mixer_encode.yaml
@@ -13,6 +13,7 @@ ingress:
 # Encode instance only services SPARQL
 serviceGroups:
   svg: null
+  node: null
   recon: null
   observation: null
   default: null

--- a/deploy/helm_charts/envs/mixer_prod.yaml
+++ b/deploy/helm_charts/envs/mixer_prod.yaml
@@ -15,11 +15,13 @@ serviceGroups:
   svg:
     replicas: 10
   recon:
-    replicas: 80
-  observation:
-    replicas: 20
-  default:
+    replicas: 60
+  node:
     replicas: 40
+  observation:
+    replicas: 40
+  default:
+    replicas: 20
 
 # GCP level config
 ip: 35.244.133.155

--- a/deploy/helm_charts/envs/mixer_staging.yaml
+++ b/deploy/helm_charts/envs/mixer_staging.yaml
@@ -15,11 +15,13 @@ serviceGroups:
   svg:
     replicas: 2
   recon:
+    replicas: 4
+  node:
     replicas: 10
   observation:
     replicas: 10
   default:
-    replicas: 10
+    replicas: 5
 
 # GCP level config
 ip: 34.107.161.252

--- a/deploy/helm_charts/mixer/values.yaml
+++ b/deploy/helm_charts/mixer/values.yaml
@@ -107,8 +107,8 @@ serviceGroups:
       - "/v1/bulk/info/variable"
     replicas: 1
     resources:
-      memoryRequest: "8G"
-      memoryLimit: "8G"
+      memoryRequest: "6G"
+      memoryLimit: "6G"
     useSearch: true
     # If the name of the recon service is changed here,
     # please also change the name in the deployment.yaml template.
@@ -121,16 +121,34 @@ serviceGroups:
       memoryLimit: "400M"
   observation:
     urlPaths:
+      - "/bulk/stats"
+      - "/stat/*"
       - "/v1/observations/*"
       - "/v1/bulk/observations/*"
+      - "/v2/observation"
+      - "/v2/resolve"
     replicas: 1
     resources:
-      memoryRequest: "4G"
-      memoryLimit: "4G"
+      memoryRequest: "2G"
+      memoryLimit: "2G"
+  node:
+    urlPaths:
+      - "/node/*"
+      - "/v1/triples/*"
+      - "/v1/properties/*"
+      - "/v1/property/values/*"
+      - "/v1/bulk/property/values/*"
+      - "/v1/bulk/triples/*"
+      - "/v1/bulk/properties/*"
+      - "/v2/node"
+    replicas: 1
+    resources:
+      memoryRequest: "2G"
+      memoryLimit: "2G"
   default:
     urlPaths:
       - "/*"
     replicas: 1
     resources:
-      memoryRequest: "4G"
-      memoryLimit: "4G"
+      memoryRequest: "2G"
+      memoryLimit: "2G"


### PR DESCRIPTION
* Move some of the most used APIs (by traffic) into the dedicated service groups (observation, node)
* Decrease the memory usage for all service group as they are over allocated now
* Decrease pods for "svg" service group as it serves APIs with data in memory with very few computations
* Decrease pods for "default" as it only serves low traffic (and fewer) APIs.