### PR TITLE
Fix for merging data in v2/node API

### DIFF
--- a/internal/merger/merger.go
+++ b/internal/merger/merger.go
@@ -88,8 +88,7 @@ func mergeLinkedGraph(
 			}
 			dcidSet := map[string]struct{}{}
 			valueSet := map[string]struct{}{}
-			mainNodes := mainArcs[prop].Nodes
-			for _, n := range mainNodes {
+			for _, n := range mainArcs[prop].Nodes {
 				if n.Dcid != "" {
 					dcidSet[n.Dcid] = struct{}{}
 				} else {
@@ -99,12 +98,12 @@ func mergeLinkedGraph(
 			for _, node := range nodes.Nodes {
 				if node.Dcid != "" {
 					if _, ok := dcidSet[node.Dcid]; !ok {
-						mainNodes = append(mainNodes, node)
+						mainArcs[prop].Nodes = append(mainArcs[prop].Nodes, node)
 					}
 				}
 				if node.Value != "" {
 					if _, ok := valueSet[node.Value]; !ok {
-						mainNodes = append(mainNodes, node)
+						mainArcs[prop].Nodes = append(mainArcs[prop].Nodes, node)
 					}
 				}
 			}

--- a/internal/merger/merger_test.go
+++ b/internal/merger/merger_test.go
@@ -334,6 +334,52 @@ func TestMergeNode(t *testing.T) {
 				},
 			},
 		},
+		// Ensure that props with same name from the same dcid are merged
+		{
+			&pbv2.NodeResponse{
+				Data: map[string]*pbv2.LinkedGraph{
+					"dcid1": {
+						Arcs: map[string]*pbv2.Nodes{
+							"prop1": {
+								Nodes: []*pb.EntityInfo{
+									{Value: "val1"},
+								},
+							},
+						},
+					},
+				},
+			},
+			&pbv2.NodeResponse{
+				Data: map[string]*pbv2.LinkedGraph{
+					"dcid1": {
+						Arcs: map[string]*pbv2.Nodes{
+							"prop1": {
+								Nodes: []*pb.EntityInfo{
+									{Value: "val2"},
+								},
+							},
+						},
+					},
+				},
+			},
+			&pbv2.NodeResponse{
+				Data: map[string]*pbv2.LinkedGraph{
+					"dcid1": {
+						Arcs: map[string]*pbv2.Nodes{
+							"prop1": {
+								Nodes: []*pb.EntityInfo{
+									{Value: "val1"},
+									{Value: "val2"},
+								},
+							},
+						},
+					},
+				},
+			},
+			nil,
+			nil,
+			nil,
+		},
 	} {
 		var err error
 


### PR DESCRIPTION
This bug fixes the the root cause of datasets not showing up in custom DC:

<img width="1402" alt="Screenshot 2024-08-18 at 9 41 53 PM" src="https://github.com/user-attachments/assets/2a4e7ebd-6ae8-4653-be28-7ecb1bd8aa02">

Fix: v2/node endpoint wasn't merging properties with the same name and same DCID when data existed both locally and in the remote mixer

Before fix:

```bash
curl "https://dc-autopush-kqb7thiuka-uc.a.run.app/api/node/propvals/in?prop=typeOf&dcids=Source"
{"Source": [{"dcid": "c/s/default"}, {"dcid": "c/s/1"}]}
```

After fix

```bash
curl "http://localhost:8080/api/node/propvals/in?prop=typeOf&dcids=Source"
{
  "Source": [
    {
      "dcid": "c/s/1"
    },
    {
      "dcid": "c/s/default"
    },
    {
      "name": "Australian Bureau of Statistics",
      "types": [
        "Source"
      ],
      "dcid": "dc/s/AustralianBureauOfStatistics",
      "provenanceId": "dc/base/GeneratedGraphs"
    },
    {
      "name": "Brazil INPE - National Institute for Space Research",
      "types": [
        "Source"
      ],
      "dcid": "dc/s/BrazilInpe-NationalInstituteForSpaceResearch",
      "provenanceId": "dc/base/GeneratedGraphs"
    },
    {
      "name": "Brazil VISDATA",
      "types": [
        "Source"
      ],
      "dcid": "dc/s/BrazilVisdata",
      "provenanceId": "dc/base/GeneratedGraphs"
    },
    {
      "name": "Brazilian Institute of Geography and Statistics (IBGE)",
      "types": [
        "Source"
      ],
      "dcid": "dc/s/BrazilianInstituteOfGeographyAndStatisticsIbge",
      "provenanceId": "dc/base/GeneratedGraphs"
    },
    ...
}
```
