### PR TITLE
[calculations] Add function to parse AST tree and find leaf SVs

### DIFF
--- a/internal/server/v2/observation/calculation_util.go
+++ b/internal/server/v2/observation/calculation_util.go
@@ -1,0 +1,168 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package observation
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"reflect"
+	"strings"
+
+	pb "github.com/datacommonsorg/mixer/internal/proto"
+)
+
+// The info of a node in the AST tree.
+type NodeData struct {
+	StatVar string
+	Facet   *pb.Facet
+}
+
+type Calculation struct {
+	Expr ast.Expr
+	// Key is encodeForParse(nodeName).
+	NodeDataMap map[string]*NodeData
+	StatVars    []string
+}
+
+// Golang's AST package is used for parsing the formula, so we need to avoid sensitive tokens for
+// AST. For those tokens, we swap them with insensitive tokens before the parsing, then swap them
+// back after the parsing.
+var (
+	encodeForParseTokenMap = map[string]string{
+		"dc/":          "_DC_SLASH_",
+		"dcAggregate/": "_DC_AGGREGATE_SLASH_",
+		"[":            "_LEFT_SQUARE_BRACKET_",
+		"]":            "_RIGHT_SQUARE_BRACKET_",
+		"=":            "_EQUAL_TO_",
+		";":            "_SEMICOLON_",
+	}
+	decodeForParseTokenMap = map[string]string{
+		"_DC_SLASH_":             "dc/",
+		"_DC_AGGREGATE_SLASH_":   "dcAggregate/",
+		"_LEFT_SQUARE_BRACKET_":  "[",
+		"_RIGHT_SQUARE_BRACKET_": "]",
+		"_EQUAL_TO_":             "=",
+		"_SEMICOLON_":            ";",
+	}
+)
+
+func encodeForParse(s string) string {
+	res := s
+	for k, v := range encodeForParseTokenMap {
+		res = strings.ReplaceAll(res, k, v)
+	}
+	return res
+}
+
+func decodeForParse(s string) string {
+	res := s
+	for k, v := range decodeForParseTokenMap {
+		res = strings.ReplaceAll(res, k, v)
+	}
+	return res
+
+}
+
+// Parse nodeName, which contains a variable and a set of filters.
+// For example: Person_Count[mm=US_Census;p=P1Y].
+func parseNode(nodeName string) (*NodeData, error) {
+	res := &NodeData{}
+
+	if strings.Contains(nodeName, "[") { // With filters.
+		if !strings.Contains(nodeName, "]") {
+			return nil, fmt.Errorf("missing ]")
+		}
+
+		leftBracketIndex := strings.Index(nodeName, "[")
+
+		res.Facet = &pb.Facet{}
+		filterString := nodeName[leftBracketIndex+1 : len(nodeName)-1]
+		for _, filter := range strings.Split(filterString, ";") {
+			filterType := filter[0:2]
+			filterVal := filter[3:]
+			switch filterType {
+			case "mm":
+				res.Facet.MeasurementMethod = filterVal
+			case "op":
+				res.Facet.ObservationPeriod = filterVal
+			case "ut":
+				res.Facet.Unit = filterVal
+			case "sf":
+				res.Facet.ScalingFactor = filterVal
+			default:
+				return nil, fmt.Errorf("unsupported filter type: %s", filterType)
+			}
+		}
+
+		res.StatVar = nodeName[0:leftBracketIndex]
+
+	} else { // No filters.
+		res.StatVar = nodeName
+	}
+
+	return res, nil
+}
+
+func NewCalculation(formula string) (*Calculation, error) {
+	expr, err := parser.ParseExpr(encodeForParse(formula))
+	if err != nil {
+		return nil, err
+	}
+
+	c := &Calculation{Expr: expr, NodeDataMap: map[string]*NodeData{}}
+	if err := processNodeInfo(expr, c); err != nil {
+		return nil, err
+	}
+
+	statVarSet := map[string]struct{}{}
+	for k := range c.NodeDataMap {
+		statVarSet[c.NodeDataMap[k].StatVar] = struct{}{}
+	}
+	statVars := []string{}
+	for k := range statVarSet {
+		statVars = append(statVars, k)
+	}
+	c.StatVars = statVars
+
+	return c, nil
+}
+
+// Recursively iterate through the AST tree, extract and parse nodeName, then fill nodeData.
+func processNodeInfo(node ast.Node, c *Calculation) error {
+	switch t := node.(type) {
+	case *ast.BinaryExpr:
+		for _, node := range []ast.Node{t.X, t.Y} {
+			if reflect.TypeOf(node).String() == "*ast.Ident" {
+				nodeName := node.(*ast.Ident).Name
+				nodeData, err := parseNode(decodeForParse(nodeName))
+				if err != nil {
+					return err
+				}
+				c.NodeDataMap[nodeName] = nodeData
+			} else {
+				if err := processNodeInfo(node, c); err != nil {
+					return err
+				}
+			}
+		}
+	case *ast.ParenExpr:
+		return processNodeInfo(t.X, c)
+	default:
+		return fmt.Errorf("unsupported AST type %T", t)
+	}
+
+	return nil
+}

