### PR TITLE
V3 node chain fix

### DIFF
--- a/internal/server/spanner/statements.go
+++ b/internal/server/spanner/statements.go
@@ -302,4 +302,5 @@ var statements = struct {
 		ORDER BY score + IF(e.object_value = @query, 1, 0) + IF(REGEXP_CONTAINS(n.subject_id, @query), 0.5, 0) desc, n.name ASC
 		LIMIT %d
 	`,
+	filterTypes: `WHERE ARRAY_INCLUDES_ANY(n.types, @types)`,
 }

--- a/internal/server/spanner/statements.go
+++ b/internal/server/spanner/statements.go
@@ -53,261 +53,254 @@ var statements = struct {
 	filterTypes string
 }{
 	getPropsBySubjectID: `
-		GRAPH DCGraph MATCH -[e:Edge
-		WHERE 
-			e.subject_id IN UNNEST(@ids)]->
-		RETURN DISTINCT
-			e.subject_id,
-			e.predicate
-		ORDER BY
-			e.subject_id,
-			e.predicate
-	`,
+    GRAPH DCGraph MATCH -[e:Edge
+    WHERE 
+      e.subject_id IN UNNEST(@ids)]->
+    RETURN DISTINCT
+      e.subject_id,
+      e.predicate
+    ORDER BY
+      e.subject_id,
+      e.predicate
+  `,
 	getPropsByObjectID: `
-		GRAPH DCGraph MATCH -[e:Edge
-		WHERE
-			e.object_id IN UNNEST(@ids)
-			AND e.object_value IS NULL
-		]->
-		RETURN DISTINCT
-			e.object_id AS subject_id,
-			e.predicate
-		ORDER BY
-			subject_id,
-			predicate
-	`,
+    GRAPH DCGraph MATCH -[e:Edge
+    WHERE
+      e.object_id IN UNNEST(@ids)
+      AND e.object_value IS NULL
+    ]->
+    RETURN DISTINCT
+      e.object_id AS subject_id,
+      e.predicate
+    ORDER BY
+      subject_id,
+      predicate
+  `,
 	getEdgesBySubjectID: `
-		GRAPH DCGraph MATCH -[e:Edge
-		WHERE
-			e.subject_id IN UNNEST(@ids)
-			AND e.object_value IS NULL%[1]s]->(n:Node)
-		RETURN 
-			e.subject_id,
-			e.predicate,
-			e.object_id,
-			'' as object_value,
-			COALESCE(e.provenance, '') AS provenance,
-			COALESCE(n.name, '') AS name,
-			COALESCE(n.types, []) AS types
-		UNION ALL
-		MATCH -[e:Edge
-		WHERE
-			e.subject_id IN UNNEST(@ids)
-			AND e.object_value IS NOT NULL%[1]s]-> 
-		RETURN 
-			e.subject_id,
-			e.predicate,
-			'' as object_id,
-			e.object_value,
-			e.provenance,
-			'' AS name,
-			ARRAY<STRING>[] AS types
-		NEXT
-		RETURN
-			subject_id,
-			predicate,
-			object_id,
-			object_value,
-			provenance,
-			name,
-			types
-		ORDER BY
-			subject_id,
-			predicate,
-			object_id,
-			object_value,
-			provenance
-	`,
+    GRAPH DCGraph MATCH -[e:Edge
+    WHERE
+      e.subject_id IN UNNEST(@ids)
+      AND e.object_value IS NULL%[1]s]->(n:Node)
+    RETURN 
+      e.subject_id,
+      e.predicate,
+      e.object_id,
+      '' as object_value,
+      COALESCE(e.provenance, '') AS provenance,
+      COALESCE(n.name, '') AS name,
+      COALESCE(n.types, []) AS types
+    UNION ALL
+    MATCH -[e:Edge
+    WHERE
+      e.subject_id IN UNNEST(@ids)
+      AND e.object_value IS NOT NULL%[1]s]-> 
+    RETURN 
+      e.subject_id,
+      e.predicate,
+      '' as object_id,
+      e.object_value,
+      e.provenance,
+      '' AS name,
+      ARRAY<STRING>[] AS types
+    NEXT
+    RETURN
+      subject_id,
+      predicate,
+      object_id,
+      object_value,
+      provenance,
+      name,
+      types
+    ORDER BY
+      subject_id,
+      predicate,
+      object_id,
+      object_value,
+      provenance
+  `,
 	getChainedEdgesBySubjectID: fmt.Sprintf(`
-		GRAPH DCGraph MATCH ANY (m:Node
-		WHERE
-			m.subject_id IN UNNEST(@ids))-[e:Edge
-		WHERE
-			e.predicate = @predicate]->{1,%d}(n:Node)
-		WHERE 
-			m != n
-		RETURN 
-			m.subject_id,
-			n.subject_id as object_id,
-			'' as object_value,
-			COALESCE(n.name, '') AS name,
-			COALESCE(n.types, []) AS types
-		UNION ALL
-		MATCH -[e:Edge
-		WHERE
-			e.subject_id IN UNNEST(@ids)
-			AND e.object_value IS NOT NULL
-			AND e.predicate = @predicate]-> 
-		RETURN 
-			e.subject_id,
-			'' AS object_id,
-			e.object_value,
-			'' AS name,
-			ARRAY<STRING>[] AS types
-		NEXT
-		RETURN
-			subject_id,
-			@result_predicate AS predicate,
-			object_id,
-			object_value,
-			'' AS provenance,
-			name, 
-			types
-		ORDER BY
-			subject_id,
-			predicate,
-			object_id,
-			object_value
-	`, MAX_HOPS),
+    GRAPH DCGraph MATCH ANY (m:Node
+    WHERE
+      m.subject_id IN UNNEST(@ids))-[e:Edge
+    WHERE
+      e.predicate = @predicate]->{1,%d}(n:Node)
+    WHERE 
+      m != n
+    RETURN 
+      m.subject_id,
+      n.subject_id as object_id,
+      '' as object_value,
+      COALESCE(n.name, '') AS name,
+      COALESCE(n.types, []) AS types
+    UNION ALL
+    MATCH -[e:Edge
+    WHERE
+      e.subject_id IN UNNEST(@ids)
+      AND e.object_value IS NOT NULL
+      AND e.predicate = @predicate]-> 
+    RETURN 
+      e.subject_id,
+      '' AS object_id,
+      e.object_value,
+      '' AS name,
+      ARRAY<STRING>[] AS types
+    NEXT
+    RETURN
+      subject_id,
+      @result_predicate AS predicate,
+      object_id,
+      object_value,
+      '' AS provenance,
+      name, 
+      types
+    ORDER BY
+      subject_id,
+      predicate,
+      object_id,
+      object_value
+  `, MAX_HOPS),
 	getEdgesByObjectID: `
-		GRAPH DCGraph MATCH <-[e:Edge
-		WHERE
-			e.object_id IN UNNEST(@ids)
-			AND e.subject_id != e.object_id%s]-(n:Node) 
-		RETURN 
-			e.object_id AS subject_id,
-			e.predicate,
-			e.subject_id AS object_id,
-			'' AS object_value,
-			COALESCE(e.provenance, '') AS provenance,
-			COALESCE(n.name, '') AS name,
-			COALESCE(n.types, []) AS types
-		ORDER BY
-			subject_id,
-			predicate,
-			object_id
-	`,
+    GRAPH DCGraph MATCH <-[e:Edge
+    WHERE
+      e.object_id IN UNNEST(@ids)
+      AND e.subject_id != e.object_id%s]-(n:Node) 
+    RETURN 
+      e.object_id AS subject_id,
+      e.predicate,
+      e.subject_id AS object_id,
+      '' AS object_value,
+      COALESCE(e.provenance, '') AS provenance,
+      COALESCE(n.name, '') AS name,
+      COALESCE(n.types, []) AS types
+    ORDER BY
+      subject_id,
+      predicate,
+      object_id
+  `,
 	getChainedEdgesByObjectID: fmt.Sprintf(`
-		GRAPH DCGraph MATCH ANY (m:Node
-		WHERE 
-			m.subject_id IN UNNEST(@ids))<-[e:Edge
-		WHERE
-			e.predicate = @predicate]-{1,%d}(n:Node) 
-		WHERE
-			m!= n	
-		RETURN 
-			m.subject_id,
-			n.subject_id AS object_id,
-			COALESCE(n.name, '') AS name,
-			COALESCE(n.types, []) AS types
-		NEXT
-		RETURN
-			subject_id, 
-			@result_predicate AS predicate,
-			object_id,
-			'' AS object_value,
-			'' AS provenance, 
-			name, 
-			types
-		ORDER BY
-			subject_id,
-			predicate,
-			object_id
-		`, MAX_HOPS),
+    GRAPH DCGraph MATCH ANY (m:Node
+    WHERE 
+      m.subject_id IN UNNEST(@ids))<-[e:Edge
+    WHERE
+      e.predicate = @predicate]-{1,%d}(n:Node) 
+    WHERE
+      m != n  
+    RETURN 
+      m.subject_id,
+      n.subject_id AS object_id,
+      COALESCE(n.name, '') AS name,
+      COALESCE(n.types, []) AS types
+    NEXT
+    RETURN
+      subject_id, 
+      @result_predicate AS predicate,
+      object_id,
+      '' AS object_value,
+      '' AS provenance, 
+      name, 
+      types
+    ORDER BY
+      subject_id,
+      predicate,
+      object_id
+    `, MAX_HOPS),
 	filterProps: `
-		AND e.predicate IN UNNEST(@props)
-	`,
+    AND e.predicate IN UNNEST(@props)
+  `,
 	filterObjects: `
-		NEXT 
-		MATCH -[e:Edge 
-		WHERE
-			e.predicate = @prop%[1]d
-			AND (
-				e.object_id IN UNNEST(@val%[1]d)
-				OR e.object_value IN UNNEST(@val%[1]d)
-			)]-> 
-		WHERE
-			e.subject_id = object_id
-		RETURN
-			subject_id,
-			predicate,
-			object_id,
-			object_value,
-			provenance,
-			name,
-			types			
-	`,
+    NEXT 
+    MATCH -[filter:Edge 
+    WHERE
+      filter.predicate = @prop%[1]d
+      AND (
+        filter.object_id IN UNNEST(@val%[1]d)
+        OR filter.object_value IN UNNEST(@val%[1]d)
+      )]-> 
+    WHERE
+      filter.subject_id = object_id
+    RETURN
+      subject_id,
+      predicate,
+      object_id,
+      object_value,
+      provenance,
+      name,
+      types     
+  `,
 	getObsByVariableAndEntity: `
-		SELECT
-			variable_measured,
-			observation_about,
-			observations,
-			provenance,
-			COALESCE(observation_period, '') AS observation_period,
-			COALESCE(measurement_method, '') AS measurement_method,
-			COALESCE(unit, '') AS unit,
-			COALESCE(scaling_factor, '') AS scaling_factor,
-			import_name,
-			provenance_url
-		FROM Observation
-		WHERE
-			variable_measured IN UNNEST(@variables) AND
-			observation_about IN UNNEST(@entities)
-	`,
+    SELECT
+      variable_measured,
+      observation_about,
+      observations,
+      provenance,
+      COALESCE(observation_period, '') AS observation_period,
+      COALESCE(measurement_method, '') AS measurement_method,
+      COALESCE(unit, '') AS unit,
+      COALESCE(scaling_factor, '') AS scaling_factor,
+      import_name,
+      provenance_url
+    FROM Observation
+    WHERE
+      variable_measured IN UNNEST(@variables) AND
+      observation_about IN UNNEST(@entities)
+  `,
 	getObsByVariableAndContainedInPlace: `
-		SELECT
-			obs.variable_measured,
-			obs.observation_about,
-			obs.observations,
-			obs.provenance,
-			COALESCE(obs.observation_period, '') AS observation_period,
-			COALESCE(obs.measurement_method, '') AS measurement_method,
-			COALESCE(obs.unit, '') AS unit,
-			COALESCE(obs.scaling_factor, '') AS scaling_factor,
-			obs.import_name, 
-			obs.provenance_url
-		FROM GRAPH_TABLE (
-				DCGraph MATCH <-[e:Edge
-				WHERE
-					e.object_id = @ancestor
-					AND e.subject_id != e.object_id
-					AND e.predicate = 'linkedContainedInPlace']-
-				RETURN 
-				e.subject_id as object_id
-				NEXT
-				MATCH -[e:Edge 
-				WHERE
-					e.predicate = 'typeOf'
-					AND e.object_id = @childPlaceType]-> 
-				WHERE e.subject_id = object_id
-				RETURN object_id
-			)result
-		INNER JOIN (
-		SELECT
-			*
-		FROM Observation
-		WHERE
-			variable_measured IN UNNEST(@variables))obs
-		ON 
-			result.object_id = obs.observation_about
-	`,
+    SELECT
+      obs.variable_measured,
+      obs.observation_about,
+      obs.observations,
+      obs.provenance,
+      COALESCE(obs.observation_period, '') AS observation_period,
+      COALESCE(obs.measurement_method, '') AS measurement_method,
+      COALESCE(obs.unit, '') AS unit,
+      COALESCE(obs.scaling_factor, '') AS scaling_factor,
+      obs.import_name, 
+      obs.provenance_url
+    FROM GRAPH_TABLE (
+        DCGraph MATCH <-[e:Edge
+        WHERE
+          e.object_id = @ancestor
+          AND e.subject_id != e.object_id
+          AND e.predicate = 'linkedContainedInPlace']-()-[{predicate: 'typeOf', object_id: @childPlaceType}]->
+        RETURN 
+        e.subject_id as object_id
+      )result
+    INNER JOIN (
+    SELECT
+      *
+    FROM Observation
+    WHERE
+      variable_measured IN UNNEST(@variables))obs
+    ON 
+      result.object_id = obs.observation_about
+  `,
 	searchNodesByQuery: fmt.Sprintf(`
-		GRAPH DCGraph
-		MATCH (n:Node)
-		WHERE 
-			SEARCH(n.name_tokenlist, @query)
-		RETURN n.subject_id, n.name, n.types, SCORE(n.name_tokenlist, @query, enhance_query => TRUE) AS score 
-		ORDER BY score + IF(n.name = @query, 1, 0) DESC, n.name ASC
-		LIMIT %d
-	`, merger.MAX_SEARCH_RESULTS),
+    GRAPH DCGraph
+    MATCH (n:Node)
+    WHERE 
+      SEARCH(n.name_tokenlist, @query)
+    RETURN n.subject_id, n.name, n.types, SCORE(n.name_tokenlist, @query, enhance_query => TRUE) AS score 
+    ORDER BY score + IF(n.name = @query, 1, 0) DESC, n.name ASC
+    LIMIT %d
+  `, merger.MAX_SEARCH_RESULTS),
 	searchNodesByQueryAndTypes: fmt.Sprintf(`
-		GRAPH DCGraph
-		MATCH (n:Node)
-		WHERE 
-			SEARCH(n.name_tokenlist, @query)
-			AND ARRAY_INCLUDES_ANY(n.types, @types)
-		RETURN n.subject_id, n.name, n.types, SCORE(n.name_tokenlist, @query, enhance_query => TRUE) AS score
-		ORDER BY score + IF(n.name = @query, 1, 0) DESC, n.name ASC
-		LIMIT %d
-	`, merger.MAX_SEARCH_RESULTS),
+    GRAPH DCGraph
+    MATCH (n:Node)
+    WHERE 
+      SEARCH(n.name_tokenlist, @query)
+      AND ARRAY_INCLUDES_ANY(n.types, @types)
+    RETURN n.subject_id, n.name, n.types, SCORE(n.name_tokenlist, @query, enhance_query => TRUE) AS score
+    ORDER BY score + IF(n.name = @query, 1, 0) DESC, n.name ASC
+    LIMIT %d
+  `, merger.MAX_SEARCH_RESULTS),
 	searchObjectValues: `
