### PR TITLE
Add pagination to formula_fetcher

### DIFF
--- a/internal/server/statvar/fetcher/formula_fetcher.go
+++ b/internal/server/statvar/fetcher/formula_fetcher.go
@@ -145,6 +145,7 @@ func FetchFormulas(
 				if err != nil {
 					return err
 				}
+				nextToken = currResp.GetNextToken()
 			}
 			remoteRespChan <- remoteResp
 			return nil

--- a/internal/server/statvar/fetcher/formula_fetcher.go
+++ b/internal/server/statvar/fetcher/formula_fetcher.go
@@ -59,13 +59,10 @@ func FetchFormulas(
 				return err
 			}
 			typeOf, ok := statCalResp.Triples["typeOf"]
-			// No StatisticalCalculations found, so return.
-			if !ok {
-				return nil
-			}
-
-			for _, node := range typeOf.Nodes {
-				statCal = append(statCal, node.Dcid)
+			if ok {
+				for _, node := range typeOf.Nodes {
+					statCal = append(statCal, node.Dcid)
+				}
 			}
 			nextToken = statCalResp.GetNextToken()
 		}

--- a/internal/server/v2/observation/golden/calculation/basic.json
+++ b/internal/server/v2/observation/golden/calculation/basic.json
@@ -2,12 +2,74 @@
   "by_variable": {
     "Count_Person_Female": {
       "by_entity": {
-        "wikidataId/Q613": {}
+        "wikidataId/Q613": {
+          "ordered_facets": [
+            {
+              "facet_id": "1382102842",
+              "observations": [
+                {
+                  "date": "1975",
+                  "value": 54366
+                },
+                {
+                  "date": "1980",
+                  "value": 88587
+                },
+                {
+                  "date": "1985",
+                  "value": 123609
+                },
+                {
+                  "date": "1995",
+                  "value": 211211
+                },
+                {
+                  "date": "2005",
+                  "value": 332148
+                }
+              ],
+              "obs_count": 5,
+              "earliest_date": "1975",
+              "latest_date": "2005"
+            }
+          ]
+        }
       }
     },
     "Count_Person_Male": {
       "by_entity": {
-        "wikidataId/Q613": {}
+        "wikidataId/Q613": {
+          "ordered_facets": [
+            {
+              "facet_id": "1382102842",
+              "observations": [
+                {
+                  "date": "1975",
+                  "value": 128821
+                },
+                {
+                  "date": "1980",
+                  "value": 187714
+                },
+                {
+                  "date": "1985",
+                  "value": 247179
+                },
+                {
+                  "date": "1995",
+                  "value": 478209
+                },
+                {
+                  "date": "2005",
+                  "value": 989305
+                }
+              ],
+              "obs_count": 5,
+              "earliest_date": "1975",
+              "latest_date": "2005"
+            }
+          ]
+        }
       }
     },
     "Count_WetBulbTemperatureEvent": {
@@ -168,6 +230,10 @@
     }
   },
   "facets": {
+    "1382102842": {
+      "import_name": "UAE_Population",
+      "provenance_url": "https://admin.bayanat.ae/Dataset/DownloadDatasetResource?fileId=26585eaf-9a9c-486d-b773-fc51ef0204c9&resourceID=11243"
+    },
     "3395834753": {
       "import_name": "WetBulbTemperatureEventPlaces_AutoRefresh",
       "provenance_url": "https://datacommons.org/"

--- a/internal/server/v2/observation/golden/calculation/two_places.json
+++ b/internal/server/v2/observation/golden/calculation/two_places.json
@@ -2,9 +2,77 @@
   "by_variable": {
     "Count_Person_Female": {
       "by_entity": {
-        "wikidataId/Q187712": {},
-        "wikidataId/Q613": {}
+        "wikidataId/Q187712": {
+          "ordered_facets": [
+            {
+              "facet_id": "1382102842",
+              "observations": [
+                {
+                  "date": "1975",
+                  "value": 56754
+                },
+                {
+                  "date": "1980",
+                  "value": 120160
+                },
+                {
+                  "date": "1985",
+                  "value": 185783
+                },
+                {
+                  "date": "1995",
+                  "value": 291719
+                },
+                {
+                  "date": "2005",
+                  "value": 472665
+                }
+              ],
+              "obs_count": 5,
+              "earliest_date": "1975",
+              "latest_date": "2005"
+            }
+          ]
+        },
+        "wikidataId/Q613": {
+          "ordered_facets": [
+            {
+              "facet_id": "1382102842",
+              "observations": [
+                {
+                  "date": "1975",
+                  "value": 54366
+                },
+                {
+                  "date": "1980",
+                  "value": 88587
+                },
+                {
+                  "date": "1985",
+                  "value": 123609
+                },
+                {
+                  "date": "1995",
+                  "value": 211211
+                },
+                {
+                  "date": "2005",
+                  "value": 332148
+                }
+              ],
+              "obs_count": 5,
+              "earliest_date": "1975",
+              "latest_date": "2005"
+            }
+          ]
+        }
       }
+    }
+  },
+  "facets": {
+    "1382102842": {
+      "import_name": "UAE_Population",
+      "provenance_url": "https://admin.bayanat.ae/Dataset/DownloadDatasetResource?fileId=26585eaf-9a9c-486d-b773-fc51ef0204c9&resourceID=11243"
     }
   }
 }

--- a/internal/server/v2/observation/golden/existence/existence.json
+++ b/internal/server/v2/observation/golden/existence/existence.json
@@ -15,7 +15,8 @@
         "country/BRA": {},
         "country/CAN": {},
         "geoId/06": {},
-        "geoId/0647766": {}
+        "geoId/0647766": {},
+        "wikidataId/Q613": {}
       }
     },
     "GenderIncomeInequality_Person_15OrMoreYears_WithIncome": {

--- a/internal/server/v2/resolve/golden/resolve_description/harvard.json
+++ b/internal/server/v2/resolve/golden/resolve_description/harvard.json
@@ -23,15 +23,7 @@
       ]
     },
     {
-      "node": "Atacama,Chile",
-      "resolvedIds": [
-        "wikidataId/Q2120"
-      ],
-      "candidates": [
-        {
-          "dcid": "wikidataId/Q2120"
-        }
-      ]
+      "node": "Atacama,Chile"
     },
     {
       "node": "Athos,Greece"

--- a/internal/server/v2/resolve/golden/resolve_description/harvard.json
+++ b/internal/server/v2/resolve/golden/resolve_description/harvard.json
@@ -23,7 +23,15 @@
       ]
     },
     {
-      "node": "Atacama,Chile"
+      "node": "Atacama,Chile",
+      "resolvedIds": [
+        "wikidataId/Q2120"
+      ],
+      "candidates": [
+        {
+          "dcid": "wikidataId/Q2120"
+        }
+      ]
     },
     {
       "node": "Athos,Greece"


### PR DESCRIPTION
Fixes a bug where the formula_fetcher previously did not include pagination, so only retrieved the first page of formulas. We recently added several hundred more formulas, so need to use pagination to retrieve them all. As part of this change, switches the formula_fetcher to use the triples package directly to make pagination simpler. 

This fixes some goldens that had been empty due to the bug before. 