### PR TITLE
Update chain query

### DIFF
--- a/internal/server/spanner/golden/query/get_node_edges_in_chain.json
+++ b/internal/server/spanner/golden/query/get_node_edges_in_chain.json
@@ -7,7 +7,9 @@
       "ObjectValue": "",
       "Provenance": "",
       "Name": "Farm With Farm Inventory Status = Inventory Sold",
-      "Types": []
+      "Types": [
+        "StatVarGroup"
+      ]
     },
     {
       "SubjectID": "dc/g/Farm_FarmInventoryStatus",
@@ -16,7 +18,9 @@
       "ObjectValue": "",
       "Provenance": "",
       "Name": "Farm With Farm Inventory Status = Inventory Sold, Farm Inventory Type",
-      "Types": []
+      "Types": [
+        "StatVarGroup"
+      ]
     }
   ]
 }

--- a/internal/server/spanner/golden/query/get_node_edges_out_chain.json
+++ b/internal/server/spanner/golden/query/get_node_edges_out_chain.json
@@ -7,7 +7,9 @@
       "ObjectValue": "",
       "Provenance": "",
       "Name": "Demographics",
-      "Types": []
+      "Types": [
+        "StatVarGroup"
+      ]
     },
     {
       "SubjectID": "dc/g/Person_Gender",
@@ -16,7 +18,9 @@
       "ObjectValue": "",
       "Provenance": "",
       "Name": "Economy",
-      "Types": []
+      "Types": [
+        "StatVarGroup"
+      ]
     },
     {
       "SubjectID": "dc/g/Person_Gender",
@@ -25,7 +29,9 @@
       "ObjectValue": "",
       "Provenance": "",
       "Name": "Employment and Business",
-      "Types": []
+      "Types": [
+        "StatVarGroup"
+      ]
     },
     {
       "SubjectID": "dc/g/Person_Gender",
@@ -34,7 +40,9 @@
       "ObjectValue": "",
       "Provenance": "",
       "Name": "Health",
-      "Types": []
+      "Types": [
+        "StatVarGroup"
+      ]
     },
     {
       "SubjectID": "dc/g/Person_Gender",
@@ -43,7 +51,9 @@
       "ObjectValue": "",
       "Provenance": "",
       "Name": "Data Commons Variables",
-      "Types": []
+      "Types": [
+        "StatVarGroup"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Use "match any" instead of "distinct" which has slightly better performance.

(Also one nice side effect is that now we can return types! I can update V2 to match as a follow up)