### PR TITLE
Joins responses from Remote and Local mixer for SearchStatVar.

### DIFF
--- a/internal/merger/merger.go
+++ b/internal/merger/merger.go
@@ -367,7 +367,7 @@ func toStatVarSummaryMap(in []*pbv1.VariableInfoResponse) map[string]*proto.Stat
 	return out
 }
 
-func processSearchStatVarResponse(resp *proto.SearchStatVarResponse, mergedStatVars []*proto.EntityInfo, matchesMap map[string]struct{}, dedupedMatches []string) ([]*proto.EntityInfo, map[string]struct{}, []string) {
+func processSearchStatVarResponse(resp *proto.SearchStatVarResponse, mergedStatVars []*proto.EntityInfo, matchesMap map[string]struct{}, dedupedMatches []string) ([]*proto.EntityInfo, []string) {
 	if resp != nil {
 		mergedStatVars = append(mergedStatVars, resp.StatVars...)
 
@@ -378,7 +378,7 @@ func processSearchStatVarResponse(resp *proto.SearchStatVarResponse, mergedStatV
 			}
 		}
 	}
-	return mergedStatVars, matchesMap, dedupedMatches
+	return mergedStatVars, dedupedMatches
 }
 
 // MergeSearchStatVarResponse merges two SearchStatVarResponse.
@@ -387,8 +387,8 @@ func MergeSearchStatVarResponse(primary, secondary *proto.SearchStatVarResponse)
 	dedupedMatches := []string{}
 	matchesMap  := map[string]struct{}{}
 	
