### PR TITLE
Add support for neighbors to V3 Node

### DIFF
--- a/internal/server/spanner/datasource.go
+++ b/internal/server/spanner/datasource.go
@@ -51,7 +51,7 @@ func (sds *SpannerDataSource) Node(ctx context.Context, req *pbv2.NodeRequest) (
 	}
 	arc := arcs[0]
 
-	// Certain requests utilize neighbors in the response so are handled differently.
+	// Certain requests contain neighbors in the response so are handled differently.
 	// This is to match the behavior of V2 Node, which reads these from the Mixer cache.
 	// TODO: Unify V2 Node clients to use arcs, since these queries are now supported in Spanner.
 	// All other chaining queries should use the normal arc syntax.

--- a/internal/server/spanner/golden/query/get_node_neighbors.json
+++ b/internal/server/spanner/golden/query/get_node_neighbors.json
@@ -1,0 +1,12 @@
+{
+  "dc/g/Farm_FarmInventoryStatus-InventorySold_FarmInventoryType": [
+    "dc/g/Farm_FarmInventoryStatus-InventorySold",
+    "dc/g/Farm_FarmInventoryStatus",
+    "dc/g/Farm",
+    "dc/g/Agriculture"
+  ],
+  "dc/g/Person_BachelorsDegreeMajor-BusinessMajor": [
+    "dc/g/Person_BachelorsDegreeMajor",
+    "dc/g/Education"
+  ]
+}

--- a/internal/server/spanner/model.go
+++ b/internal/server/spanner/model.go
@@ -41,6 +41,12 @@ type Edge struct {
 	Types       []string `spanner:"types"`
 }
 
+// Neighbor struct represents a path of neighbors for a node.
+type Neighbor struct {
+	SubjectID string   `spanner:"subject_id"`
+	Neighbors []string `spanner:"neighbors"`
+}
+
 // Observation struct represents a single row in the Observation table.
 type Observation struct {
 	VariableMeasured  string     `spanner:"variable_measured"`

--- a/internal/server/v3/node/golden/neighbors.json
+++ b/internal/server/v3/node/golden/neighbors.json
@@ -1,0 +1,30 @@
+{
+  "data": {
+    "dc/g/Farm_FarmInventoryStatus-InventorySold_FarmInventoryType": {
+      "neighbor": {
+        "dc/g/Farm_FarmInventoryStatus-InventorySold": {
+          "neighbor": {
+            "dc/g/Farm_FarmInventoryStatus": {
+              "neighbor": {
+                "dc/g/Farm": {
+                  "neighbor": {
+                    "dc/g/Agriculture": {}
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "dc/g/Person_BachelorsDegreeMajor-BusinessMajor": {
+      "neighbor": {
+        "dc/g/Person_BachelorsDegreeMajor": {
+          "neighbor": {
+            "dc/g/Education": {}
+          }
+        }
+      }
+    }
+  }
+}

--- a/internal/server/v3/node/golden/node_test.go
+++ b/internal/server/v3/node/golden/node_test.go
@@ -46,7 +46,7 @@ func TestV3Node(t *testing.T) {
 			nextToken  string
 			goldenFile string
 		}{
-			{
+			/*{
 				"Out properties",
 				[]string{
 					"Count_Person_Female",
@@ -65,6 +65,16 @@ func TestV3Node(t *testing.T) {
 				"->*",
 				"",
 				"out_pv_all.json",
+			},*/
+			{
+				"Node neighbors",
+				[]string{
+					"dc/g/Farm_FarmInventoryStatus-InventorySold_FarmInventoryType",
+					"dc/g/Person_BachelorsDegreeMajor-BusinessMajor",
+				},
+				"->specializationOf+{typeOf:StatVarGroup}",
+				"",
+				"neighbors.json",
 			},
 		} {
 			goldenFile := c.goldenFile

--- a/internal/server/v3/node/golden/node_test.go
+++ b/internal/server/v3/node/golden/node_test.go
@@ -46,7 +46,7 @@ func TestV3Node(t *testing.T) {
 			nextToken  string
 			goldenFile string
 		}{
-			/*{
+			{
 				"Out properties",
 				[]string{
 					"Count_Person_Female",
@@ -65,7 +65,7 @@ func TestV3Node(t *testing.T) {
 				"->*",
 				"",
 				"out_pv_all.json",
-			},*/
+			},
 			{
 				"Node neighbors",
 				[]string{


### PR DESCRIPTION
This is currently only used for one hardcoded case in V2: https://github.com/datacommonsorg/mixer/blob/bbfacfd7e542df897658f94e44b9b2dcfafcdc2f/internal/server/v2/propertyvalues/api.go#L201-L234 , so I added a similar special case in V3. 

Eventually, I think we should migrate website to use arcs for this request too, since now we don't need to cache this and can use Spanner directly. 

This can use Spanner instead of the Mixer cache, since all Spanner custom DCs will use the new Custom DC architecture so SVGs will no longer be in BT (so no dc/g/Custom_), and so neighbors for Custom groups should be handled by sql datasource separately 