### PR TITLE
Fix place info merge bug and btGroup nil access bug

### DIFF
--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -267,8 +267,12 @@ func (s *Server) Search(
 func (s *Server) GetVersion(
 	ctx context.Context, in *pb.GetVersionRequest,
 ) (*pb.GetVersionResponse, error) {
+	tableNames := []string{}
+	if s.store.BtGroup != nil {
+		tableNames = s.store.BtGroup.TableNames()
+	}
 	return &pb.GetVersionResponse{
-		Tables:            s.store.BtGroup.TableNames(),
+		Tables:            tableNames,
 		Bigquery:          s.metadata.BigQueryDataset,
 		GitHash:           os.Getenv("MIXER_HASH"),
 		RemoteMixerDomain: s.metadata.RemoteMixerDomain,

--- a/internal/server/place/places.go
+++ b/internal/server/place/places.go
@@ -233,11 +233,11 @@ func GetPlaceMetadataHelper(
 	for _, entity := range entities {
 		entInfo, ok := metaMap[entity]
 		if !ok {
-			entInfo = &pb.PlaceMetadataCache_PlaceInfo{Dcid: entity}
+			continue
 		}
 		processed := pb.PlaceMetadata{}
 		processed.Self = &pb.PlaceMetadata_PlaceInfo{
-			Dcid: entity,
+			Dcid: entInfo.Dcid,
 			Name: entInfo.Name,
 			Type: entInfo.Type,
 		}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -52,6 +52,9 @@ type Server struct {
 }
 
 func (s *Server) updateBranchTable(ctx context.Context, branchTableName string) {
+	if s.store.BtGroup == nil {
+		return
+	}
 	branchTable, err := bigtable.NewBtTable(
 		ctx,
 		bigtable.BranchBigtableProject,

--- a/internal/server/v1/info/golden/bulk_place_info/bulk_place_info.json
+++ b/internal/server/v1/info/golden/bulk_place_info/bulk_place_info.json
@@ -1,12 +1,7 @@
 {
   "data": [
     {
-      "node": "earth",
-      "info": {
-        "self": {
-          "dcid": "earth"
-        }
-      }
+      "node": "earth"
     },
     {
       "node": "geoId/02158000100",

--- a/internal/server/v1/info/place.go
+++ b/internal/server/v1/info/place.go
@@ -74,6 +74,5 @@ func BulkPlaceInfo(
 		}
 		resp.Data = append(resp.Data, item)
 	}
-
 	return resp, nil
 }

--- a/internal/server/v1/propertyvalues/api.go
+++ b/internal/server/v1/propertyvalues/api.go
@@ -59,7 +59,7 @@ func PropertyValues(
 	}
 	data, pi, err := Fetch(
 		ctx,
-		store,
+		store.BtGroup,
 		[]string{node},
 		[]string{property},
 		limit,
@@ -109,7 +109,7 @@ func BulkPropertyValues(
 	}
 	data, pi, err := Fetch(
 		ctx,
-		store,
+		store.BtGroup,
 		nodes,
 		[]string{property},
 		limit,

--- a/internal/server/v1/propertyvalues/linked.go
+++ b/internal/server/v1/propertyvalues/linked.go
@@ -66,7 +66,7 @@ func LinkedPropertyValues(
 	// Fetch names
 	data, _, err := Fetch(
 		ctx,
-		store,
+		store.BtGroup,
 		valueDcids,
 		[]string{"name"},
 		0,
@@ -129,7 +129,7 @@ func BulkLinkedPropertyValues(
 	// Fetch names
 	data, _, err := Fetch(
 		ctx,
-		store,
+		store.BtGroup,
 		valueDcids,
 		[]string{"name"},
 		0,

--- a/internal/server/v1/triples/triples.go
+++ b/internal/server/v1/triples/triples.go
@@ -108,7 +108,7 @@ func Triples(
 	properties := propsResp.GetProperties()
 	data, pi, err := propertyvalues.Fetch(
 		ctx,
-		store,
+		store.BtGroup,
 		[]string{node},
 		properties,
 		0,
@@ -187,7 +187,7 @@ func BulkTriples(
 	}
 	data, pi, err := propertyvalues.Fetch(
 		ctx,
-		store,
+		store.BtGroup,
 		regularDcids,
 		properties,
 		0,

--- a/internal/server/v2/propertyvalues/api.go
+++ b/internal/server/v2/propertyvalues/api.go
@@ -101,7 +101,7 @@ func API(
 
 		data, pi, err := v1pv.Fetch(
 			ctx,
-			store,
+			store.BtGroup,
 			regularNodes,
 			properties,
 			limit,
@@ -164,7 +164,7 @@ func LinkedPropertyValues(
 		}
 		nameResp, _, err := v1pv.Fetch(
 			ctx,
-			store,
+			store.BtGroup,
 			descendents,
 			[]string{"name"},
 			0,


### PR DESCRIPTION
As place info is always set (but only with dcid), it would not fetch remote place info, hence giving incomplete data for custom DC.

The btGroup nil access is result from previous PR.