### PR TITLE
Support node properties request in sql datasource.

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -242,6 +242,12 @@ func main() {
 		}
 	}
 
+	// SQL Data Source
+	if *enableV3 && sqldb.IsConnected(&sqlClient) {
+		var ds datasource.DataSource = sqldb.NewSQLDataSource(&sqlClient)
+		sources = append(sources, &ds)
+	}
+
 	// Store
 	if len(tables) == 0 && *remoteMixerDomain == "" && !sqldb.IsConnected(&sqlClient) {
 		log.Fatal("No bigtables or remote mixer domain or sql database are provided")

--- a/internal/merger/merger.go
+++ b/internal/merger/merger.go
@@ -89,11 +89,15 @@ func MergeMultiResolve(allResp []*pbv2.ResolveResponse) *pbv2.ResolveResponse {
 func mergeLinkedGraph(
 	mainData, auxData map[string]*pbv2.LinkedGraph,
 ) map[string]*pbv2.LinkedGraph {
+	if mainData == nil {
+		mainData = map[string]*pbv2.LinkedGraph{}
+	}
+
 	for dcid, linkedGraph := range auxData {
-		if mainData == nil {
-			mainData = map[string]*pbv2.LinkedGraph{}
+		if isEmptyLinkedGraph(linkedGraph) {
+			continue
 		}
-		if _, ok := mainData[dcid]; !ok || mainData[dcid].GetArcs() == nil {
+		if isEmptyLinkedGraph(mainData[dcid]) {
 			mainData[dcid] = linkedGraph
 			continue
 		}
@@ -128,6 +132,10 @@ func mergeLinkedGraph(
 		}
 	}
 	return mainData
+}
+
+func isEmptyLinkedGraph(linkedGraph *pbv2.LinkedGraph) bool {
+	return linkedGraph == nil || (len(linkedGraph.Arcs) == 0 && len(linkedGraph.Properties) == 0)
 }
 
 // MergeNode merges two V2 node responses.

--- a/internal/server/datasources/datasources.go
+++ b/internal/server/datasources/datasources.go
@@ -38,10 +38,11 @@ func (ds *DataSources) Node(ctx context.Context, in *pbv2.NodeRequest) (*pbv2.No
 	dsRespChan := []chan *pbv2.NodeResponse{}
 
 	for _, source := range ds.sources {
+		src := *source
 		respChan := make(chan *pbv2.NodeResponse, 1)
 		errGroup.Go(func() error {
 			defer close(respChan)
-			resp, err := (*source).Node(errCtx, in)
+			resp, err := src.Node(errCtx, in)
 			if err != nil {
 				return err
 			}
@@ -68,10 +69,11 @@ func (ds *DataSources) Observation(ctx context.Context, in *pbv2.ObservationRequ
 	dsRespChan := []chan *pbv2.ObservationResponse{}
 
 	for _, source := range ds.sources {
+		src := *source
 		respChan := make(chan *pbv2.ObservationResponse, 1)
 		errGroup.Go(func() error {
 			defer close(respChan)
-			resp, err := (*source).Observation(errCtx, in)
+			resp, err := src.Observation(errCtx, in)
 			if err != nil {
 				return err
 			}
@@ -98,10 +100,11 @@ func (ds *DataSources) NodeSearch(ctx context.Context, in *pbv2.NodeSearchReques
 	dsRespChan := []chan *pbv2.NodeSearchResponse{}
 
 	for _, source := range ds.sources {
+		src := *source
 		respChan := make(chan *pbv2.NodeSearchResponse, 1)
 		errGroup.Go(func() error {
 			defer close(respChan)
-			resp, err := (*source).NodeSearch(errCtx, in)
+			resp, err := src.NodeSearch(errCtx, in)
 			if err != nil {
 				return err
 			}
@@ -128,10 +131,11 @@ func (ds *DataSources) Resolve(ctx context.Context, in *pbv2.ResolveRequest) (*p
 	dsRespChan := []chan *pbv2.ResolveResponse{}
 
 	for _, source := range ds.sources {
+		src := *source
 		respChan := make(chan *pbv2.ResolveResponse, 1)
 		errGroup.Go(func() error {
 			defer close(respChan)
-			resp, err := (*source).Resolve(errCtx, in)
+			resp, err := src.Resolve(errCtx, in)
 			if err != nil {
 				return err
 			}

--- a/internal/server/v2/graph.go
+++ b/internal/server/v2/graph.go
@@ -15,6 +15,8 @@
 // Package v2 is the version 2 of the Data Commons REST API.
 package v2
 
+import "github.com/datacommonsorg/mixer/internal/util"
+
 // Arc represents an arc in the graph.
 type Arc struct {
 	// Whether it's out or in arc.
@@ -27,6 +29,17 @@ type Arc struct {
 	BracketProps []string
 	// The filter of the arc: filter key -> filter values.
 	Filter map[string][]string
+}
+
+func (arc *Arc) Direction() string {
+	if arc.Out {
+		return util.DirectionOut
+	}
+	return util.DirectionIn
+}
+
+func (arc *Arc) IsNodePropertiesArc() bool {
+	return arc.SingleProp == "" && len(arc.BracketProps) == 0
 }
 
 // LinkedNodes represents a local graph starting from a node with connected arcs.

--- a/internal/server/v3/node/golden/in_prop.json
+++ b/internal/server/v3/node/golden/in_prop.json
@@ -1,0 +1,16 @@
+{
+  "data": {
+    "Count_Person_Female": {
+      "properties": [
+        "measurementDenominator"
+      ]
+    },
+    "foo": {},
+    "test_var_1": {
+      "properties": [
+        "measuredProperty",
+        "outputProperty"
+      ]
+    }
+  }
+}

--- a/internal/server/v3/node/golden/node_test.go
+++ b/internal/server/v3/node/golden/node_test.go
@@ -51,10 +51,22 @@ func TestV3Node(t *testing.T) {
 				[]string{
 					"Count_Person_Female",
 					"foo",
+					"test_var_1",
 				},
 				"->",
 				"",
 				"out_prop.json",
+			},
+			{
+				"In properties",
+				[]string{
+					"Count_Person_Female",
+					"foo",
+					"test_var_1",
+				},
+				"<-",
+				"",
+				"in_prop.json",
 			},
 			{
 				"All out property-values",

--- a/internal/server/v3/node/golden/out_prop.json
+++ b/internal/server/v3/node/golden/out_prop.json
@@ -14,6 +14,16 @@
         "typeOf"
       ]
     },
-    "foo": {}
+    "foo": {},
+    "test_var_1": {
+      "properties": [
+        "typeOf",
+        "measuredProperty",
+        "statType",
+        "name",
+        "description",
+        "memberOf"
+      ]
+    }
   }
 }

--- a/internal/server/v3/node/golden/out_pv_all.json
+++ b/internal/server/v3/node/golden/out_pv_all.json
@@ -10,14 +10,14 @@
                 "Property"
               ],
               "dcid": "gender",
-              "provenanceId": "dc/base/HumanReadableStatVars"
+              "provenance_id": "dc/base/HumanReadableStatVars"
             }
           ]
         },
         "extendedName": {
           "nodes": [
             {
-              "provenanceId": "dc/base/HumanReadableStatVars",
+              "provenance_id": "dc/base/HumanReadableStatVars",
               "value": "Female Population"
             }
           ]
@@ -30,14 +30,14 @@
                 "GenderType"
               ],
               "dcid": "Female",
-              "provenanceId": "dc/base/HumanReadableStatVars"
+              "provenance_id": "dc/base/HumanReadableStatVars"
             }
           ]
         },
         "localCuratorLevelId": {
           "nodes": [
             {
-              "provenanceId": "dc/base/HumanReadableStatVars",
+              "provenance_id": "dc/base/HumanReadableStatVars",
               "value": "dcid:Count_Person_Female"
             }
           ]
@@ -50,7 +50,7 @@
                 "Property"
               ],
               "dcid": "count",
-              "provenanceId": "dc/base/HumanReadableStatVars"
+              "provenance_id": "dc/base/HumanReadableStatVars"
             }
           ]
         },
@@ -62,14 +62,14 @@
                 "StatVarGroup"
               ],
               "dcid": "dc/g/Person_Gender-Female",
-              "provenanceId": "dc/base/HumanReadableStatVars"
+              "provenance_id": "dc/base/HumanReadableStatVars"
             }
           ]
         },
         "name": {
           "nodes": [
             {
-              "provenanceId": "dc/base/HumanReadableStatVars",
+              "provenance_id": "dc/base/HumanReadableStatVars",
               "value": "Female Population"
             }
           ]
@@ -82,7 +82,7 @@
                 "Class"
               ],
               "dcid": "Person",
-              "provenanceId": "dc/base/HumanReadableStatVars"
+              "provenance_id": "dc/base/HumanReadableStatVars"
             }
           ]
         },
@@ -94,7 +94,7 @@
                 "Property"
               ],
               "dcid": "measuredValue",
