### PR TITLE
Add the ability to use only certain big tables

### DIFF
--- a/internal/server/statvar/golden/search_statvar/accommodation_food_services.json
+++ b/internal/server/statvar/golden/search_statvar/accommodation_food_services.json
@@ -1,26 +1,4 @@
 {
-  "statVars": [
-    {
-      "name": "Annual payroll ($1,000): Accommodation and food services (2012 NAICS code); All establishments (Tax status code); All establishments (Type of operation code)",
-      "dcid": "data.census.gov/table/EC1200A1/variable/PAYANN__naics2012--72%%taxstat--00%%typop--00"
-    },
-    {
-      "name": "First-quarter payroll ($1,000): Accommodation and food services (2012 NAICS code); All establishments (Tax status code); All establishments (Type of operation code)",
-      "dcid": "data.census.gov/table/EC1200A1/variable/PAYQTR1__naics2012--72%%taxstat--00%%typop--00"
-    },
-    {
-      "name": "Number of employees: Accommodation and food services (2012 NAICS code); All establishments (Tax status code); All establishments (Type of operation code)",
-      "dcid": "data.census.gov/table/EC1200A1/variable/EMP__naics2012--72%%taxstat--00%%typop--00"
-    },
-    {
-      "name": "Number of establishments: Accommodation and food services (2012 NAICS code); All establishments (Tax status code); All establishments (Type of operation code)",
-      "dcid": "data.census.gov/table/EC1200A1/variable/ESTAB__naics2012--72%%taxstat--00%%typop--00"
-    },
-    {
-      "name": "Sales, value of shipments, or revenue ($1,000): Accommodation and food services (2012 NAICS code); All establishments (Tax status code); All establishments (Type of operation code)",
-      "dcid": "data.census.gov/table/EC1200A1/variable/RCPTOT__naics2012--72%%taxstat--00%%typop--00"
-    }
-  ],
   "statVarGroups": [
     {
       "dcid": "dc/g/Person_Industry-NAICS/7172_PlaceOfBirth",

--- a/internal/server/statvar/golden/search_statvar/fem.json
+++ b/internal/server/statvar/golden/search_statvar/fem.json
@@ -35275,100 +35275,6 @@
       ]
     },
     {
-      "dcid": "dc/g/MortalityEvent_Age_Gender-Female",
-      "name": "Mortality Event With Age, Gender = Female",
-      "statVars": [
-        {
-          "name": "Count of Mortality Event: 10 - 14 Years, Female",
-          "dcid": "Count_Death_10To14Years_Female"
-        },
-        {
-          "name": "Count of Mortality Event: 15 - 19 Years, Female",
-          "dcid": "Count_Death_15To19Years_Female"
-        },
-        {
-          "name": "Count of Mortality Event: 15 - 64 Years, Female",
-          "dcid": "Count_Death_15To64Years_Female"
-        },
-        {
-          "name": "Count of Mortality Event: 20 - 24 Years, Female",
-          "dcid": "Count_Death_20To24Years_Female"
-        },
-        {
-          "name": "Count of Mortality Event: 25 - 29 Years, Female",
-          "dcid": "Count_Death_25To29Years_Female"
-        },
-        {
-          "name": "Count of Mortality Event: 30 - 34 Years, Female",
-          "dcid": "Count_Death_30To34Years_Female"
-        },
-        {
-          "name": "Count of Mortality Event: 35 - 39 Years, Female",
-          "dcid": "Count_Death_35To39Years_Female"
-        },
-        {
-          "name": "Count of Mortality Event: 4 Years or Less, Female",
-          "dcid": "Count_Death_Upto4Years_Female"
-        },
-        {
-          "name": "Count of Mortality Event: 40 - 44 Years, Female",
-          "dcid": "Count_Death_40To44Years_Female"
-        },
-        {
-          "name": "Count of Mortality Event: 45 - 49 Years, Female",
-          "dcid": "Count_Death_45To49Years_Female"
-        },
-        {
-          "name": "Count of Mortality Event: 5 - 19 Years, Female",
-          "dcid": "dc/rxg50w6jfgld4"
-        },
-        {
-          "name": "Count of Mortality Event: 5 - 9 Years, Female",
-          "dcid": "Count_Death_5To9Years_Female"
-        },
-        {
-          "name": "Count of Mortality Event: 50 - 54 Years, Female",
-          "dcid": "Count_Death_50To54Years_Female"
-        },
-        {
-          "name": "Count of Mortality Event: 55 - 59 Years, Female",
-          "dcid": "Count_Death_55To59Years_Female"
-        },
-        {
-          "name": "Count of Mortality Event: 60 - 64 Years, Female",
-          "dcid": "Count_Death_60To64Years_Female"
-        },
-        {
-          "name": "Count of Mortality Event: 65 - 69 Years, Female",
-          "dcid": "Count_Death_65To69Years_Female"
-        },
-        {
-          "name": "Count of Mortality Event: 65 Years or More, Female",
-          "dcid": "Count_Death_65OrMoreYears_Female"
-        },
-        {
-          "name": "Count of Mortality Event: 70 - 74 Years, Female",
-          "dcid": "Count_Death_70To74Years_Female"
-        },
-        {
-          "name": "Count of Mortality Event: 75 - 79 Years, Female",
-          "dcid": "Count_Death_75To79Years_Female"
-        },
-        {
-          "name": "Count of Mortality Event: 75 Years or More, Female",
-          "dcid": "dc/sw43w4pbtgq4d"
-        },
-        {
-          "name": "Count of Mortality Event: 80 Years or More, Female",
-          "dcid": "Count_Death_80OrMoreYears_Female"
-        },
-        {
-          "name": "Female Infant Mortality Rate",
-          "dcid": "Count_Death_0Years_Female_AsFractionOf_Count_BirthEvent_LiveBirth_Female"
-        }
-      ]
-    },
-    {
       "dcid": "dc/g/SDGVCVOVGDSD_gender-SDGSexEnumFEMALE_sdggroundsOfDiscrimination",
       "name": "Proportion of Population Reporting Having Felt Discriminated Against With Gender = Female, Grounds of Discrimination",
       "statVars": [
@@ -35455,6 +35361,92 @@
         {
           "name": "Proportion of population reporting having felt discriminated against: Traditions, Female",
           "dcid": "sdg/VC_VOV_GDSD_TRAD_FEMALE"
+        }
+      ]
+    },
+    {
+      "dcid": "dc/g/MortalityEvent_Age_Gender-Female",
+      "name": "Mortality Event With Age, Gender = Female",
+      "statVars": [
+        {
+          "name": "Count of Mortality Event: 10 - 14 Years, Female",
+          "dcid": "Count_Death_10To14Years_Female"
+        },
+        {
+          "name": "Count of Mortality Event: 15 - 19 Years, Female",
+          "dcid": "Count_Death_15To19Years_Female"
+        },
+        {
+          "name": "Count of Mortality Event: 15 - 64 Years, Female",
+          "dcid": "Count_Death_15To64Years_Female"
+        },
+        {
+          "name": "Count of Mortality Event: 20 - 24 Years, Female",
+          "dcid": "Count_Death_20To24Years_Female"
+        },
+        {
+          "name": "Count of Mortality Event: 25 - 29 Years, Female",
+          "dcid": "Count_Death_25To29Years_Female"
+        },
+        {
+          "name": "Count of Mortality Event: 30 - 34 Years, Female",
+          "dcid": "Count_Death_30To34Years_Female"
+        },
+        {
+          "name": "Count of Mortality Event: 35 - 39 Years, Female",
+          "dcid": "Count_Death_35To39Years_Female"
+        },
+        {
+          "name": "Count of Mortality Event: 4 Years or Less, Female",
+          "dcid": "Count_Death_Upto4Years_Female"
+        },
+        {
+          "name": "Count of Mortality Event: 40 - 44 Years, Female",
+          "dcid": "Count_Death_40To44Years_Female"
+        },
+        {
+          "name": "Count of Mortality Event: 45 - 49 Years, Female",
+          "dcid": "Count_Death_45To49Years_Female"
+        },
+        {
+          "name": "Count of Mortality Event: 5 - 9 Years, Female",
+          "dcid": "Count_Death_5To9Years_Female"
+        },
+        {
+          "name": "Count of Mortality Event: 50 - 54 Years, Female",
+          "dcid": "Count_Death_50To54Years_Female"
+        },
+        {
+          "name": "Count of Mortality Event: 55 - 59 Years, Female",
+          "dcid": "Count_Death_55To59Years_Female"
+        },
+        {
+          "name": "Count of Mortality Event: 60 - 64 Years, Female",
+          "dcid": "Count_Death_60To64Years_Female"
+        },
+        {
+          "name": "Count of Mortality Event: 65 - 69 Years, Female",
+          "dcid": "Count_Death_65To69Years_Female"
+        },
+        {
+          "name": "Count of Mortality Event: 65 Years or More, Female",
+          "dcid": "Count_Death_65OrMoreYears_Female"
+        },
+        {
+          "name": "Count of Mortality Event: 70 - 74 Years, Female",
+          "dcid": "Count_Death_70To74Years_Female"
+        },
+        {
+          "name": "Count of Mortality Event: 75 - 79 Years, Female",
+          "dcid": "Count_Death_75To79Years_Female"
+        },
+        {
+          "name": "Count of Mortality Event: 80 Years or More, Female",
+          "dcid": "Count_Death_80OrMoreYears_Female"
+        },
+        {
+          "name": "Female Infant Mortality Rate",
+          "dcid": "Count_Death_0Years_Female_AsFractionOf_Count_BirthEvent_LiveBirth_Female"
         }
       ]
     },
@@ -35705,6 +35697,80 @@
       ]
     },
     {
+      "dcid": "dc/g/Person_EducationalAttainment_Gender-Female",
+      "name": "Person With Educational Attainment, Gender = Female",
+      "statVars": [
+        {
+          "name": "Percentage: Bachelor Degree or Higher, Female",
+          "dcid": "dc/648tvf392fz0c"
+        },
+        {
+          "name": "Population: 10th Grade, Female",
+          "dcid": "Count_Person_25OrMoreYears_EducationalAttainment10ThGrade_Female"
+        },
+        {
+          "name": "Population: 11th Grade, Female",
+          "dcid": "Count_Person_25OrMoreYears_EducationalAttainment11ThGrade_Female"
+        },
+        {
+          "name": "Population: 12th Grade No Diploma, Female",
+          "dcid": "Count_Person_25OrMoreYears_EducationalAttainment12ThGradeNoDiploma_Female"
+        },
+        {
+          "name": "Population: 5th And 6th Grade, Female",
+          "dcid": "Count_Person_25OrMoreYears_EducationalAttainment5ThAnd6ThGrade_Female"
+        },
+        {
+          "name": "Population: 7th And 8th Grade, Female",
+          "dcid": "Count_Person_25OrMoreYears_EducationalAttainment7ThAnd8ThGrade_Female"
+        },
+        {
+          "name": "Population: 9th Grade, Female",
+          "dcid": "Count_Person_25OrMoreYears_EducationalAttainment9ThGrade_Female"
+        },
+        {
+          "name": "Population: Masters Degree, Female",
+          "dcid": "Count_Person_25OrMoreYears_EducationalAttainmentMastersDegree_Female"
+        },
+        {
+          "name": "Population: No Schooling Completed, Female",
+          "dcid": "Count_Person_25OrMoreYears_EducationalAttainmentNoSchoolingCompleted_Female"
+        },
+        {
+          "name": "Population: Nursery To 4th Grade, Female",
+          "dcid": "Count_Person_25OrMoreYears_EducationalAttainmentNurseryTo4ThGrade_Female"
+        },
+        {
+          "name": "Population: Professional School Degree, Female",
+          "dcid": "Count_Person_25OrMoreYears_EducationalAttainmentProfessionalSchoolDegree_Female"
+        },
+        {
+          "name": "Population: Some College 1 or More Years No Degree, Female",
+          "dcid": "Count_Person_25OrMoreYears_EducationalAttainmentSomeCollege1OrMoreYearsNoDegree_Female"
+        },
+        {
+          "name": "Population: Some College Less Than 1 Year, Female",
+          "dcid": "Count_Person_25OrMoreYears_EducationalAttainmentSomeCollegeLessThan1Year_Female"
+        },
+        {
+          "name": "Population: Masters Degree or Higher, Female (As Fraction of Count Person 25 or More Years Female)",
+          "dcid": "Count_Person_25OrMoreYears_Female_MastersDegreeOrHigher_AsFractionOf_Count_Person_25OrMoreYears_Female"
+        },
+        {
+          "name": "Population: 25 - 64 Years, Less Than Primary Education \u0026 Primary Education \u0026 Lower Secondary Education, Female (As Fraction of Count Person 25 To 64 Years Female)",
+          "dcid": "Count_Person_25To64Years_LessThanPrimaryEducationOrPrimaryEducationOrLowerSecondaryEducation_Female_AsAFractionOfCount_Person_25To64Years_Female"
+        },
+        {
+          "name": "Population: 25 - 64 Years, Upper Secondary Education \u0026 Post Secondary Non Tertiary Education, Female (As Fraction of Count Person 25 To 64 Years Female)",
+          "dcid": "Count_Person_25To64Years_UpperSecondaryEducationOrPostSecondaryNonTertiaryEducation_Female_AsAFractionOfCount_Person_25To64Years_Female"
+        },
+        {
+          "name": "Population: 25 - 64 Years, Upper Secondary Education or Higher, Female (As Fraction of Count Person 25 To 64 Years Female)",
+          "dcid": "Count_Person_25To64Years_UpperSecondaryEducationOrHigher_Female_AsAFractionOfCount_Person_25To64Years_Female"
+        }
+      ]
+    },
+    {
       "dcid": "dc/g/SDGSLDOMTSPD_age_gender-SDGSexEnumFEMALE",
       "name": "Proportion of Time Spent on Unpaid Domestic Chores And Care Work With Age, Gender = Female",
       "statVars": [
@@ -35923,76 +35989,6 @@
         {
           "name": "Proportion of population reporting having felt discriminated against: Persons without disability, Socioeconomic status, Female",
           "dcid": "sdg/VC_VOV_GDSD_PWD_SOCIOECON_FEMALE"
-        }
-      ]
-    },
-    {
-      "dcid": "dc/g/Person_EducationalAttainment_Gender-Female",
-      "name": "Person With Educational Attainment, Gender = Female",
-      "statVars": [
-        {
-          "name": "Population: 10th Grade, Female",
-          "dcid": "Count_Person_25OrMoreYears_EducationalAttainment10ThGrade_Female"
-        },
-        {
-          "name": "Population: 11th Grade, Female",
-          "dcid": "Count_Person_25OrMoreYears_EducationalAttainment11ThGrade_Female"
-        },
-        {
-          "name": "Population: 12th Grade No Diploma, Female",
-          "dcid": "Count_Person_25OrMoreYears_EducationalAttainment12ThGradeNoDiploma_Female"
-        },
-        {
-          "name": "Population: 5th And 6th Grade, Female",
-          "dcid": "Count_Person_25OrMoreYears_EducationalAttainment5ThAnd6ThGrade_Female"
-        },
-        {
-          "name": "Population: 7th And 8th Grade, Female",
-          "dcid": "Count_Person_25OrMoreYears_EducationalAttainment7ThAnd8ThGrade_Female"
-        },
-        {
-          "name": "Population: 9th Grade, Female",
-          "dcid": "Count_Person_25OrMoreYears_EducationalAttainment9ThGrade_Female"
-        },
-        {
-          "name": "Population: Masters Degree, Female",
-          "dcid": "Count_Person_25OrMoreYears_EducationalAttainmentMastersDegree_Female"
-        },
-        {
-          "name": "Population: No Schooling Completed, Female",
-          "dcid": "Count_Person_25OrMoreYears_EducationalAttainmentNoSchoolingCompleted_Female"
-        },
-        {
-          "name": "Population: Nursery To 4th Grade, Female",
-          "dcid": "Count_Person_25OrMoreYears_EducationalAttainmentNurseryTo4ThGrade_Female"
-        },
-        {
-          "name": "Population: Professional School Degree, Female",
-          "dcid": "Count_Person_25OrMoreYears_EducationalAttainmentProfessionalSchoolDegree_Female"
-        },
-        {
-          "name": "Population: Some College 1 or More Years No Degree, Female",
-          "dcid": "Count_Person_25OrMoreYears_EducationalAttainmentSomeCollege1OrMoreYearsNoDegree_Female"
-        },
-        {
-          "name": "Population: Some College Less Than 1 Year, Female",
-          "dcid": "Count_Person_25OrMoreYears_EducationalAttainmentSomeCollegeLessThan1Year_Female"
-        },
-        {
-          "name": "Population: Masters Degree or Higher, Female (As Fraction of Count Person 25 or More Years Female)",
-          "dcid": "Count_Person_25OrMoreYears_Female_MastersDegreeOrHigher_AsFractionOf_Count_Person_25OrMoreYears_Female"
-        },
-        {
-          "name": "Population: 25 - 64 Years, Less Than Primary Education \u0026 Primary Education \u0026 Lower Secondary Education, Female (As Fraction of Count Person 25 To 64 Years Female)",
-          "dcid": "Count_Person_25To64Years_LessThanPrimaryEducationOrPrimaryEducationOrLowerSecondaryEducation_Female_AsAFractionOfCount_Person_25To64Years_Female"
-        },
-        {
-          "name": "Population: 25 - 64 Years, Upper Secondary Education \u0026 Post Secondary Non Tertiary Education, Female (As Fraction of Count Person 25 To 64 Years Female)",
-          "dcid": "Count_Person_25To64Years_UpperSecondaryEducationOrPostSecondaryNonTertiaryEducation_Female_AsAFractionOfCount_Person_25To64Years_Female"
-        },
-        {
-          "name": "Population: 25 - 64 Years, Upper Secondary Education or Higher, Female (As Fraction of Count Person 25 To 64 Years Female)",
-          "dcid": "Count_Person_25To64Years_UpperSecondaryEducationOrHigher_Female_AsAFractionOfCount_Person_25To64Years_Female"
         }
       ]
     },
