### PR TITLE
Allow missing field in API response when reading from remote mixer

### DIFF
--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -643,7 +643,8 @@ func FetchRemote(
 		return err
 	}
 	// Convert response body to string
-	return protojson.Unmarshal(responseBodyBytes, out)
+	unmarshaler := protojson.UnmarshalOptions{DiscardUnknown: true}
+	return unmarshaler.Unmarshal(responseBodyBytes, out)
 }
 
 // HasCollectionCache decides whether the Bigtable collection cache exists


### PR DESCRIPTION
Custom DC mixer may have outdated protobuf compared with the remote mixer (main DC API). This prevents mixer error out in such cases.

We should also be more careful on updating and deprecating mixer fields in the future since the mixer response data does persist now, not in storage, but in custom DC.