### PR TITLE
Add another entry to recon_name_to_types.json

### DIFF
--- a/internal/store/files/recon_name_to_types.json
+++ b/internal/store/files/recon_name_to_types.json
@@ -155,5 +155,6 @@
   "form": ["MeSH Descriptor"],
   "disease": ["Disease", "MeSH Descriptor"],
   "cui": ["Gene"],
-  "prevalence": ["MeSH Descriptor"]
+  "prevalence": ["MeSH Descriptor"],
+  "genetic": ["MeSH Descriptor"]
 }


### PR DESCRIPTION
the word "genetic" is a common word to use in queries and should not be recognized as is as an entity