@@ -36781,52 +36777,6 @@
         {
           "name": "Std Deviation State Referenced Achievement of Student: Female, Third Grade, Mathematics",
           "dcid": "dc/sdfm4kc8cgh06"
-        }
-      ]
-    },
-    {
-      "dcid": "dc/g/Person_Gender-Female",
-      "name": "Person With Gender = Female",
-      "statVars": [
-        {
-          "name": "Female Life Expectancy",
-          "dcid": "LifeExpectancy_Person_Female"
-        },
-        {
-          "name": "Female Population",
-          "dcid": "Count_Person_Female"
-        },
-        {
-          "name": "Unemployment Rate of the Female Population",
-          "dcid": "UnemploymentRate_Person_Female"
-        },
-        {
-          "name": "Mean Wages Daily: Female",
-          "dcid": "Mean_WagesDaily_Worker_Female"
-        },
-        {
-          "name": "Mean Wages Monthly: Female",
-          "dcid": "Mean_WagesMonthly_Worker_Female"
-        },
-        {
-          "name": "Median Age of Female Population",
-          "dcid": "Median_Age_Person_Female"
-        },
-        {
-          "name": "Median Income of Women (15 Years or Older) With Income",
-          "dcid": "Median_Income_Person_15OrMoreYears_Female_WithIncome"
-        },
-        {
-          "name": "Female Population With Disabilities",
-          "dcid": "Count_Person_WithDisability_Female"
-        },
-        {
-          "name": "Percentage: Bachelor Degree or Higher, Female",
-          "dcid": "dc/648tvf392fz0c"
-        },
-        {
-          "name": "Percentage: Female, Below Poverty Level in The Past 12 Months",
-          "dcid": "dc/k0zg5lw8686z8"
         }
       ]
     },
