### PR TITLE
[sv hierarchy] mount blocklist svg to a volume

### DIFF
--- a/deploy/helm_charts/mixer/templates/deployment.yaml
+++ b/deploy/helm_charts/mixer/templates/deployment.yaml
@@ -63,6 +63,10 @@ spec:
         - name: schema-mapping
           configMap:
             name: {{ include "mixer.fullname" $ }}-schema-mapping
+        - name: blocklist-svg
+          configMap:
+            name: blocklist-svg
+            optional: true
       containers:
         - name: mixer
           image:  "{{ $.Values.mixer.image.repository }}:{{ $.Values.mixer.image.tag | default $.Chart.AppVersion }}"
@@ -96,6 +100,8 @@ spec:
               mountPath: /datacommons/mapping
             - name: memdb-config
               mountPath: /datacommons/memdb
+            - name: blocklist-svg
+              mountPath: /datacommons/svg
           env:
             - name: HOST_PROJECT
               valueFrom:

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -152,9 +152,15 @@ func NewCache(ctx context.Context, store *store.Store, searchOptions SearchOptio
 		if searchOptions.BuildSvgSearchIndex {
 			var blocklistSvg []string
 			// Read blocklisted svg from file.
-			file, _ := os.ReadFile("/datacommons/svg/blocklist_svg.json")
-			if err := json.Unmarshal(file, &blocklistSvg); err != nil {
+			file, err := os.ReadFile("/datacommons/svg/blocklist_svg.json")
+			if err != nil {
+				log.Printf("Could not read blocklist svg file. Using empty blocklist svg list.")
 				blocklistSvg = []string{}
+			} else {
+				if err := json.Unmarshal(file, &blocklistSvg); err != nil {
+					log.Printf("Could not unmarshal blocklist svg file. Using empty blocklist svg list.")
+					blocklistSvg = []string{}
+				}
 			}
 			result.SvgSearchIndex = statvar.BuildStatVarSearchIndex(rawSvg, parentSvgMap, blocklistSvg)
 		}


### PR DESCRIPTION
- although configmap won't be created in mixer deployment, in order to use configmap from website deployment, mixer still needs to mount that configmap to a volume.