-		GRAPH DCGraph 
-		MATCH -[e:Edge 
-			WHERE e.predicate IN UNNEST(@predicates) AND SEARCH(e.object_value_tokenlist, @query)
-		]->(n:Node %s)
-		RETURN n.subject_id, n.name, n.types, e.predicate AS predicate, e.object_value AS object_value, SCORE(e.object_value_tokenlist, @query, enhance_query => TRUE) AS score
-		ORDER BY score + IF(e.object_value = @query, 1, 0) + IF(REGEXP_CONTAINS(n.subject_id, @query), 0.5, 0) desc, n.name ASC
-		LIMIT %d
-	`,
+    GRAPH DCGraph 
+    MATCH -[e:Edge 
+      WHERE e.predicate IN UNNEST(@predicates) AND SEARCH(e.object_value_tokenlist, @query)
+    ]->(n:Node %s)
+    RETURN n.subject_id, n.name, n.types, e.predicate AS predicate, e.object_value AS object_value, SCORE(e.object_value_tokenlist, @query, enhance_query => TRUE) AS score
+    ORDER BY score + IF(e.object_value = @query, 1, 0) + IF(REGEXP_CONTAINS(n.subject_id, @query), 0.5, 0) desc, n.name ASC
+    LIMIT %d
+  `,
 	filterTypes: `WHERE ARRAY_INCLUDES_ANY(n.types, @types)`,
 }