@@ -41603,6 +41553,44 @@
         {
           "name": "Std Deviation Assessment Score of Student: Female, School Grade 8, Writing, Public School",
           "dcid": "StdDeviation_AssessmentScore_Student_Female_SchoolGrade8_Writing_PublicSchool"
+        }
+      ]
+    },
+    {
+      "dcid": "dc/g/Person_Gender-Female",
+      "name": "Person With Gender = Female",
+      "statVars": [
+        {
+          "name": "Female Life Expectancy",
+          "dcid": "LifeExpectancy_Person_Female"
+        },
+        {
+          "name": "Female Population",
+          "dcid": "Count_Person_Female"
+        },
+        {
+          "name": "Unemployment Rate of the Female Population",
+          "dcid": "UnemploymentRate_Person_Female"
+        },
+        {
+          "name": "Mean Wages Daily: Female",
+          "dcid": "Mean_WagesDaily_Worker_Female"
+        },
+        {
+          "name": "Mean Wages Monthly: Female",
+          "dcid": "Mean_WagesMonthly_Worker_Female"
+        },
+        {
+          "name": "Median Age of Female Population",
+          "dcid": "Median_Age_Person_Female"
+        },
+        {
+          "name": "Median Income of Women (15 Years or Older) With Income",
+          "dcid": "Median_Income_Person_15OrMoreYears_Female_WithIncome"
+        },
+        {
+          "name": "Female Population With Disabilities",
+          "dcid": "Count_Person_WithDisability_Female"
         }
       ]
     },
@@ -53325,24 +53313,6 @@
       ]
     },
     {
-      "dcid": "dc/g/Person_Gender-Female_MedicalCondition",
-      "name": "Person With Gender = Female, Medical Condition",
-      "statVars": [
-        {
-          "name": "Prevalence: Female, Diabetes",
-          "dcid": "dc/nh3s4skee5483"
-        },
-        {
-          "name": "Population: 4 Years or Less, Female, Severe Wasting (As Fraction of Count Person Upto 4 Years Female)",
-          "dcid": "Count_Person_Upto4Years_Female_SevereWasting_AsFractionOf_Count_Person_Upto4Years_Female"
-        },
-        {
-          "name": "Population: 4 Years or Less, Female, Wasting (As Fraction of Count Person Upto 4 Years Female)",
-          "dcid": "Count_Person_Upto4Years_Female_Wasting_AsFractionOf_Count_Person_Upto4Years_Female"
-        }
-      ]
-    },
-    {
       "dcid": "dc/g/Person_Gender-Female_Nativity-ForeignBorn",
       "name": "Person With Gender = Female, Nativity = Foreign Born",
       "statVars": [
@@ -58231,6 +58201,20 @@
         {
           "name": "Population: Years 22, Female",
           "dcid": "Count_Person_22Years_Female"
+        }
+      ]
+    },
+    {
+      "dcid": "dc/g/Person_Age-Years23_Gender-Female",
+      "name": "Person With Age = Years 23, Gender = Female",
+      "statVars": [
+        {
+          "name": "Life Expectancy: Years 23, Female",
+          "dcid": "LifeExpectancy_Person_23Years_Female"
+        },
+        {
+          "name": "Population: Years 23, Female",
+          "dcid": "Count_Person_23Years_Female"
         }
       ]
     }

--- a/internal/server/statvar/golden/search_statvar/female.json
+++ b/internal/server/statvar/golden/search_statvar/female.json
@@ -1247,6 +1247,34 @@
       ]
     },
     {
+      "dcid": "dc/g/MedicalConditionIncident_Gender-Female_MedicalCondition-Listeriosis_MedicalStatus",
+      "name": "Medical Condition Incident With Gender = Female, Medical Condition = Listeriosis, Medical Status",
+      "statVars": [
+        {
+          "name": "Count of Confirmed, Female Listeriosis incidents",
+          "dcid": "Count_MedicalConditionIncident_Female_ConditionListeriosis_ConfirmedCase"
+        },
+        {
+          "name": "Count of Probable, Female Listeriosis incidents",
+          "dcid": "Count_MedicalConditionIncident_Female_ConditionListeriosis_ProbableCase"
+        }
+      ]
+    },
+    {
+      "dcid": "dc/g/MedicalConditionIncident_Gender-Female_MedicalCondition-LymeDisease_MedicalStatus",
+      "name": "Medical Condition Incident With Gender = Female, Medical Condition = Lyme Disease, Medical Status",
+      "statVars": [
+        {
+          "name": "Count of Confirmed, Female Lyme disease incidents",
+          "dcid": "Count_MedicalConditionIncident_Female_ConditionLymeDisease_ConfirmedCase"
+        },
+        {
+          "name": "Count of Probable, Female Lyme disease incidents",
+          "dcid": "Count_MedicalConditionIncident_Female_ConditionLymeDisease_ProbableCase"
+        }
+      ]
+    },
+    {
       "dcid": "dc/g/SDG_3.7.1",
       "name": "3.7.1: Proportion of women of reproductive age (aged 15-49 years) who have their need for family planning satisfied with modern methods",
       "statVars": [
@@ -4513,26 +4541,6 @@
         {
           "name": "Count of Invasive pneumococcal, Age \u003c5 years, Female pneumococcal disease incidents",
           "dcid": "Count_MedicalConditionIncident_5_LessYears_Female_ConditionStreptococcusPneumonia"
-        }
-      ]
-    },
-    {
-      "dcid": "dc/g/MedicalConditionIncident_Gender-Female_MedicalCondition-Listeriosis_MedicalStatus",
-      "name": "Medical Condition Incident With Gender = Female, Medical Condition = Listeriosis, Medical Status",
-      "statVars": [
-        {
-          "name": "Count of Confirmed, Female Listeriosis incidents",
-          "dcid": "Count_MedicalConditionIncident_Female_ConditionListeriosis_ConfirmedCase"
-        }
-      ]
-    },
-    {
-      "dcid": "dc/g/MedicalConditionIncident_Gender-Female_MedicalCondition-LymeDisease_MedicalStatus",
-      "name": "Medical Condition Incident With Gender = Female, Medical Condition = Lyme Disease, Medical Status",
-      "statVars": [
-        {
-          "name": "Count of Confirmed, Female Lyme disease incidents",
-          "dcid": "Count_MedicalConditionIncident_Female_ConditionLymeDisease_ConfirmedCase"
         }
       ]
     },

