### PR TITLE
Create simple utility for logging with tags and log all remote mixer calls.

### DIFF
--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -142,6 +142,20 @@ const (
 	SQLDriverMySQL                    // SQLDriverMySQL = 2
 )
 
+// Define the DCLogTag enum
+type DCLogTag string
+
+// Enum values for different log types
+const (
+	DCLogRemoteMixerCall DCLogTag = "RemoteMixerCall"
+	// Add more log types as needed
+)
+
+// DCLog logs messages with the specified DCLogTag
+func DCLog(tag DCLogTag, msg string) {
+	log.Printf("[DC][%s] %s", tag, msg)
+}
+
 // ZipAndEncode Compresses the given contents using gzip and encodes it in base64
 func ZipAndEncode(contents []byte) (string, error) {
 	// Zip the string
@@ -663,6 +677,7 @@ func FetchRemote(
 	}
 	request.Header.Set("Content-Type", "application/json")
 	request.Header.Set("X-API-Key", metadata.RemoteMixerAPIKey)
+	DCLog(DCLogRemoteMixerCall, fmt.Sprintf("url=%s", url))
 	response, err := httpClient.Do(request)
 	if err != nil {
 		return err


### PR DESCRIPTION
* Log tags can be defined as `DCLogTag` enums.
* `DCLog` function can be called to log tagged messages.
* This PR uses the above to log all calls to remote mixer.
   + Example: `[DC][RemoteMixerCall] url=https://api.datacommons.org/v2/node`
   + Currently it only logs the URL being called.
   + We could consider supporting a debug mode and log requests / responses in the future.