-	mergedStatVars, matchesMap, dedupedMatches = processSearchStatVarResponse(primary, mergedStatVars, matchesMap, dedupedMatches)
-	mergedStatVars, matchesMap, dedupedMatches = processSearchStatVarResponse(secondary, mergedStatVars, matchesMap, dedupedMatches)
+	mergedStatVars, dedupedMatches = processSearchStatVarResponse(primary, mergedStatVars, matchesMap, dedupedMatches)
+	mergedStatVars, dedupedMatches = processSearchStatVarResponse(secondary, mergedStatVars, matchesMap, dedupedMatches)
 	
 	merged := &proto.SearchStatVarResponse{
 		StatVars: mergedStatVars,

--- a/internal/merger/merger.go
+++ b/internal/merger/merger.go
@@ -374,9 +374,7 @@ func MergeSearchStatVarResponse(primary, secondary *proto.SearchStatVarResponse)
 	matchesMap  := map[string]bool{}
 
 	if primary != nil {
-		for _, sv := range primary.StatVars {
-			mergedStatVars = append(mergedStatVars, sv)
-		}
+		mergedStatVars = append(mergedStatVars, primary.StatVars...)
 
 		for _, m := range primary.Matches {
 			if _, ok := matchesMap[m]; ok {
@@ -389,9 +387,7 @@ func MergeSearchStatVarResponse(primary, secondary *proto.SearchStatVarResponse)
 	}
 	
 	if secondary != nil {
-		for _, sv := range secondary.StatVars {
-			mergedStatVars = append(mergedStatVars, sv)
-		}
+		mergedStatVars = append(mergedStatVars, secondary.StatVars...)
 
 		for _, m := range secondary.Matches {
 			if _, ok := matchesMap[m]; ok {

--- a/internal/merger/merger.go
+++ b/internal/merger/merger.go
@@ -366,3 +366,54 @@ func toStatVarSummaryMap(in []*pbv1.VariableInfoResponse) map[string]*proto.Stat
 	}
 	return out
 }
+
+// MergeSearchStatVarResponse merges two SearchStatVarResponse.
+func MergeSearchStatVarResponse(primary, secondary *proto.SearchStatVarResponse) *proto.SearchStatVarResponse {
+	mergedStatVars := []*proto.EntityInfo{}
+	dedupedMatches := []string{}
+	matchesMap  := map[string]bool{}
+
+	if primary != nil {
+		for _, sv := range primary.StatVars {
+			mergedStatVars = append(mergedStatVars, sv)
+		}
+
+		for _, m := range primary.Matches {
+			if _, ok := matchesMap[m]; ok {
+				// skip
+			} else {
+				matchesMap[m] = true
+				dedupedMatches = append(dedupedMatches, m)
+			}
+		}
+	}
+	
+	if secondary != nil {
+		for _, sv := range secondary.StatVars {
+			mergedStatVars = append(mergedStatVars, sv)
+		}
+
+		for _, m := range secondary.Matches {
+			if _, ok := matchesMap[m]; ok {
+				// skip
+			} else {
+				matchesMap[m] = true
+				dedupedMatches = append(dedupedMatches, m)
+			}
+		}
+	}
+
+	// dedupedMatches := make([]string, len(matchesMap))
+	// i := 0
+	// for m := range matchesMap {
+	// 	dedupedMatches[i] = m
+	// 	i++
+	// }
+
+	merged := &proto.SearchStatVarResponse{
+		StatVars: mergedStatVars,
+		Matches: dedupedMatches,
+	}
+
+	return merged
+}

--- a/internal/merger/merger.go
+++ b/internal/merger/merger.go
@@ -403,13 +403,6 @@ func MergeSearchStatVarResponse(primary, secondary *proto.SearchStatVarResponse)
 		}
 	}
 
-	// dedupedMatches := make([]string, len(matchesMap))
-	// i := 0
-	// for m := range matchesMap {
-	// 	dedupedMatches[i] = m
-	// 	i++
-	// }
-
 	merged := &proto.SearchStatVarResponse{
 		StatVars: mergedStatVars,
 		Matches: dedupedMatches,

--- a/internal/merger/merger_test.go
+++ b/internal/merger/merger_test.go
@@ -978,3 +978,124 @@ func TestMergeBulkVariableInfoResponse(t *testing.T) {
 		}
 	}
 }
+
+
+func TestMergeSearchStatVarResponse(t *testing.T) {
+	cmpOpts := cmp.Options{protocmp.Transform()}
+	for _, tc := range []struct {
+		desc      string
+		primary   *pb.SearchStatVarResponse
+		secondary *pb.SearchStatVarResponse
+		want      *pb.SearchStatVarResponse
+	}{{
+		desc: "primary only",
+		primary: &pb.SearchStatVarResponse{
+			StatVars: []*pb.EntityInfo{
+				{
+					Name: "sv1",
+					Dcid: "svid1",
+				},
+				{
+					Name: "sv2",
+					Dcid: "svid2",					
+				},
+			},
+			Matches: []string{"match1", "match2"},
+		},
+		want: &pb.SearchStatVarResponse{
+			StatVars: []*pb.EntityInfo{
+				{
+					Name: "sv1",
+					Dcid: "svid1",
+				},
+				{
+					Name: "sv2",
+					Dcid: "svid2",
+				},
+			},
+			Matches: []string{"match1", "match2"},
+		},
+	}, {
+		desc: "secondary only",
+		secondary: &pb.SearchStatVarResponse{
+			StatVars: []*pb.EntityInfo{
+				{
+					Name: "sv1",
+					Dcid: "svid1",
+				},
+				{
+					Name: "sv2",
+					Dcid: "svid2",				
+				},
+			},
+			Matches: []string{"match1", "match2"},
+		},
+		want: &pb.SearchStatVarResponse{
+			StatVars: []*pb.EntityInfo{
+				{
+					Name: "sv1",
+					Dcid: "svid1",
+				},
+				{
+					Name: "sv2",
+					Dcid: "svid2",		
+				},
+			},
+			Matches: []string{"match1", "match2"},
+		},
+	}, {
+		desc: "combined",
+		primary: &pb.SearchStatVarResponse{
+			StatVars: []*pb.EntityInfo{
+				{
+					Name: "sv1",
+					Dcid: "svid1",
+				},
+				{
+					Name: "sv2",
+					Dcid: "svid2",					
+				},
+			},
+			Matches: []string{"match1", "match2"},
+		},
+		secondary: &pb.SearchStatVarResponse{
+			StatVars: []*pb.EntityInfo{
+				{
+					Name: "sv3",
+					Dcid: "svid3",
+				},
+				{
+					Name: "sv4",
+					Dcid: "svid4",					
+				},
+			},
+			Matches: []string{"match1", "match3"},
+		},
+		want: &pb.SearchStatVarResponse{
+			StatVars: []*pb.EntityInfo{
+				{
+					Name: "sv1",
+					Dcid: "svid1",
+				},
+				{
+					Name: "sv2",
+					Dcid: "svid2",					
+				},
+				{
+					Name: "sv3",
+					Dcid: "svid3",
+				},
+				{
+					Name: "sv4",
+					Dcid: "svid4",					
+				},
+			},
+			Matches: []string{"match1", "match2", "match3"},
+		},
+	}} {
+		got := MergeSearchStatVarResponse(tc.primary, tc.secondary)
+		if diff := cmp.Diff(got, tc.want, cmpOpts); diff != "" {
+			t.Errorf("%s: got diff: %s", tc.desc, diff)
+		}
+	}
+}

--- a/internal/server/handler_v1.go
+++ b/internal/server/handler_v1.go
@@ -546,9 +546,7 @@ func (s *Server) SearchStatVar(
 		}
 	}
 
