### PR TITLE
add "the" to recon names to types

### DIFF
--- a/internal/store/files/recon_name_to_types.json
+++ b/internal/store/files/recon_name_to_types.json
@@ -158,5 +158,6 @@
   "prevalence": ["MeSH Descriptor"],
   "genetic": ["MeSH Descriptor"],
   "o": ["Drug"],
-  "no": ["Drug"]
+  "no": ["Drug"],
+  "the": ["ChemicalCompound", "Drug"]
 }


### PR DESCRIPTION
discovered that "the" is a drugTradeName property value, so adding it to the list of names that need to be preceded by its type