### PR TITLE
Fix non deterministic facet ranking

### DIFF
--- a/internal/server/ranking/ranking.go
+++ b/internal/server/ranking/ranking.go
@@ -473,5 +473,8 @@ func (a FacetByRank) Less(i, j int) bool {
 	if oi.Facet.ProvenanceUrl != oj.Facet.ProvenanceUrl {
 		return oi.Facet.ProvenanceUrl < oj.Facet.ProvenanceUrl
 	}
+	if oi.Facet.ImportName != oj.Facet.ImportName {
+		return oi.Facet.ImportName < oj.Facet.ImportName
+	}
 	return true
 }

--- a/internal/server/v2/facet/golden/series_facet/series_facet_test_ranking.json
+++ b/internal/server/v2/facet/golden/series_facet/series_facet_test_ranking.json
@@ -1,0 +1,54 @@
+{
+  "by_variable": {
+    "Count_Death_AgeAdjusted_AsAFractionOf_Count_Person": {
+      "by_entity": {
+        "geoId/01": {
+          "ordered_facets": [
+            {
+              "facet_id": "1151455814",
+              "obs_count": 18,
+              "earliest_date": "2001",
+              "latest_date": "2020"
+            },
+            {
+              "facet_id": "1123266408",
+              "obs_count": 18,
+              "earliest_date": "2001",
+              "latest_date": "2020"
+            }
+          ]
+        },
+        "geoId/02": {
+          "ordered_facets": [
+            {
+              "facet_id": "1151455814",
+              "obs_count": 18,
+              "earliest_date": "2001",
+              "latest_date": "2020"
+            },
+            {
+              "facet_id": "1123266408",
+              "obs_count": 18,
+              "earliest_date": "2001",
+              "latest_date": "2020"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "facets": {
+    "1123266408": {
+      "import_name": "OECDRegionalDemography_Mortality",
+      "provenance_url": "https://stats.oecd.org/Index.aspx?DataSetCode=REGION_DEMOGR#",
+      "measurement_method": "OECDRegionalStatistics",
+      "observation_period": "P1Y"
+    },
+    "1151455814": {
+      "import_name": "OECDRegionalDemography",
+      "provenance_url": "https://stats.oecd.org/Index.aspx?DataSetCode=REGION_DEMOGR#",
+      "measurement_method": "OECDRegionalStatistics",
+      "observation_period": "P1Y"
+    }
+  }
+}

--- a/internal/server/v2/facet/golden/series_facet_test.go
+++ b/internal/server/v2/facet/golden/series_facet_test.go
@@ -45,6 +45,11 @@ func TestSeriesFacet(t *testing.T) {
 				[]string{"country/USA", "geoId/06", "Earth"},
 				"series_facet.json",
 			},
+			{
+				[]string{"Count_Death_AgeAdjusted_AsAFractionOf_Count_Person"},
+				[]string{"geoId/01", "geoId/02"},
+				"series_facet_test_ranking.json",
+			},
 		} {
 			goldenFile := c.goldenFile
 			resp, err := mixer.V2Observation(ctx, &pbv2.ObservationRequest{


### PR DESCRIPTION
Update facet ranking to take import name into account because some facets differ by only the import name. This non-deterministic ranking of facets causes flaky NL tests in the website repository because NL chooses the top ranked facet.