### PR TITLE
Update spanner queries

### DIFF
--- a/internal/server/spanner/golden/query/search_nodes_with_type.json
+++ b/internal/server/spanner/golden/query/search_nodes_with_type.json
@@ -350,6 +350,13 @@
     ]
   },
   {
+    "SubjectID": "oecd/IDD_INCACTOTAL_TOT_CURRENT_METH2011",
+    "Name": "Income Distribution Database: All age groups: mean disposable income (current prices), Total population, Current definition, Income definition until 2011",
+    "Types": [
+      "StatisticalVariable"
+    ]
+  },
+  {
     "SubjectID": "oecd/IDD_INCCTOTAL_WA_INCOMPARABLE_METH2012",
     "Name": "Income Distribution Database: Mean disposable income (current prices), Working age population: 18-65, Previous definition - without overlap year, New income definition since 2012",
     "Types": [
@@ -371,6 +378,13 @@
     ]
   },
   {
+    "SubjectID": "oecd/IDD_P90P10_TOT_CURRENT_METH2012",
+    "Name": "Income Distribution Database: P90/P10 disposable income decile ratio, Total population, Current definition, New income definition since 2012",
+    "Types": [
+      "StatisticalVariable"
+    ]
+  },
+  {
     "SubjectID": "oecd/IDD_P90P50_TOT_INCOMPARABLE_METH2012",
     "Name": "Income Distribution Database: P90/P50  disposable income decile ratio, Total population, Previous definition - without overlap year, New income definition since 2012",
     "Types": [
@@ -387,20 +401,6 @@
   {
     "SubjectID": "oecd/IDD_SEICTOTAL_WA_INCOMPARABLE_METH2012",
     "Name": "Income Distribution Database: Income from self-employment and from goods produced for own consumption (current prices), Working age population: 18-65, Previous definition - without overlap year, New income definition since 2012",
-    "Types": [
-      "StatisticalVariable"
-    ]
-  },
-  {
-    "SubjectID": "oecd/IDD_INCACTOTAL_TOT_CURRENT_METH2011",
-    "Name": "Income Distribution Database: All age groups: mean disposable income (current prices), Total population, Current definition, Income definition until 2011",
-    "Types": [
-      "StatisticalVariable"
-    ]
-  },
-  {
-    "SubjectID": "oecd/IDD_P90P10_TOT_CURRENT_METH2012",
-    "Name": "Income Distribution Database: P90/P10 disposable income decile ratio, Total population, Current definition, New income definition since 2012",
     "Types": [
       "StatisticalVariable"
     ]

--- a/internal/server/spanner/golden/query/search_nodes_without_type.json
+++ b/internal/server/spanner/golden/query/search_nodes_without_type.json
@@ -406,6 +406,13 @@
     ]
   },
   {
+    "SubjectID": "dc/g/Household_HouseholdType-MarriedCoupleFamilyHousehold_Income_IncomeStatus-WithIncome",
+    "Name": "Household With Household Type = Married Couple Family Household, Income, Income Status = With Income",
+    "Types": [
+      "StatVarGroup"
+    ]
+  },
+  {
     "SubjectID": "dc/g/Household_HouseholdType-NonfamilyHousehold_Income_IncomeStatus-WithIncome",
     "Name": "Household With Household Type = Nonfamily Household, Income, Income Status = With Income",
     "Types": [
@@ -448,6 +455,13 @@
     ]
   },
   {
+    "SubjectID": "oecd/IDD_INCACTOTAL_TOT_CURRENT_METH2011",
+    "Name": "Income Distribution Database: All age groups: mean disposable income (current prices), Total population, Current definition, Income definition until 2011",
+    "Types": [
+      "StatisticalVariable"
+    ]
+  },
+  {
     "SubjectID": "oecd/IDD_INCCTOTAL_WA_INCOMPARABLE_METH2012",
     "Name": "Income Distribution Database: Mean disposable income (current prices), Working age population: 18-65, Previous definition - without overlap year, New income definition since 2012",
     "Types": [
@@ -469,6 +483,13 @@
     ]
   },
   {
+    "SubjectID": "oecd/IDD_P90P10_TOT_CURRENT_METH2012",
+    "Name": "Income Distribution Database: P90/P10 disposable income decile ratio, Total population, Current definition, New income definition since 2012",
+    "Types": [
+      "StatisticalVariable"
+    ]
+  },
+  {
     "SubjectID": "oecd/IDD_P90P50_TOT_INCOMPARABLE_METH2012",
     "Name": "Income Distribution Database: P90/P50  disposable income decile ratio, Total population, Previous definition - without overlap year, New income definition since 2012",
     "Types": [
@@ -485,27 +506,6 @@
   {
     "SubjectID": "oecd/IDD_SEICTOTAL_WA_INCOMPARABLE_METH2012",
     "Name": "Income Distribution Database: Income from self-employment and from goods produced for own consumption (current prices), Working age population: 18-65, Previous definition - without overlap year, New income definition since 2012",
-    "Types": [
-      "StatisticalVariable"
-    ]
-  },
-  {
-    "SubjectID": "dc/g/Household_HouseholdType-MarriedCoupleFamilyHousehold_Income_IncomeStatus-WithIncome",
-    "Name": "Household With Household Type = Married Couple Family Household, Income, Income Status = With Income",
-    "Types": [
-      "StatVarGroup"
-    ]
-  },
-  {
-    "SubjectID": "oecd/IDD_INCACTOTAL_TOT_CURRENT_METH2011",
-    "Name": "Income Distribution Database: All age groups: mean disposable income (current prices), Total population, Current definition, Income definition until 2011",
-    "Types": [
-      "StatisticalVariable"
-    ]
-  },
-  {
-    "SubjectID": "oecd/IDD_P90P10_TOT_CURRENT_METH2012",
-    "Name": "Income Distribution Database: P90/P10 disposable income decile ratio, Total population, Current definition, New income definition since 2012",
     "Types": [
       "StatisticalVariable"
     ]


### PR DESCRIPTION
* Updates node queries to use only GQL. This helps improve performance for querying with filters
* Removes extra join in observation with contained in place query. After speaking with Mingtian, he recommends adding observation to the graph to remove additional joins. This will require updating the graph schema, and there are some implications for write throughput, but we can potentially explore this (can discuss more later)
* Updates some search tests (it's unclear if this is just flaky, so if it starts to fail again, we can consider updating the test to support potentially inconsistent ordering) 