--- a/internal/server/spanner/statements.go
+++ b/internal/server/spanner/statements.go
@@ -53,254 +53,253 @@ var statements = struct {
 	filterTypes string
 }{
 	getPropsBySubjectID: `
-    GRAPH DCGraph MATCH -[e:Edge
-    WHERE 
-      e.subject_id IN UNNEST(@ids)]->
-    RETURN DISTINCT
-      e.subject_id,
-      e.predicate
-    ORDER BY
-      e.subject_id,
-      e.predicate
-  `,
+		GRAPH DCGraph MATCH -[e:Edge
+		WHERE 
+			e.subject_id IN UNNEST(@ids)]->
+		RETURN DISTINCT
+			e.subject_id,
+			e.predicate
+		ORDER BY
+			e.subject_id,
+			e.predicate
+	`,
 	getPropsByObjectID: `
-    GRAPH DCGraph MATCH -[e:Edge
-    WHERE
-      e.object_id IN UNNEST(@ids)
-      AND e.object_value IS NULL
-    ]->
-    RETURN DISTINCT
-      e.object_id AS subject_id,
-      e.predicate
-    ORDER BY
-      subject_id,
-      predicate
-  `,
+		GRAPH DCGraph MATCH -[e:Edge
+		WHERE
+			e.object_id IN UNNEST(@ids)
+			AND e.object_value IS NULL
+		]->
+		RETURN DISTINCT
+			e.object_id AS subject_id,
+			e.predicate
+		ORDER BY
+			subject_id,
+			predicate
+	`,
 	getEdgesBySubjectID: `
-    GRAPH DCGraph MATCH -[e:Edge
-    WHERE
-      e.subject_id IN UNNEST(@ids)
-      AND e.object_value IS NULL%[1]s]->(n:Node)
-    RETURN 
-      e.subject_id,
-      e.predicate,
-      e.object_id,
-      '' as object_value,
-      COALESCE(e.provenance, '') AS provenance,
-      COALESCE(n.name, '') AS name,
-      COALESCE(n.types, []) AS types
-    UNION ALL
-    MATCH -[e:Edge
-    WHERE
-      e.subject_id IN UNNEST(@ids)
-      AND e.object_value IS NOT NULL%[1]s]-> 
-    RETURN 
-      e.subject_id,
-      e.predicate,
-      '' as object_id,
-      e.object_value,
-      e.provenance,
-      '' AS name,
-      ARRAY<STRING>[] AS types
-    NEXT
-    RETURN
-      subject_id,
-      predicate,
-      object_id,
-      object_value,
-      provenance,
-      name,
-      types
-    ORDER BY
-      subject_id,
-      predicate,
-      object_id,
-      object_value,
-      provenance
-  `,
+		GRAPH DCGraph MATCH -[e:Edge
+		WHERE
+			e.subject_id IN UNNEST(@ids)
+			AND e.object_value IS NULL%[1]s]->(n:Node)
+		RETURN 
+			e.subject_id,
+			e.predicate,
+			e.object_id,
+			'' as object_value,
+			COALESCE(e.provenance, '') AS provenance,
+			COALESCE(n.name, '') AS name,
+			COALESCE(n.types, []) AS types
+		UNION ALL
+		MATCH -[e:Edge
+		WHERE
+			e.subject_id IN UNNEST(@ids)
+			AND e.object_value IS NOT NULL%[1]s]-> 
+		RETURN 
+			e.subject_id,
+			e.predicate,
+			'' as object_id,
+			e.object_value,
+			e.provenance,
+			'' AS name,
+			ARRAY<STRING>[] AS types
+		NEXT
+		RETURN
+			subject_id,
+			predicate,
+			object_id,
+			object_value,
+			provenance,
+			name,
+			types
+		ORDER BY
+			subject_id,
+			predicate,
+			object_id,
+			object_value,
+			provenance
+	`,
 	getChainedEdgesBySubjectID: fmt.Sprintf(`
-    GRAPH DCGraph MATCH ANY (m:Node
-    WHERE
-      m.subject_id IN UNNEST(@ids))-[e:Edge
-    WHERE
-      e.predicate = @predicate]->{1,%d}(n:Node)
-    WHERE 
-      m != n
-    RETURN 
-      m.subject_id,
-      n.subject_id as object_id,
-      '' as object_value,
-      COALESCE(n.name, '') AS name,
-      COALESCE(n.types, []) AS types
-    UNION ALL
-    MATCH -[e:Edge
-    WHERE
-      e.subject_id IN UNNEST(@ids)
-      AND e.object_value IS NOT NULL
-      AND e.predicate = @predicate]-> 
-    RETURN 
-      e.subject_id,
-      '' AS object_id,
-      e.object_value,
-      '' AS name,
-      ARRAY<STRING>[] AS types
-    NEXT
-    RETURN
-      subject_id,
-      @result_predicate AS predicate,
-      object_id,
-      object_value,
-      '' AS provenance,
-      name, 
-      types
-    ORDER BY
-      subject_id,
-      predicate,
-      object_id,
-      object_value
-  `, MAX_HOPS),
+		GRAPH DCGraph MATCH ANY (m:Node
+		WHERE
+			m.subject_id IN UNNEST(@ids))-[e:Edge
+		WHERE
+			e.predicate = @predicate]->{1,%d}(n:Node)
+		WHERE 
+			m != n
+		RETURN 
+			m.subject_id,
+			n.subject_id as object_id,
+			'' as object_value,
+			COALESCE(n.name, '') AS name,
+			COALESCE(n.types, []) AS types
+		UNION ALL
+		MATCH -[e:Edge
+		WHERE
+			e.subject_id IN UNNEST(@ids)
+			AND e.object_value IS NOT NULL
+			AND e.predicate = @predicate]-> 
+		RETURN 
+			e.subject_id,
+			'' AS object_id,
+			e.object_value,
+			'' AS name,
+			ARRAY<STRING>[] AS types
+		NEXT
+		RETURN
+			subject_id,
+			@result_predicate AS predicate,
+			object_id,
+			object_value,
+			'' AS provenance,
+			name, 
+			types
+		ORDER BY
+			subject_id,
+			predicate,
+			object_id,
+			object_value
+	`, MAX_HOPS),
 	getEdgesByObjectID: `
-    GRAPH DCGraph MATCH <-[e:Edge
-    WHERE
-      e.object_id IN UNNEST(@ids)
-      AND e.subject_id != e.object_id%s]-(n:Node) 
-    RETURN 
-      e.object_id AS subject_id,
-      e.predicate,
-      e.subject_id AS object_id,
-      '' AS object_value,
-      COALESCE(e.provenance, '') AS provenance,
-      COALESCE(n.name, '') AS name,
-      COALESCE(n.types, []) AS types
-    ORDER BY
-      subject_id,
-      predicate,
-      object_id
-  `,
+		GRAPH DCGraph MATCH <-[e:Edge
+		WHERE
+			e.object_id IN UNNEST(@ids)
+			AND e.subject_id != e.object_id%s]-(n:Node) 
+		RETURN 
+			e.object_id AS subject_id,
+			e.predicate,
+			e.subject_id AS object_id,
+			'' AS object_value,
+			COALESCE(e.provenance, '') AS provenance,
+			COALESCE(n.name, '') AS name,
+			COALESCE(n.types, []) AS types
+		ORDER BY
+			subject_id,
+			predicate,
+			object_id
+	`,
 	getChainedEdgesByObjectID: fmt.Sprintf(`
