### PR TITLE
Return names and actual types of properties.

### DIFF
--- a/internal/server/v2/propertyvalues/golden/simple/test_var_2.json
+++ b/internal/server/v2/propertyvalues/golden/simple/test_var_2.json
@@ -5,8 +5,9 @@
         "measuredProperty": {
           "nodes": [
             {
+              "name": "total number of sql joins",
               "types": [
-                "Thing"
+                "StatisticalVariable"
               ],
               "dcid": "test_var_2"
             }
@@ -15,8 +16,9 @@
         "memberOf": {
           "nodes": [
             {
+              "name": "SQLite stat var group",
               "types": [
-                "Thing"
+                "StatVarGroup"
               ],
               "dcid": "dc/g/SQLite"
             }


### PR DESCRIPTION
* The current query that fetches triples is executed first, followed by a query to get names and types of all dcids in the triples response.
* Those are then used to populate the names and types of properties in the response.
* Note that if properties reference entities in base DC, those will not be fetched and will continue to be returned as they currently are. 
   + If we need their names / types to also be fetched, that will have to be done via a separate remote mixer call.
   + We can implement this in a separate PR if necessary.