### PR TITLE
Encapsulate all remaining queries in sql client.

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -216,7 +216,7 @@ func main() {
 	}
 
 	if *useCloudSQL {
-		if sqlClient.DB != nil {
+		if sqldb.IsConnected(&sqlClient) {
 			log.Printf("SQL client has already been created, will not use CloudSQL")
 		} else {
 			client, err := sqldb.NewCloudSQLClient(*cloudSQLInstance)
@@ -237,7 +237,7 @@ func main() {
 	}
 
 	// Store
-	if len(tables) == 0 && *remoteMixerDomain == "" && sqlClient.DB == nil {
+	if len(tables) == 0 && *remoteMixerDomain == "" && !sqldb.IsConnected(&sqlClient) {
 		log.Fatal("No bigtables or remote mixer domain or sql database are provided")
 	}
 	store, err := store.NewStore(
@@ -251,7 +251,7 @@ func main() {
 	cacheOptions := cache.CacheOptions{
 		FetchSVG:       *cacheSVG,
 		SearchSVG:      *cacheSVG,
-		CacheSQL:       store.SQLClient.DB != nil,
+		CacheSQL:       sqldb.IsConnected(&store.SQLClient),
 		CacheSVFormula: *cacheSVFormula,
 	}
 	c, err := cache.NewCache(ctx, store, cacheOptions, metadata)

--- a/internal/server/cache/cache.go
+++ b/internal/server/cache/cache.go
@@ -133,12 +133,12 @@ func NewCache(
 	}
 
 	if options.CacheSQL {
-		sqlProv, err := sqlquery.GetProvenances(store.SQLClient.DB)
+		sqlProv, err := sqlquery.GetProvenances(ctx, &store.SQLClient)
 		if err != nil {
 			return nil, err
 		}
 		c.sqlProvenances = sqlProv
-		sqlExistenceMap, err := sqlquery.EntityVariableExistence(store.SQLClient.DB)
+		sqlExistenceMap, err := sqlquery.EntityVariableExistence(ctx, &store.SQLClient)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -319,6 +319,6 @@ func (s *Server) UpdateCache(
 func (s *Server) GetImportTableData(
 	ctx context.Context, in *pb.GetImportTableDataRequest,
 ) (*pb.GetImportTableDataResponse, error) {
-	response, err := sqlquery.GetImportTableData(s.store.SQLClient.DB)
+	response, err := sqlquery.GetImportTableData(ctx, &s.store.SQLClient)
 	return response, err
 }

--- a/internal/sqldb/client.go
+++ b/internal/sqldb/client.go
@@ -48,9 +48,6 @@ const (
 
 // SQLClient encapsulates a SQL DB connection.
 type SQLClient struct {
-	// Direct access to the DB will be disabled eventually (by making it private).
-	// It's exposed right now so we can incrementally encapsulate all SQL functionality in the client before disabling it.
-	DB  *sql.DB
 	dbx *sqlx.DB
 }
 
@@ -58,7 +55,6 @@ type SQLClient struct {
 // This method is to workaround the fact that we currently need to maintain the client by value in the store but connections by reference.
 // This method should be removed once the store maintains the client by reference.
 func (sc *SQLClient) UseConnections(src *SQLClient) {
-	sc.DB = src.DB
 	sc.dbx = src.dbx
 }
 
@@ -92,7 +88,6 @@ func NewCloudSQLClient(instanceName string) (*SQLClient, error) {
 
 func newSQLClient(db *sql.DB, driver string) *SQLClient {
 	return &SQLClient{
-		DB:  db,
 		dbx: sqlx.NewDb(db, driver),
 	}
 }

--- a/internal/sqldb/model.go
+++ b/internal/sqldb/model.go
@@ -133,7 +133,7 @@ type EntityVariable struct {
 	Variable string `db:"variable"`
 }
 
-// EntityVariable represents a row that includes an entity and a variable.
+// ProvenanceInfo represents a row that includes provenance info (id, name, URL).
 type ProvenanceInfo struct {
 	ID   string `db:"provenance_id"`
 	Name string `db:"provenance_name"`

--- a/internal/sqldb/model.go
+++ b/internal/sqldb/model.go
@@ -16,6 +16,7 @@
 package sqldb
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 )
@@ -124,4 +125,50 @@ type ObservationCount struct {
 	Entity   string `db:"entity"`
 	Variable string `db:"variable"`
 	Count    int    `db:"num_obs"`
+}
+
+// EntityVariable represents a row that includes an entity and a variable.
+type EntityVariable struct {
+	Entity   string `db:"entity"`
+	Variable string `db:"variable"`
+}
+
+// EntityVariable represents a row that includes an entity and a variable.
+type ProvenanceInfo struct {
+	ID   string `db:"provenance_id"`
+	Name string `db:"provenance_name"`
+	URL  string `db:"provenance_url"`
+}
+
+// ImportMetadata represents the metadata column in the imports table.
+type ImportMetadata struct {
+	NumObs  *int32 `json:"numObs"`
+	NumVars *int32 `json:"numVars"`
+}
+
+// Scan implements the sql.Scanner interface for ImportMetadata.
+func (md *ImportMetadata) Scan(src interface{}) error {
+	if src == nil {
+		return nil
+	}
+
+	var data []byte
+
+	switch v := src.(type) {
+	case []byte:
+		data = v
+	case string:
+		data = []byte(v)
+	default:
+		return fmt.Errorf("failed to decode ImportMetadata: type = %T, value = %v", src, src)
+	}
+
+	return json.Unmarshal(data, md)
+}
+
+// ImportInfo represents a row in the imports table
+type ImportInfo struct {
+	ImportedAt string         `db:"imported_at"`
+	Status     string         `db:"status"`
+	Metadata   ImportMetadata `db:"metadata"`
 }

--- a/internal/sqldb/sqlquery/get_import_table_test.go
+++ b/internal/sqldb/sqlquery/get_import_table_test.go
@@ -15,15 +15,16 @@
 package sqlquery
 
 import (
-	"database/sql"
+	"context"
 	"testing"
 
 	pb "github.com/datacommonsorg/mixer/internal/proto"
+	"github.com/datacommonsorg/mixer/internal/sqldb"
 	"github.com/go-test/deep"
 )
 
 func TestGetImportTableData(t *testing.T) {
-	sqlClient, err := sql.Open("sqlite", "../../../test/test_get_import_table_data.db")
+	sqlClient, err := sqldb.NewSQLiteClient("../../../test/test_get_import_table_data.db")
 	if err != nil {
 		t.Fatalf("Could not open testing database: %s", err)
 	}
@@ -47,9 +48,9 @@ func TestGetImportTableData(t *testing.T) {
 			},
 		},
 	} {
-		expect, err := GetImportTableData(sqlClient)
+		expect, err := GetImportTableData(context.Background(), sqlClient)
 		if err != nil {
-			t.Fatalf("Error execute CountObservation(): %s", err)
+			t.Fatalf("Error executing GetImportTableData(): %s", err)
 		}
 		if diff := deep.Equal(c.want, expect); diff != nil {
 			t.Errorf("Unexpected diff %v", diff)

--- a/internal/sqldb/statements.go
+++ b/internal/sqldb/statements.go
@@ -32,11 +32,14 @@ var statements = struct {
 	getAllEntitiesOfType                      string
 	getContainedInPlace                       string
 	getEntityVariables                        string
+	getAllEntitiesAndVariables                string
 	getTableColumns                           string
 	getObsCountByVariableAndEntity            string
 	getEntityInfoTriples                      string
 	getSubjectTriples                         string
 	getObjectTriples                          string
+	getAllProvenances                         string
+	getAllImports                             string
 }{
 	getObsByVariableAndEntity: `
 		SELECT entity, variable, date, value, provenance, unit, scaling_factor, measurement_method, observation_period, properties 
@@ -228,6 +231,10 @@ var statements = struct {
 		WHERE entity in (:entities)
 		GROUP BY entity;
 	`,
+	getAllEntitiesAndVariables: `
+		SELECT DISTINCT entity, variable
+		FROM observations;
+	`,
 	// Query for column names in a table. Table name must be added via string interpolation.
 	getTableColumns: `
 		SELECT * FROM %s LIMIT 0;
@@ -276,5 +283,23 @@ var statements = struct {
 		FROM all_pairs a
 		INNER JOIN triples t ON a.node = t.object_id AND a.prop = t.predicate
 		GROUP BY a.node, a.prop, subject_id, predicate, object_id, object_value;
+	`,
+	getAllProvenances: `
+		SELECT t1.subject_id provenance_id, t2.object_value provenance_name, t3.object_value provenance_url
+		FROM 
+			triples AS t1
+			JOIN triples AS t2 ON t1.subject_id = t2.subject_id
+			JOIN triples AS t3 ON t1.subject_id = t3.subject_id
+		WHERE 
+			t1.predicate = "typeOf"
+			AND t1.object_id = "Provenance"
+			AND t2.predicate = "name"
+			AND t3.predicate = "url"
+	`,
+	getAllImports: `
+		SELECT imported_at, status, metadata
+		FROM imports
+		ORDER BY imported_at DESC
+		LIMIT 100;
 	`,
 }

--- a/internal/sqldb/statements.go
+++ b/internal/sqldb/statements.go
@@ -296,6 +296,8 @@ var statements = struct {
 			AND t2.predicate = "name"
 			AND t3.predicate = "url"
 	`,
+	// Gets info about all imports into the DB sorted from newest to oldest.
+	// Limits to the most recent 100 imports to keep the number of results bounded.
 	getAllImports: `
 		SELECT imported_at, status, metadata
 		FROM imports


### PR DESCRIPTION
* All queries are now encapsulated!
* Removed the public DB variable from the client since it's no longer needed.
* One remaining thing is to use a SQLClient pointer (vs by value) in the store - will do that in the next PR.