--- a/internal/server/statvar/golden/search_statvar/women.json
+++ b/internal/server/statvar/golden/search_statvar/women.json
@@ -35275,100 +35275,6 @@
       ]
     },
     {
-      "dcid": "dc/g/MortalityEvent_Age_Gender-Female",
-      "name": "Mortality Event With Age, Gender = Female",
-      "statVars": [
-        {
-          "name": "Count of Mortality Event: 10 - 14 Years, Female",
-          "dcid": "Count_Death_10To14Years_Female"
-        },
-        {
-          "name": "Count of Mortality Event: 15 - 19 Years, Female",
-          "dcid": "Count_Death_15To19Years_Female"
-        },
-        {
-          "name": "Count of Mortality Event: 15 - 64 Years, Female",
-          "dcid": "Count_Death_15To64Years_Female"
-        },
-        {
-          "name": "Count of Mortality Event: 20 - 24 Years, Female",
-          "dcid": "Count_Death_20To24Years_Female"
-        },
-        {
-          "name": "Count of Mortality Event: 25 - 29 Years, Female",
-          "dcid": "Count_Death_25To29Years_Female"
-        },
-        {
-          "name": "Count of Mortality Event: 30 - 34 Years, Female",
-          "dcid": "Count_Death_30To34Years_Female"
-        },
-        {
-          "name": "Count of Mortality Event: 35 - 39 Years, Female",
-          "dcid": "Count_Death_35To39Years_Female"
-        },
-        {
-          "name": "Count of Mortality Event: 4 Years or Less, Female",
-          "dcid": "Count_Death_Upto4Years_Female"
-        },
-        {
-          "name": "Count of Mortality Event: 40 - 44 Years, Female",
-          "dcid": "Count_Death_40To44Years_Female"
-        },
-        {
-          "name": "Count of Mortality Event: 45 - 49 Years, Female",
-          "dcid": "Count_Death_45To49Years_Female"
-        },
-        {
-          "name": "Count of Mortality Event: 5 - 19 Years, Female",
-          "dcid": "dc/rxg50w6jfgld4"
-        },
-        {
-          "name": "Count of Mortality Event: 5 - 9 Years, Female",
-          "dcid": "Count_Death_5To9Years_Female"
-        },
-        {
-          "name": "Count of Mortality Event: 50 - 54 Years, Female",
-          "dcid": "Count_Death_50To54Years_Female"
-        },
-        {
-          "name": "Count of Mortality Event: 55 - 59 Years, Female",
-          "dcid": "Count_Death_55To59Years_Female"
-        },
-        {
-          "name": "Count of Mortality Event: 60 - 64 Years, Female",
-          "dcid": "Count_Death_60To64Years_Female"
-        },
-        {
-          "name": "Count of Mortality Event: 65 - 69 Years, Female",
-          "dcid": "Count_Death_65To69Years_Female"
-        },
-        {
-          "name": "Count of Mortality Event: 65 Years or More, Female",
-          "dcid": "Count_Death_65OrMoreYears_Female"
-        },
-        {
-          "name": "Count of Mortality Event: 70 - 74 Years, Female",
-          "dcid": "Count_Death_70To74Years_Female"
-        },
-        {
-          "name": "Count of Mortality Event: 75 - 79 Years, Female",
-          "dcid": "Count_Death_75To79Years_Female"
-        },
-        {
-          "name": "Count of Mortality Event: 75 Years or More, Female",
-          "dcid": "dc/sw43w4pbtgq4d"
-        },
-        {
-          "name": "Count of Mortality Event: 80 Years or More, Female",
-          "dcid": "Count_Death_80OrMoreYears_Female"
-        },
-        {
-          "name": "Female Infant Mortality Rate",
-          "dcid": "Count_Death_0Years_Female_AsFractionOf_Count_BirthEvent_LiveBirth_Female"
-        }
-      ]
-    },
-    {
       "dcid": "dc/g/SDGVCVOVGDSD_gender-SDGSexEnumFEMALE_sdggroundsOfDiscrimination",
       "name": "Proportion of Population Reporting Having Felt Discriminated Against With Gender = Female, Grounds of Discrimination",
       "statVars": [
@@ -35455,6 +35361,92 @@
         {
           "name": "Proportion of population reporting having felt discriminated against: Traditions, Female",
           "dcid": "sdg/VC_VOV_GDSD_TRAD_FEMALE"
+        }
+      ]
+    },
+    {
+      "dcid": "dc/g/MortalityEvent_Age_Gender-Female",
+      "name": "Mortality Event With Age, Gender = Female",
+      "statVars": [
+        {
+          "name": "Count of Mortality Event: 10 - 14 Years, Female",
+          "dcid": "Count_Death_10To14Years_Female"
+        },
+        {
+          "name": "Count of Mortality Event: 15 - 19 Years, Female",
+          "dcid": "Count_Death_15To19Years_Female"
+        },
+        {
+          "name": "Count of Mortality Event: 15 - 64 Years, Female",
+          "dcid": "Count_Death_15To64Years_Female"
+        },
+        {
+          "name": "Count of Mortality Event: 20 - 24 Years, Female",
+          "dcid": "Count_Death_20To24Years_Female"
+        },
+        {
+          "name": "Count of Mortality Event: 25 - 29 Years, Female",
+          "dcid": "Count_Death_25To29Years_Female"
+        },
+        {
+          "name": "Count of Mortality Event: 30 - 34 Years, Female",
+          "dcid": "Count_Death_30To34Years_Female"
+        },
+        {
+          "name": "Count of Mortality Event: 35 - 39 Years, Female",
+          "dcid": "Count_Death_35To39Years_Female"
+        },
+        {
+          "name": "Count of Mortality Event: 4 Years or Less, Female",
+          "dcid": "Count_Death_Upto4Years_Female"
+        },
+        {
+          "name": "Count of Mortality Event: 40 - 44 Years, Female",
+          "dcid": "Count_Death_40To44Years_Female"
+        },
+        {
+          "name": "Count of Mortality Event: 45 - 49 Years, Female",
+          "dcid": "Count_Death_45To49Years_Female"
+        },
+        {
+          "name": "Count of Mortality Event: 5 - 9 Years, Female",
+          "dcid": "Count_Death_5To9Years_Female"
+        },
+        {
+          "name": "Count of Mortality Event: 50 - 54 Years, Female",
+          "dcid": "Count_Death_50To54Years_Female"
+        },
+        {
+          "name": "Count of Mortality Event: 55 - 59 Years, Female",
+          "dcid": "Count_Death_55To59Years_Female"
+        },
+        {
+          "name": "Count of Mortality Event: 60 - 64 Years, Female",
+          "dcid": "Count_Death_60To64Years_Female"
+        },
+        {
+          "name": "Count of Mortality Event: 65 - 69 Years, Female",
+          "dcid": "Count_Death_65To69Years_Female"
+        },
+        {
+          "name": "Count of Mortality Event: 65 Years or More, Female",
+          "dcid": "Count_Death_65OrMoreYears_Female"
+        },
+        {
+          "name": "Count of Mortality Event: 70 - 74 Years, Female",
+          "dcid": "Count_Death_70To74Years_Female"
+        },
+        {
+          "name": "Count of Mortality Event: 75 - 79 Years, Female",
+          "dcid": "Count_Death_75To79Years_Female"
+        },
+        {
+          "name": "Count of Mortality Event: 80 Years or More, Female",
+          "dcid": "Count_Death_80OrMoreYears_Female"
+        },
+        {
+          "name": "Female Infant Mortality Rate",
+          "dcid": "Count_Death_0Years_Female_AsFractionOf_Count_BirthEvent_LiveBirth_Female"
         }
       ]
     },
