### PR TITLE
Create a basic spanner graph client.

### DIFF
--- a/deploy/storage/spanner_graph_info.yaml
+++ b/deploy/storage/spanner_graph_info.yaml
@@ -1,0 +1,3 @@
+project: datcom-store
+instance: dc-kg-test
+database: dc_graph

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	cloud.google.com/go/iam v1.1.2 // indirect
 	cloud.google.com/go/longrunning v0.5.1 // indirect
+	cloud.google.com/go/spanner v1.47.0
 	github.com/andybalholm/brotli v1.0.5 // indirect
 	github.com/apache/arrow/go/v12 v12.0.1 // indirect
 	github.com/apache/thrift v0.19.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ cloud.google.com/go/pubsub v1.33.0 h1:6SPCPvWav64tj0sVX/+npCBKhUi/UjJehy9op/V3p2
 cloud.google.com/go/pubsub v1.33.0/go.mod h1:f+w71I33OMyxf9VpMVcZbnG5KSUkCOUHYpFd5U1GdRc=
 cloud.google.com/go/secretmanager v1.11.1 h1:cLTCwAjFh9fKvU6F13Y4L9vPcx9yiWPyWXE4+zkuEQs=
 cloud.google.com/go/secretmanager v1.11.1/go.mod h1:znq9JlXgTNdBeQk9TBW/FnR/W4uChEKGeqQWAJ8SXFw=
+cloud.google.com/go/spanner v1.47.0 h1:aqiMP8dhsEXgn9K5EZBWxPG7dxIiyM2VaikqeU4iteg=
+cloud.google.com/go/spanner v1.47.0/go.mod h1:IXsJwVW2j4UKs0eYDqodab6HgGuA1bViSqW4uH9lfUI=
 cloud.google.com/go/storage v1.33.0 h1:PVrDOkIC8qQVa1P3SXGpQvfuJhN2LHOoyZvWs8D2X5M=
 cloud.google.com/go/storage v1.33.0/go.mod h1:Hhh/dogNRGca7IWv1RC2YqEn0c0G77ctA/OxflYkiD8=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=

--- a/internal/server/spanner/client.go
+++ b/internal/server/spanner/client.go
@@ -1,0 +1,125 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// A spanner client wrapped.
+package spanner
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"cloud.google.com/go/spanner"
+	"google.golang.org/api/iterator"
+	"gopkg.in/yaml.v3"
+)
+
+// SpannerClient encapsulates the Spanner client.
+type SpannerClient struct {
+	client *spanner.Client
+	// Store SQL statements for better organization
+	statements struct {
+		getNodesByID string
+	}
+}
+
+// newSpannerClient creates a new SpannerClient and initializes the statements.
+func newSpannerClient(client *spanner.Client) *SpannerClient {
+	sc := &SpannerClient{client: client}
+
+	// Initialize the SQL statements
+	sc.statements.getNodesByID = `
+	SELECT id, typeOf, name, properties, provenances
+	FROM Node
+	WHERE id IN UNNEST(@ids)
+	`
+
+	return sc
+}
+
+// GetNodesByID retrieves nodes from Spanner given a list of IDs and returns a map.
+func (sc *SpannerClient) GetNodesByID(ctx context.Context, ids []string) (map[string]*Node, error) {
+	nodes := make(map[string]*Node)
+	if len(ids) == 0 {
+		return nodes, nil
+	}
+
+	stmt := spanner.Statement{
+		SQL:    sc.statements.getNodesByID,
+		Params: map[string]interface{}{"ids": ids},
+	}
+
+	iter := sc.client.Single().Query(ctx, stmt)
+	defer iter.Stop()
+
+	for {
+		row, err := iter.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch row: %w", err)
+		}
+
+		var node Node
+		if err := row.ToStruct(&node); err != nil {
+			return nil, fmt.Errorf("failed to parse row: %w", err)
+		}
+		nodes[node.ID] = &node
+	}
+
+	return nodes, nil
+}
+
+// NewSpannerClient creates a new SpannerClient from the yaml config file.
+func NewSpannerClient(ctx context.Context, yamlPath string) (*SpannerClient, error) {
+	cfg, err := readSpannerConfig(yamlPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create SpannerClient: %w", err)
+	}
+	client, err := createSpannerClient(ctx, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create SpannerClient: %w", err)
+	}
+	return newSpannerClient(client), nil
+}
+
+// createSpannerClient creates the database name string and initializes the Spanner client.
+func createSpannerClient(ctx context.Context, cfg *SpannerConfig) (*spanner.Client, error) {
+	// Construct the database name string
+	databaseName := fmt.Sprintf("projects/%s/instances/%s/databases/%s", cfg.Project, cfg.Instance, cfg.Database)
+
+	// Create the Spanner client
+	client, err := spanner.NewClient(ctx, databaseName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Spanner client: %w", err)
+	}
+
+	return client, nil
+}
+
+// readSpannerConfig reads the config from the yaml path and returns a SpannerConfig object.
+func readSpannerConfig(yamlPath string) (*SpannerConfig, error) {
+	data, err := os.ReadFile(yamlPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read spanner yaml file: %w", err)
+	}
+
+	var cfg SpannerConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal config: %w", err)
+	}
+
+	return &cfg, nil
+}

