### PR TITLE
Create script to clear redis cache.

### DIFF
--- a/tools/clearcache/clear_autopush.sh
+++ b/tools/clearcache/clear_autopush.sh
@@ -13,5 +13,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-SCRIPT_PATH=`dirname $0`
-$SCRIPT_PATH/run.sh datcom-mixer-autopush mixer-us-central1 us-central1
+SCRIPT_PATH=$(dirname "$0")
+"$SCRIPT_PATH/run.sh" datcom-mixer-autopush mixer-us-central1 us-central1

--- a/tools/clearcache/clear_autopush.sh
+++ b/tools/clearcache/clear_autopush.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SCRIPT_PATH=`dirname $0`
+$SCRIPT_PATH/run.sh datcom-mixer-autopush mixer-us-central1 us-central1

--- a/tools/clearcache/run.sh
+++ b/tools/clearcache/run.sh
@@ -13,6 +13,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This script clears the Redis cache for a specified GCP project, cluster, and location.
+#
+# Usage:
+#   run.sh <PROJECT_ID> <CLUSTER_NAME> <LOCATION> [REDIS_REGION]
+#
+#   - PROJECT_ID: The ID of your Google Cloud Project.
+#   - CLUSTER_NAME: The name of your Kubernetes cluster.
+#   - LOCATION:  The location (region or zone) of your Kubernetes cluster.
+#   - REDIS_REGION: (Optional) The region where your Redis instance is located.
+#                   If not provided, it defaults to the cluster's LOCATION.
+# Example usage:
+#   run.sh datcom-mixer-autopush mixer-us-central1 us-central1
+
 PROJECT_ID=$1
 CLUSTER_NAME=$2
 LOCATION=$3

--- a/tools/clearcache/run.sh
+++ b/tools/clearcache/run.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+PROJECT_ID=$1
+CLUSTER_NAME=$2
+LOCATION=$3
+# Optional: Set REDIS_REGION if it is different from the cluster LOCATION arg
+REDIS_REGION=$4
+
+# Exit the script if there's an error
+set -e
+
+gcloud config set project $PROJECT_ID
+
+# Set default redis region if not passed in
+if [ -z "${REDIS_REGION}" ]; then
+  REDIS_REGION=$LOCATION
+fi
+
+# Set cluster region or zone
+if [[ $LOCATION =~ ^[a-z]+-[a-z0-9]+$ ]]; then
+  REGION=$LOCATION
+else
+  ZONE=$LOCATION
+fi
+gcloud container clusters get-credentials $CLUSTER_NAME \
+  ${REGION:+--region=$REGION} ${ZONE:+--zone=$ZONE} --project=$PROJECT_ID
+
+POD_NAME=$(kubectl get pods -n mixer -o=jsonpath='{.items[0].metadata.name}')
+HOST=$(gcloud redis instances describe mixer-cache --region="$REDIS_REGION" --format="get(host)")
+
+echo "Clearing Redis cache for $PROJECT_ID/$CLUSTER_NAME/$LOCATION, redis host $HOST"
+
+# Execute the clearcache tool, passing the Redis host as an argument.
+kubectl exec -it $POD_NAME -n mixer -- /bin/bash -c "
+  /go/bin/tools/clearcache --redis_host=$HOST
+"

--- a/tools/clearcache/run.sh
+++ b/tools/clearcache/run.sh
@@ -41,7 +41,7 @@ gcloud container clusters get-credentials $CLUSTER_NAME \
 POD_NAME=$(kubectl get pods -n mixer -o=jsonpath='{.items[0].metadata.name}')
 HOST=$(gcloud redis instances describe mixer-cache --region="$REDIS_REGION" --format="get(host)")
 
-echo "Clearing Redis cache for $PROJECT_ID/$CLUSTER_NAME/$LOCATION, redis host $HOST"
+echo "Clearing Redis cache for $PROJECT_ID/$CLUSTER_NAME/$LOCATION, redis host: $HOST, using pod: $POD_NAME"
 
 # Execute the clearcache tool, passing the Redis host as an argument.
 kubectl exec -it $POD_NAME -n mixer -- /bin/bash -c "

--- a/tools/clearcache/run.sh
+++ b/tools/clearcache/run.sh
@@ -22,7 +22,7 @@ REDIS_REGION=$4
 # Exit the script if there's an error
 set -e
 
-gcloud config set project $PROJECT_ID
+gcloud config set project "$PROJECT_ID"
 
 # Set default redis region if not passed in
 if [ -z "${REDIS_REGION}" ]; then
@@ -35,8 +35,8 @@ if [[ $LOCATION =~ ^[a-z]+-[a-z0-9]+$ ]]; then
 else
   ZONE=$LOCATION
 fi
-gcloud container clusters get-credentials $CLUSTER_NAME \
-  ${REGION:+--region=$REGION} ${ZONE:+--zone=$ZONE} --project=$PROJECT_ID
+gcloud container clusters get-credentials "$CLUSTER_NAME" \
+  ${REGION:+--region="$REGION"} ${ZONE:+--zone="$ZONE"} --project="$PROJECT_ID"
 
 POD_NAME=$(kubectl get pods -n mixer -o=jsonpath='{.items[0].metadata.name}')
 HOST=$(gcloud redis instances describe mixer-cache --region="$REDIS_REGION" --format="get(host)")
@@ -44,6 +44,6 @@ HOST=$(gcloud redis instances describe mixer-cache --region="$REDIS_REGION" --fo
 echo "Clearing Redis cache for $PROJECT_ID/$CLUSTER_NAME/$LOCATION, redis host: $HOST, using pod: $POD_NAME"
 
 # Execute the clearcache tool, passing the Redis host as an argument.
-kubectl exec -it $POD_NAME -n mixer -- /bin/bash -c "
+kubectl exec -it "$POD_NAME" -n mixer -- /bin/bash -c "
   /go/bin/tools/clearcache --redis_host=$HOST
 "


### PR DESCRIPTION
* `run.sh` looks up the redis host for a given region and calls the go utility to clear the cache on that host.
* `clear_autopush.sh` calls `run.sh` for the autopush mixer.
   + Need to figure out a way for this to be invoked automatically on deployment.
* Verified it by running `clear_autopush.sh` from my machine. Here's the output:
```
$ ./tools/clearcache/clear_autopush.sh
Updated property [core/project].
Fetching cluster endpoint and auth data.
kubeconfig entry generated for mixer-us-central1.
Clearing Redis cache for datcom-mixer-autopush/mixer-us-central1/us-central1, redis host: 10.244.163.180, using pod: mixer-autopush-default-6cbc8896f-4b29s
Defaulted container "mixer" out of: mixer, esp
Cleared redis cache: 10.244.163.180:6379
```