-    GRAPH DCGraph MATCH ANY (m:Node
-    WHERE 
-      m.subject_id IN UNNEST(@ids))<-[e:Edge
-    WHERE
-      e.predicate = @predicate]-{1,%d}(n:Node) 
-    WHERE
-      m != n  
-    RETURN 
-      m.subject_id,
-      n.subject_id AS object_id,
-      COALESCE(n.name, '') AS name,
-      COALESCE(n.types, []) AS types
-    NEXT
-    RETURN
-      subject_id, 
-      @result_predicate AS predicate,
-      object_id,
-      '' AS object_value,
-      '' AS provenance, 
-      name, 
-      types
-    ORDER BY
-      subject_id,
-      predicate,
-      object_id
-    `, MAX_HOPS),
+		GRAPH DCGraph MATCH ANY (m:Node
+		WHERE 
+			m.subject_id IN UNNEST(@ids))<-[e:Edge
+		WHERE
+			e.predicate = @predicate]-{1,%d}(n:Node) 
+		WHERE
+			m != n	
+		RETURN 
+			m.subject_id,
+			n.subject_id AS object_id,
+			COALESCE(n.name, '') AS name,
+			COALESCE(n.types, []) AS types
+		NEXT
+		RETURN
+			subject_id, 
+			@result_predicate AS predicate,
+			object_id,
+			'' AS object_value,
+			'' AS provenance, 
+			name, 
+			types
+		ORDER BY
+			subject_id,
+			predicate,
+			object_id
+		`, MAX_HOPS),
 	filterProps: `
-    AND e.predicate IN UNNEST(@props)
-  `,
+		AND e.predicate IN UNNEST(@props)
+	`,
 	filterObjects: `
