### PR TITLE
Update SSL Certificates in helm charts

### DIFF
--- a/deploy/helm_charts/envs/mixer_autopush.yaml
+++ b/deploy/helm_charts/envs/mixer_autopush.yaml
@@ -8,7 +8,7 @@ ingress:
   name: mixer-ingress-autopush
   annotations:
     {
-      ingress.gcp.kubernetes.io/pre-shared-cert: "mixer-certificate,multi-domain-2022",
+      ingress.gcp.kubernetes.io/pre-shared-cert: "mixer-certificate,multi-domain-2024",
     }
 
 # GCP level config.

--- a/deploy/helm_charts/envs/mixer_prod.yaml
+++ b/deploy/helm_charts/envs/mixer_prod.yaml
@@ -8,7 +8,7 @@ ingress:
   name: mixer-ingress-prod
   annotations:
     {
-      ingress.gcp.kubernetes.io/pre-shared-cert: "mixer-certificate,multi-domain-2022",
+      ingress.gcp.kubernetes.io/pre-shared-cert: "mixer-certificate,multi-domain-2024",
     }
 
 serviceGroups:

--- a/deploy/helm_charts/envs/mixer_staging.yaml
+++ b/deploy/helm_charts/envs/mixer_staging.yaml
@@ -8,7 +8,7 @@ ingress:
   name: mixer-ingress-staging
   annotations:
     {
-      ingress.gcp.kubernetes.io/pre-shared-cert: "mixer-certificate,multi-domain-2022",
+      ingress.gcp.kubernetes.io/pre-shared-cert: "mixer-certificate,multi-domain-2024",
     }
 
 serviceGroups:


### PR DESCRIPTION
Updates the `multi-domain-<year>` ssl certificates linked in our helm charts from the expired `multi-domain-2022` to the newly created `multi-domain-2024`. A `multi-domain-2024` ssl cert was created for each of their host projects manually in GCP.