### PR TITLE
Configure sql data source with a secondary data source.

### DIFF
--- a/internal/sqldb/datasource.go
+++ b/internal/sqldb/datasource.go
@@ -26,10 +26,14 @@ import (
 // SQLDataSource represents a data source that interacts with SQL.
 type SQLDataSource struct {
 	client *SQLClient
+	// The secondary data source is used to fetch certain data (e.g. child places) that is not available in SQL.
+	// If one is not configured, those calls will be skipped.
+	// The secondary data source is typically a remote data source but it could be a different data source (like spanner) in tests.
+	secondaryDataSource datasource.DataSource
 }
 
-func NewSQLDataSource(client *SQLClient) *SQLDataSource {
-	return &SQLDataSource{client: client}
+func NewSQLDataSource(client *SQLClient, secondaryDataSource datasource.DataSource) *SQLDataSource {
+	return &SQLDataSource{client: client, secondaryDataSource: secondaryDataSource}
 }
 
 // Type returns the type of the data source.

--- a/internal/sqldb/datasource_test.go
+++ b/internal/sqldb/datasource_test.go
@@ -28,6 +28,6 @@ func TestId(t *testing.T) {
 
 	assert.Equal(t, "sqlite-../../test/sqlquery/key_value/datacommons.db", sqlClient.id)
 
-	sqlDataSource := NewSQLDataSource(sqlClient)
+	sqlDataSource := NewSQLDataSource(sqlClient, nil)
 	assert.Equal(t, "sql-sqlite-../../test/sqlquery/key_value/datacommons.db", sqlDataSource.Id())
 }

--- a/test/setup.go
+++ b/test/setup.go
@@ -130,12 +130,13 @@ func setupInternal(
 	// Data sources.
 	sources := []*datasource.DataSource{}
 
+	var spannerDataSource datasource.DataSource
 	if enableV3 && useSpannerGraph {
 		spannerClient := NewSpannerClient()
 		if spannerClient != nil {
-			var ds datasource.DataSource = spanner.NewSpannerDataSource(spannerClient)
+			spannerDataSource = spanner.NewSpannerDataSource(spannerClient)
 			// TODO: Order sources by priority once other implementations are added.
-			sources = append(sources, &ds)
+			sources = append(sources, &spannerDataSource)
 		}
 	}
 
@@ -170,7 +171,7 @@ func setupInternal(
 			log.Fatalf("SQL database validation failed: %v", err)
 		}
 		if enableV3 {
-			var ds datasource.DataSource = sqldb.NewSQLDataSource(&sqlClient)
+			var ds datasource.DataSource = sqldb.NewSQLDataSource(&sqlClient, spannerDataSource)
 			sources = append(sources, &ds)
 		}
 	}


### PR DESCRIPTION
* The sql data source will need a secondary data source (typically a remote mixer) to fetch certain data (e.g. [child places](https://github.com/datacommonsorg/mixer/blob/f9709fd33930b976b525569a353e3db5a03ccd5f/internal/server/v2/observation/contained_in.go#L196))
* The PR simply wires a secondary data source to the sql data source (remote for main, spanner for tests) and does not use it yet.
* It will be used in a follow-up PR that implements contained in place in the sql data source.