-    NEXT 
-    MATCH -[filter:Edge 
-    WHERE
-      filter.predicate = @prop%[1]d
-      AND (
-        filter.object_id IN UNNEST(@val%[1]d)
-        OR filter.object_value IN UNNEST(@val%[1]d)
-      )]-> 
-    WHERE
-      filter.subject_id = object_id
-    RETURN
-      subject_id,
-      predicate,
-      object_id,
-      object_value,
-      provenance,
-      name,
-      types     
-  `,
+		NEXT 
+		MATCH -[filter:Edge 
+		WHERE
+			filter.predicate = @prop%[1]d
+			AND (
+				filter.object_id IN UNNEST(@val%[1]d)
+				OR filter.object_value IN UNNEST(@val%[1]d)
+			)]-> 
+		WHERE
+			filter.subject_id = object_id
+		RETURN
+			subject_id,
+			predicate,
+			object_id,
+			object_value,
+			provenance,
+			name,
+			types			
+	`,
 	getObsByVariableAndEntity: `
-    SELECT
-      variable_measured,
-      observation_about,
-      observations,
-      provenance,
-      COALESCE(observation_period, '') AS observation_period,
-      COALESCE(measurement_method, '') AS measurement_method,
-      COALESCE(unit, '') AS unit,
-      COALESCE(scaling_factor, '') AS scaling_factor,
-      import_name,
-      provenance_url
-    FROM Observation
-    WHERE
-      variable_measured IN UNNEST(@variables) AND
-      observation_about IN UNNEST(@entities)
-  `,
+		SELECT
+			variable_measured,
+			observation_about,
+			observations,
+			provenance,
+			COALESCE(observation_period, '') AS observation_period,
+			COALESCE(measurement_method, '') AS measurement_method,
+			COALESCE(unit, '') AS unit,
+			COALESCE(scaling_factor, '') AS scaling_factor,
+			import_name,
+			provenance_url
+		FROM Observation
+		WHERE
+			variable_measured IN UNNEST(@variables) AND
+			observation_about IN UNNEST(@entities)
+	`,
 	getObsByVariableAndContainedInPlace: `