@@ -35705,6 +35697,80 @@
       ]
     },
     {
+      "dcid": "dc/g/Person_EducationalAttainment_Gender-Female",
+      "name": "Person With Educational Attainment, Gender = Female",
+      "statVars": [
+        {
+          "name": "Percentage: Bachelor Degree or Higher, Female",
+          "dcid": "dc/648tvf392fz0c"
+        },
+        {
+          "name": "Population: 10th Grade, Female",
+          "dcid": "Count_Person_25OrMoreYears_EducationalAttainment10ThGrade_Female"
+        },
+        {
+          "name": "Population: 11th Grade, Female",
+          "dcid": "Count_Person_25OrMoreYears_EducationalAttainment11ThGrade_Female"
+        },
+        {
+          "name": "Population: 12th Grade No Diploma, Female",
+          "dcid": "Count_Person_25OrMoreYears_EducationalAttainment12ThGradeNoDiploma_Female"
+        },
+        {
+          "name": "Population: 5th And 6th Grade, Female",
+          "dcid": "Count_Person_25OrMoreYears_EducationalAttainment5ThAnd6ThGrade_Female"
+        },
+        {
+          "name": "Population: 7th And 8th Grade, Female",
+          "dcid": "Count_Person_25OrMoreYears_EducationalAttainment7ThAnd8ThGrade_Female"
+        },
+        {
+          "name": "Population: 9th Grade, Female",
+          "dcid": "Count_Person_25OrMoreYears_EducationalAttainment9ThGrade_Female"
+        },
+        {
+          "name": "Population: Masters Degree, Female",
+          "dcid": "Count_Person_25OrMoreYears_EducationalAttainmentMastersDegree_Female"
+        },
+        {
+          "name": "Population: No Schooling Completed, Female",
+          "dcid": "Count_Person_25OrMoreYears_EducationalAttainmentNoSchoolingCompleted_Female"
+        },
+        {
+          "name": "Population: Nursery To 4th Grade, Female",
+          "dcid": "Count_Person_25OrMoreYears_EducationalAttainmentNurseryTo4ThGrade_Female"
+        },
+        {
+          "name": "Population: Professional School Degree, Female",
+          "dcid": "Count_Person_25OrMoreYears_EducationalAttainmentProfessionalSchoolDegree_Female"
+        },
+        {
+          "name": "Population: Some College 1 or More Years No Degree, Female",
+          "dcid": "Count_Person_25OrMoreYears_EducationalAttainmentSomeCollege1OrMoreYearsNoDegree_Female"
+        },
+        {
+          "name": "Population: Some College Less Than 1 Year, Female",
+          "dcid": "Count_Person_25OrMoreYears_EducationalAttainmentSomeCollegeLessThan1Year_Female"
+        },
+        {
+          "name": "Population: Masters Degree or Higher, Female (As Fraction of Count Person 25 or More Years Female)",
+          "dcid": "Count_Person_25OrMoreYears_Female_MastersDegreeOrHigher_AsFractionOf_Count_Person_25OrMoreYears_Female"
+        },
+        {
+          "name": "Population: 25 - 64 Years, Less Than Primary Education \u0026 Primary Education \u0026 Lower Secondary Education, Female (As Fraction of Count Person 25 To 64 Years Female)",
+          "dcid": "Count_Person_25To64Years_LessThanPrimaryEducationOrPrimaryEducationOrLowerSecondaryEducation_Female_AsAFractionOfCount_Person_25To64Years_Female"
+        },
+        {
+          "name": "Population: 25 - 64 Years, Upper Secondary Education \u0026 Post Secondary Non Tertiary Education, Female (As Fraction of Count Person 25 To 64 Years Female)",
+          "dcid": "Count_Person_25To64Years_UpperSecondaryEducationOrPostSecondaryNonTertiaryEducation_Female_AsAFractionOfCount_Person_25To64Years_Female"
+        },
+        {
+          "name": "Population: 25 - 64 Years, Upper Secondary Education or Higher, Female (As Fraction of Count Person 25 To 64 Years Female)",
+          "dcid": "Count_Person_25To64Years_UpperSecondaryEducationOrHigher_Female_AsAFractionOfCount_Person_25To64Years_Female"
+        }
+      ]
+    },
+    {
       "dcid": "dc/g/SDGSLDOMTSPD_age_gender-SDGSexEnumFEMALE",
       "name": "Proportion of Time Spent on Unpaid Domestic Chores And Care Work With Age, Gender = Female",
       "statVars": [
@@ -35923,76 +35989,6 @@
         {
           "name": "Proportion of population reporting having felt discriminated against: Persons without disability, Socioeconomic status, Female",
           "dcid": "sdg/VC_VOV_GDSD_PWD_SOCIOECON_FEMALE"
-        }
-      ]
-    },
-    {
-      "dcid": "dc/g/Person_EducationalAttainment_Gender-Female",
-      "name": "Person With Educational Attainment, Gender = Female",
-      "statVars": [
-        {
-          "name": "Population: 10th Grade, Female",
-          "dcid": "Count_Person_25OrMoreYears_EducationalAttainment10ThGrade_Female"
-        },
-        {
-          "name": "Population: 11th Grade, Female",
-          "dcid": "Count_Person_25OrMoreYears_EducationalAttainment11ThGrade_Female"
-        },
-        {
-          "name": "Population: 12th Grade No Diploma, Female",
-          "dcid": "Count_Person_25OrMoreYears_EducationalAttainment12ThGradeNoDiploma_Female"
-        },
-        {
-          "name": "Population: 5th And 6th Grade, Female",
-          "dcid": "Count_Person_25OrMoreYears_EducationalAttainment5ThAnd6ThGrade_Female"
-        },
-        {
-          "name": "Population: 7th And 8th Grade, Female",
-          "dcid": "Count_Person_25OrMoreYears_EducationalAttainment7ThAnd8ThGrade_Female"
-        },
-        {
-          "name": "Population: 9th Grade, Female",
-          "dcid": "Count_Person_25OrMoreYears_EducationalAttainment9ThGrade_Female"
-        },
-        {
-          "name": "Population: Masters Degree, Female",
-          "dcid": "Count_Person_25OrMoreYears_EducationalAttainmentMastersDegree_Female"
-        },
-        {
-          "name": "Population: No Schooling Completed, Female",
-          "dcid": "Count_Person_25OrMoreYears_EducationalAttainmentNoSchoolingCompleted_Female"
-        },
-        {
-          "name": "Population: Nursery To 4th Grade, Female",
-          "dcid": "Count_Person_25OrMoreYears_EducationalAttainmentNurseryTo4ThGrade_Female"
-        },
-        {
-          "name": "Population: Professional School Degree, Female",
-          "dcid": "Count_Person_25OrMoreYears_EducationalAttainmentProfessionalSchoolDegree_Female"
-        },
-        {
-          "name": "Population: Some College 1 or More Years No Degree, Female",
-          "dcid": "Count_Person_25OrMoreYears_EducationalAttainmentSomeCollege1OrMoreYearsNoDegree_Female"
-        },
-        {
-          "name": "Population: Some College Less Than 1 Year, Female",
-          "dcid": "Count_Person_25OrMoreYears_EducationalAttainmentSomeCollegeLessThan1Year_Female"
-        },
-        {
-          "name": "Population: Masters Degree or Higher, Female (As Fraction of Count Person 25 or More Years Female)",
-          "dcid": "Count_Person_25OrMoreYears_Female_MastersDegreeOrHigher_AsFractionOf_Count_Person_25OrMoreYears_Female"
-        },
-        {
-          "name": "Population: 25 - 64 Years, Less Than Primary Education \u0026 Primary Education \u0026 Lower Secondary Education, Female (As Fraction of Count Person 25 To 64 Years Female)",
-          "dcid": "Count_Person_25To64Years_LessThanPrimaryEducationOrPrimaryEducationOrLowerSecondaryEducation_Female_AsAFractionOfCount_Person_25To64Years_Female"
-        },
-        {
-          "name": "Population: 25 - 64 Years, Upper Secondary Education \u0026 Post Secondary Non Tertiary Education, Female (As Fraction of Count Person 25 To 64 Years Female)",
-          "dcid": "Count_Person_25To64Years_UpperSecondaryEducationOrPostSecondaryNonTertiaryEducation_Female_AsAFractionOfCount_Person_25To64Years_Female"
-        },
-        {
-          "name": "Population: 25 - 64 Years, Upper Secondary Education or Higher, Female (As Fraction of Count Person 25 To 64 Years Female)",
-          "dcid": "Count_Person_25To64Years_UpperSecondaryEducationOrHigher_Female_AsAFractionOfCount_Person_25To64Years_Female"
         }
       ]
     },
@@ -36781,52 +36777,6 @@
         {
           "name": "Std Deviation State Referenced Achievement of Student: Female, Third Grade, Mathematics",
           "dcid": "dc/sdfm4kc8cgh06"
-        }
-      ]
-    },
-    {
-      "dcid": "dc/g/Person_Gender-Female",
-      "name": "Person With Gender = Female",
-      "statVars": [
-        {
-          "name": "Female Life Expectancy",
-          "dcid": "LifeExpectancy_Person_Female"
-        },
-        {
-          "name": "Female Population",
-          "dcid": "Count_Person_Female"
-        },
-        {
-          "name": "Unemployment Rate of the Female Population",
-          "dcid": "UnemploymentRate_Person_Female"
-        },
-        {
-          "name": "Mean Wages Daily: Female",
-          "dcid": "Mean_WagesDaily_Worker_Female"
-        },
-        {
-          "name": "Mean Wages Monthly: Female",
-          "dcid": "Mean_WagesMonthly_Worker_Female"
-        },
-        {
-          "name": "Median Age of Female Population",
-          "dcid": "Median_Age_Person_Female"
-        },
-        {
-          "name": "Median Income of Women (15 Years or Older) With Income",
-          "dcid": "Median_Income_Person_15OrMoreYears_Female_WithIncome"
-        },
-        {
-          "name": "Female Population With Disabilities",
-          "dcid": "Count_Person_WithDisability_Female"
-        },
-        {
-          "name": "Percentage: Bachelor Degree or Higher, Female",
-          "dcid": "dc/648tvf392fz0c"
-        },
-        {
-          "name": "Percentage: Female, Below Poverty Level in The Past 12 Months",
-          "dcid": "dc/k0zg5lw8686z8"
         }
       ]
     },
