### PR TITLE
Ignore key parameter instead of failing request.

### DIFF
--- a/esp/envoy-config.yaml
+++ b/esp/envoy-config.yaml
@@ -49,6 +49,7 @@ static_resources:
                       print_options:
                         always_print_enums_as_ints: false
                         preserve_proto_field_names: false
+                      ignored_query_parameters: ["key"]
                   - name: envoy.filters.http.router
                     typed_config:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router


### PR DESCRIPTION
* This PR ignores the `key` parameter in the request vs failing requests with that parameter.
* This makes it convenient for users that sometimes copy main dc api urls and use them for their custom dc without updating any parameters. 
  + Currently if the original URL includes a `key` parameter it fails on custom dcs with an obscure 415 error even though the key is not used by custom DCs.
  + With this fix, it will ignore the parameter and proceed with handling the request as usual.
* Fixit task: http://shortn/_9STKYyVCoR

#### Before

```
~ curl -I -X GET "https://dc-autopush-kqb7thiuka-uc.a.run.app/core/api/v2/node?nodes=Class&property=<-typeOf&key=foo"
HTTP/2 415 
content-type: application/grpc
x-envoy-upstream-service-time: 0
x-cloud-trace-context: e94d41d4dab5d53dba1664ef053c33aa;o=1
date: Tue, 08 Oct 2024 17:55:57 GMT
server: Google Frontend
content-length: 0
alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
```

#### After

```
~ curl -I -X GET "http://localhost:8081/v2/node?nodes=Class&property=<-typeOf&key=foo"
HTTP/1.1 200 OK
content-type: application/json
x-envoy-upstream-service-time: 149
grpc-status: 0
grpc-message: 
content-length: 56329
date: Tue, 08 Oct 2024 17:56:10 GMT
server: envoy
```