### PR TITLE
Migrate ESP to v2 and fixes service management quota issue

### DIFF
--- a/deploy/helm_charts/envs/mixer_private.yaml
+++ b/deploy/helm_charts/envs/mixer_private.yaml
@@ -3,10 +3,6 @@ mixer:
   hostProject: datcom-mixer-statvar
   serviceName: mixer.endpoints.datcom-mixer-statvar.cloud.goog
 
-  useTMCFCSVData: true
-  tmcfCSVBucket: datcom-public
-  tmcfCSVFolder: food
-
 ingress:
   enabled: true
   name: mixer-ingress-private

--- a/deploy/helm_charts/mixer/templates/deployment.yaml
+++ b/deploy/helm_charts/mixer/templates/deployment.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -64,6 +64,10 @@ spec:
           configMap:
             name: blocklist-svg
             optional: true
+        - name: service-config-volume
+          configMap:
+            defaultMode: 420
+            name: service-config-configmap
       containers:
         - name: mixer
           image:  "{{ $.Values.mixer.image.repository }}:{{ $.Values.mixer.image.tag | default $.Chart.AppVersion }}"
@@ -85,11 +89,6 @@ spec:
             - --use_branch_bigtable={{ $.Values.mixer.useBranchBigtable }}
             {{- if eq $.Values.mixer.bigqueryOnly true }}
             - --bigquery_only=true
-            {{- end }}
-            {{- if eq $.Values.mixer.useTMCFCSVData true }}
-            - --use_tmcf_csv_data=true
-            - --tmcf_csv_bucket={{ $.Values.mixer.tmcfCSVBucket }}
-            - --tmcf_csv_folder={{ $.Values.mixer.tmcfCSVFolder }}
             {{- end }}
             - --use_search={{ default false $group.useSearch }}
             {{- if eq $.Values.mixer.foldRemoteRootSvg true }}
@@ -154,13 +153,15 @@ spec:
               memory: "300M"
             requests:
               memory: "300M"
+          volumeMounts:
+            - mountPath: /etc/espv2_config
+              name: service-config-volume
           args:
-            - --service=$(SERVICE_NAME)
-            - --rollout_strategy=managed
-            - --http_port=8081
+            - --listener_port=8081
             - --backend=grpc://127.0.0.1:12345
             - --cors_preset=basic
             - --healthz=healthz
+            - --service_json_path=/etc/espv2_config/service_config.json
           env:
             - name: SERVICE_NAME
               valueFrom:

--- a/deploy/helm_charts/mixer/values.yaml
+++ b/deploy/helm_charts/mixer/values.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -41,12 +41,6 @@ mixer:
   useBranchBigtable: true
   useCustomBigtable: false
   foldRemoteRootSvg: false
-  useTMCFCSVData: false
-  # Name of the GCS bucket without scheme.
-  # Example: datcom-public
-  tmcfCSVBucket:
-  # Folder under the CSV bucket.
-  tmcfCSVFolder:
 
   # If bigqueryOnly is True, bigqueryTableRef must be specified.
   bigqueryOnly: false
@@ -72,7 +66,7 @@ esp:
   image:
     repository: gcr.io/endpoints-release/endpoints-runtime
     pullPolicy: IfNotPresent
-    tag: "1"
+    tag: "2"
 
 # Config for k8s-sa(service account). The k8s-sa will be bound to a
 # GCP-sa using annotations, specified below.

--- a/test/setup.go
+++ b/test/setup.go
@@ -67,8 +67,6 @@ var (
 // provide service account credential when running on GCP.
 const (
 	bigqueryBillingProject = "datcom-store"
-	tmcfCsvBucket          = "datcom-public"
-	tmcfCsvPrefix          = "food"
 	hostProject            = "datcom-ci"
 )
 


### PR DESCRIPTION
More details and ration can be found in https://cloud.google.com/endpoints/docs/grpc/get-started-kubernetes-engine-espv2#deploying_the_sample_api_and_esp_to_the_cluster

Also removed deprecated flag from memdb.