@@ -41603,6 +41553,44 @@
         {
           "name": "Std Deviation Assessment Score of Student: Female, School Grade 8, Writing, Public School",
           "dcid": "StdDeviation_AssessmentScore_Student_Female_SchoolGrade8_Writing_PublicSchool"
+        }
+      ]
+    },
+    {
+      "dcid": "dc/g/Person_Gender-Female",
+      "name": "Person With Gender = Female",
+      "statVars": [
+        {
+          "name": "Female Life Expectancy",
+          "dcid": "LifeExpectancy_Person_Female"
+        },
+        {
+          "name": "Female Population",
+          "dcid": "Count_Person_Female"
+        },
+        {
+          "name": "Unemployment Rate of the Female Population",
+          "dcid": "UnemploymentRate_Person_Female"
+        },
+        {
+          "name": "Mean Wages Daily: Female",
+          "dcid": "Mean_WagesDaily_Worker_Female"
+        },
+        {
+          "name": "Mean Wages Monthly: Female",
+          "dcid": "Mean_WagesMonthly_Worker_Female"
+        },
+        {
+          "name": "Median Age of Female Population",
+          "dcid": "Median_Age_Person_Female"
+        },
+        {
+          "name": "Median Income of Women (15 Years or Older) With Income",
+          "dcid": "Median_Income_Person_15OrMoreYears_Female_WithIncome"
+        },
+        {
+          "name": "Female Population With Disabilities",
+          "dcid": "Count_Person_WithDisability_Female"
         }
       ]
     },
@@ -53941,24 +53929,6 @@
       ]
     },
     {
-      "dcid": "dc/g/Person_Gender-Female_MedicalCondition",
-      "name": "Person With Gender = Female, Medical Condition",
-      "statVars": [
-        {
-          "name": "Prevalence: Female, Diabetes",
-          "dcid": "dc/nh3s4skee5483"
-        },
-        {
-          "name": "Population: 4 Years or Less, Female, Severe Wasting (As Fraction of Count Person Upto 4 Years Female)",
-          "dcid": "Count_Person_Upto4Years_Female_SevereWasting_AsFractionOf_Count_Person_Upto4Years_Female"
-        },
-        {
-          "name": "Population: 4 Years or Less, Female, Wasting (As Fraction of Count Person Upto 4 Years Female)",
-          "dcid": "Count_Person_Upto4Years_Female_Wasting_AsFractionOf_Count_Person_Upto4Years_Female"
-        }
-      ]
-    },
-    {
       "dcid": "dc/g/Person_Gender-Female_Nativity-ForeignBorn",
       "name": "Person With Gender = Female, Nativity = Foreign Born",
       "statVars": [
@@ -58511,6 +58481,20 @@
         {
           "name": "Sales of Establishment: Manufacturer Sales Branches And Offices, Women's And Children's Clothing Merch. Whls. (NAICS/42433)",
           "dcid": "dc/79vrq3849kfeg"
+        }
+      ]
+    },
+    {
+      "dcid": "dc/g/Establishment_BusinessOperationType-MerchantWholesalersExcludingManufacturerSalesBranchesAndOffices_Industry-NAICS/42433",
+      "name": "Establishment With Business Operation Type = Merchant Wholesalers Excluding Manufacturer Sales Branches And Offices, Industry = Women's And Children's Clothing Merch. Whls. (NAICS/42433)",
+      "statVars": [
+        {
+          "name": "Count of Establishment: Merchant Wholesalers Excluding Manufacturer Sales Branches And Offices, Women's And Children's Clothing Merch. Whls. (NAICS/42433)",
+          "dcid": "dc/ww85jq324j3gc"
+        },
+        {
+          "name": "Sales of Establishment: Merchant Wholesalers Excluding Manufacturer Sales Branches And Offices, Women's And Children's Clothing Merch. Whls. (NAICS/42433)",
+          "dcid": "dc/ggp40c14cfw7b"
         }
       ]
     }

--- a/internal/server/v1/info/golden/variable_group_info/demographics.json
+++ b/internal/server/v1/info/golden/variable_group_info/demographics.json
@@ -99,7 +99,7 @@
         "id": "dc/g/Person_Age",
         "specializedEntity": "Age",
         "displayName": "Person by Age",
-        "descendentStatVarCount": 22198
+        "descendentStatVarCount": 22197
       },
       {
         "id": "dc/g/Household_BenefitsStatus",
@@ -276,7 +276,7 @@
         "descendentStatVarCount": 104
       }
     ],
-    "descendentStatVarCount": 33619,
+    "descendentStatVarCount": 33618,
     "parentStatVarGroups": [
       "dc/g/Root"
     ]

--- a/internal/server/v1/info/golden/variable_group_info/root.json
+++ b/internal/server/v1/info/golden/variable_group_info/root.json
@@ -13,13 +13,13 @@
         "id": "dc/g/Demographics",
         "specializedEntity": "Demographics",
         "displayName": "Demographics",
-        "descendentStatVarCount": 33619
+        "descendentStatVarCount": 33618
       },
       {
         "id": "dc/g/Economy",
         "specializedEntity": "Economy",
         "displayName": "Economy",
-        "descendentStatVarCount": 65593
+        "descendentStatVarCount": 65592
       },
       {
         "id": "dc/g/Education",
@@ -43,7 +43,7 @@
         "id": "dc/g/Health",
         "specializedEntity": "Health",
         "displayName": "Health",
-        "descendentStatVarCount": 15798
+        "descendentStatVarCount": 15792
       },
       {
         "id": "dc/g/Housing",
@@ -61,7 +61,7 @@
         "id": "dc/g/Uncategorized",
         "specializedEntity": "Uncategorized",
         "displayName": "Uncategorized",
-        "descendentStatVarCount": 14529
+        "descendentStatVarCount": 14379
       },
       {
         "id": "oecd/g/OECD",
@@ -80,6 +80,6 @@
         "descendentStatVarCount": 9
       }
     ],
-    "descendentStatVarCount": 593752
+    "descendentStatVarCount": 593595
   }
 }

