### PR TITLE
Quoted date string when fetching obserations

### DIFF
--- a/internal/sqldb/sqlquery/observation.go
+++ b/internal/sqldb/sqlquery/observation.go
@@ -199,7 +199,7 @@ func getObservationsSQLQuery(variables []string,
 		variablesStr,
 	)
 	if queryDate != "" && queryDate != shared.LATEST {
-		query += fmt.Sprintf("AND date = (%s) ", queryDate)
+		query += fmt.Sprintf("AND date = ('%s') ", queryDate)
 	}
 	query += "ORDER BY date ASC;"
 	return query


### PR DESCRIPTION
This fixes a bug where requesting observations for a date that contains a hyphen (Example: `2024-09`) would return an empty result set.

Before:

```
curl -XPOST "http://localhost:8080/core/api/v2/observation" -d '
{
     "select": [
         "date",
         "value",
         "variable",
         "entity"
     ],
     "entity": {
         "expression": "country/USA<-containedInPlace+{typeOf:State}"
     },
     "variable": {
         "dcids": [
             "Count_SubsidizedHousingUnit"
         ]
     },
     "date": "2023-12-31"
}
'
```

Returns

```
{"byVariable":{"Count_SubsidizedHousingUnit":{}}}
```


After:

Returns

```
{"byVariable":{"Count_SubsidizedHousingUnit":{"byEntity":{"geoId/40":{"orderedFacets":[{"facetId":"4243125145","observations":[{"date":"2023-12-31","value":53562}],"obsCount":1,"earliestDate":"2023-12-31","latestDate":"2023-12-31"}]},"geoId/41":{"orderedFacets":[{"facetId":"4243125145","observations":[{"date":"2023-12-31","value":57113}],"obsCount":1,"earliestDate":"2023-12-31","latestDate":"2023-12-31"}]},"geoId/02":{"orderedFacets":[{"facetId":"4243125145","observations":[{"date":"2023-12-31","value":7962}],"obsCount":1,"earliestDate":"2023-12-31","latestDate":"2023-12-31"}]}, ... }}
```

TODO: Add test cases