### PR TITLE
[sv hierarchy] remove deploying blocklist svg config map

### DIFF
--- a/deploy/helm_charts/envs/mixer_private.yaml
+++ b/deploy/helm_charts/envs/mixer_private.yaml
@@ -125,6 +125,3 @@ ip: 35.244.175.66
 region: us-central1
 api_title: DataCommons API (Private)
 nodes: 3
-
-svg:
-  blocklistFile: ["dc/g/Uncategorized", "dc/g/SDG", "sdg/g/SDG"]

--- a/deploy/helm_charts/envs/mixer_prod.yaml
+++ b/deploy/helm_charts/envs/mixer_prod.yaml
@@ -28,6 +28,3 @@ ip: 35.244.133.155
 region: us-central1
 api_title: DataCommons API
 nodes: 6
-
-svg:
-  blocklistFile: ["dc/g/Uncategorized", "dc/g/SDG"]

--- a/deploy/helm_charts/envs/mixer_staging.yaml
+++ b/deploy/helm_charts/envs/mixer_staging.yaml
@@ -28,6 +28,3 @@ ip: 34.107.161.252
 region: us-central1
 api_title: DataCommons API (Staging)
 nodes: 2
-
-svg:
-  blocklistFile: ["dc/g/Uncategorized", "dc/g/SDG"]

--- a/deploy/helm_charts/envs/mixer_stanford.yaml
+++ b/deploy/helm_charts/envs/mixer_stanford.yaml
@@ -24,6 +24,3 @@ ip: 35.244.157.41
 region: us-central1
 api_title: DataCommons API (Stanford)
 nodes: 2
-
-svg:
-  blocklistFile: ["dc/g/Uncategorized", "dc/g/SDG", "sdg/g/SDG"]

--- a/deploy/helm_charts/mixer/templates/config_maps.yaml
+++ b/deploy/helm_charts/mixer/templates/config_maps.yaml
@@ -75,12 +75,3 @@ data:
   {{ $key }}: |
     {{ $val | nindent 4 }}
   {{ end  }}
-
----
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: blocklist-svg
-  namespace: {{ .Values.namespace.name }}
-data:
-  blocklist_svg.json: {{ toJson .Values.svg.blocklistFile | quote }}

--- a/deploy/helm_charts/mixer/templates/deployment.yaml
+++ b/deploy/helm_charts/mixer/templates/deployment.yaml
@@ -63,9 +63,6 @@ spec:
         - name: schema-mapping
           configMap:
             name: {{ include "mixer.fullname" $ }}-schema-mapping
-        - name: blocklist-svg
-          configMap:
-            name: blocklist-svg
       containers:
         - name: mixer
           image:  "{{ $.Values.mixer.image.repository }}:{{ $.Values.mixer.image.tag | default $.Chart.AppVersion }}"
@@ -99,8 +96,6 @@ spec:
               mountPath: /datacommons/mapping
             - name: memdb-config
               mountPath: /datacommons/memdb
-            - name: blocklist-svg
-              mountPath: /datacommons/svg
           env:
             - name: HOST_PROJECT
               valueFrom:

--- a/deploy/helm_charts/mixer/values.yaml
+++ b/deploy/helm_charts/mixer/values.yaml
@@ -152,6 +152,3 @@ serviceGroups:
     resources:
       memoryRequest: "2G"
       memoryLimit: "2G"
-
-svg:
-  blocklistFile: []


### PR DESCRIPTION
- remove deployment of a blocklist svg config map. When deployed with website, mixer will read the blocklist svg from the website config map & when deployed on its own, mixer will not have a list of blocklist svgs