### PR TITLE
add more names to recon_name_to_types.json

### DIFF
--- a/internal/store/files/recon_name_to_types.json
+++ b/internal/store/files/recon_name_to_types.json
@@ -156,5 +156,7 @@
   "disease": ["Disease", "MeSH Descriptor"],
   "cui": ["Gene"],
   "prevalence": ["MeSH Descriptor"],
-  "genetic": ["MeSH Descriptor"]
+  "genetic": ["MeSH Descriptor"],
+  "o": ["Drug"],
+  "no": ["Drug"]
 }


### PR DESCRIPTION
we added a new property (drugTradeName) to recognize its values as an entity, but some of those values are generic words. To control for when we recognize those generic words as an entity, adding them to this recon_name_to_types.json file