### PR TITLE
RecogPlace: Add support for a side alternateNames file

### DIFF
--- a/internal/server/recon/golden/recognize_places/result.json
+++ b/internal/server/recon/golden/recognize_places/result.json
@@ -93,18 +93,12 @@
           "span": "crime in"
         },
         {
-          "span": "new york",
+          "span": "new york state",
           "places": [
             {
               "dcid": "geoId/36"
-            },
-            {
-              "dcid": "geoId/3651000"
             }
           ]
-        },
-        {
-          "span": "state"
         }
       ]
     },
@@ -158,7 +152,7 @@
           "span": "New York",
           "places": [
             {
-              "dcid": "geoId/36"
+              "dcid": "geoId/3651000"
             },
             {
               "dcid": "geoId/3651000"

--- a/internal/server/v2/resolve/golden/resolve_description/city.json
+++ b/internal/server/v2/resolve/golden/resolve_description/city.json
@@ -20,6 +20,7 @@
     {
       "node": "New York City",
       "resolvedIds": [
+        "geoId/3651000",
         "geoId/3651000"
       ]
     }

--- a/internal/store/files/WorldGeosForPlaceRecognitionAlternateNames.csv
+++ b/internal/store/files/WorldGeosForPlaceRecognitionAlternateNames.csv
@@ -1,0 +1,4 @@
+id,alternateNames
+geoId/3651000,"New York City,NYC"
+country/USA,America
+wikidataId/Q174,Sao Paulo

--- a/internal/store/files/recog_place_store_test.go
+++ b/internal/store/files/recog_place_store_test.go
@@ -93,9 +93,9 @@ func TestLoadRecogPlaceStore(t *testing.T) {
 							{
 								Parts: []string{"united", "states"},
 							},
-              {
-                Parts: []string{"america"},
-              },
+							{
+								Parts: []string{"america"},
+							},
 						},
 						Dcid:             "country/USA",
 						ContainingPlaces: []string{"Earth", "northamerica"},

--- a/internal/store/files/recog_place_store_test.go
+++ b/internal/store/files/recog_place_store_test.go
@@ -93,6 +93,9 @@ func TestLoadRecogPlaceStore(t *testing.T) {
 							{
 								Parts: []string{"united", "states"},
 							},
+              {
+                Parts: []string{"america"},
+              },
 						},
 						Dcid:             "country/USA",
 						ContainingPlaces: []string{"Earth", "northamerica"},


### PR DESCRIPTION
Add a few names.

Ensure that "New York" maps to the city (like [google](https://www.google.com/search?q=new+york&oq=new+york&gs_lcrp=EgZjaHJvbWUqBwgAEAAYjwIyBwgAEAAYjwIyCggBEC4YsQMYgAQyDQgCEAAYgwEYsQMYgAQyBggDEEUYQDIGCAQQRRhBMgYIBRBFGEAyBggGEEUYPTIGCAcQRRg90gEIMTIxMGowajGoAgCwAgA&sourceid=chrome&ie=UTF-8)).  Otherwise based on population it will always return New York State.