### PR TITLE
Update Golang to 1.20.7 to mitigate docker image security issue

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -19,11 +19,8 @@
 # base: image with Go modules download and protobuf built
 # server: image for mixer server
 
-FROM envoyproxy/envoy:v1.26.0 AS envoy
 
-# =========  protoc stage ==========
-
-FROM golang:1.20.4 AS go-protoc
+FROM golang:1.20.7 AS go-protoc
 
 WORKDIR /mixer
 
@@ -43,10 +40,9 @@ RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.30.0
 RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.3.0
 
 
-# =========  base stage ==========
 # Use pre-built go-protoc image from last step.
 
-FROM gcr.io/datcom-ci/go-protoc:latest AS base
+FROM gcr.io/datcom-ci/go-protoc:latest AS server
 WORKDIR /mixer
 # Docker cache: Download modules
 COPY go.mod go.sum /mixer/
@@ -76,18 +72,4 @@ RUN GRPC_HEALTH_PROBE_VERSION=v0.4.7 && \
 COPY cmd/ cmd
 COPY esp/ esp
 RUN go build -o /go/bin/mixer cmd/main.go
-
-
-# =========  server stage ==========
-FROM base as server
 ENTRYPOINT ["/go/bin/mixer"]
-
-
-# =========  start mixer with envoy ==========
-FROM base as rest_server
-
-COPY deploy/ deploy
-COPY --from=envoy /usr/local/bin/envoy /usr/local/bin/envoy
-COPY build/compose.sh .
-EXPOSE 8081
-CMD ./compose.sh

--- a/build/ci/cloudbuild.push.yaml
+++ b/build/ci/cloudbuild.push.yaml
@@ -49,13 +49,6 @@ steps:
         docker push gcr.io/datcom-ci/datacommons-mixer:$SHORT_SHA
         docker push gcr.io/datcom-ci/datacommons-mixer:latest
 
-        docker build -f build/Dockerfile --target base \
-          -t gcr.io/datcom-ci/datacommons-mixer-base:$SHORT_SHA \
-          -t gcr.io/datcom-ci/datacommons-mixer-base:latest \
-          .
-        docker push gcr.io/datcom-ci/datacommons-mixer-base:$SHORT_SHA
-        docker push gcr.io/datcom-ci/datacommons-mixer-base:latest
-
   # Push the grpc descriptor to gcs.
   - id: push-grpc-descriptor
     name: gcr.io/cloud-builders/gsutil


### PR DESCRIPTION
The old Golang base image has security vulnerability that prevents the GCP project to give IAM access to external account (ex, stanford.edu)

Base mixer image is not used anymore, since the website-compose image (under website repo) will have Golang in it and build mixer binary as well.