### PR TITLE
Add observation response limits to spanner

### DIFF
--- a/internal/server/spanner/datasource.go
+++ b/internal/server/spanner/datasource.go
@@ -97,8 +97,9 @@ func (sds *SpannerDataSource) Observation(ctx context.Context, req *pbv2.Observa
 	if len(observations) > shared.MaxSeries {
 		return nil, status.Errorf(
 			codes.Internal,
-			"Stop processing large number of concurrent observation series: %d",
+			"Request exceeds the allowed limit on the number of time series processed: %d > %d. Please try reducing the number of variables or entities in the request.",
 			len(observations),
+			shared.MaxSeries,
 		)
 	}
 


### PR DESCRIPTION
This is to match the behavior of V2 which returns the same error for large requests (e.g. Count_Person for country/USA<-containedInPlace+{typeOf:City}) to prevent timeouts/memory limits: https://github.com/datacommonsorg/mixer/blob/master/internal/server/v2/observation/contained_in.go#L160

Currently the limit is set to the same as V2 (5000 series per response) 