--- a/internal/server/v2/observation/calculation_util.go
+++ b/internal/server/v2/observation/calculation_util.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 
 	pb "github.com/datacommonsorg/mixer/internal/proto"
-  pbv2 "github.com/datacommonsorg/mixer/internal/proto/v2"
+	pbv2 "github.com/datacommonsorg/mixer/internal/proto/v2"
 )
 
 // The info of a node in the AST tree.
@@ -34,8 +34,8 @@ type ASTNode struct {
 type VariableFormula struct {
 	Expr ast.Expr
 	// Map of leaves in AST tree formula to the corresponding StatVar and Facet.
-	// The key is encodeForParse(nodeName), where nodeName contains the variable and filters,
-	// for example: Count_Person[mm=US_Census;p=P1Y].
+	// The key is encodeForParse(nodeName), where nodeName contains the StatVar dcid and filters,
+	// (for example: "Count_Person[mm=US_Census;p=P1Y]").
 	LeafData map[string]*ASTNode
 	// List of distinct StatVars in the formula.
 	StatVars []string

--- a/internal/server/v2/observation/calculation_util.go
+++ b/internal/server/v2/observation/calculation_util.go
@@ -25,15 +25,15 @@ import (
 )
 
 // The info of a node in the AST tree.
-type NodeData struct {
+type ASTNode struct {
 	StatVar string
 	Facet   *pb.Facet
 }
 
-type Calculation struct {
+type VariableFormula struct {
 	Expr ast.Expr
-	// Key is encodeForParse(nodeName).
-	NodeDataMap map[string]*NodeData
+	// Key is encodeForParse(<name of ASTNode>).
+	NodeDataMap map[string]*ASTNode
 	StatVars    []string
 }
 
@@ -77,9 +77,9 @@ func decodeForParse(s string) string {
 }
 
 // Parse nodeName, which contains a variable and a set of filters.
-// For example: Person_Count[mm=US_Census;p=P1Y].
-func parseNode(nodeName string) (*NodeData, error) {
-	res := &NodeData{}
+// For example: Count_Person[mm=US_Census;p=P1Y].
+func parseNode(nodeName string) (*ASTNode, error) {
+	res := &ASTNode{}
 
 	if strings.Contains(nodeName, "[") { // With filters.
 		if !strings.Contains(nodeName, "]") {
@@ -116,13 +116,13 @@ func parseNode(nodeName string) (*NodeData, error) {
 	return res, nil
 }
 
-func NewCalculation(formula string) (*Calculation, error) {
+func NewVariableFormula(formula string) (*VariableFormula, error) {
 	expr, err := parser.ParseExpr(encodeForParse(formula))
 	if err != nil {
 		return nil, err
 	}
 
-	c := &Calculation{Expr: expr, NodeDataMap: map[string]*NodeData{}}
+	c := &VariableFormula{Expr: expr, NodeDataMap: map[string]*ASTNode{}}
 	if err := processNodeInfo(expr, c); err != nil {
 		return nil, err
 	}
@@ -141,7 +141,7 @@ func NewCalculation(formula string) (*Calculation, error) {
 }
 
 // Recursively iterate through the AST tree, extract and parse nodeName, then fill nodeData.
-func processNodeInfo(node ast.Node, c *Calculation) error {
+func processNodeInfo(node ast.Node, c *VariableFormula) error {
 	switch t := node.(type) {
 	case *ast.BinaryExpr:
 		for _, node := range []ast.Node{t.X, t.Y} {

--- a/internal/server/v2/observation/calculation_util_test.go
+++ b/internal/server/v2/observation/calculation_util_test.go
@@ -1,0 +1,88 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package observation
+
+import (
+	"reflect"
+	"testing"
+
+	pb "github.com/datacommonsorg/mixer/internal/proto"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestParseNodeName(t *testing.T) {
+	for _, c := range []struct {
+		nodeName string
+		want     *NodeData
+	}{
+		{
+			"Count_Person",
+			&NodeData{StatVar: "Count_Person"},
+		},
+		{
+			"Count_Person_Female[ut=NumberUnit;mm=dcAggregate/Census;op=P1Y;sf=100]",
+			&NodeData{
+				StatVar: "Count_Person_Female",
+				Facet: &pb.Facet{
+					MeasurementMethod: "dcAggregate/Census",
+					ObservationPeriod: "P1Y",
+					Unit:              "NumberUnit",
+					ScalingFactor:     "100",
+				},
+			},
+		},
+	} {
+		got, err := parseNode(c.nodeName)
+		if err != nil {
+			t.Errorf("parseNodeName(%s) = %s", c.nodeName, err)
+		}
+		if ok := reflect.DeepEqual(got, c.want); !ok {
+			t.Errorf("parseVarName(%s) = %v, want %v",
+				c.nodeName, got, c.want)
+		}
+	}
+}
+
+func TestCalculatorParseFormula(t *testing.T) {
+	strCmpOpts := cmpopts.SortSlices(func(a, b string) bool { return a < b })
+
+	for _, c := range []struct {
+		formula      string
+		wantStatVars []string
+	}{
+		{
+			"Person_Count_Female[ut=NumberUnit;mm=dcAggregate/Census;op=P1Y]/Person_Count[ut=Census]",
+			[]string{"Person_Count_Female", "Person_Count"},
+		},
+		{
+			"Person_Count-Person_Count_Female-Person_Count_Male",
+			[]string{"Person_Count_Female", "Person_Count", "Person_Count_Male"},
+		},
+		{
+			"(Person_Count-Person_Count_Female) / Person_Count_Female",
+			[]string{"Person_Count_Female", "Person_Count"},
+		},
+	} {
+		calculation, err := NewCalculation(c.formula)
+		if err != nil {
+			t.Errorf("NewCalculation(%s) = %s", c.formula, err)
+		}
+		gotStatVars := calculation.StatVars
+		if diff := cmp.Diff(gotStatVars, c.wantStatVars, strCmpOpts); diff != "" {
+			t.Errorf("calculation.StatVars(%s) diff (-want +got):\n%s", c.formula, diff)
+		}
+	}
+}

--- a/internal/server/v2/observation/calculation_util_test.go
+++ b/internal/server/v2/observation/calculation_util_test.go
@@ -26,15 +26,15 @@ import (
 func TestParseNodeName(t *testing.T) {
 	for _, c := range []struct {
 		nodeName string
-		want     *NodeData
+		want     *ASTNode
 	}{
 		{
 			"Count_Person",
-			&NodeData{StatVar: "Count_Person"},
+			&ASTNode{StatVar: "Count_Person"},
 		},
 		{
 			"Count_Person_Female[ut=NumberUnit;mm=dcAggregate/Census;op=P1Y;sf=100]",
-			&NodeData{
+			&ASTNode{
 				StatVar: "Count_Person_Female",
 				Facet: &pb.Facet{
 					MeasurementMethod: "dcAggregate/Census",
@@ -56,7 +56,7 @@ func TestParseNodeName(t *testing.T) {
 	}
 }
 
-func TestCalculatorParseFormula(t *testing.T) {
+func TestVariableFormulaParseFormula(t *testing.T) {
 	strCmpOpts := cmpopts.SortSlices(func(a, b string) bool { return a < b })
 
 	for _, c := range []struct {
@@ -76,13 +76,13 @@ func TestCalculatorParseFormula(t *testing.T) {
 			[]string{"Person_Count_Female", "Person_Count"},
 		},
 	} {
-		calculation, err := NewCalculation(c.formula)
+		vf, err := NewVariableFormula(c.formula)
 		if err != nil {
-			t.Errorf("NewCalculation(%s) = %s", c.formula, err)
+			t.Errorf("NewVariableFormula(%s) = %s", c.formula, err)
 		}
-		gotStatVars := calculation.StatVars
+		gotStatVars := vf.StatVars
 		if diff := cmp.Diff(gotStatVars, c.wantStatVars, strCmpOpts); diff != "" {
-			t.Errorf("calculation.StatVars(%s) diff (-want +got):\n%s", c.formula, diff)
+			t.Errorf("vf.StatVars(%s) diff (-want +got):\n%s", c.formula, diff)
 		}
 	}
 }


### PR DESCRIPTION
Given a formula, returns a Calculation struct which contains 
* AST tree
* Map of leaf data (currently just SV dcid and facet) 
* List of leaf SVs

This follows a lot of logic/tests in Calculator for parsing the tree, except doesn't use a class and doesn't store candidates. (Data candidate handling will be deferred to each caller.) 