### PR TITLE
Fix docker issue with system lib not found

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -23,7 +23,7 @@ FROM envoyproxy/envoy:v1.26.0 AS envoy
 
 # =========  protoc stage ==========
 
-FROM golang:1.20.6 AS go-protoc
+FROM golang:1.20.4 AS go-protoc
 
 WORKDIR /mixer
 


### PR DESCRIPTION
The newer golang image will introduce this error "/lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.14' not found" in the website-compose build.