### PR TITLE
Fix empty data check when merging v2 node responses

### DIFF
--- a/internal/merger/merger.go
+++ b/internal/merger/merger.go
@@ -75,18 +75,20 @@ func mergeLinkedGraph(
 		if mainData == nil {
 			mainData = map[string]*pbv2.LinkedGraph{}
 		}
-		if _, ok := mainData[dcid]; !ok {
+		if _, ok := mainData[dcid]; !ok || mainData[dcid].GetArcs() == nil {
 			mainData[dcid] = linkedGraph
 			continue
 		}
+		mainArcs := mainData[dcid].GetArcs()
+
 		for prop, nodes := range linkedGraph.GetArcs() {
-			if _, ok := mainData[dcid].GetArcs()[prop]; !ok {
-				mainData[dcid].GetArcs()[prop] = nodes
+			if _, ok := mainArcs[prop]; !ok || len(mainArcs[prop].GetNodes()) == 0 {
+				mainData[dcid].Arcs[prop] = nodes
 				continue
 			}
 			dcidSet := map[string]struct{}{}
 			valueSet := map[string]struct{}{}
-			mainNodes := mainData[dcid].GetArcs()[prop].Nodes
+			mainNodes := mainArcs[prop].Nodes
 			for _, n := range mainNodes {
 				if n.Dcid != "" {
 					dcidSet[n.Dcid] = struct{}{}

--- a/internal/merger/merger_test.go
+++ b/internal/merger/merger_test.go
@@ -110,6 +110,46 @@ func TestMergeNode(t *testing.T) {
 				Data: map[string]*pbv2.LinkedGraph{
 					"dcid1": {
 						Arcs: map[string]*pbv2.Nodes{
+							"prop1": nil,
+						},
+					},
+				},
+			},
+			&pbv2.NodeResponse{
+				Data: map[string]*pbv2.LinkedGraph{
+					"dcid1": {
+						Arcs: map[string]*pbv2.Nodes{
+							"prop1": {
+								Nodes: []*pb.EntityInfo{
+									{Value: "val1"},
+								},
+							},
+						},
+					},
+				},
+			},
+			&pbv2.NodeResponse{
+				Data: map[string]*pbv2.LinkedGraph{
+					"dcid1": {
+						Arcs: map[string]*pbv2.Nodes{
+							"prop1": {
+								Nodes: []*pb.EntityInfo{
+									{Value: "val1"},
+								},
+							},
+						},
+					},
+				},
+			},
+			nil,
+			nil,
+			nil,
+		},
+		{
+			&pbv2.NodeResponse{
+				Data: map[string]*pbv2.LinkedGraph{
+					"dcid1": {
+						Arcs: map[string]*pbv2.Nodes{
 							"prop1": {
 								Nodes: []*pb.EntityInfo{
 									{Value: "val1"},
@@ -315,11 +355,11 @@ func TestMergeNode(t *testing.T) {
 
 		got, err := MergeNode(c.local, c.remote)
 		if err != nil {
-			t.Errorf("MergeEvent(%v, %v) = %s", c.local, c.remote, err)
+			t.Errorf("MergeNode(%v, %v) = %s", c.local, c.remote, err)
 			continue
 		}
 		if diff := cmp.Diff(got, c.want, cmpOpts); diff != "" {
-			t.Errorf("MergeEvent(%v, %v) got diff: %s", c.local, c.remote, diff)
+			t.Errorf("MergeNode(%v, %v) got diff: %s", c.local, c.remote, diff)
 		}
 	}
 }

--- a/internal/merger/merger_test.go
+++ b/internal/merger/merger_test.go
@@ -226,7 +226,15 @@ func TestMergeNode(t *testing.T) {
 			},
 		},
 		{
-			&pbv2.NodeResponse{},
+			&pbv2.NodeResponse{
+				Data: map[string]*pbv2.LinkedGraph{
+					"dcid1": {
+						Arcs: map[string]*pbv2.Nodes{
+							"prop1.2": {},
+						},
+					},
+				},
+			},
 			&pbv2.NodeResponse{
 				Data: map[string]*pbv2.LinkedGraph{
 					"dcid1": {

--- a/internal/server/handler_v2.go
+++ b/internal/server/handler_v2.go
@@ -102,7 +102,8 @@ func (s *Server) V2Node(ctx context.Context, in *pbv2.NodeRequest) (
 		} else {
 			remoteRespChan <- nil
 		}
-	} else { // in.GetNextToken() != ""
+	} else {
+		// in.GetNextToken() != ""
 		// In this case, the call needs pagination, and it's not the first call/page.
 
 		paginationInfo, err := pagination.Decode(in.GetNextToken())

--- a/internal/server/place/places.go
+++ b/internal/server/place/places.go
@@ -16,7 +16,6 @@ package place
 
 import (
 	"context"
-	"time"
 
 	"github.com/datacommonsorg/mixer/internal/store/bigtable"
 	"google.golang.org/protobuf/proto"
@@ -190,7 +189,6 @@ func GetPlaceMetadataHelper(
 	entities []string,
 	store *store.Store,
 ) (map[string]*pb.PlaceMetadata, error) {
-	defer util.TimeTrack(time.Now(), "GetPlaceMetadataHelper")
 	// Place metadata are from base geo imports. Only trust the base cache.
 	btDataList, err := bigtable.Read(
 		ctx,

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -496,6 +496,9 @@ func EncodeProto(m proto.Message) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if len(data) == 0 {
+		return "", nil
+	}
 	return ZipAndEncode(data)
 }
 


### PR DESCRIPTION
When no data is present, the empty data is not nil but rather empty arcs and nodes.