### PR TITLE
Create a dispatcher framework for managing request lifecycle.

### DIFF
--- a/internal/server/dispatcher/dispatcher.go
+++ b/internal/server/dispatcher/dispatcher.go
@@ -1,0 +1,154 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dispatcher
+
+import (
+	"context"
+
+	"github.com/datacommonsorg/mixer/internal/server/datasources"
+	"google.golang.org/protobuf/proto"
+
+	pbv2 "github.com/datacommonsorg/mixer/internal/proto/v2"
+)
+
+// RequestType represents the type of request.
+type RequestType string
+
+const (
+	TypeNode        RequestType = "Node"
+	TypeNodeSearch  RequestType = "NodeSearch"
+	TypeObservation RequestType = "Observation"
+	TypeResolve     RequestType = "Resolve"
+)
+
+// RequestContext holds the context for a given request.
+
+// NOTE: We are using the base proto.Message for requests and responses.
+// Other options were using generics or going with different *RequestContext struct for each type of request.
+// The downside of using a base type is that it needs casting wherever it it used.
+// The upside is that we only have one context object
+// and if there aren't many processors that deal with the RequestContext, casting in a small number of places is ok.
+// We can revisit and use a different approach if this proves to be cumbersome.
+type RequestContext struct {
+	context.Context
+	Type            RequestType
+	OriginalRequest proto.Message
+	CurrentRequest  proto.Message
+	CurrentResponse proto.Message
+}
+
+// Processor interface defines methods for performing pre and post processing operations.
+type Processor interface {
+	PreProcess(*RequestContext) error
+	PostProcess(*RequestContext) error
+}
+
+// Dispatcher struct handles requests by dispatching requests to various processors and datasources as appropriate.
+type Dispatcher struct {
+	processors []*Processor
+	sources    *datasources.DataSources
+}
+
+func NewDispatcher(processors []*Processor, sources *datasources.DataSources) *Dispatcher {
+	return &Dispatcher{
+		processors: processors,
+		sources:    sources,
+	}
+}
+
+// handle handles a request lifecycle - pre-processing, core handling and post-processing.
+func (dispatcher *Dispatcher) handle(requestContext *RequestContext, handler func(context.Context, proto.Message) (proto.Message, error)) (proto.Message, error) {
+	for _, processor := range dispatcher.processors {
+		if err := (*processor).PreProcess(requestContext); err != nil {
+			return nil, err
+		}
+	}
+
+	response, err := handler(requestContext.Context, requestContext.CurrentRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	requestContext.CurrentResponse = response
+
+	for _, processor := range dispatcher.processors {
+		if err := (*processor).PostProcess(requestContext); err != nil {
+			return nil, err
+		}
+	}
+
+	return requestContext.CurrentResponse, nil
+}
+
+func (dispatcher *Dispatcher) Node(ctx context.Context, in *pbv2.NodeRequest) (*pbv2.NodeResponse, error) {
+	requestContext := newRequestContext(ctx, in, TypeNode)
+
+	response, err := dispatcher.handle(requestContext, func(ctx context.Context, request proto.Message) (proto.Message, error) {
+		return dispatcher.sources.Node(ctx, request.(*pbv2.NodeRequest))
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	return response.(*pbv2.NodeResponse), nil
+}
+
+func (dispatcher *Dispatcher) Observation(ctx context.Context, in *pbv2.ObservationRequest) (*pbv2.ObservationResponse, error) {
+	requestContext := newRequestContext(ctx, in, TypeObservation)
+
+	response, err := dispatcher.handle(requestContext, func(ctx context.Context, request proto.Message) (proto.Message, error) {
+		return dispatcher.sources.Observation(ctx, request.(*pbv2.ObservationRequest))
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	return response.(*pbv2.ObservationResponse), nil
+}
+
+func (dispatcher *Dispatcher) NodeSearch(ctx context.Context, in *pbv2.NodeSearchRequest) (*pbv2.NodeSearchResponse, error) {
+	requestContext := newRequestContext(ctx, in, TypeNodeSearch)
+
+	response, err := dispatcher.handle(requestContext, func(ctx context.Context, request proto.Message) (proto.Message, error) {
+		return dispatcher.sources.NodeSearch(ctx, request.(*pbv2.NodeSearchRequest))
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	return response.(*pbv2.NodeSearchResponse), nil
+}
+
+func (dispatcher *Dispatcher) Resolve(ctx context.Context, in *pbv2.ResolveRequest) (*pbv2.ResolveResponse, error) {
+	requestContext := newRequestContext(ctx, in, TypeResolve)
+
+	response, err := dispatcher.handle(requestContext, func(ctx context.Context, request proto.Message) (proto.Message, error) {
+		return dispatcher.sources.Resolve(ctx, request.(*pbv2.ResolveRequest))
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	return response.(*pbv2.ResolveResponse), nil
+}
+
+func newRequestContext(ctx context.Context, request proto.Message, requestType RequestType) *RequestContext {
+	return &RequestContext{
+		Context:         ctx,
+		Type:            requestType,
+		OriginalRequest: proto.Clone(request),
+		CurrentRequest:  request,
+	}
+}

--- a/internal/server/handler_v3.go
+++ b/internal/server/handler_v3.go
@@ -25,26 +25,26 @@ import (
 func (s *Server) V3Node(ctx context.Context, in *pbv2.NodeRequest) (
 	*pbv2.NodeResponse, error,
 ) {
-	return s.dataSources.Node(ctx, in)
+	return s.dispatcher.Node(ctx, in)
 }
 
 // V3Observation implements API for mixer.V3Observation.
 func (s *Server) V3Observation(ctx context.Context, in *pbv2.ObservationRequest) (
 	*pbv2.ObservationResponse, error,
 ) {
-	return s.dataSources.Observation(ctx, in)
+	return s.dispatcher.Observation(ctx, in)
 }
 
 // V3NodeSearch implements API for mixer.V3NodeSearch.
 func (s *Server) V3NodeSearch(ctx context.Context, in *pbv2.NodeSearchRequest) (
 	*pbv2.NodeSearchResponse, error,
 ) {
-	return s.dataSources.NodeSearch(ctx, in)
+	return s.dispatcher.NodeSearch(ctx, in)
 }
 
 // V3Resolve implements API for mixer.V3Resolve.
 func (s *Server) V3Resolve(ctx context.Context, in *pbv2.ResolveRequest) (
 	*pbv2.ResolveResponse, error,
 ) {
-	return s.dataSources.Resolve(ctx, in)
+	return s.dispatcher.Resolve(ctx, in)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -30,7 +30,7 @@ import (
 	"github.com/datacommonsorg/mixer/internal/parser/mcf"
 	dcpubsub "github.com/datacommonsorg/mixer/internal/pubsub"
 	"github.com/datacommonsorg/mixer/internal/server/cache"
-	"github.com/datacommonsorg/mixer/internal/server/datasources"
+	"github.com/datacommonsorg/mixer/internal/server/dispatcher"
 	"github.com/datacommonsorg/mixer/internal/server/resource"
 	"github.com/datacommonsorg/mixer/internal/store"
 	"github.com/datacommonsorg/mixer/internal/store/bigtable"
@@ -42,12 +42,12 @@ import (
 
 // Server holds resources for a mixer server
 type Server struct {
-	store       *store.Store
-	metadata    *resource.Metadata
-	cachedata   atomic.Pointer[cache.Cache]
-	mapsClient  *maps.Client
-	httpClient  *http.Client
-	dataSources *datasources.DataSources
+	store      *store.Store
+	metadata   *resource.Metadata
+	cachedata  atomic.Pointer[cache.Cache]
+	mapsClient *maps.Client
+	httpClient *http.Client
+	dispatcher *dispatcher.Dispatcher
 }
 
 func (s *Server) updateBranchTable(ctx context.Context, branchTableName string) error {
@@ -149,15 +149,15 @@ func NewMixerServer(
 	metadata *resource.Metadata,
 	cachedata *cache.Cache,
 	mapsClient *maps.Client,
-	dataSources *datasources.DataSources,
+	dispatcher *dispatcher.Dispatcher,
 ) *Server {
 	s := &Server{
-		store:       store,
-		metadata:    metadata,
-		cachedata:   atomic.Pointer[cache.Cache]{},
-		mapsClient:  mapsClient,
-		httpClient:  &http.Client{},
-		dataSources: dataSources,
+		store:      store,
+		metadata:   metadata,
+		cachedata:  atomic.Pointer[cache.Cache]{},
+		mapsClient: mapsClient,
+		httpClient: &http.Client{},
+		dispatcher: dispatcher,
 	}
 	s.cachedata.Store(cachedata)
 	return s

--- a/internal/server/v3/observation/calculation.go
+++ b/internal/server/v3/observation/calculation.go
@@ -1,0 +1,50 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package observation
+
+import (
+	"log"
+
+	"github.com/datacommonsorg/mixer/internal/server/datasources"
+	"github.com/datacommonsorg/mixer/internal/server/dispatcher"
+)
+
+// CalculationProcessor implements the dispatcher.Processor interface for performing calculations.
+type CalculationProcessor struct {
+	// Set and use datasources if needed.
+	_ *datasources.DataSources
+}
+
+func (processor *CalculationProcessor) PreProcess(requestContext *dispatcher.RequestContext) error {
+	switch requestContext.Type {
+	case dispatcher.TypeObservation:
+		log.Printf("Pre-processing observation request.")
+		return nil
+	default:
+		log.Printf("NOT pre-processing request of type: %s", requestContext.Type)
+		return nil
+	}
+}
+
+func (processor *CalculationProcessor) PostProcess(requestContext *dispatcher.RequestContext) error {
+	switch requestContext.Type {
+	case dispatcher.TypeObservation:
+		log.Printf("Post-processing observation request.")
+		return nil
+	default:
+		log.Printf("NOT post-processing request of type: %s", requestContext.Type)
+		return nil
+	}
+}


### PR DESCRIPTION
* Introduced a `Dispatcher` for managing a request's lifecycle - pre-processing, handling, post-processing.
  + Could have done this in the handler itself but a standalone struct allows us to test it independent of a server.
* Introduced a `Processor` interface that can be implemented for pre and post processing.
* Created a no-op `CalculationProcessor` as an example.
   + To be replaced with a real implementation subsequently.
* Made a pragmatic call to use casting to get to the concrete request and response types.
   + See code comments for details.