### PR TITLE
Use varchar vs text columns when creating sql tables.

### DIFF
--- a/internal/sqldb/createtables.go
+++ b/internal/sqldb/createtables.go
@@ -22,9 +22,9 @@ import (
 func CreateTables(sqlClient *sql.DB) error {
 	tripleStatement := `
 	CREATE TABLE IF NOT EXISTS triples (
-		subject_id TEXT,
-		predicate TEXT,
-		object_id TEXT,
+		subject_id varchar(255),
+		predicate varchar(255),
+		object_id varchar(255),
 		object_value TEXT
 	);
 	`
@@ -35,11 +35,11 @@ func CreateTables(sqlClient *sql.DB) error {
 
 	observationStatement := `
 	CREATE TABLE IF NOT EXISTS observations (
-		entity TEXT,
-		variable TEXT,
-		date TEXT,
-		value TEXT,
-		provenance TEXT
+		entity varchar(255),
+		variable varchar(255),
+		date varchar(255),
+		value varchar(255),
+		provenance varchar(255)
 	);
 	`
 	_, err = sqlClient.Exec(observationStatement)


### PR DESCRIPTION
* Typically, the tables are first created by mixer.
* Currently, it creates text columns which can't be indexed.
* Changes all columns except `object_value` to varchar so they can be.
* This also makes it consistent with the [loader script](https://github.com/datacommonsorg/import/blob/7d197583b6ad0dfe0568532f919482527c004a8e/simple/stats/db.py#L62-L80).