--- a/internal/server/v1/info/golden/variable_group_info/weather.json
+++ b/internal/server/v1/info/golden/variable_group_info/weather.json
@@ -1,0 +1,509 @@
+{
+  "node": "dc/g/Weather",
+  "info": {
+    "absoluteName": "Weather",
+    "childStatVars": [
+      {
+        "id": "ConsecutiveDryDays",
+        "searchNames": [
+          "Consecutive Dry Days of Place"
+        ],
+        "displayName": "Consecutive Dry Days",
+        "definition": "mp=consecutiveDryDays,pt=Place",
+        "hasData": true
+      },
+      {
+        "id": "HeavyPrecipitationIndex",
+        "searchNames": [
+          "Heavy Precipitation Index of Place"
+        ],
+        "displayName": "Heavy Precipitation Index",
+        "definition": "mp=heavyPrecipitationIndex,pt=Place",
+        "hasData": true
+      },
+      {
+        "id": "Kurtosis_DailyMaxTemperature",
+        "searchNames": [
+          "Kurtosis Daily Max Temperature of Place"
+        ],
+        "displayName": "Kurtosis Daily Max Temperature",
+        "definition": "mq=Daily,st=kurtosisValue,mp=maxTemperature,pt=Place",
+        "hasData": true
+      },
+      {
+        "id": "Kurtosis_DailyMinTemperature",
+        "searchNames": [
+          "Kurtosis Daily Min Temperature of Place"
+        ],
+        "displayName": "Kurtosis Daily Min Temperature",
+        "definition": "mq=Daily,st=kurtosisValue,mp=minTemperature,pt=Place",
+        "hasData": true
+      },
+      {
+        "id": "Kurtosis_DailyPrecipitation",
+        "searchNames": [
+          "Kurtosis Daily Precipitation of Place"
+        ],
+        "displayName": "Kurtosis Daily Precipitation",
+        "definition": "mq=Daily,st=kurtosisValue,mp=precipitation,pt=Place",
+        "hasData": true
+      },
+      {
+        "id": "Max_BarometricPressure",
+        "searchNames": [
+          "Max Barometric Pressure of Place"
+        ],
+        "displayName": "Max Barometric Pressure",
+        "definition": "st=maxValue,mp=barometricPressure,pt=Place",
+        "hasData": true
+      },
+      {
+        "id": "Max_CloudCover",
+        "searchNames": [
+          "Max Cloud Cover of Place"
+        ],
+        "displayName": "Max Cloud Cover",
+        "definition": "st=maxValue,mp=cloudCover,pt=Place",
+        "hasData": true
+      },
+      {
+        "id": "Max_PrecipitableWater_Atmosphere",
+        "searchNames": [
+          "Max Precipitable Water of Place"
+        ],
+        "displayName": "Max Precipitable Water",
+        "definition": "st=maxValue,mp=precipitableWater,pt=Place",
+        "hasData": true
+      },
+      {
+        "id": "Max_Rainfall",
+        "searchNames": [
+          "Max Rainfall of Place"
+        ],
+        "displayName": "Max Rainfall",
+        "definition": "st=maxValue,mp=rainfall,pt=Place",
+        "hasData": true
+      },
+      {
+        "id": "Max_Snowfall",
+        "searchNames": [
+          "Max Snowfall of Place"
+        ],
+        "displayName": "Max Snowfall",
+        "definition": "st=maxValue,mp=snowfall,pt=Place",
+        "hasData": true
+      },
+      {
+        "id": "DifferenceAcrossModels_Max_Temperature",
+        "searchNames": [
+          "Max Temperature of Place (Difference Across Models)"
+        ],
+        "displayName": "Max Temperature (Difference Across Models)",
+        "definition": "mq=DifferenceAcrossModels,st=maxValue,mp=temperature,pt=Place",
+        "hasData": true
+      },
+      {
+        "id": "InterannualRange_Monthly_MaxTemperature",
+        "searchNames": [
+          "Max Temperature of Place (Interannual Range of Monthly Aggregate)"
+        ],
+        "displayName": "Max Temperature (Interannual Range of Monthly Aggregate)",
+        "definition": "mq=InterannualRangeOfMonthlyAggregate,mp=maxTemperature,pt=Place",
+        "hasData": true
+      },
+      {
+        "id": "Max_Visibility",
+        "searchNames": [
+          "Max Visibility of Place"
+        ],
+        "displayName": "Max Visibility",
+        "definition": "st=maxValue,mp=visibility,pt=Place",
+        "hasData": true
+      },
+      {
+        "id": "Max_Temperature",
+        "searchNames": [
+          "Max Temperature of Place"
+        ],
+        "displayName": "Maximum Temperature",
+        "definition": "st=maxValue,mp=temperature,pt=Place",
+        "hasData": true
+      },
+      {
+        "id": "Mean_BarometricPressure",
+        "searchNames": [
+          "Mean Barometric Pressure of Place"
+        ],
+        "displayName": "Mean Barometric Pressure",
+        "definition": "st=meanValue,mp=barometricPressure,pt=Place",
+        "hasData": true
+      },
+      {
+        "id": "Mean_CloudCover",
+        "searchNames": [
+          "Mean Cloud Cover of Place"
+        ],
+        "displayName": "Mean Cloud Cover",
+        "definition": "st=meanValue,mp=cloudCover,pt=Place",
+        "hasData": true
+      },
+      {
+        "id": "Mean_PrecipitableWater_Atmosphere",
+        "searchNames": [
+          "Mean Precipitable Water of Place"
+        ],
+        "displayName": "Mean Precipitable Water",
+        "definition": "st=meanValue,mp=precipitableWater,pt=Place",
+        "hasData": true
+      },
+      {
+        "id": "Mean_Rainfall",
+        "searchNames": [
+          "Mean Rainfall of Place"
+        ],
+        "displayName": "Mean Rainfall",
+        "definition": "st=meanValue,mp=rainfall,pt=Place",
+        "hasData": true
+      },
+      {
+        "id": "Mean_Snowfall",
+        "searchNames": [
+          "Mean Snowfall of Place"
+        ],
+        "displayName": "Mean Snowfall",
+        "definition": "st=meanValue,mp=snowfall,pt=Place",
+        "hasData": true
+      },
+      {
+        "id": "Mean_Temperature",
+        "searchNames": [
+          "Mean Temperature of Place"
+        ],
+        "displayName": "Mean Temperature",
+        "definition": "st=meanValue,mp=temperature,pt=Place",
+        "hasData": true
+      },
+      {
+        "id": "Mean_VaporPressureDeficit",
+        "searchNames": [
+          "Mean Vapor Pressure Deficit of Place"
+        ],
+        "displayName": "Mean Vapor Pressure Deficit (VPD)",
+        "definition": "st=meanValue,mp=vaporPressureDeficit,pt=Place",
+        "hasData": true
+      },
+      {
+        "id": "Mean_Visibility",
+        "searchNames": [
+          "Mean Visibility of Place"
+        ],
+        "displayName": "Mean Visibility",
+        "definition": "st=meanValue,mp=visibility,pt=Place",
+        "hasData": true
+      },
+      {
+        "id": "Mean_WindSpeed",
+        "searchNames": [
+          "Mean Wind Speed of Place"
+        ],
+        "displayName": "Mean Wind Speed",
+        "definition": "st=meanValue,mp=windSpeed,pt=Place",
+        "hasData": true
+      },
+      {
+        "id": "DifferenceAcrossModels_Mean_WindSpeed",
+        "searchNames": [
+          "Mean Wind Speed of Place (Difference Across Models)"
+        ],
+        "displayName": "Mean Wind Speed (Difference Across Models)",
+        "definition": "mq=DifferenceAcrossModels,st=meanValue,mp=windSpeed,pt=Place",
+        "hasData": true
+      },
+      {
+        "id": "Mean_MaxTemperature",
+        "searchNames": [
+          "Mean Max Temperature of Place"
+        ],
+        "displayName": "Mean maximum temperature",
+        "definition": "st=meanValue,mp=maxTemperature,pt=Place",
+        "hasData": true
+      },
+      {
+        "id": "Min_BarometricPressure",
+        "searchNames": [
+          "Min Barometric Pressure of Place"
+        ],
+        "displayName": "Min Barometric Pressure",
+        "definition": "st=minValue,mp=barometricPressure,pt=Place",
+        "hasData": true
+      },
+      {
+        "id": "Min_CloudCover",
+        "searchNames": [
+          "Min Cloud Cover of Place"
+        ],
+        "displayName": "Min Cloud Cover",
+        "definition": "st=minValue,mp=cloudCover,pt=Place",
+        "hasData": true
+      },
+      {
+        "id": "Min_PrecipitableWater_Atmosphere",
+        "searchNames": [
+          "Min Precipitable Water of Place"
+        ],
+        "displayName": "Min Precipitable Water",
+        "definition": "st=minValue,mp=precipitableWater,pt=Place",
+        "hasData": true
+      },
+      {
+        "id": "Min_Rainfall",
+        "searchNames": [
+          "Min Rainfall of Place"
+        ],
+        "displayName": "Min Rainfall",
+        "definition": "st=minValue,mp=rainfall,pt=Place",
+        "hasData": true
+      },
+      {
+        "id": "Min_Snowfall",
+        "searchNames": [
+          "Min Snowfall of Place"
+        ],
+        "displayName": "Min Snowfall",
+        "definition": "st=minValue,mp=snowfall,pt=Place",
+        "hasData": true
+      },
+      {
+        "id": "Min_Temperature",
+        "searchNames": [
+          "Min Temperature of Place"
+        ],
+        "displayName": "Min Temperature",
+        "definition": "st=minValue,mp=temperature,pt=Place",
+        "hasData": true
+      },
+      {
+        "id": "DifferenceAcrossModels_Min_Temperature",
+        "searchNames": [
+          "Min Temperature of Place (Difference Across Models)"
+        ],
+        "displayName": "Min Temperature (Difference Across Models)",
+        "definition": "mq=DifferenceAcrossModels,st=minValue,mp=temperature,pt=Place",
+        "hasData": true
+      },
+      {
+        "id": "InterannualRange_Monthly_MinTemperature",
+        "searchNames": [
+          "Min Temperature of Place (Interannual Range of Monthly Aggregate)"
+        ],
+        "displayName": "Min Temperature (Interannual Range of Monthly Aggregate)",
+        "definition": "mq=InterannualRangeOfMonthlyAggregate,mp=minTemperature,pt=Place",
+        "hasData": true
+      },
+      {
+        "id": "Min_Visibility",
+        "searchNames": [
+          "Min Visibility of Place"
+        ],
+        "displayName": "Min Visibility",
+        "definition": "st=minValue,mp=visibility,pt=Place",
+        "hasData": true
+      },
+      {
+        "id": "InterannualRange_Monthly_Precipitation",
+        "searchNames": [
+          "Precipitation of Place (Interannual Range of Monthly Aggregate)"
+        ],
+        "displayName": "Precipitation (Interannual Range of Monthly Aggregate)",
+        "definition": "mq=InterannualRangeOfMonthlyAggregate,mp=precipitation,pt=Place",
+        "hasData": true
+      },
+      {
+        "id": "PrecipitationRate",
+        "searchNames": [
+          "Precipitation Rate of Place"
+        ],
+        "displayName": "Precipitation Rate",
+        "definition": "mp=precipitationRate,pt=Place",
+        "hasData": true
+      },
+      {
+        "id": "DifferenceAcrossModels_PrecipitationRate",
+        "searchNames": [
+          "Precipitation Rate of Place (Difference Across Models)"
+        ],
+        "displayName": "Precipitation Rate (Difference Across Models)",
+        "definition": "mq=DifferenceAcrossModels,mp=precipitationRate,pt=Place",
+        "hasData": true
+      },
+      {
+        "id": "Skewness_DailyMaxTemperature",
+        "searchNames": [
+          "Skewness Daily Max Temperature of Place"
+        ],
+        "displayName": "Skewness Daily Max Temperature",
+        "definition": "mq=Daily,st=skewnessValue,mp=maxTemperature,pt=Place",
+        "hasData": true
+      },
+      {
+        "id": "Skewness_DailyMinTemperature",
+        "searchNames": [
+          "Skewness Daily Min Temperature of Place"
+        ],
+        "displayName": "Skewness Daily Min Temperature",
+        "definition": "mq=Daily,st=skewnessValue,mp=minTemperature,pt=Place",
+        "hasData": true
+      },
+      {
+        "id": "Skewness_DailyPrecipitation",
+        "searchNames": [
+          "Skewness Daily Precipitation of Place"
+        ],
+        "displayName": "Skewness Daily Precipitation",
+        "definition": "mq=Daily,st=skewnessValue,mp=precipitation,pt=Place",
+        "hasData": true
+      },
+      {
+        "id": "StandardDeviation_DailyMaxTemperature",
+        "searchNames": [
+          "Std Deviation Daily Max Temperature of Place"
+        ],
+        "displayName": "Std Deviation Daily Max Temperature",
+        "definition": "mq=Daily,st=stdDeviationValue,mp=maxTemperature,pt=Place",
+        "hasData": true
+      },
+      {
+        "id": "StandardDeviation_DailyMinTemperature",
+        "searchNames": [
+          "Std Deviation Daily Min Temperature of Place"
+        ],
+        "displayName": "Std Deviation Daily Min Temperature",
+        "definition": "mq=Daily,st=stdDeviationValue,mp=minTemperature,pt=Place",
+        "hasData": true
+      },
+      {
+        "id": "StandardDeviation_DailyPrecipitation",
+        "searchNames": [
+          "Std Deviation Daily Precipitation of Place"
+        ],
+        "displayName": "Std Deviation Daily Precipitation",
+        "definition": "mq=Daily,st=stdDeviationValue,mp=precipitation,pt=Place",
+        "hasData": true
+      },
+      {
+        "id": "DifferenceAcrossModels_Temperature",
+        "searchNames": [
+          "Temperature of Place (Difference Across Models)"
+        ],
+        "displayName": "Temperature (Difference Across Models)",
+        "definition": "mq=DifferenceAcrossModels,mp=temperature,pt=Place",
+        "hasData": true
+      },
+      {
+        "id": "Temperature",
+        "searchNames": [
+          "Temperature of Place"
+        ],
+        "displayName": "Temperature in a Location",
+        "definition": "mp=temperature,pt=Place",
+        "hasData": true
+      }
+    ],
+    "childStatVarGroups": [
+      {
+        "id": "dc/g/Place_AreaType",
+        "specializedEntity": "Area Type",
+        "displayName": "Place by Area Type",
+        "descendentStatVarCount": 4
+      },
+      {
+        "id": "dc/g/Place_DeltaFromReferenceDate",
+        "specializedEntity": "Delta From Reference Date",
+        "displayName": "Place by Delta From Reference Date",
+        "descendentStatVarCount": 368
+      },
+      {
+        "id": "dc/g/Place_EmissionsScenario",
+        "specializedEntity": "Emissions Scenario (Projected)",
+        "displayName": "Place by Emissions Scenario",
+        "descendentStatVarCount": 606
+      },
+      {
+        "id": "dc/g/Place_ExtremesOverTime",
+        "specializedEntity": "Extremes Over Time",
+        "displayName": "Place by Extremes Over Time",
+        "descendentStatVarCount": 128
+      },
+      {
+        "id": "dc/g/HeatWaveEvent",
+        "specializedEntity": "Heat Wave Event",
+        "displayName": "Heat Wave Event",
+        "descendentStatVarCount": 6
+      },
+      {
+        "id": "dc/g/Place_Height",
+        "specializedEntity": "Height",
+        "displayName": "Place by Height",
+        "descendentStatVarCount": 11
+      },
+      {
+        "id": "dc/g/Place_HumidityParameter",
+        "specializedEntity": "Humidity Parameter",
+        "displayName": "Place by Humidity Parameter",
+        "descendentStatVarCount": 80
+      },
+      {
+        "id": "dc/g/Place_MaxTemperature",
+        "specializedEntity": "Max Temperature",
+        "displayName": "Place by Max Temperature",
+        "descendentStatVarCount": 27
+      },
+      {
+        "id": "dc/g/Place_MinTemperature",
+        "specializedEntity": "Min Temperature",
+        "displayName": "Place by Min Temperature",
+        "descendentStatVarCount": 27
+      },
+      {
+        "id": "dc/g/Place_MultiModelEnsemble",
+        "specializedEntity": "Multi Model Ensemble",
+        "displayName": "Place by Multi Model Ensemble",
+        "descendentStatVarCount": 279
+      },
+      {
+        "id": "dc/g/Place_RadiationDirection",
+        "specializedEntity": "Radiation Direction",
+        "displayName": "Place by Radiation Direction",
+        "descendentStatVarCount": 55
+      },
+      {
+        "id": "dc/g/Place_RadiationWavelength",
+        "specializedEntity": "Radiation Wavelength",
+        "displayName": "Place by Radiation Wavelength",
+        "descendentStatVarCount": 55
+      },
+      {
+        "id": "dc/g/Place_SocioeconomicScenario",
+        "specializedEntity": "Socioeconomic Scenario (Projected)",
+        "displayName": "Place by Socioeconomic Scenario",
+        "descendentStatVarCount": 448
+      },
+      {
+        "id": "dc/g/Place_WetBulbTemperature",
+        "specializedEntity": "Wet Bulb Temperature",
+        "displayName": "Place by Wet Bulb Temperature",
+        "descendentStatVarCount": 11
+      },
+      {
+        "id": "dc/g/Place_WindComponent",
+        "specializedEntity": "Wind Component",
+        "displayName": "Place by Wind Component",
+        "descendentStatVarCount": 8
+      }
+    ],
+    "descendentStatVarCount": 737,
+    "parentStatVarGroups": [
+      "dc/g/Environment"
+    ]
+  }
+}