-              "provenanceId": "dc/base/HumanReadableStatVars"
+              "provenance_id": "dc/base/HumanReadableStatVars"
             }
           ]
         },
@@ -106,7 +106,7 @@
                 "Class"
               ],
               "dcid": "StatisticalVariable",
-              "provenanceId": "dc/base/HumanReadableStatVars"
+              "provenance_id": "dc/base/HumanReadableStatVars"
             }
           ]
         }

--- a/internal/sqldb/client.go
+++ b/internal/sqldb/client.go
@@ -57,6 +57,7 @@ type SQLClient struct {
 // This method should be removed once the store maintains the client by reference.
 func (sc *SQLClient) UseConnections(src *SQLClient) {
 	sc.dbx = src.dbx
+	sc.id = src.id
 }
 
 // Close closes the underlying database connection

--- a/internal/sqldb/dsutil.go
+++ b/internal/sqldb/dsutil.go
@@ -1,0 +1,39 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Utility functions used by the SQLDataSource.
+
+package sqldb
+
+import (
+	pbv2 "github.com/datacommonsorg/mixer/internal/proto/v2"
+)
+
+// nodePredicatesToNodeResponse converts a list of NodePredicates to a NodeResponse proto.
+func nodePredicatesToNodeResponse(nodePredicates []*NodePredicate) *pbv2.NodeResponse {
+	nodeResponse := &pbv2.NodeResponse{
+		Data: make(map[string]*pbv2.LinkedGraph),
+	}
+
+	for _, nodePredicate := range nodePredicates {
+		node, predicate := nodePredicate.Node, nodePredicate.Predicate
+		linkedGraph, ok := nodeResponse.Data[node]
+		if !ok {
+			nodeResponse.Data[node] = &pbv2.LinkedGraph{}
+			linkedGraph = nodeResponse.Data[node]
+		}
+		linkedGraph.Properties = append(linkedGraph.Properties, predicate)
+	}
+	return nodeResponse
+}

--- a/test/setup.go
+++ b/test/setup.go
@@ -169,6 +169,10 @@ func setupInternal(
 		if err != nil {
 			log.Fatalf("SQL database validation failed: %v", err)
 		}
+		if enableV3 {
+			var ds datasource.DataSource = sqldb.NewSQLDataSource(&sqlClient)
+			sources = append(sources, &ds)
+		}
 	}
 
 	metadata, err := server.NewMetadata(


### PR DESCRIPTION
* Creates and adds a sql datasource if v3 is enabled and sql params are configured both for runtime and golden tests.
* Implements the node properties request.
* Fixes some response merge logic.