--- a/internal/server/spanner/golden/query/get_nodes_by_id.json
+++ b/internal/server/spanner/golden/query/get_nodes_by_id.json
@@ -1,0 +1,40 @@
+[
+  {
+    "ID": "StatisticalVariable",
+    "TypeOf": "Class",
+    "Name": "StatisticalVariable",
+    "Properties": {
+      "Map": {
+        "description": "Represents any type of statistical metric that can be measured at a place and time. An instance typically corresponds to a pair of StatisticalPopulation and Observation node with some generalization (such as, not defining location, observationDate and measuredValue).",
+        "localCuratorLevelId": "dcid:StatisticalVariable",
+        "name": "StatisticalVariable"
+      }
+    },
+    "Provenances": {
+      "Map": {
+        "description": "dc/base/BaseSchema",
+        "localCuratorLevelId": "dc/base/BaseSchema",
+        "name": "dc/base/BaseSchema"
+      }
+    }
+  },
+  {
+    "ID": "USD",
+    "TypeOf": "Currency",
+    "Name": "USD",
+    "Properties": {
+      "Map": {
+        "description": "US Dollar.",
+        "localCuratorLevelId": "dcid:USD",
+        "name": "USD"
+      }
+    },
+    "Provenances": {
+      "Map": {
+        "description": "dc/base/BaseSchema",
+        "localCuratorLevelId": "dc/base/BaseSchema",
+        "name": "dc/base/BaseSchema"
+      }
+    }
+  }
+]

