### PR TITLE
Fix and improvement for mixer timeout

### DIFF
--- a/deploy/helm_charts/mixer/templates/ingress.yaml
+++ b/deploy/helm_charts/mixer/templates/ingress.yaml
@@ -36,6 +36,11 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  defaultBackend:
+    service:
+      name: {{ include "mixer.fullname" $ }}-default
+      port:
+        number: 80
   rules:
     - http:
         paths:
@@ -45,7 +50,7 @@ spec:
             pathType: ImplementationSpecific
             backend:
               service:
-                name: {{ include "mixer.fullname" $ }}-{{ $serviceName }} 
+                name: {{ include "mixer.fullname" $ }}-{{ $serviceName }}
                 port:
                   number: 80
           {{- end }}

--- a/deploy/helm_charts/mixer/templates/service.yaml
+++ b/deploy/helm_charts/mixer/templates/service.yaml
@@ -31,7 +31,7 @@ metadata:
     {{- include "mixer.labels" $ | nindent 4 }}
   annotations:
     # This is to get longer timeout for the Cloud Load Balancer.
-    cloud.google.com/backend-config: '{"ports": {"8081":"{{ include "mixer.fullname" $ }}-backendconfig"}}'
+    cloud.google.com/backend-config: '{"ports": {"80":"{{ include "mixer.fullname" $ }}-backendconfig"}}'
 spec:
   type: NodePort
   ports:
@@ -54,6 +54,6 @@ metadata:
   namespace: {{ .Values.namespace.name }}
 spec:
   # Timeout for load balancer and the GKE pod connection
-  timeoutSec: 60
+  timeoutSec: 300
   connectionDraining:
-    drainingTimeoutSec: 60
+    drainingTimeoutSec: 300

--- a/esp/endpoints.yaml.tmpl
+++ b/esp/endpoints.yaml.tmpl
@@ -35,9 +35,12 @@ endpoints:
 
 backend:
   rules:
+    # Default timeout for the ESP and mixer GRPC server.
     - selector: "datacommons.Mixer.*"
-      # Timeout for the ESP and mixer GRPC server.
       deadline: 60
+    # Longer timeout for the Sparql endpoint.
+    - selector: "datacommons.Mixer.Query"
+      deadline: 300
 
 usage:
   rules:


### PR DESCRIPTION
* Add `defaultBackend` field in the ingress so no default backend is created in the load balancer
* Backend-config should point to port 80 instead of 8081. Because of this, the backend config (timeout etc) was not used at all.
* Have a longer timeout for Sparql endpoint and adjust the load balancer <-> backend accordingly. Non Sparql API would still timeout in 60s.