### PR TITLE
Fix error due to value being returned as byte array by mysql.

### DIFF
--- a/internal/sqldb/model.go
+++ b/internal/sqldb/model.go
@@ -54,10 +54,17 @@ func (s *StringSlice) Scan(src interface{}) error {
 		return nil
 	}
 
-	val, ok := src.(string)
-	if !ok {
-		return fmt.Errorf("failed to decode []string: (%v)", src)
+	var val string
+
+	switch v := src.(type) {
+	case []byte:
+		val = string(v)
+	case string:
+		val = v
+	default:
+		return fmt.Errorf("failed to decode []string: type = %T, value = %v", src, src)
 	}
+
 	*s = strings.Split(val, ",")
 	return nil
 }


### PR DESCRIPTION
* GROUP_CONCAT values are returned as strings by sqlite but as byte arrays by mysql (cloud sql).
* This led to errors (see image below).
* This was not caught by golden tests since they use sqlite.

<img width="1171" alt="image" src="https://github.com/user-attachments/assets/07502971-db52-49f7-ac8b-b4713bbdeef7" />