--- a/internal/server/spanner/golden/query_test.go
+++ b/internal/server/spanner/golden/query_test.go
@@ -1,0 +1,77 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package golden
+
+import (
+	"context"
+	"path"
+	"runtime"
+	"testing"
+
+	"github.com/datacommonsorg/mixer/internal/server/spanner"
+	"github.com/datacommonsorg/mixer/test"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestGetNodesByID(t *testing.T) {
+	client := test.NewSpannerClient()
+	if client == nil {
+		return
+	}
+
+	t.Parallel()
+	ctx := context.Background()
+	_, filename, _, _ := runtime.Caller(0)
+	goldenDir := path.Join(path.Dir(filename), "query")
+	goldenFile := "get_nodes_by_id.json"
+
+	ids := []string{"StatisticalVariable", "USD"}
+
+	actual, err := client.GetNodesByID(ctx, ids)
+	if err != nil {
+		t.Fatalf("GetNodesByID error (%v): %v", goldenFile, err)
+	}
+
+	// Use ordered list of nodes so that the golden file is deterministic.
+	var ordered []*spanner.Node
+	for _, id := range ids {
+		if node, ok := actual[id]; ok {
+			ordered = append(ordered, node)
+		}
+	}
+
+	got, err := test.StructToJSON(ordered)
+	if err != nil {
+		t.Fatalf("StructToJSON error (%v): %v", goldenFile, err)
+	}
+
+	if test.GenerateGolden {
+		err = test.WriteGolden(got, goldenDir, goldenFile)
+		if err != nil {
+			t.Fatalf("WriteGolden error (%v): %v", goldenFile, err)
+		}
+		return
+	}
+
+	want, err := test.ReadGolden(goldenDir, goldenFile)
+	if err != nil {
+		t.Fatalf("ReadGolden error (%v): %v", goldenFile, err)
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("%v payload mismatch (-want +got):\n%s", goldenFile, diff)
+	}
+
+}

--- a/internal/server/spanner/model.go
+++ b/internal/server/spanner/model.go
@@ -15,13 +15,18 @@
 // Model objects related to the spanner graph database.
 package spanner
 
+import (
+	"encoding/json"
+	"fmt"
+)
+
 // Node struct representing a single row in the Node table.
 type Node struct {
-	ID          string            `spanner:"id"`
-	TypeOf      string            `spanner:"typeOf"`
-	Name        string            `spanner:"name"`
-	Properties  map[string]string `spanner:"properties"`
-	Provenances map[string]string `spanner:"provenances"`
+	ID          string  `spanner:"id"`
+	TypeOf      string  `spanner:"typeOf"`
+	Name        string  `spanner:"name"`
+	Properties  JSONMap `spanner:"properties"`
+	Provenances JSONMap `spanner:"provenances"`
 }
 
 // SpannerConfig struct to hold the YAML configuration to a spanner database.
@@ -29,4 +34,22 @@ type SpannerConfig struct {
 	Project  string `yaml:"project"`
 	Instance string `yaml:"instance"`
 	Database string `yaml:"database"`
+}
+
+// JSONMap struct represents spanner JSON fields as golang maps.
+type JSONMap struct {
+	Map map[string]string
+}
+
+// Convert a JSON field to a JSONMap value.
+// Note that the undecoded value happens to be a string.
+func (m *JSONMap) DecodeSpanner(val interface{}) (err error) {
+	strVal, ok := val.(string)
+	if !ok {
+		return fmt.Errorf("failed to decode JSONMap: %v", val)
+	}
+	if err := json.Unmarshal([]byte(strVal), &m.Map); err != nil {
+		return fmt.Errorf("failed to unmarshal JSON to map: %w", err)
+	}
+	return nil
 }

--- a/internal/server/spanner/model.go
+++ b/internal/server/spanner/model.go
@@ -1,0 +1,32 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Model objects related to the spanner graph database.
+package spanner
+
+// Node struct representing a single row in the Node table.
+type Node struct {
+	ID          string            `spanner:"id"`
+	TypeOf      string            `spanner:"typeOf"`
+	Name        string            `spanner:"name"`
+	Properties  map[string]string `spanner:"properties"`
+	Provenances map[string]string `spanner:"provenances"`
+}
+
+// SpannerConfig struct to hold the YAML configuration to a spanner database.
+type SpannerConfig struct {
+	Project  string `yaml:"project"`
+	Instance string `yaml:"instance"`
+	Database string `yaml:"database"`
+}

--- a/internal/server/spanner/query.go
+++ b/internal/server/spanner/query.go
@@ -1,0 +1,69 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Queries executed by the SpannerClient.
+package spanner
+
+import (
+	"context"
+	"fmt"
+
+	"cloud.google.com/go/spanner"
+	"google.golang.org/api/iterator"
+)
+
+// SQL / GQL statements executed by the SpannerClient
+var statements = struct {
+	getNodesByID string
+}{
+	getNodesByID: `
+	SELECT id, typeOf, name, properties, provenances
+	FROM Node
+	WHERE id IN UNNEST(@ids)
+	`,
+}
+
+// GetNodesByID retrieves nodes from Spanner given a list of IDs and returns a map.
+func (sc *SpannerClient) GetNodesByID(ctx context.Context, ids []string) (map[string]*Node, error) {
+	nodes := make(map[string]*Node)
+	if len(ids) == 0 {
+		return nodes, nil
+	}
+
+	stmt := spanner.Statement{
+		SQL:    statements.getNodesByID,
+		Params: map[string]interface{}{"ids": ids},
+	}
+
+	iter := sc.client.Single().Query(ctx, stmt)
+	defer iter.Stop()
+
+	for {
+		row, err := iter.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch row: %w", err)
+		}
+
+		var node Node
+		if err := row.ToStructLenient(&node); err != nil {
+			return nil, fmt.Errorf("failed to parse row: %w", err)
+		}
+		nodes[node.ID] = &node
+	}
+
+	return nodes, nil
+}


### PR DESCRIPTION
* Creates a basic spanner client that connects to a cloud spanner graph.
* Implements a simple query that gets nodes by their IDs (does not fetch its edges yet).
* Setup a framework for spanner golden tests.
* Tests are currently no-op by default and require an `ENABLE_SPANNER_GRAPH` variable to be set to `true` for them to be executed.
  + This is to ensure it is only run on workstations of people actively developing against it and does not affect existing tests.