### PR TITLE
Fix mixer bigtable read context cancel issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,4 +61,4 @@ scripts/tmp*.sh
 http_memprof_out
 
 # custom dc data
-data/
+/data

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -47,6 +47,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
+	cbt "cloud.google.com/go/bigtable"
 	_ "github.com/mattn/go-sqlite3" // import the sqlite3 driver
 )
 
@@ -146,10 +147,17 @@ func main() {
 		if err != nil {
 			log.Fatalf("Failed to read branch cache folder: %v", err)
 		}
-		branchTable, err := bigtable.NewBtTable(
+		btClient, err := cbt.NewClient(
 			ctx,
 			bigtable.BranchBigtableProject,
 			bigtable.BranchBigtableInstance,
+		)
+		if err != nil {
+			log.Fatalf("Failed to create branch bigtable client: %v", err)
+
+		}
+		branchTable := bigtable.NewBtTable(
+			btClient,
 			branchTableName,
 		)
 		if err != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -127,8 +127,7 @@ func NewMetadata(
 }
 
 // SubscribeBranchCacheUpdate subscribe for branch cache update.
-func (s *Server) SubscribeBranchCacheUpdate(ctx context.Context,
-) error {
+func (s *Server) SubscribeBranchCacheUpdate(ctx context.Context) error {
 	return dcpubsub.Subscribe(
 		ctx,
 		bigtable.BranchBigtableProject,
@@ -137,8 +136,7 @@ func (s *Server) SubscribeBranchCacheUpdate(ctx context.Context,
 		func(ctx context.Context, msg *pubsub.Message) error {
 			branchTableName := string(msg.Data)
 			log.Printf("branch cache subscriber message received with table name: %s\n", branchTableName)
-			s.updateBranchTable(ctx, branchTableName)
-			return nil
+			return s.updateBranchTable(ctx, branchTableName)
 		},
 	)
 }

--- a/internal/store/bigtable/reader.go
+++ b/internal/store/bigtable/reader.go
@@ -62,7 +62,8 @@ func readRowFn(
 				parts := strings.Split(strings.TrimPrefix(btRow.Key(), prefix), "^")
 				btRowChan <- BtRow{parts, elem}
 				return true
-			}); err != nil {
+			},
+		); err != nil {
 			return err
 		}
 		return nil


### PR DESCRIPTION
This issue is uncovered from observation series BT cache read where O(100) variable and O(10) places are queried. In this case, the context used to read Bigtable is canceled after certain amount of read call. This won't be an issue when the variable and place number is small.

In the previous implementation, each Bigtable table has its own client to the instance, thus there are 10+ client from one binary connected to the instance. With this change, there is only one shared client for all the base bigtable (one for each import group). This apparently solves the issue.