-	resp := &pb.SearchStatVarResponse{
-		StatVars: append(localResp.StatVars[:], remoteResp.StatVars...),
-		Matches:  append(localResp.Matches[:], remoteResp.Matches...),
-	}
-	return resp, nil
+	merged := merger.MergeSearchStatVarResponse(localResp, remoteResp)
+
+	return merged, nil
 }

--- a/internal/server/handler_v1.go
+++ b/internal/server/handler_v1.go
@@ -532,20 +532,23 @@ func (s *Server) SearchStatVar(
 	if err != nil {
 		return nil, err
 	}
-	if len(localResp.StatVars) == 0 && len(localResp.Matches) == 0 {
-		if s.metadata.RemoteMixerDomain != "" {
-			remoteResp := &pb.SearchStatVarResponse{}
-			if err := util.FetchRemote(
-				s.metadata,
-				s.httpClient,
-				"/v1/variable/search",
-				in,
-				remoteResp,
-			); err != nil {
-				return nil, err
-			}
-			return remoteResp, nil
+
+	remoteResp := &pb.SearchStatVarResponse{}
+	if s.metadata.RemoteMixerDomain != "" {
+		if err := util.FetchRemote(
+			s.metadata,
+			s.httpClient,
+			"/v1/variable/search",
+			in,
+			remoteResp,
+		); err != nil {
+			return nil, err
 		}
 	}
-	return localResp, nil
+
+	resp := &pb.SearchStatVarResponse{
+		StatVars: append(localResp.StatVars[:], remoteResp.StatVars...),
+		Matches:  append(localResp.Matches[:], remoteResp.Matches...),
+	}
+	return resp, nil
 }

--- a/internal/server/recon/recognize_test.go
+++ b/internal/server/recon/recognize_test.go
@@ -277,6 +277,21 @@ func TestCombineContainedIn(t *testing.T) {
 					{Tokens: []string{"!?"}},
 				},
 			},
+			&pb.TokenSpans{
+				Spans: []*pb.TokenSpans_Span{
+					{Tokens: []string{"Really?"}},
+					{
+						Tokens: []string{"Mountain", "View", ",", "California", ",", "USA"},
+						Places: []*pb.RecogPlace{
+							{
+								Dcid:             "geoId/Moutain_View",
+								ContainingPlaces: []string{"country/USA", "geoId/CA"},
+							},
+						},
+					},
+					{Tokens: []string{"!?"}},
+				},
+			},
 		},
 		// No combination.
 		{

--- a/internal/server/recon/recognize_test.go
+++ b/internal/server/recon/recognize_test.go
@@ -277,21 +277,6 @@ func TestCombineContainedIn(t *testing.T) {
 					{Tokens: []string{"!?"}},
 				},
 			},
-			&pb.TokenSpans{
-				Spans: []*pb.TokenSpans_Span{
-					{Tokens: []string{"Really?"}},
-					{
-						Tokens: []string{"Mountain", "View", ",", "California", ",", "USA"},
-						Places: []*pb.RecogPlace{
-							{
-								Dcid:             "geoId/Moutain_View",
-								ContainingPlaces: []string{"country/USA", "geoId/CA"},
-							},
-						},
-					},
-					{Tokens: []string{"!?"}},
-				},
-			},
 		},
 		// No combination.
 		{


### PR DESCRIPTION
Includes responses from both local (custom DC) and remote (base DC) mixers in stat var search. This PR aims to resolve https://b.corp.google.com/issues/370730321

Local testing verified the behavior.
See the two custom DC Stat vars: https://screenshot.googleplex.com/7a3F7W44xGyL5pR
Here is the stat var search: https://screenshot.googleplex.com/BE35RoUiEZhCcUX