### PR TITLE
[Place Recognition] Add abbreviations and alternate names

### DIFF
--- a/internal/server/v2/resolve/golden/resolve_description/city.json
+++ b/internal/server/v2/resolve/golden/resolve_description/city.json
@@ -13,11 +13,5 @@
         "geoId/3651000"
       ]
     }
-    {
-      "node": "Tohoku,Japan",
-      "resolvedIds": [
-        "wikidataId/Q1194394"
-      ]
-    }
   ]
 }

--- a/internal/server/v2/resolve/golden/resolve_description/city.json
+++ b/internal/server/v2/resolve/golden/resolve_description/city.json
@@ -4,7 +4,6 @@
       "node": "Mountain View",
       "resolvedIds": [
         "geoId/0649670",
-        "geoId/1553300",
         "geoId/3744770"
       ]
     },
@@ -12,6 +11,12 @@
       "node": "New York City",
       "resolvedIds": [
         "geoId/3651000"
+      ]
+    }
+    {
+      "node": "Tohoku,Japan",
+      "resolvedIds": [
+        "wikidataId/Q1194394"
       ]
     }
   ]

--- a/internal/server/v2/resolve/golden/resolve_description/harvard.json
+++ b/internal/server/v2/resolve/golden/resolve_description/harvard.json
@@ -151,7 +151,10 @@
       ]
     },
     {
-      "node": "Tohoku,Japan"
+      "node": "Tohoku,Japan",
+      "resolvedIds": [
+        "wikidataId/Q1194394"
+      ]
     },
     {
       "node": "Toukai,Japan"

--- a/internal/store/files/recog_place_store_test.go
+++ b/internal/store/files/recog_place_store_test.go
@@ -46,6 +46,9 @@ func TestRecogPlaceMap(t *testing.T) {
 							{
 								Parts: []string{"sunnyvale"},
 							},
+							{
+								Parts:[]string{"city", "of", "sunnyvale"},
+							},
 						},
 						Dcid: "geoId/0677000",
 						ContainingPlaces: []string{"Earth", "country/USA", "geoId/06",
@@ -64,6 +67,42 @@ func TestRecogPlaceMap(t *testing.T) {
 							"geoId/48113", "northamerica", "usc/SouthRegion",
 							"usc/WestSouthCentralDivision"},
 						Population: 8062,
+					},
+				},
+			},
+		},
+		{
+			"usa",
+			&pb.RecogPlaces{
+				Places: []*pb.RecogPlace{
+					{
+						Names: []*pb.RecogPlace_Name{
+							{
+								Parts: []string{"united", "states"},
+							},
+							{
+								Parts:[]string{"usa"},
+							},
+							{
+								Parts: []string{"us"},
+							},
+							{
+								Parts: []string{"u.s."},
+							},
+						},
+						Dcid: "country/USA",
+						ContainingPlaces: []string{"Earth", "northamerica"},
+						Population: 331893745,
+					},
+					{
+						Names: []*pb.RecogPlace_Name{
+							{
+								Parts: []string{"usa"},
+							},
+						},
+						Dcid: "wikidataId/Q114147",
+						ContainingPlaces: []string{"Earth", "asia", "country/JPN", "wikidataId/Q133924"},
+						Population: 55534,
 					},
 				},
 			},

--- a/internal/store/files/recog_place_store_test.go
+++ b/internal/store/files/recog_place_store_test.go
@@ -81,13 +81,13 @@ func TestRecogPlaceMap(t *testing.T) {
 								Parts: []string{"united", "states"},
 							},
 							{
-								Parts:[]string{"usa"},
-							},
-							{
 								Parts: []string{"us"},
 							},
 							{
 								Parts: []string{"u.s."},
+							},
+							{
+								Parts:[]string{"usa"},
 							},
 						},
 						Dcid: "country/USA",


### PR DESCRIPTION
The list of alternate names and abbreviations were produced using this BQ Query:

```
SELECT 
  id,
  name, 
  alternate_name,
  iso_code, 
  country_alpha_2_code, 
  country_alpha_3_code,
  CONCAT(
    IFNULL(CONCAT(REPLACE(alternate_name, ",", " "), ","), ""), 
    IFNULL(CONCAT(iso_code, ","), ""), 
    IFNULL(CONCAT(country_alpha_2_code, ","), ""),
    IFNULL(CONCAT(country_alpha_3_code, ","), "") ) AS alternates
FROM `datcom-store.dc_kg_latest.Place` 
WHERE TRUE
AND name NOT LIKE '%Cell%' 
AND (alternate_name != "" OR iso_code != "" OR country_alpha_2_code != "" or country_alpha_3_code != "")
```

This produces 189,031 rows. The existing csv of places (one per row) had 103,490 rows. For all these existing places, replacing the ``name`` column with a name + unique(alternates) concatenation (separated by commas). 