### PR TITLE
Allow calling V2Resolve without an API key.

### DIFF
--- a/esp/endpoints.yaml.tmpl
+++ b/esp/endpoints.yaml.tmpl
@@ -105,3 +105,5 @@ usage:
     allow_unregistered_calls: true
   - selector: "datacommons.Mixer.ResolveIds"
     allow_unregistered_calls: true
+  - selector: "datacommons.Mixer.V2Resolve"
+    allow_unregistered_calls: true


### PR DESCRIPTION
* This allows the import tool to call into the v2 resolve api.