-    SELECT
-      obs.variable_measured,
-      obs.observation_about,
-      obs.observations,
-      obs.provenance,
-      COALESCE(obs.observation_period, '') AS observation_period,
-      COALESCE(obs.measurement_method, '') AS measurement_method,
-      COALESCE(obs.unit, '') AS unit,
-      COALESCE(obs.scaling_factor, '') AS scaling_factor,
-      obs.import_name, 
-      obs.provenance_url
-    FROM GRAPH_TABLE (
-        DCGraph MATCH <-[e:Edge
-        WHERE
-          e.object_id = @ancestor
-          AND e.subject_id != e.object_id
-          AND e.predicate = 'linkedContainedInPlace']-()-[{predicate: 'typeOf', object_id: @childPlaceType}]->
-        RETURN 
-        e.subject_id as object_id
-      )result
-    INNER JOIN (
-    SELECT
-      *
-    FROM Observation
-    WHERE
-      variable_measured IN UNNEST(@variables))obs
-    ON 
-      result.object_id = obs.observation_about
-  `,
+		SELECT
+			obs.variable_measured,
+			obs.observation_about,
+			obs.observations,
+			obs.provenance,
+			COALESCE(obs.observation_period, '') AS observation_period,
+			COALESCE(obs.measurement_method, '') AS measurement_method,
+			COALESCE(obs.unit, '') AS unit,
+			COALESCE(obs.scaling_factor, '') AS scaling_factor,
+			obs.import_name, 
+			obs.provenance_url
+		FROM GRAPH_TABLE (
+				DCGraph MATCH <-[e:Edge
+				WHERE
+					e.object_id = @ancestor
+					AND e.subject_id != e.object_id
+					AND e.predicate = 'linkedContainedInPlace']-()-[{predicate: 'typeOf', object_id: @childPlaceType}]->
+				RETURN 
+				e.subject_id as object_id
+			)result
+		INNER JOIN (
+		SELECT
+			*
+		FROM Observation
+		WHERE
+			variable_measured IN UNNEST(@variables))obs
+		ON 
+			result.object_id = obs.observation_about
+	`,
 	searchNodesByQuery: fmt.Sprintf(`
-    GRAPH DCGraph
-    MATCH (n:Node)
-    WHERE 
-      SEARCH(n.name_tokenlist, @query)
-    RETURN n.subject_id, n.name, n.types, SCORE(n.name_tokenlist, @query, enhance_query => TRUE) AS score 
-    ORDER BY score + IF(n.name = @query, 1, 0) DESC, n.name ASC
-    LIMIT %d
-  `, merger.MAX_SEARCH_RESULTS),
+		GRAPH DCGraph
+		MATCH (n:Node)
+		WHERE 
+			SEARCH(n.name_tokenlist, @query)
+		RETURN n.subject_id, n.name, n.types, SCORE(n.name_tokenlist, @query, enhance_query => TRUE) AS score 
+		ORDER BY score + IF(n.name = @query, 1, 0) DESC, n.name ASC
+		LIMIT %d
+	`, merger.MAX_SEARCH_RESULTS),
 	searchNodesByQueryAndTypes: fmt.Sprintf(`
