### PR TITLE
Place Recog: Fix regions some more

### DIFF
--- a/internal/store/files/recog_place_store.go
+++ b/internal/store/files/recog_place_store.go
@@ -153,9 +153,6 @@ func LoadRecogPlaceStore() (*RecogPlaceStore, error) {
 				"Empty names for CSV record: %v", record)
 		}
 		names := strings.Split(strings.TrimSpace(record[2]), ",")
-		for i := range names {
-			names[i] = strings.TrimSpace(names[i])
-		}
 
 		// Add alternate names if any.
 		altNames, ok := dcidToAlternateNames[dcid]

--- a/internal/store/files/recog_place_store.go
+++ b/internal/store/files/recog_place_store.go
@@ -153,6 +153,9 @@ func LoadRecogPlaceStore() (*RecogPlaceStore, error) {
 				"Empty names for CSV record: %v", record)
 		}
 		names := strings.Split(strings.TrimSpace(record[2]), ",")
+		for i := range names {
+			names[i] = strings.TrimSpace(names[i])
+		}
 
 		// Add alternate names if any.
 		altNames, ok := dcidToAlternateNames[dcid]

--- a/internal/store/files/recog_place_store_test.go
+++ b/internal/store/files/recog_place_store_test.go
@@ -68,26 +68,6 @@ func TestLoadRecogPlaceStore(t *testing.T) {
 				},
 			},
 		},
-		{
-			"subsaharan",
-			&pb.RecogPlaces{
-				Places: []*pb.RecogPlace{
-					{
-						Names: []*pb.RecogPlace_Name{
-							{
-								Parts: []string{"sub", "saharan", "africa"},
-							},
-							{
-								Parts: []string{"subsaharan", "africa"},
-							},
-						},
-						Dcid:             "SubSaharanAfrica",
-						ContainingPlaces: []string{"Earth", "africa"},
-						Population:       579000000,
-					},
-				},
-			},
-		},
 	} {
 		got, ok := recogPlaceStore.RecogPlaceMap[c.key]
 		if !ok {

--- a/internal/store/files/recog_place_store_test.go
+++ b/internal/store/files/recog_place_store_test.go
@@ -68,6 +68,26 @@ func TestLoadRecogPlaceStore(t *testing.T) {
 				},
 			},
 		},
+		{
+			"subsaharan",
+			&pb.RecogPlaces{
+				Places: []*pb.RecogPlace{
+					{
+						Names: []*pb.RecogPlace_Name{
+							{
+								Parts: []string{"sub", "saharan", "africa"},
+							},
+							{
+								Parts: []string{"subsaharan", "africa"},
+							},
+						},
+						Dcid:             "SubSaharanAfrica",
+						ContainingPlaces: []string{"Earth", "africa"},
+						Population:       579000000,
+					},
+				},
+			},
+		},
 	} {
 		got, ok := recogPlaceStore.RecogPlaceMap[c.key]
 		if !ok {


### PR DESCRIPTION
When the query comes in with "sub-saharan africa", NL passes in "sub saharan africa", so in the names replace `-` with space.  Also trim leading spaces when there's multiple names.

I've filed https://github.com/datacommonsorg/mixer/issues/1263 for the parser to be more tolerant.