### PR TITLE
Recon:  fix empty array access

### DIFF
--- a/internal/server/recon/coordinate.go
+++ b/internal/server/recon/coordinate.go
@@ -107,8 +107,11 @@ func ResolveCoordinates(
 		return nil, err
 	}
 	s2PolygonMap := map[string]*s2.Polygon{}
-	for place, entities := range geoJSONData {
-		s2Polygon, err := parseGeoJSON(entities[0].Value)
+	for place, gjValues := range geoJSONData {
+		if len(gjValues) == 0 {
+			continue
+		}
+		s2Polygon, err := parseGeoJSON(gjValues[0].Value)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/server/recon/golden/resolve_coordinates/result.json
+++ b/internal/server/recon/golden/resolve_coordinates/result.json
@@ -120,6 +120,24 @@
           "dominantType": "Country"
         }
       ]
+    },
+    {
+      "latitude": -6.72177,
+      "longitude": -38.18998,
+      "placeDcids": [
+        "ipcc_50/-6.75_-38.25_BRA",
+        "country/BRA"
+      ],
+      "places": [
+        {
+          "dcid": "ipcc_50/-6.75_-38.25_BRA",
+          "dominantType": "IPCCPlace_50"
+        },
+        {
+          "dcid": "country/BRA",
+          "dominantType": "Country"
+        }
+      ]
     }
   ]
 }

--- a/internal/server/recon/golden/resolve_coordinates_test.go
+++ b/internal/server/recon/golden/resolve_coordinates_test.go
@@ -50,6 +50,10 @@ func TestResolveCoordinates(t *testing.T) {
 							Latitude:  32.41,
 							Longitude: -102.11,
 						},
+						{
+							Latitude:  -6.72177,
+							Longitude: -38.18998,
+						},
 					},
 				},
 				"result.json",


### PR DESCRIPTION
This suggests that the recon coordinate cache is staler than the triples cache, which can happen because the coordinate cache is built on-demand.

The likely sequence of events is that cl/597359495 modified Brazil AA2 geojsons (specifically seems to have removed some boundaries as part of fixing some buggy boundaries), but didn't rebuild the coordinate recon cache.   A fire event located within Brazil AA2 tries to look up the now removed geojson and fails.

Two part fix:
1.  Make the code more resilient
2. Rebuild recon cache