### PR TITLE
Create datasources layer and wire it to v3 handler.

### DIFF
--- a/internal/server/datasource/datasource.go
+++ b/internal/server/datasource/datasource.go
@@ -17,7 +17,7 @@ package datasource
 import (
 	"context"
 
-	v2 "github.com/datacommonsorg/mixer/internal/proto/v2"
+	v3 "github.com/datacommonsorg/mixer/internal/proto/v3"
 )
 
 // DataSourceType represents the type of data source.
@@ -31,5 +31,5 @@ const (
 // DataSource interface defines the common methods for all data sources.
 type DataSource interface {
 	Type() DataSourceType
-	Node(context.Context, *v2.NodeRequest) (*v2.NodeResponse, error)
+	Node(context.Context, *v3.NodeRequest) (*v3.NodeResponse, error)
 }

--- a/internal/server/datasources/datasources.go
+++ b/internal/server/datasources/datasources.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package spanner
+package datasources
 
 import (
 	"context"
@@ -22,25 +22,21 @@ import (
 	"github.com/datacommonsorg/mixer/internal/server/datasource"
 )
 
-// SpannerDataSource represents a data source that interacts with Spanner.
-type SpannerDataSource struct {
-	client *SpannerClient
+// DataSources struct uses underlying data sources to respond to API requests.
+type DataSources struct {
+	sources []datasource.DataSource
 }
 
-func NewSpannerDataSource(client *SpannerClient) *SpannerDataSource {
-	return &SpannerDataSource{client: client}
+func NewDataSources(sources []datasource.DataSource) *DataSources {
+	return &DataSources{sources: sources}
 }
 
-// Type returns the type of the data source.
-func (sds *SpannerDataSource) Type() datasource.DataSourceType {
-	return datasource.TypeSpanner
-}
-
-// Node retrieves node data from Spanner.
-func (sds *SpannerDataSource) Node(ctx context.Context, req *v3.NodeRequest) (*v3.NodeResponse, error) {
-	edges, err := sds.client.GetNodeEdgesByID(ctx, req.Nodes)
-	if err != nil {
-		return nil, fmt.Errorf("error getting node edges: %v", err)
+func (ds *DataSources) Node(ctx context.Context, req *v3.NodeRequest) (*v3.NodeResponse, error) {
+	if len(ds.sources) == 0 {
+		return nil, fmt.Errorf("unimplemented")
 	}
-	return nodeEdgesToNodeResponse(edges), nil
+
+	// Currently this simply returns the node response from the first source.
+	// TODO: Call data sources and parallel and return a merged response.
+	return ds.sources[0].Node(ctx, req)
 }

--- a/internal/server/datasources/datasources.go
+++ b/internal/server/datasources/datasources.go
@@ -37,6 +37,6 @@ func (ds *DataSources) Node(ctx context.Context, req *v3.NodeRequest) (*v3.NodeR
 	}
 
 	// Currently this simply returns the node response from the first source.
-	// TODO: Call data sources and parallel and return a merged response.
+	// TODO: Call all data sources in parallel and return a merged response.
 	return ds.sources[0].Node(ctx, req)
 }

--- a/internal/server/handler_v3.go
+++ b/internal/server/handler_v3.go
@@ -18,28 +18,12 @@ package server
 import (
 	"context"
 
-	pbv2 "github.com/datacommonsorg/mixer/internal/proto/v2"
-	pbv3 "github.com/datacommonsorg/mixer/internal/proto/v3"
+	v3 "github.com/datacommonsorg/mixer/internal/proto/v3"
 )
 
 // V3Node implements API for mixer.V3Node.
-func (s *Server) V3Node(ctx context.Context, in *pbv3.NodeRequest) (
-	*pbv3.NodeResponse, error,
+func (s *Server) V3Node(ctx context.Context, in *v3.NodeRequest) (
+	*v3.NodeResponse, error,
 ) {
-	// Temporarily call V2Node.
-	// TODO: Replace with V3 implementation.
-	v2in := &pbv2.NodeRequest{
-		Nodes:     in.Nodes,
-		Property:  in.Property,
-		Limit:     in.Limit,
-		NextToken: in.NextToken,
-	}
-	v2resp, err := s.V2Node(ctx, v2in)
-	if err != nil {
-		return nil, err
-	}
-	return &pbv3.NodeResponse{
-		Data:      v2resp.Data,
-		NextToken: v2resp.NextToken,
-	}, nil
+	return s.dataSources.Node(ctx, in)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -30,6 +30,7 @@ import (
 	"github.com/datacommonsorg/mixer/internal/parser/mcf"
 	dcpubsub "github.com/datacommonsorg/mixer/internal/pubsub"
 	"github.com/datacommonsorg/mixer/internal/server/cache"
+	"github.com/datacommonsorg/mixer/internal/server/datasources"
 	"github.com/datacommonsorg/mixer/internal/server/resource"
 	"github.com/datacommonsorg/mixer/internal/store"
 	"github.com/datacommonsorg/mixer/internal/store/bigtable"
@@ -41,11 +42,12 @@ import (
 
 // Server holds resources for a mixer server
 type Server struct {
-	store      *store.Store
-	metadata   *resource.Metadata
-	cachedata  atomic.Pointer[cache.Cache]
-	mapsClient *maps.Client
-	httpClient *http.Client
+	store       *store.Store
+	metadata    *resource.Metadata
+	cachedata   atomic.Pointer[cache.Cache]
+	mapsClient  *maps.Client
+	httpClient  *http.Client
+	dataSources *datasources.DataSources
 }
 
 func (s *Server) updateBranchTable(ctx context.Context, branchTableName string) error {
@@ -147,13 +149,15 @@ func NewMixerServer(
 	metadata *resource.Metadata,
 	cachedata *cache.Cache,
 	mapsClient *maps.Client,
+	dataSources *datasources.DataSources,
 ) *Server {
 	s := &Server{
-		store:      store,
-		metadata:   metadata,
-		cachedata:  atomic.Pointer[cache.Cache]{},
-		mapsClient: mapsClient,
-		httpClient: &http.Client{},
+		store:       store,
+		metadata:    metadata,
+		cachedata:   atomic.Pointer[cache.Cache]{},
+		mapsClient:  mapsClient,
+		httpClient:  &http.Client{},
+		dataSources: dataSources,
 	}
 	s.cachedata.Store(cachedata)
 	return s

--- a/internal/server/spanner/dsutil.go
+++ b/internal/server/spanner/dsutil.go
@@ -19,11 +19,12 @@ package spanner
 import (
 	"github.com/datacommonsorg/mixer/internal/proto"
 	v2 "github.com/datacommonsorg/mixer/internal/proto/v2"
+	v3 "github.com/datacommonsorg/mixer/internal/proto/v3"
 )
 
 // nodeEdgesToNodeResponse converts a map from subject id to its edges to a NodeResponse proto.
-func nodeEdgesToNodeResponse(edgesBySubjectID map[string][]*Edge) *v2.NodeResponse {
-	nodeResponse := &v2.NodeResponse{
+func nodeEdgesToNodeResponse(edgesBySubjectID map[string][]*Edge) *v3.NodeResponse {
+	nodeResponse := &v3.NodeResponse{
 		Data: make(map[string]*v2.LinkedGraph),
 	}
 

--- a/internal/server/spanner/golden/datasource_test.go
+++ b/internal/server/spanner/golden/datasource_test.go
@@ -20,7 +20,7 @@ import (
 	"runtime"
 	"testing"
 
-	v2 "github.com/datacommonsorg/mixer/internal/proto/v2"
+	v3 "github.com/datacommonsorg/mixer/internal/proto/v3"
 	"github.com/datacommonsorg/mixer/internal/server/spanner"
 	"github.com/datacommonsorg/mixer/test"
 	"github.com/google/go-cmp/cmp"
@@ -40,7 +40,7 @@ func TestNode(t *testing.T) {
 	goldenDir := path.Join(path.Dir(filename), "datasource")
 	goldenFile := "node.json"
 
-	req := &v2.NodeRequest{
+	req := &v3.NodeRequest{
 		Nodes: []string{"Aadhaar", "Monthly_Average_RetailPrice_Electricity_Residential"},
 	}
 
@@ -54,7 +54,7 @@ func TestNode(t *testing.T) {
 		return
 	}
 
-	var want v2.NodeResponse
+	var want v3.NodeResponse
 	if err = test.ReadJSON(goldenDir, goldenFile, &want); err != nil {
 		t.Fatalf("ReadJSON error (%v): %v", goldenFile, err)
 	}

--- a/test/setup.go
+++ b/test/setup.go
@@ -33,6 +33,7 @@ import (
 	pbs "github.com/datacommonsorg/mixer/internal/proto/service"
 	"github.com/datacommonsorg/mixer/internal/server"
 	"github.com/datacommonsorg/mixer/internal/server/cache"
+	"github.com/datacommonsorg/mixer/internal/server/datasources"
 	"github.com/datacommonsorg/mixer/internal/server/resource"
 	"github.com/datacommonsorg/mixer/internal/server/spanner"
 	"github.com/datacommonsorg/mixer/internal/sqldb"
@@ -172,7 +173,7 @@ func setupInternal(
 		return nil, err
 	}
 
-	return newClient(st, tables, metadata, c, mapsClient)
+	return newClient(st, tables, metadata, c, mapsClient, nil)
 }
 
 // SetupBqOnly creates local server and client with access to BigQuery only.
@@ -203,7 +204,7 @@ func SetupBqOnly() (pbs.MixerClient, error) {
 	if err != nil {
 		return nil, err
 	}
-	return newClient(st, nil, metadata, nil, nil)
+	return newClient(st, nil, metadata, nil, nil, nil)
 }
 
 func newClient(
@@ -212,8 +213,9 @@ func newClient(
 	metadata *resource.Metadata,
 	cachedata *cache.Cache,
 	mapsClient *maps.Client,
+	dataSources *datasources.DataSources,
 ) (pbs.MixerClient, error) {
-	mixerServer := server.NewMixerServer(mixerStore, metadata, cachedata, mapsClient)
+	mixerServer := server.NewMixerServer(mixerStore, metadata, cachedata, mapsClient, dataSources)
 	srv := grpc.NewServer()
 	pbs.RegisterMixerServer(srv, mixerServer)
 	reflection.Register(srv)


### PR DESCRIPTION
* Mixer server can now be optionally bootstrapped to connect to spanner via the command flags `user_spanner_graph` and `spanner_graph_info`
* Test setup has not been wired up to use spanner.

#### Example

##### Command

```
go run cmd/main.go \
    ...
    --use_spanner_graph=true \
    --spanner_graph_info="$(cat deploy/storage/spanner_graph_info.yaml)"
```

##### v3node api call

![image](https://github.com/user-attachments/assets/e0c96a5f-3a59-4530-a904-ef278709ecfc)