--- a/internal/server/v1/info/golden/variable_group_info_test.go
+++ b/internal/server/v1/info/golden/variable_group_info_test.go
@@ -50,6 +50,11 @@ func TestVariableGroupInfo(t *testing.T) {
 				"demographics.json",
 			},
 			{
+				"dc/g/Weather",
+				[]string{},
+				"weather.json",
+			},
+			{
 				"dc/g/Demographics",
 				[]string{"country/GBR"},
 				"demographics_gbr.json",

--- a/internal/server/v1/propertyvalues/core.go
+++ b/internal/server/v1/propertyvalues/core.go
@@ -55,7 +55,9 @@ func Fetch(
 	// Empty cursor groups when no token is given.
 	var cursorGroups []*pbv1.CursorGroup
 	if token == "" {
-		cursorGroups = buildDefaultCursorGroups(nodes, properties, propType, len(store.BtGroup.Tables()))
+		cursorGroups = buildDefaultCursorGroups(
+			nodes, properties, propType, len(store.BtGroup.Tables(nil)),
+		)
 	} else {
 		pi, err := pagination.Decode(token)
 		if err != nil {

--- a/internal/store/bigtable/group.go
+++ b/internal/store/bigtable/group.go
@@ -105,11 +105,14 @@ func SortTables(tables []*Table) {
 }
 
 // Tables is the accessor for all the Bigtable client stubs.
-func (g *Group) Tables() []*cbt.Table {
+func (g *Group) Tables(filter func(*Table) bool) []*cbt.Table {
 	g.lock.RLock()
 	defer g.lock.RUnlock()
 	result := []*cbt.Table{}
 	for _, t := range g.tables {
+		if filter != nil && !filter(t) {
+			continue
+		}
 		result = append(result, t.table)
 	}
 	return result

--- a/internal/store/bigtable/table.go
+++ b/internal/store/bigtable/table.go
@@ -43,6 +43,11 @@ func (t *Table) Name() string {
 	return t.name
 }
 
+// IsCustom access the isCustom bit of a table
+func (t *Table) IsCustom() bool {
+	return t.isCustom
+}
+
 // NewBtTable creates a new cbt.Table instance.
 func NewBtTable(ctx context.Context, projectID, instanceID, tableID string) (
 	*cbt.Table, error) {


### PR DESCRIPTION
SV and SVG in "infrequent" and other import groups could be stale. To prevent them from showing up in the hierarchy and to avoid building the new BT for them, this introduces a way to filter big tables during cache read.