### PR TITLE
Use spanner data source in v3 node

### DIFF
--- a/internal/server/datasource/datasource.go
+++ b/internal/server/datasource/datasource.go
@@ -33,7 +33,3 @@ type DataSource interface {
 	Type() DataSourceType
 	Node(context.Context, *v3.NodeRequest) (*v3.NodeResponse, error)
 }
-
-type DataSources struct {
-	Sources []*DataSource
-}

--- a/internal/server/datasource/datasource.go
+++ b/internal/server/datasource/datasource.go
@@ -17,7 +17,7 @@ package datasource
 import (
 	"context"
 
-	v2 "github.com/datacommonsorg/mixer/internal/proto/v2"
+	v3 "github.com/datacommonsorg/mixer/internal/proto/v3"
 )
 
 // DataSourceType represents the type of data source.
@@ -31,5 +31,9 @@ const (
 // DataSource interface defines the common methods for all data sources.
 type DataSource interface {
 	Type() DataSourceType
-	Node(context.Context, *v2.NodeRequest) (*v2.NodeResponse, error)
+	Node(context.Context, *v3.NodeRequest) (*v3.NodeResponse, error)
+}
+
+type DataSources struct {
+	Sources []*DataSource
 }

--- a/internal/server/datasources/datasources.go
+++ b/internal/server/datasources/datasources.go
@@ -1,0 +1,64 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datasources
+
+import (
+	"context"
+
+	pbv3 "github.com/datacommonsorg/mixer/internal/proto/v3"
+	"github.com/datacommonsorg/mixer/internal/server/datasource"
+	"github.com/datacommonsorg/mixer/internal/server/datasources/node"
+
+	"golang.org/x/sync/errgroup"
+)
+
+// DataSources struct uses underlying data sources to respond to API requests.
+type DataSources struct {
+	sources []*datasource.DataSource
+}
+
+func NewDataSources(sources []*datasource.DataSource) *DataSources {
+	return &DataSources{sources: sources}
+}
+
+func (ds *DataSources) Node(ctx context.Context, in *pbv3.NodeRequest) (*pbv3.NodeResponse, error) {
+	errGroup, errCtx := errgroup.WithContext(ctx)
+	dsRespChan := []chan *pbv3.NodeResponse{}
+
+	for _, source := range ds.sources {
+		respChan := make(chan *pbv3.NodeResponse, 1)
+		errGroup.Go(func() error {
+			resp, err := (*source).Node(errCtx, in)
+			if err != nil {
+				return err
+			}
+			respChan <- resp
+			return nil
+		})
+		dsRespChan = append(dsRespChan, respChan)
+	}
+
+	if err := errGroup.Wait(); err != nil {
+		return nil, err
+	}
+
+	allResp := []*pbv3.NodeResponse{}
+	for _, respChan := range dsRespChan {
+		close(respChan)
+		allResp = append(allResp, <-respChan)
+	}
+
+	return node.MergeNode(allResp)
+}

--- a/internal/server/datasources/node/node.go
+++ b/internal/server/datasources/node/node.go
@@ -15,12 +15,9 @@
 package node
 
 import (
-	"context"
-
 	pbv1 "github.com/datacommonsorg/mixer/internal/proto/v1"
 	pbv2 "github.com/datacommonsorg/mixer/internal/proto/v2"
 	pbv3 "github.com/datacommonsorg/mixer/internal/proto/v3"
-	"github.com/datacommonsorg/mixer/internal/server/datasource"
 	"github.com/datacommonsorg/mixer/internal/server/pagination"
 	"github.com/datacommonsorg/mixer/internal/util"
 )
@@ -121,7 +118,7 @@ func mergeNodeResponse(main, aux *pbv3.NodeResponse) (*pbv3.NodeResponse, error)
 
 // Merges multiple V3 NodeResponses.
 // Assumes the responses are in order of prioirty.
-func mergeNode(
+func MergeNode(
 	allResp []*pbv3.NodeResponse,
 ) (*pbv3.NodeResponse, error) {
 	if len(allResp) == 0 {
@@ -136,20 +133,4 @@ func mergeNode(
 		prev = cur
 	}
 	return prev, nil
-}
-
-func V3NodeInternal(
-	ctx context.Context,
-	in *pbv3.NodeRequest,
-	dataSources *datasource.DataSources,
-) (*pbv3.NodeResponse, error) {
-	allResp := []*pbv3.NodeResponse{}
-	for _, source := range dataSources.Sources {
-		resp, err := (*source).Node(ctx, in)
-		if err != nil {
-			return nil, err
-		}
-		allResp = append(allResp, resp)
-	}
-	return mergeNode(allResp)
 }

--- a/internal/server/handler_v3.go
+++ b/internal/server/handler_v3.go
@@ -19,12 +19,11 @@ import (
 	"context"
 
 	pbv3 "github.com/datacommonsorg/mixer/internal/proto/v3"
-	"github.com/datacommonsorg/mixer/internal/server/v3/node"
 )
 
 // V3Node implements API for mixer.V3Node.
 func (s *Server) V3Node(ctx context.Context, in *pbv3.NodeRequest) (
 	*pbv3.NodeResponse, error,
 ) {
-	return node.V3NodeInternal(ctx, in, s.dataSources)
+	return s.dataSources.Node(ctx, in)
 }

--- a/internal/server/handler_v3.go
+++ b/internal/server/handler_v3.go
@@ -18,28 +18,13 @@ package server
 import (
 	"context"
 
-	pbv2 "github.com/datacommonsorg/mixer/internal/proto/v2"
 	pbv3 "github.com/datacommonsorg/mixer/internal/proto/v3"
+	"github.com/datacommonsorg/mixer/internal/server/v3/node"
 )
 
 // V3Node implements API for mixer.V3Node.
 func (s *Server) V3Node(ctx context.Context, in *pbv3.NodeRequest) (
 	*pbv3.NodeResponse, error,
 ) {
-	// Temporarily call V2Node.
-	// TODO: Replace with V3 implementation.
-	v2in := &pbv2.NodeRequest{
-		Nodes:     in.Nodes,
-		Property:  in.Property,
-		Limit:     in.Limit,
-		NextToken: in.NextToken,
-	}
-	v2resp, err := s.V2Node(ctx, v2in)
-	if err != nil {
-		return nil, err
-	}
-	return &pbv3.NodeResponse{
-		Data:      v2resp.Data,
-		NextToken: v2resp.NextToken,
-	}, nil
+	return node.V3NodeInternal(ctx, in, s.dataSources)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -30,6 +30,7 @@ import (
 	"github.com/datacommonsorg/mixer/internal/parser/mcf"
 	dcpubsub "github.com/datacommonsorg/mixer/internal/pubsub"
 	"github.com/datacommonsorg/mixer/internal/server/cache"
+	"github.com/datacommonsorg/mixer/internal/server/datasource"
 	"github.com/datacommonsorg/mixer/internal/server/resource"
 	"github.com/datacommonsorg/mixer/internal/store"
 	"github.com/datacommonsorg/mixer/internal/store/bigtable"
@@ -41,11 +42,12 @@ import (
 
 // Server holds resources for a mixer server
 type Server struct {
-	store      *store.Store
-	metadata   *resource.Metadata
-	cachedata  atomic.Pointer[cache.Cache]
-	mapsClient *maps.Client
-	httpClient *http.Client
+	store       *store.Store
+	metadata    *resource.Metadata
+	cachedata   atomic.Pointer[cache.Cache]
+	mapsClient  *maps.Client
+	httpClient  *http.Client
+	dataSources *datasource.DataSources
 }
 
 func (s *Server) updateBranchTable(ctx context.Context, branchTableName string) error {
@@ -147,13 +149,15 @@ func NewMixerServer(
 	metadata *resource.Metadata,
 	cachedata *cache.Cache,
 	mapsClient *maps.Client,
+	dataSources *datasource.DataSources,
 ) *Server {
 	s := &Server{
-		store:      store,
-		metadata:   metadata,
-		cachedata:  atomic.Pointer[cache.Cache]{},
-		mapsClient: mapsClient,
-		httpClient: &http.Client{},
+		store:       store,
+		metadata:    metadata,
+		cachedata:   atomic.Pointer[cache.Cache]{},
+		mapsClient:  mapsClient,
+		httpClient:  &http.Client{},
+		dataSources: dataSources,
 	}
 	s.cachedata.Store(cachedata)
 	return s

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -30,7 +30,7 @@ import (
 	"github.com/datacommonsorg/mixer/internal/parser/mcf"
 	dcpubsub "github.com/datacommonsorg/mixer/internal/pubsub"
 	"github.com/datacommonsorg/mixer/internal/server/cache"
-	"github.com/datacommonsorg/mixer/internal/server/datasource"
+	"github.com/datacommonsorg/mixer/internal/server/datasources"
 	"github.com/datacommonsorg/mixer/internal/server/resource"
 	"github.com/datacommonsorg/mixer/internal/store"
 	"github.com/datacommonsorg/mixer/internal/store/bigtable"
@@ -47,7 +47,7 @@ type Server struct {
 	cachedata   atomic.Pointer[cache.Cache]
 	mapsClient  *maps.Client
 	httpClient  *http.Client
-	dataSources *datasource.DataSources
+	dataSources *datasources.DataSources
 }
 
 func (s *Server) updateBranchTable(ctx context.Context, branchTableName string) error {
@@ -149,7 +149,7 @@ func NewMixerServer(
 	metadata *resource.Metadata,
 	cachedata *cache.Cache,
 	mapsClient *maps.Client,
-	dataSources *datasource.DataSources,
+	dataSources *datasources.DataSources,
 ) *Server {
 	s := &Server{
 		store:       store,

--- a/internal/server/spanner/datasource.go
+++ b/internal/server/spanner/datasource.go
@@ -38,7 +38,7 @@ func (sds *SpannerDataSource) Type() datasource.DataSourceType {
 
 // Node retrieves node data from Spanner.
 func (sds *SpannerDataSource) Node(ctx context.Context, req *v3.NodeRequest) (*v3.NodeResponse, error) {
-	// TODO: Support pagination.
+	// TODO: Support additional Node functionality (properties, pagination, etc).
 	edges, err := sds.client.GetNodeEdgesByID(ctx, req.Nodes)
 	if err != nil {
 		return nil, fmt.Errorf("error getting node edges: %v", err)

--- a/internal/server/spanner/datasource.go
+++ b/internal/server/spanner/datasource.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"fmt"
 
-	v2 "github.com/datacommonsorg/mixer/internal/proto/v2"
+	v3 "github.com/datacommonsorg/mixer/internal/proto/v3"
 	"github.com/datacommonsorg/mixer/internal/server/datasource"
 )
 
@@ -37,7 +37,8 @@ func (sds *SpannerDataSource) Type() datasource.DataSourceType {
 }
 
 // Node retrieves node data from Spanner.
-func (sds *SpannerDataSource) Node(ctx context.Context, req *v2.NodeRequest) (*v2.NodeResponse, error) {
+func (sds *SpannerDataSource) Node(ctx context.Context, req *v3.NodeRequest) (*v3.NodeResponse, error) {
+	// TODO: Support pagination.
 	edges, err := sds.client.GetNodeEdgesByID(ctx, req.Nodes)
 	if err != nil {
 		return nil, fmt.Errorf("error getting node edges: %v", err)

--- a/internal/server/spanner/dsutil.go
+++ b/internal/server/spanner/dsutil.go
@@ -19,11 +19,12 @@ package spanner
 import (
 	"github.com/datacommonsorg/mixer/internal/proto"
 	v2 "github.com/datacommonsorg/mixer/internal/proto/v2"
+	v3 "github.com/datacommonsorg/mixer/internal/proto/v3"
 )
 
 // nodeEdgesToNodeResponse converts a map from subject id to its edges to a NodeResponse proto.
-func nodeEdgesToNodeResponse(edgesBySubjectID map[string][]*Edge) *v2.NodeResponse {
-	nodeResponse := &v2.NodeResponse{
+func nodeEdgesToNodeResponse(edgesBySubjectID map[string][]*Edge) *v3.NodeResponse {
+	nodeResponse := &v3.NodeResponse{
 		Data: make(map[string]*v2.LinkedGraph),
 	}
 

--- a/internal/server/spanner/golden/datasource_test.go
+++ b/internal/server/spanner/golden/datasource_test.go
@@ -20,7 +20,7 @@ import (
 	"runtime"
 	"testing"
 
-	v2 "github.com/datacommonsorg/mixer/internal/proto/v2"
+	v3 "github.com/datacommonsorg/mixer/internal/proto/v3"
 	"github.com/datacommonsorg/mixer/internal/server/spanner"
 	"github.com/datacommonsorg/mixer/test"
 	"github.com/google/go-cmp/cmp"
@@ -40,7 +40,7 @@ func TestNode(t *testing.T) {
 	goldenDir := path.Join(path.Dir(filename), "datasource")
 	goldenFile := "node.json"
 
-	req := &v2.NodeRequest{
+	req := &v3.NodeRequest{
 		Nodes: []string{"Aadhaar", "Monthly_Average_RetailPrice_Electricity_Residential"},
 	}
 
@@ -54,7 +54,7 @@ func TestNode(t *testing.T) {
 		return
 	}
 
-	var want v2.NodeResponse
+	var want v3.NodeResponse
 	if err = test.ReadJSON(goldenDir, goldenFile, &want); err != nil {
 		t.Fatalf("ReadJSON error (%v): %v", goldenFile, err)
 	}

--- a/internal/server/v3/node/golden/node_test.go
+++ b/internal/server/v3/node/golden/node_test.go
@@ -1,0 +1,92 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package golden
+
+import (
+	"context"
+	"path"
+	"runtime"
+	"testing"
+
+	pbs "github.com/datacommonsorg/mixer/internal/proto/service"
+	pbv3 "github.com/datacommonsorg/mixer/internal/proto/v3"
+	"github.com/datacommonsorg/mixer/test"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+func TestV3Node(t *testing.T) {
+	if !test.EnableSpannerGraph {
+		return
+	}
+	t.Parallel()
+	ctx := context.Background()
+
+	_, filename, _, _ := runtime.Caller(0)
+	goldenPath := path.Dir(filename)
+
+	testSuite := func(mixer pbs.MixerClient, latencyTest bool) {
+		for _, c := range []struct {
+			desc       string
+			nodes      []string
+			property   string
+			nextToken  string
+			goldenFile string
+		}{
+			{
+				"All out property-values",
+				[]string{
+					"Count_Person_Female",
+				},
+				"->*",
+				"",
+				"out_pv_all.json",
+			},
+		} {
+			goldenFile := c.goldenFile
+			resp, err := mixer.V3Node(ctx, &pbv3.NodeRequest{
+				Nodes:    c.nodes,
+				Property: c.property,
+			})
+			if err != nil {
+				t.Errorf("Could not run V3Node: %s", err)
+				continue
+			}
+			if latencyTest {
+				continue
+			}
+			if test.GenerateGolden {
+				test.UpdateGolden(resp, goldenPath, goldenFile)
+				continue
+			}
+			var expected pbv3.NodeResponse
+			if err = test.ReadJSON(goldenPath, goldenFile, &expected); err != nil {
+				t.Errorf("Could not Unmarshal golden file: %s", err)
+				continue
+			}
+			if diff := cmp.Diff(resp, &expected, protocmp.Transform()); diff != "" {
+				t.Errorf("%s: got diff: %s", c.desc, diff)
+				continue
+			}
+		}
+	}
+	if err := test.TestDriver(
+		"TestV3Node",
+		&test.TestOption{UseSQLite: true, UseSpannerGraph: true},
+		testSuite,
+	); err != nil {
+		t.Errorf("TestDriver() for TestV3Node = %s", err)
+	}
+}

--- a/internal/server/v3/node/golden/node_test.go
+++ b/internal/server/v3/node/golden/node_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func TestV3Node(t *testing.T) {
+	// TODO: Remove check once enabled.
 	if !test.EnableSpannerGraph {
 		return
 	}
@@ -57,8 +58,9 @@ func TestV3Node(t *testing.T) {
 		} {
 			goldenFile := c.goldenFile
 			resp, err := mixer.V3Node(ctx, &pbv3.NodeRequest{
-				Nodes:    c.nodes,
-				Property: c.property,
+				Nodes:     c.nodes,
+				Property:  c.property,
+				NextToken: c.nextToken,
 			})
 			if err != nil {
 				t.Errorf("Could not run V3Node: %s", err)

--- a/internal/server/v3/node/golden/out_pv_all.json
+++ b/internal/server/v3/node/golden/out_pv_all.json
@@ -1,0 +1,89 @@
+{
+  "data": {
+    "Count_Person_Female": {
+      "arcs": {
+        "constraintProperties": {
+          "nodes": [
+            {
+              "dcid": "gender",
+              "provenanceId": "dc/base/HumanReadableStatVars"
+            }
+          ]
+        },
+        "extendedName": {
+          "nodes": [
+            {
+              "provenanceId": "dc/base/HumanReadableStatVars",
+              "value": "Female Population"
+            }
+          ]
+        },
+        "gender": {
+          "nodes": [
+            {
+              "dcid": "Female",
+              "provenanceId": "dc/base/HumanReadableStatVars"
+            }
+          ]
+        },
+        "localCuratorLevelId": {
+          "nodes": [
+            {
+              "provenanceId": "dc/base/HumanReadableStatVars",
+              "value": "dcid:Count_Person_Female"
+
+            }
+          ]
+        },
+        "measuredProp": {
+          "nodes": [
+            {
+              "dcid": "count",
+              "provenanceId": "dc/base/HumanReadableStatVars"
+            }
+          ]
+        },
+        "memberOf": {
+          "nodes": [
+            {
+              "dcid": "dc/g/Person_Gender-Female",
+              "provenanceId": "dc/base/HumanReadableStatVars"
+            }
+          ]
+        },
+        "name": {
+          "nodes": [
+            {
+              "provenanceId": "dc/base/HumanReadableStatVars",
+              "value": "Female Population"
+            }
+          ]
+        },
+        "populationType": {
+          "nodes": [
+            {
+              "dcid": "Person",
+              "provenanceId": "dc/base/HumanReadableStatVars"
+            }
+          ]
+        },
+        "statType": {
+          "nodes": [
+            {
+              "dcid": "measuredValue",
+              "provenanceId": "dc/base/HumanReadableStatVars"
+            }
+          ]
+        },
+        "typeOf": {
+          "nodes": [
+            {
+              "dcid": "StatisticalVariable",
+              "provenanceId": "dc/base/HumanReadableStatVars"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/internal/server/v3/node/node.go
+++ b/internal/server/v3/node/node.go
@@ -1,0 +1,155 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package node
+
+import (
+	"context"
+
+	pbv1 "github.com/datacommonsorg/mixer/internal/proto/v1"
+	pbv2 "github.com/datacommonsorg/mixer/internal/proto/v2"
+	pbv3 "github.com/datacommonsorg/mixer/internal/proto/v3"
+	"github.com/datacommonsorg/mixer/internal/server/datasource"
+	"github.com/datacommonsorg/mixer/internal/server/pagination"
+	"github.com/datacommonsorg/mixer/internal/util"
+)
+
+func mergeLinkedGraph(
+	mainData, auxData map[string]*pbv2.LinkedGraph,
+) map[string]*pbv2.LinkedGraph {
+	for dcid, linkedGraph := range auxData {
+		if mainData == nil {
+			mainData = map[string]*pbv2.LinkedGraph{}
+		}
+		if _, ok := mainData[dcid]; !ok || mainData[dcid].GetArcs() == nil {
+			mainData[dcid] = linkedGraph
+			continue
+		}
+		mainArcs := mainData[dcid].GetArcs()
+
+		for prop, nodes := range linkedGraph.GetArcs() {
+			if _, ok := mainArcs[prop]; !ok || len(mainArcs[prop].GetNodes()) == 0 {
+				mainData[dcid].Arcs[prop] = nodes
+				continue
+			}
+			dcidSet := map[string]struct{}{}
+			valueSet := map[string]struct{}{}
+			for _, n := range mainArcs[prop].Nodes {
+				if n.Dcid != "" {
+					dcidSet[n.Dcid] = struct{}{}
+				} else {
+					valueSet[n.Value] = struct{}{}
+				}
+			}
+			for _, node := range nodes.Nodes {
+				if node.Dcid != "" {
+					if _, ok := dcidSet[node.Dcid]; !ok {
+						mainArcs[prop].Nodes = append(mainArcs[prop].Nodes, node)
+					}
+				}
+				if node.Value != "" {
+					if _, ok := valueSet[node.Value]; !ok {
+						mainArcs[prop].Nodes = append(mainArcs[prop].Nodes, node)
+					}
+				}
+			}
+		}
+	}
+	return mainData
+}
+
+// Merges two V3 NodeResponses.
+func mergeNodeResponse(main, aux *pbv3.NodeResponse) (*pbv3.NodeResponse, error) {
+	if aux == nil {
+		return main, nil
+	}
+	if main == nil {
+		if aux.GetNextToken() != "" {
+			remotePaginationInfo, err := pagination.Decode(aux.GetNextToken())
+			if err != nil {
+				return nil, err
+			}
+			updatedPaginationInfo := &pbv1.PaginationInfo{
+				RemotePaginationInfo: remotePaginationInfo,
+			}
+			updatedNextToken, err := util.EncodeProto(updatedPaginationInfo)
+			if err != nil {
+				return nil, err
+			}
+			aux.NextToken = updatedNextToken
+		}
+		return aux, nil
+	}
+	main.Data = mergeLinkedGraph(main.GetData(), aux.GetData())
+	// Merge |next_token|.
+	resPaginationInfo := &pbv1.PaginationInfo{}
+	if main.GetNextToken() != "" {
+		mainPaginationInfo, err := pagination.Decode(main.GetNextToken())
+		if err != nil {
+			return nil, err
+		}
+		resPaginationInfo = mainPaginationInfo
+	}
+	if aux.GetNextToken() != "" {
+		auxPaginationInfo, err := pagination.Decode(aux.GetNextToken())
+		if err != nil {
+			return nil, err
+		}
+		resPaginationInfo.RemotePaginationInfo = auxPaginationInfo
+	}
+	if main.GetNextToken() != "" || aux.GetNextToken() != "" {
+		resNextToken, err := util.EncodeProto(resPaginationInfo)
+		if err != nil {
+			return nil, err
+		}
+		main.NextToken = resNextToken
+	}
+
+	return main, nil
+}
+
+// Merges multiple V3 NodeResponses.
+// Assumes the responses are in order of prioirty.
+func mergeNode(
+	allResp []*pbv3.NodeResponse,
+) (*pbv3.NodeResponse, error) {
+	if len(allResp) == 0 {
+		return nil, nil
+	}
+	prev := allResp[0]
+	for i := 1; i < len(allResp); i++ {
+		cur, err := mergeNodeResponse(prev, allResp[i])
+		if err != nil {
+			return nil, err
+		}
+		prev = cur
+	}
+	return prev, nil
+}
+
+func V3NodeInternal(
+	ctx context.Context,
+	in *pbv3.NodeRequest,
+	dataSources *datasource.DataSources,
+) (*pbv3.NodeResponse, error) {
+	allResp := []*pbv3.NodeResponse{}
+	for _, source := range dataSources.Sources {
+		resp, err := (*source).Node(ctx, in)
+		if err != nil {
+			return nil, err
+		}
+		allResp = append(allResp, resp)
+	}
+	return mergeNode(allResp)
+}

--- a/test/setup.go
+++ b/test/setup.go
@@ -33,6 +33,7 @@ import (
 	pbs "github.com/datacommonsorg/mixer/internal/proto/service"
 	"github.com/datacommonsorg/mixer/internal/server"
 	"github.com/datacommonsorg/mixer/internal/server/cache"
+	"github.com/datacommonsorg/mixer/internal/server/datasource"
 	"github.com/datacommonsorg/mixer/internal/server/resource"
 	"github.com/datacommonsorg/mixer/internal/server/spanner"
 	"github.com/datacommonsorg/mixer/internal/sqldb"
@@ -54,6 +55,7 @@ type TestOption struct {
 	UseCustomTable    bool
 	UseSQLite         bool
 	CacheSVFormula    bool
+	UseSpannerGraph   bool
 	RemoteMixerDomain string
 }
 
@@ -80,7 +82,7 @@ const (
 
 // Setup creates local server and client.
 func Setup(option ...*TestOption) (pbs.MixerClient, error) {
-	fetchSVG, searchSVG, useCustomTable, useSQLite, cacheSVFormula, remoteMixerDomain := false, false, false, false, false, ""
+	fetchSVG, searchSVG, useCustomTable, useSQLite, cacheSVFormula, useSpannerGraph, remoteMixerDomain := false, false, false, false, false, false, ""
 	var cacheOptions cache.CacheOptions
 	if len(option) == 1 {
 		fetchSVG = option[0].FetchSVG
@@ -92,6 +94,7 @@ func Setup(option ...*TestOption) (pbs.MixerClient, error) {
 		cacheOptions.FetchSVG = fetchSVG
 		cacheOptions.SearchSVG = searchSVG
 		cacheOptions.CacheSVFormula = cacheSVFormula
+		useSpannerGraph = option[0].UseSpannerGraph
 		remoteMixerDomain = option[0].RemoteMixerDomain
 	}
 	return setupInternal(
@@ -101,6 +104,7 @@ func Setup(option ...*TestOption) (pbs.MixerClient, error) {
 		"../deploy/mapping",
 		useCustomTable,
 		useSQLite,
+		useSpannerGraph,
 		cacheOptions,
 		remoteMixerDomain,
 	)
@@ -108,7 +112,7 @@ func Setup(option ...*TestOption) (pbs.MixerClient, error) {
 
 func setupInternal(
 	bigqueryVersionFile, baseBigtableInfoYaml, testBigtableInfoYaml, mcfPath string,
-	useCustomTable, useSQLite bool,
+	useCustomTable, useSQLite, useSpannerGraph bool,
 	cacheOptions cache.CacheOptions,
 	remoteMixerDomain string,
 ) (pbs.MixerClient, error) {
@@ -116,6 +120,16 @@ func setupInternal(
 	_, filename, _, _ := runtime.Caller(0)
 	bqTableID, _ := os.ReadFile(path.Join(path.Dir(filename), bigqueryVersionFile))
 	schemaPath := path.Join(path.Dir(filename), mcfPath)
+
+	var dataSources datasource.DataSources
+	if useSpannerGraph {
+		spannerClient := NewSpannerClient()
+		if spannerClient != nil {
+			var ds datasource.DataSource = spanner.NewSpannerDataSource(spannerClient)
+			// TODO: Order dataSources by priority once other implementations are added.
+			dataSources.Sources = append(dataSources.Sources, &ds)
+		}
+	}
 
 	baseBigtableInfo, _ := os.ReadFile(path.Join(path.Dir(filename), baseBigtableInfoYaml))
 	tables, err := bigtable.CreateBigtables(ctx, string(baseBigtableInfo), false /*isCustom=*/)
@@ -172,7 +186,7 @@ func setupInternal(
 		return nil, err
 	}
 
-	return newClient(st, tables, metadata, c, mapsClient)
+	return newClient(st, tables, metadata, c, mapsClient, &dataSources)
 }
 
 // SetupBqOnly creates local server and client with access to BigQuery only.
@@ -203,7 +217,7 @@ func SetupBqOnly() (pbs.MixerClient, error) {
 	if err != nil {
 		return nil, err
 	}
-	return newClient(st, nil, metadata, nil, nil)
+	return newClient(st, nil, metadata, nil, nil, nil)
 }
 
 func newClient(
@@ -212,8 +226,9 @@ func newClient(
 	metadata *resource.Metadata,
 	cachedata *cache.Cache,
 	mapsClient *maps.Client,
+	dataSources *datasource.DataSources,
 ) (pbs.MixerClient, error) {
-	mixerServer := server.NewMixerServer(mixerStore, metadata, cachedata, mapsClient)
+	mixerServer := server.NewMixerServer(mixerStore, metadata, cachedata, mapsClient, dataSources)
 	srv := grpc.NewServer()
 	pbs.RegisterMixerServer(srv, mixerServer)
 	reflection.Register(srv)


### PR DESCRIPTION
Uses spanner data source Node implementation for V3 node

This primarily links the V3 node implementation to use the DataSource interface (though currently only spanner is supported) and adds a sample test

* Currently this just reuses the merging logic from V2 (but allows more than two responses). I forked the merging code in case we want to modify it later, independently of V2 (for example, to handle pagination)
* This PR doesn't modify the spanner Node implementation, so the response is still incomplete (doesn't include properties, pagination, or the full EntityInfo). I'll start updating the functionality as a followup 