### PR TITLE
Add support for facet requests for sql backends.

### DIFF
--- a/internal/server/v2/facet/contained_in.go
+++ b/internal/server/v2/facet/contained_in.go
@@ -20,13 +20,16 @@ import (
 	"net/http"
 	"sort"
 
+	"github.com/datacommonsorg/mixer/internal/merger"
 	pb "github.com/datacommonsorg/mixer/internal/proto"
 	pbv2 "github.com/datacommonsorg/mixer/internal/proto/v2"
 	"github.com/datacommonsorg/mixer/internal/server/cache"
 	"github.com/datacommonsorg/mixer/internal/server/ranking"
 	"github.com/datacommonsorg/mixer/internal/server/resource"
 	"github.com/datacommonsorg/mixer/internal/server/stat"
+	observationhelper "github.com/datacommonsorg/mixer/internal/server/v2/observation/helper"
 	"github.com/datacommonsorg/mixer/internal/server/v2/shared"
+	"github.com/datacommonsorg/mixer/internal/sqldb"
 	"github.com/datacommonsorg/mixer/internal/store"
 	"github.com/datacommonsorg/mixer/internal/store/bigtable"
 	"github.com/datacommonsorg/mixer/internal/util"
@@ -42,6 +45,7 @@ func ContainedInFacet(
 	store *store.Store,
 	cachedata *cache.Cache,
 	metadata *resource.Metadata,
+	sqlProvenances map[string]*pb.Facet,
 	httpClient *http.Client,
 	remoteMixer string,
 	variables []string,
@@ -60,191 +64,280 @@ func ContainedInFacet(
 		result.ByVariable[variable].ByEntity[""] = &pbv2.EntityObservation{}
 	}
 	if store.BtGroup != nil {
-		readCollectionCache := util.HasCollectionCache(ancestor, childType)
-		if readCollectionCache && queryDate != "" {
-			btDataList, err := bigtable.Read(
-				ctx,
-				store.BtGroup,
-				bigtable.BtObsCollectionPlaceVariableFacet,
-				[][]string{{ancestor}, {childType}, variables, {queryDate}},
-				func(jsonRaw []byte) (interface{}, error) {
-					var placeVarfacets pb.PlaceVariableFacets
-					if err := proto.Unmarshal(jsonRaw, &placeVarfacets); err != nil {
-						return nil, err
-					}
-					return &placeVarfacets, nil
-				},
-			)
-			if err != nil {
-				return nil, err
-			}
-			// Get the list of facets for each sv
-			svToFacetList := map[string][]*pb.PlaceVariableFacet{}
-			for _, btData := range btDataList {
-				for _, row := range btData {
-					sv := row.Parts[2]
-					if _, ok := svToFacetList[sv]; !ok {
-						svToFacetList[sv] = []*pb.PlaceVariableFacet{}
-					}
-					svToFacetList[sv] = append(
-						svToFacetList[sv],
-						row.Data.(*pb.PlaceVariableFacets).GetPlaceVariableFacets()...,
-					)
-				}
-			}
-			// Go through each list of facets, sort and remove duplicates, and add to
-			// result.
-			for sv, facetList := range svToFacetList {
-				entityObservation := &pbv2.EntityObservation{}
-				sort.Sort(ranking.FacetByRank(facetList))
-				seenFacets := map[string]struct{}{}
-				for _, facet := range facetList {
-					facetID := util.GetFacetID(facet.Facet)
-					if _, ok := seenFacets[facetID]; ok {
-						continue
-					}
-					seenFacets[facetID] = struct{}{}
-					// TODO: Add additional ObsCount, EarliestDate, LatestDate information.
-					// These fields need to be added to collection cache first.
-					entityObservation.OrderedFacets = append(
-						entityObservation.OrderedFacets,
-						&pbv2.FacetObservation{FacetId: facetID},
-					)
-					result.Facets[facetID] = facet.Facet
-				}
-				result.ByVariable[sv].ByEntity[""] = entityObservation
-			}
-		} else {
-			childPlaces, err := shared.FetchChildPlaces(
-				ctx, store, metadata, httpClient, remoteMixer, ancestor, childType)
-			if err != nil {
-				return nil, err
-			}
-			totalSeries := len(variables) * len(childPlaces)
-			if totalSeries > shared.MaxSeries {
-				return nil, status.Errorf(
-					codes.Internal,
-					"Stop processing large number of concurrent observation series: %d",
-					totalSeries,
-				)
-			}
-			log.Println("Fetch series cache in contained-in observation query")
-			// When date doesn't matter, use SeriesFacet to get the facets for the
-			// child places
-			if queryDate == "" || queryDate == shared.LATEST {
-				resp, err := SeriesFacet(ctx, store, cachedata, variables, childPlaces)
-				if err != nil {
-					return nil, err
-				}
-				for _, entityData := range resp.ByVariable {
-					seenFacet := map[string]*pbv2.FacetObservation{}
-					orderedFacetId := []string{}
-					mergedFacetData := &pbv2.EntityObservation{
-						OrderedFacets: []*pbv2.FacetObservation{},
-					}
-					// Note there are no perfect facet order for all the entities.
-					// The order here is only an approximate.
-					for _, entity := range childPlaces {
-						if facetData, ok := entityData.ByEntity[entity]; ok {
-							for _, item := range facetData.OrderedFacets {
-								// obsCount is the number of entities with data for this facet
-								obsCount := int32(1)
-								// earliest date is the earliest date any entities have data for
-								// this facet
-								earliestDate := item.EarliestDate
-								// latest date is the latest date any entities have data for
-								// this facet
-								latestDate := item.LatestDate
-								// if this facet has been seen before, update obsCount,
-								// earliestDate, and latestDate accordingly.
-								if facetObs, ok := seenFacet[item.FacetId]; ok {
-									obsCount += facetObs.ObsCount
-									if earliestDate == "" || (facetObs.EarliestDate != "" && facetObs.EarliestDate < earliestDate) {
-										earliestDate = facetObs.EarliestDate
-									}
-									if facetObs.LatestDate > latestDate {
-										latestDate = facetObs.LatestDate
-									}
-								} else {
-									orderedFacetId = append(orderedFacetId, item.FacetId)
-								}
-								seenFacet[item.FacetId] = &pbv2.FacetObservation{
-									FacetId:      item.FacetId,
-									ObsCount:     obsCount,
-									EarliestDate: earliestDate,
-									LatestDate:   latestDate,
-								}
-							}
-						}
-					}
-					for _, facetId := range orderedFacetId {
-						mergedFacetData.OrderedFacets = append(
-							mergedFacetData.OrderedFacets,
-							seenFacet[facetId],
-						)
-					}
-					entityData.ByEntity = map[string]*pbv2.EntityObservation{
-						"": mergedFacetData,
-					}
-				}
-				return resp, nil
-			}
-			// Otherwise, get all source series and process them to get the facets
-			btData, err := stat.ReadStatsPb(ctx, store.BtGroup, childPlaces, variables)
-			if err != nil {
-				return nil, err
-			}
-			for _, variable := range variables {
-				result.ByVariable[variable] = &pbv2.VariableObservation{
-					ByEntity: map[string]*pbv2.EntityObservation{},
-				}
-				seenFacet := map[string]*pb.PlaceVariableFacet{}
-				for _, entity := range childPlaces {
-					series := btData[entity][variable].SourceSeries
-					for _, series := range series {
-						facet := util.GetFacet(series)
-						facetID := util.GetFacetID(facet)
-						for date := range series.Val {
-							if queryDate == date {
-								// obsCount is the number of entities with data for this facet
-								// for this date.
-								obsCount := int32(1)
-								if _, ok := seenFacet[facetID]; ok {
-									obsCount += seenFacet[facetID].ObsCount
-								}
-								seenFacet[facetID] = &pb.PlaceVariableFacet{
-									Facet:        facet,
-									ObsCount:     obsCount,
-									EarliestDate: date,
-									LatestDate:   date,
-								}
-								break
-							}
-						}
-					}
-				}
-				facetList := []*pb.PlaceVariableFacet{}
-				for _, placeVarFacet := range seenFacet {
-					facetList = append(facetList, placeVarFacet)
-				}
-				sort.Sort(ranking.FacetByRank(facetList))
-				entityObservation := &pbv2.EntityObservation{}
-				for _, placeVarFacet := range facetList {
-					facetID := util.GetFacetID(placeVarFacet.Facet)
-					entityObservation.OrderedFacets = append(entityObservation.OrderedFacets,
-						&pbv2.FacetObservation{
-							FacetId:      facetID,
-							ObsCount:     placeVarFacet.ObsCount,
-							EarliestDate: placeVarFacet.EarliestDate,
-							LatestDate:   placeVarFacet.LatestDate,
-						})
-					result.Facets[facetID] = placeVarFacet.Facet
-				}
-				// Use empty string entity to hold list of all facets available for the
-				// variable.
-				result.ByVariable[variable].ByEntity[""] = entityObservation
-			}
+		err := btContainedInFacet(ctx, store, cachedata, metadata, httpClient, remoteMixer, variables, ancestor, childType, queryDate, result)
+		if err != nil {
+			return nil, err
 		}
 	}
+	if sqldb.IsConnected(&store.SQLClient) {
+		sqlResult, err := sqlContainedInFacet(
+			ctx,
+			store,
+			metadata,
+			sqlProvenances,
+			httpClient,
+			remoteMixer,
+			variables,
+			ancestor,
+			childType,
+			queryDate)
+		if err != nil {
+			return nil, err
+		}
+		// Prefer SQL data over BT data, so put sqlResult first.
+		result = merger.MergeObservation(sqlResult, result)
+	}
 	return result, nil
+}
+
+// btContainedInFacet gets facets from BT and populates the specified result.
+func btContainedInFacet(
+	ctx context.Context,
+	store *store.Store,
+	cachedata *cache.Cache,
+	metadata *resource.Metadata,
+	httpClient *http.Client,
+	remoteMixer string,
+	variables []string,
+	ancestor string,
+	childType string,
+	queryDate string,
+	result *pbv2.ObservationResponse,
+) error {
+	readCollectionCache := util.HasCollectionCache(ancestor, childType)
+	if readCollectionCache && queryDate != "" {
+		btDataList, err := bigtable.Read(
+			ctx,
+			store.BtGroup,
+			bigtable.BtObsCollectionPlaceVariableFacet,
+			[][]string{{ancestor}, {childType}, variables, {queryDate}},
+			func(jsonRaw []byte) (interface{}, error) {
+				var placeVarfacets pb.PlaceVariableFacets
+				if err := proto.Unmarshal(jsonRaw, &placeVarfacets); err != nil {
+					return nil, err
+				}
+				return &placeVarfacets, nil
+			},
+		)
+		if err != nil {
+			return err
+		}
+		// Get the list of facets for each sv
+		svToFacetList := map[string][]*pb.PlaceVariableFacet{}
+		for _, btData := range btDataList {
+			for _, row := range btData {
+				sv := row.Parts[2]
+				if _, ok := svToFacetList[sv]; !ok {
+					svToFacetList[sv] = []*pb.PlaceVariableFacet{}
+				}
+				svToFacetList[sv] = append(
+					svToFacetList[sv],
+					row.Data.(*pb.PlaceVariableFacets).GetPlaceVariableFacets()...,
+				)
+			}
+		}
+		// Go through each list of facets, sort and remove duplicates, and add to
+		// result.
+		for sv, facetList := range svToFacetList {
+			entityObservation := &pbv2.EntityObservation{}
+			sort.Sort(ranking.FacetByRank(facetList))
+			seenFacets := map[string]struct{}{}
+			for _, facet := range facetList {
+				facetID := util.GetFacetID(facet.Facet)
+				if _, ok := seenFacets[facetID]; ok {
+					continue
+				}
+				seenFacets[facetID] = struct{}{}
+				// TODO: Add additional ObsCount, EarliestDate, LatestDate information.
+				// These fields need to be added to collection cache first.
+				entityObservation.OrderedFacets = append(
+					entityObservation.OrderedFacets,
+					&pbv2.FacetObservation{FacetId: facetID},
+				)
+				result.Facets[facetID] = facet.Facet
+			}
+			result.ByVariable[sv].ByEntity[""] = entityObservation
+		}
+	} else {
+		childPlaces, err := shared.FetchChildPlaces(
+			ctx, store, metadata, httpClient, remoteMixer, ancestor, childType)
+		if err != nil {
+			return err
+		}
+		totalSeries := len(variables) * len(childPlaces)
+		if totalSeries > shared.MaxSeries {
+			return status.Errorf(
+				codes.Internal,
+				"Stop processing large number of concurrent observation series: %d",
+				totalSeries,
+			)
+		}
+		log.Println("Fetch series cache in contained-in observation query")
+		// When date doesn't matter, use SeriesFacet to get the facets for the
+		// child places
+		if queryDate == "" || queryDate == shared.LATEST {
+			resp, err := SeriesFacet(ctx, store, cachedata, variables, childPlaces)
+			if err != nil {
+				return err
+			}
+			for _, entityData := range resp.ByVariable {
+				seenFacet := map[string]*pbv2.FacetObservation{}
+				orderedFacetId := []string{}
+				mergedFacetData := &pbv2.EntityObservation{
+					OrderedFacets: []*pbv2.FacetObservation{},
+				}
+				// Note there are no perfect facet order for all the entities.
+				// The order here is only an approximate.
+				for _, entity := range childPlaces {
+					if facetData, ok := entityData.ByEntity[entity]; ok {
+						for _, item := range facetData.OrderedFacets {
+							// obsCount is the number of entities with data for this facet
+							obsCount := int32(1)
+							// earliest date is the earliest date any entities have data for
+							// this facet
+							earliestDate := item.EarliestDate
+							// latest date is the latest date any entities have data for
+							// this facet
+							latestDate := item.LatestDate
+							// if this facet has been seen before, update obsCount,
+							// earliestDate, and latestDate accordingly.
+							if facetObs, ok := seenFacet[item.FacetId]; ok {
+								obsCount += facetObs.ObsCount
+								if earliestDate == "" || (facetObs.EarliestDate != "" && facetObs.EarliestDate < earliestDate) {
+									earliestDate = facetObs.EarliestDate
+								}
+								if facetObs.LatestDate > latestDate {
+									latestDate = facetObs.LatestDate
+								}
+							} else {
+								orderedFacetId = append(orderedFacetId, item.FacetId)
+							}
+							seenFacet[item.FacetId] = &pbv2.FacetObservation{
+								FacetId:      item.FacetId,
+								ObsCount:     obsCount,
+								EarliestDate: earliestDate,
+								LatestDate:   latestDate,
+							}
+						}
+					}
+				}
+				for _, facetId := range orderedFacetId {
+					mergedFacetData.OrderedFacets = append(
+						mergedFacetData.OrderedFacets,
+						seenFacet[facetId],
+					)
+				}
+				entityData.ByEntity = map[string]*pbv2.EntityObservation{
+					"": mergedFacetData,
+				}
+			}
+			for k, v := range resp.ByVariable {
+				result.ByVariable[k] = v
+			}
+			for k, v := range resp.Facets {
+				result.Facets[k] = v
+			}
+			return nil
+		}
+		// Otherwise, get all source series and process them to get the facets
+		btData, err := stat.ReadStatsPb(ctx, store.BtGroup, childPlaces, variables)
+		if err != nil {
+			return err
+		}
+		for _, variable := range variables {
+			result.ByVariable[variable] = &pbv2.VariableObservation{
+				ByEntity: map[string]*pbv2.EntityObservation{},
+			}
+			seenFacet := map[string]*pb.PlaceVariableFacet{}
+			for _, entity := range childPlaces {
+				series := btData[entity][variable].SourceSeries
+				for _, series := range series {
+					facet := util.GetFacet(series)
+					facetID := util.GetFacetID(facet)
+					for date := range series.Val {
+						if queryDate == date {
+							// obsCount is the number of entities with data for this facet
+							// for this date.
+							obsCount := int32(1)
+							if _, ok := seenFacet[facetID]; ok {
+								obsCount += seenFacet[facetID].ObsCount
+							}
+							seenFacet[facetID] = &pb.PlaceVariableFacet{
+								Facet:        facet,
+								ObsCount:     obsCount,
+								EarliestDate: date,
+								LatestDate:   date,
+							}
+							break
+						}
+					}
+				}
+			}
+			facetList := []*pb.PlaceVariableFacet{}
+			for _, placeVarFacet := range seenFacet {
+				facetList = append(facetList, placeVarFacet)
+			}
+			sort.Sort(ranking.FacetByRank(facetList))
+			entityObservation := &pbv2.EntityObservation{}
+			for _, placeVarFacet := range facetList {
+				facetID := util.GetFacetID(placeVarFacet.Facet)
+				entityObservation.OrderedFacets = append(entityObservation.OrderedFacets,
+					&pbv2.FacetObservation{
+						FacetId:      facetID,
+						ObsCount:     placeVarFacet.ObsCount,
+						EarliestDate: placeVarFacet.EarliestDate,
+						LatestDate:   placeVarFacet.LatestDate,
+					})
+				result.Facets[facetID] = placeVarFacet.Facet
+			}
+			// Use empty string entity to hold list of all facets available for the
+			// variable.
+			result.ByVariable[variable].ByEntity[""] = entityObservation
+		}
+	}
+	return nil
+}
+
+// sqlContainedInFacet gets facets from SQL.
+func sqlContainedInFacet(
+	ctx context.Context,
+	store *store.Store,
+	metadata *resource.Metadata,
+	sqlProvenances map[string]*pb.Facet,
+	httpClient *http.Client,
+	remoteMixer string,
+	variables []string,
+	ancestor string,
+	childType string,
+	queryDate string,
+) (*pbv2.ObservationResponse, error) {
+	response, err := observationhelper.FetchSQLContainedIn(ctx, store, metadata, sqlProvenances,
+		httpClient, remoteMixer, variables, ancestor, childType, queryDate, &pbv2.FacetFilter{}, []string{})
+	if err != nil {
+		return nil, err
+	}
+	// Put facets under an empty string entity (which is the convention for a facet response).
+	for _, variableData := range response.ByVariable {
+		seenFacets := map[int]struct{}{}
+		facets := []*pbv2.FacetObservation{}
+
+		// Remove all entities and collect all facets.
+		for entityID, entityData := range variableData.ByEntity {
+			for facetID := range entityData.OrderedFacets {
+				if _, ok := seenFacets[facetID]; !ok {
+					seenFacets[facetID] = struct{}{}
+					facets = append(facets, &pbv2.FacetObservation{
+						FacetId: entityData.OrderedFacets[facetID].FacetId,
+					})
+				}
+			}
+			delete(variableData.ByEntity, entityID)
+		}
+
+		// Use an empty string entity to hold list of all facets available for the variable.
+		variableData.ByEntity[""] = &pbv2.EntityObservation{
+			OrderedFacets: facets,
+		}
+	}
+	return response, nil
 }

--- a/internal/server/v2/facet/golden/contained_in_facet/US_State.json
+++ b/internal/server/v2/facet/golden/contained_in_facet/US_State.json
@@ -5,6 +5,9 @@
         "": {
           "ordered_facets": [
             {
+              "facet_id": "2921750529"
+            },
+            {
               "facet_id": "2176550201"
             },
             {
@@ -74,6 +77,17 @@
             },
             {
               "facet_id": "815809675"
+            }
+          ]
+        }
+      }
+    },
+    "test_var_1": {
+      "by_entity": {
+        "": {
+          "ordered_facets": [
+            {
+              "facet_id": "2921750529"
             }
           ]
         }
@@ -153,6 +167,10 @@
     "2825511676": {
       "import_name": "CDC_Mortality_UnderlyingCause",
       "provenance_url": "https://wonder.cdc.gov/ucd-icd10.html"
+    },
+    "2921750529": {
+      "import_name": "Custom Prov",
+      "provenance_url": "custom.datacommons.org"
     },
     "3144703963": {
       "import_name": "CensusACS5YearSurvey_SubjectTables_S2602PR",

--- a/internal/server/v2/facet/golden/contained_in_facet_test.go
+++ b/internal/server/v2/facet/golden/contained_in_facet_test.go
@@ -60,7 +60,7 @@ func TestContainedInFacet(t *testing.T) {
 				"CA_County_all.json",
 			},
 			{
-				[]string{"Count_Person", "Median_Age_Person"},
+				[]string{"Count_Person", "Median_Age_Person", "test_var_1"},
 				"country/USA<-containedInPlace+{typeOf:State}",
 				"LATEST",
 				"US_State.json",

--- a/internal/server/v2/observation/observation.go
+++ b/internal/server/v2/observation/observation.go
@@ -137,6 +137,7 @@ func ObservationCore(
 				store,
 				cachedata,
 				metadata,
+				cachedata.SQLProvenances(),
 				httpClient,
 				metadata.RemoteMixerDomain,
 				variable.GetDcids(),

--- a/internal/server/v2/shared/shared.go
+++ b/internal/server/v2/shared/shared.go
@@ -20,7 +20,9 @@ import (
 	"fmt"
 	"net/http"
 
+	pb "github.com/datacommonsorg/mixer/internal/proto"
 	pbv2 "github.com/datacommonsorg/mixer/internal/proto/v2"
+
 	"github.com/datacommonsorg/mixer/internal/server/placein"
 	"github.com/datacommonsorg/mixer/internal/server/resource"
 	"github.com/datacommonsorg/mixer/internal/store"
@@ -135,4 +137,24 @@ func FetchChildPlaces(
 		}
 	}
 	return childPlaces, nil
+}
+
+// TrimObservationsResponse removes entities with no observations from the response.
+func TrimObservationsResponse(resp *pbv2.ObservationResponse) *pbv2.ObservationResponse {
+	result := &pbv2.ObservationResponse{
+		ByVariable: map[string]*pbv2.VariableObservation{},
+		Facets:     map[string]*pb.Facet{},
+	}
+	for variable, variableData := range resp.ByVariable {
+		for entity, entityData := range variableData.ByEntity {
+			if len(entityData.OrderedFacets) == 0 {
+				delete(variableData.ByEntity, entity)
+			}
+		}
+		result.ByVariable[variable] = variableData
+	}
+	for facet, res := range resp.Facets {
+		result.Facets[facet] = res
+	}
+	return result
 }


### PR DESCRIPTION
* Context: https://issuetracker.google.com/issues/400486979#comment2
* Moved observation helpers for sql under a different package to avoid a cycle.

### Before

```
$ curl -X POST \
     -H "Content-Type: application/json" \
     -d '{
         "select": ["variable", "entity", "facet"],
         "entity": {
             "expression": "Earth<-containedInPlace+{typeOf:Country}"
         },
         "variable": {
             "dcids": ["gender_wage_gap"]
         },
         "date": ""
     }' \
     https://dc-autopush-kqb7thiuka-uc.a.run.app/core/api/v2/observation

{"byVariable":{"gender_wage_gap":{"byEntity":{"":{}}}}}
```

### After (local)

```
curl -X POST \
     -H "Content-Type: application/json" \
     -d '{
         "select": ["variable", "entity", "facet"],
         "entity": {
             "expression": "Earth<-containedInPlace+{typeOf:Country}"
         },
         "variable": {
             "dcids": ["gender_wage_gap"]
         },
         "date": ""
     }' \
     http://localhost:8081/v2/observation

{"byVariable":{"gender_wage_gap":{"byEntity":{"":{"orderedFacets":[{"facetId":"130410494"}]}}}},"facets":{"130410494":{"importName":"OECD Data","provenanceUrl":"https://data.oecd.org/"}}}
```