### PR TITLE
Change 'Atacama' to 'Atacama Desert' in resolve_description_test

### DIFF
--- a/internal/server/v2/resolve/golden/resolve_description/harvard.json
+++ b/internal/server/v2/resolve/golden/resolve_description/harvard.json
@@ -23,7 +23,7 @@
       ]
     },
     {
-      "node": "Atacama,Chile"
+      "node": "Atacama Desert,Chile"
     },
     {
       "node": "Athos,Greece"

--- a/internal/server/v2/resolve/golden/resolve_description_test.go
+++ b/internal/server/v2/resolve/golden/resolve_description_test.go
@@ -53,7 +53,7 @@ func TestResolveDescription(t *testing.T) {
 			{
 				[]string{
 					"Brussels,Belgium",
-					"Atacama,Chile",
+					"Atacama Desert,Chile",
 					"Sjælland,Denmark",
 					"Athos,Greece",
 					"Illes Balears,Spain",


### PR DESCRIPTION
This is to fix the flakiness in the resolve_description_test for "Atacama,Chile" 

The flakiness comes from the Google Maps API. We currently map `wikidataId/Q2120` to "Atacama Region" in `WorldGeosForPlaceRecognition` (and in our KG), so `RecognizePlaces` will fail, and the resolver will default to using the Maps API. However, the `FindPlaceFromText` API for "Atacama,Chile" will nondeterministically return either "ChIJRxzvf1JGr5YR3COCqre7TQM" ("Atacama Desert", which we do not have a corresponding dcid for, so the resolver will not find a match) or "ChIJXyWul5E3kZYRNDjx8hodVB4" ("Atacama", which we map to `wikidataId/Q2120`). Using the more specific "Atacama Desert" will more reliably return "ChIJXyWul5E3kZYRNDjx8hodVB4". 

Going forward, we could:
* Add a corresponding DC place node for "Atacama Desert" to match  "ChIJXyWul5E3kZYRNDjx8hodVB4"
* Add "Atacama" as an alternate name for `wikidataId/Q2120` (note that Wikidata does use "Region" https://www.wikidata.org/wiki/Q2120), though it was unclear whether just "Atacama" should refer to the region or the desert