### PR TITLE
Fix mysql error with prepared statement.

### DIFF
--- a/internal/sqldb/sqlquery/key_value.go
+++ b/internal/sqldb/sqlquery/key_value.go
@@ -34,7 +34,7 @@ func GetKeyValue(sqlClient *sql.DB, key string, out protoreflect.ProtoMessage) (
 	query := `
 SELECT value
 FROM key_value_store
-WHERE lookup_key = $1;
+WHERE lookup_key = ?;
 `
 
 	stmt, err := sqlClient.Prepare(query)


### PR DESCRIPTION
* This fixes the following error when mixer connects to mysql:

```
main.go:237: Failed to create cache: Error 1054 (42S22): Unknown column '$1' in 'where clause'
```