-    GRAPH DCGraph
-    MATCH (n:Node)
-    WHERE 
-      SEARCH(n.name_tokenlist, @query)
-      AND ARRAY_INCLUDES_ANY(n.types, @types)
-    RETURN n.subject_id, n.name, n.types, SCORE(n.name_tokenlist, @query, enhance_query => TRUE) AS score
-    ORDER BY score + IF(n.name = @query, 1, 0) DESC, n.name ASC
-    LIMIT %d
-  `, merger.MAX_SEARCH_RESULTS),
+		GRAPH DCGraph
+		MATCH (n:Node)
+		WHERE 
+			SEARCH(n.name_tokenlist, @query)
+			AND ARRAY_INCLUDES_ANY(n.types, @types)
+		RETURN n.subject_id, n.name, n.types, SCORE(n.name_tokenlist, @query, enhance_query => TRUE) AS score
+		ORDER BY score + IF(n.name = @query, 1, 0) DESC, n.name ASC
+		LIMIT %d
+	`, merger.MAX_SEARCH_RESULTS),
 	searchObjectValues: `
-    GRAPH DCGraph 
-    MATCH -[e:Edge 
-      WHERE e.predicate IN UNNEST(@predicates) AND SEARCH(e.object_value_tokenlist, @query)
-    ]->(n:Node %s)
-    RETURN n.subject_id, n.name, n.types, e.predicate AS predicate, e.object_value AS object_value, SCORE(e.object_value_tokenlist, @query, enhance_query => TRUE) AS score
-    ORDER BY score + IF(e.object_value = @query, 1, 0) + IF(REGEXP_CONTAINS(n.subject_id, @query), 0.5, 0) desc, n.name ASC
-    LIMIT %d
-  `,
-	filterTypes: `WHERE ARRAY_INCLUDES_ANY(n.types, @types)`,
+		GRAPH DCGraph 
+		MATCH -[e:Edge 
+			WHERE e.predicate IN UNNEST(@predicates) AND SEARCH(e.object_value_tokenlist, @query)
+		]->(n:Node %s)
+		RETURN n.subject_id, n.name, n.types, e.predicate AS predicate, e.object_value AS object_value, SCORE(e.object_value_tokenlist, @query, enhance_query => TRUE) AS score
+		ORDER BY score + IF(e.object_value = @query, 1, 0) + IF(REGEXP_CONTAINS(n.subject_id, @query), 0.5, 0) desc, n.name ASC
+		LIMIT %d
+	`,
 }

--- a/internal/server/v3/node/golden/in_chain_filter.json
+++ b/internal/server/v3/node/golden/in_chain_filter.json
@@ -1,0 +1,224 @@
+{
+  "data": {
+    "geoId/06085": {
+      "arcs": {
+        "containedInPlace+": {
+          "nodes": [
+            {
+              "name": "Alum Rock",
+              "types": [
+                "City",
+                "Neighborhood"
+              ],
+              "dcid": "geoId/0601458"
+            },
+            {
+              "name": "Alviso",
+              "types": [
+                "City",
+                "Neighborhood"
+              ],
+              "dcid": "geoId/0601486"
+            },
+            {
+              "name": "Buena Vista",
+              "types": [
+                "City",
+                "Neighborhood"
+              ],
+              "dcid": "geoId/0608848"
+            },
+            {
+              "name": "Burbank",
+              "types": [
+                "City",
+                "Neighborhood"
+              ],
+              "dcid": "geoId/0608968"
+            },
+            {
+              "name": "Cambrian Park",
+              "types": [
+                "City"
+              ],
+              "dcid": "geoId/0610088"
+            },
+            {
+              "name": "Campbell",
+              "types": [
+                "City"
+              ],
+              "dcid": "geoId/0610345"
+            },
+            {
+              "name": "Cupertino",
+              "types": [
+                "City"
+              ],
+              "dcid": "geoId/0617610"
+            },
+            {
+              "name": "East Foothills",
+              "types": [
+                "City",
+                "Neighborhood"
+              ],
+              "dcid": "geoId/0620598"
+            },
+            {
+              "name": "Fruitdale",
+              "types": [
+                "City"
+              ],
+              "dcid": "geoId/0627080"
+            },
+            {
+              "name": "Gilroy",
+              "types": [
+                "City"
+              ],
+              "dcid": "geoId/0629504"
+            },
+            {
+              "name": "Lexington Hills",
+              "types": [
+                "City"
+              ],
+              "dcid": "geoId/0641282"
+            },
+            {
+              "name": "Los Altos",
+              "types": [
+                "City"
+              ],
+              "dcid": "geoId/0643280"
+            },
+            {
+              "name": "Los Altos Hills",
+              "types": [
+                "City",
+                "Town"
+              ],
+              "dcid": "geoId/0643294"
+            },
+            {
+              "name": "Los Gatos",
+              "types": [
+                "City",
+                "Town"
+              ],
+              "dcid": "geoId/0644112"
+            },
+            {
+              "name": "Loyola",
+              "types": [
+                "City"
+              ],
+              "dcid": "geoId/0644378"
+            },
+            {
+              "name": "Milpitas",
+              "types": [
+                "City"
+              ],
+              "dcid": "geoId/0647766"
+            },
+            {
+              "name": "Monte Sereno",
+              "types": [
+                "City"
+              ],
+              "dcid": "geoId/0648956"
+            },
+            {
+              "name": "Morgan Hill",
+              "types": [
+                "City"
+              ],
+              "dcid": "geoId/0649278"
+            },
+            {
+              "name": "Mountain View",
+              "types": [
+                "City"
+              ],
+              "dcid": "geoId/0649670"
+            },
+            {
+              "name": "Palo Alto",
+              "types": [
+                "City"
+              ],
+              "dcid": "geoId/0655282"
+            },
+            {
+              "name": "San Jose",
+              "types": [
+                "City"
+              ],
+              "dcid": "geoId/0668000"
+            },
+            {
+              "name": "San Martin",
+              "types": [
+                "City"
+              ],
+              "dcid": "geoId/0668238"
+            },
+            {
+              "name": "Santa Clara",
+              "types": [
+                "City"
+              ],
+              "dcid": "geoId/0669084"
+            },
+            {
+              "name": "Saratoga",
+              "types": [
+                "City"
+              ],
+              "dcid": "geoId/0670280"
+            },
+            {
+              "name": "Seven Trees",
+              "types": [
+                "City"
+              ],
+              "dcid": "geoId/0671074"
+            },
+            {
+              "name": "Stanford",
+              "types": [
+                "City"
+              ],
+              "dcid": "geoId/0673906"
+            },
+            {
+              "name": "Sunnyvale",
+              "types": [
+                "City"
+              ],
+              "dcid": "geoId/0677000"
+            },
+            {
+              "name": "Cambrian Park",
+              "types": [
+                "City",
+                "Neighborhood"
+              ],
+              "dcid": "wikidataId/Q1911837"
+            },
+            {
+              "name": "Sunol-Midtown",
+              "types": [
+                "City",
+                "Neighborhood"
+              ],
+              "dcid": "wikidataId/Q2214519"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/internal/server/v3/node/golden/in_filter.json
+++ b/internal/server/v3/node/golden/in_filter.json
@@ -1,0 +1,480 @@
+{
+  "data": {
+    "country/USA": {
+      "arcs": {
+        "containedInPlace": {
+          "nodes": [
+            {
+              "name": "Alabama",
+              "types": [
+                "AdministrativeArea1",
+                "State"
+              ],
+              "dcid": "geoId/01",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "Alaska",
+              "types": [
+                "AdministrativeArea1",
+                "State"
+              ],
+              "dcid": "geoId/02",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "Arizona",
+              "types": [
+                "AdministrativeArea1",
+                "State"
+              ],
+              "dcid": "geoId/04",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "Arkansas",
+              "types": [
+                "AdministrativeArea1",
+                "State"
+              ],
+              "dcid": "geoId/05",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "California",
+              "types": [
+                "AdministrativeArea1",
+                "State"
+              ],
+              "dcid": "geoId/06",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "Colorado",
+              "types": [
+                "AdministrativeArea1",
+                "State"
+              ],
+              "dcid": "geoId/08",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "Connecticut",
+              "types": [
+                "AdministrativeArea1",
+                "State"
+              ],
+              "dcid": "geoId/09",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "Delaware",
+              "types": [
+                "AdministrativeArea1",
+                "State"
+              ],
+              "dcid": "geoId/10",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "District of Columbia",
+              "types": [
+                "AdministrativeArea1",
+                "State"
+              ],
+              "dcid": "geoId/11",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "Florida",
+              "types": [
+                "AdministrativeArea1",
+                "State"
+              ],
+              "dcid": "geoId/12",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "Georgia",
+              "types": [
+                "AdministrativeArea1",
+                "State"
+              ],
+              "dcid": "geoId/13",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "Hawaii",
+              "types": [
+                "AdministrativeArea1",
+                "State"
+              ],
+              "dcid": "geoId/15",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "Idaho",
+              "types": [
+                "AdministrativeArea1",
+                "State"
+              ],
+              "dcid": "geoId/16",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "Illinois",
+              "types": [
+                "AdministrativeArea1",
+                "State"
+              ],
+              "dcid": "geoId/17",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "Indiana",
+              "types": [
+                "AdministrativeArea1",
+                "State"
+              ],
+              "dcid": "geoId/18",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "Iowa",
+              "types": [
+                "AdministrativeArea1",
+                "State"
+              ],
+              "dcid": "geoId/19",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "Kansas",
+              "types": [
+                "AdministrativeArea1",
+                "State"
+              ],
+              "dcid": "geoId/20",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "Kentucky",
+              "types": [
+                "AdministrativeArea1",
+                "State"
+              ],
+              "dcid": "geoId/21",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "Louisiana",
+              "types": [
+                "AdministrativeArea1",
+                "State"
+              ],
+              "dcid": "geoId/22",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "Maine",
+              "types": [
+                "AdministrativeArea1",
+                "State"
+              ],
+              "dcid": "geoId/23",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "Maryland",
+              "types": [
+                "AdministrativeArea1",
+                "State"
+              ],
+              "dcid": "geoId/24",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "Massachusetts",
+              "types": [
+                "AdministrativeArea1",
+                "State"
+              ],
+              "dcid": "geoId/25",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "Michigan",
+              "types": [
+                "AdministrativeArea1",
+                "State"
+              ],
+              "dcid": "geoId/26",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "Minnesota",
+              "types": [
+                "AdministrativeArea1",
+                "State"
+              ],
+              "dcid": "geoId/27",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "Mississippi",
+              "types": [
+                "AdministrativeArea1",
+                "State"
+              ],
+              "dcid": "geoId/28",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "Missouri",
+              "types": [
+                "AdministrativeArea1",
+                "State"
+              ],
+              "dcid": "geoId/29",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "Montana",
+              "types": [
+                "AdministrativeArea1",
+                "State"
+              ],
+              "dcid": "geoId/30",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "Nebraska",
+              "types": [
+                "AdministrativeArea1",
+                "State"
+              ],
+              "dcid": "geoId/31",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "Nevada",
+              "types": [
+                "AdministrativeArea1",
+                "State"
+              ],
+              "dcid": "geoId/32",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "New Hampshire",
+              "types": [
+                "AdministrativeArea1",
+                "State"
+              ],
+              "dcid": "geoId/33",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "New Jersey",
+              "types": [
+                "AdministrativeArea1",
+                "State"
+              ],
+              "dcid": "geoId/34",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "New Mexico",
+              "types": [
+                "AdministrativeArea1",
+                "State"
+              ],
+              "dcid": "geoId/35",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "New York",
+              "types": [
+                "State",
+                "AdministrativeArea1"
+              ],
+              "dcid": "geoId/36",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "North Carolina",
+              "types": [
+                "State",
+                "AdministrativeArea1"
+              ],
+              "dcid": "geoId/37",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "North Dakota",
+              "types": [
+                "AdministrativeArea1",
+                "State"
+              ],
+              "dcid": "geoId/38",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "Ohio",
+              "types": [
+                "AdministrativeArea1",
+                "State"
+              ],
+              "dcid": "geoId/39",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "Oklahoma",
+              "types": [
+                "State",
+                "AdministrativeArea1"
+              ],
+              "dcid": "geoId/40",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "Oregon",
+              "types": [
+                "State",
+                "AdministrativeArea1"
+              ],
+              "dcid": "geoId/41",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "Pennsylvania",
+              "types": [
+                "State",
+                "AdministrativeArea1"
+              ],
+              "dcid": "geoId/42",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "Rhode Island",
+              "types": [
+                "AdministrativeArea1",
+                "State"
+              ],
+              "dcid": "geoId/44",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "South Carolina",
+              "types": [
+                "AdministrativeArea1",
+                "State"
+              ],
+              "dcid": "geoId/45",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "South Dakota",
+              "types": [
+                "AdministrativeArea1",
+                "State"
+              ],
+              "dcid": "geoId/46",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "Tennessee",
+              "types": [
+                "AdministrativeArea1",
+                "State"
+              ],
+              "dcid": "geoId/47",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "Texas",
+              "types": [
+                "AdministrativeArea1",
+                "State"
+              ],
+              "dcid": "geoId/48",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "Utah",
+              "types": [
+                "AdministrativeArea1",
+                "State"
+              ],
+              "dcid": "geoId/49",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "Vermont",
+              "types": [
+                "AdministrativeArea1",
+                "State"
+              ],
+              "dcid": "geoId/50",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "Virginia",
+              "types": [
+                "State",
+                "AdministrativeArea1"
+              ],
+              "dcid": "geoId/51",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "Washington",
+              "types": [
+                "AdministrativeArea1",
+                "State"
+              ],
+              "dcid": "geoId/53",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "West Virginia",
+              "types": [
+                "State",
+                "AdministrativeArea1"
+              ],
+              "dcid": "geoId/54",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "Wisconsin",
+              "types": [
+                "State",
+                "AdministrativeArea1"
+              ],
+              "dcid": "geoId/55",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "Wyoming",
+              "types": [
+                "AdministrativeArea1",
+                "State"
+              ],
+              "dcid": "geoId/56",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            },
+            {
+              "name": "Puerto Rico",
+              "types": [
+                "State",
+                "AdministrativeArea1"
+              ],
+              "dcid": "geoId/72",
+              "provenance_id": "dc/base/WikidataOtherIdGeos"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/internal/server/v3/node/golden/node_test.go
+++ b/internal/server/v3/node/golden/node_test.go
@@ -107,7 +107,7 @@ func TestV3Node(t *testing.T) {
 				"in_pv_some.json",
 			},
 			{
-				"In with filter",
+				"In property-values with filter",
 				[]string{
 					"country/USA",
 				},
@@ -116,7 +116,7 @@ func TestV3Node(t *testing.T) {
 				"in_filter.json",
 			},
 			{
-				"In chain with filter",
+				"In chained property-values with filter",
 				[]string{
 					"geoId/06085",
 				},

--- a/internal/server/v3/node/golden/node_test.go
+++ b/internal/server/v3/node/golden/node_test.go
@@ -106,6 +106,24 @@ func TestV3Node(t *testing.T) {
 				"",
 				"in_pv_some.json",
 			},
+			{
+				"In with filter",
+				[]string{
+					"country/USA",
+				},
+				"<-containedInPlace{typeOf:State}",
+				"",
+				"in_filter.json",
+			},
+			{
+				"In chain with filter",
+				[]string{
+					"geoId/06085",
+				},
+				"<-containedInPlace+{typeOf:City}",
+				"",
+				"in_chain_filter.json",
+			},
 		} {
 			goldenFile := c.goldenFile
 			resp, err := mixer.V3Node(ctx, &pbv2.NodeRequest{


### PR DESCRIPTION
Fixes error with chain and filters for V3 node

Also optimizes the containedInPlace V3 observation query

However, the chained query for getting states in USA (nodes=country/USA&property=<-containedInPlace+{typeOf:State}) still time outs. This is because there's a huge number of places in USA. I was wondering if it's worth to just switch all <-containedInPlace+ node queries to <-linkedContainedInPlace internally (like we do for /v3/observation) since this is a pretty common use case - wdyt?