### PR TITLE
Add entity existence requests to V3 observation

### DIFF
--- a/internal/server/spanner/datasource.go
+++ b/internal/server/spanner/datasource.go
@@ -17,6 +17,7 @@ package spanner
 import (
 	"context"
 	"fmt"
+	"log"
 
 	pbv2 "github.com/datacommonsorg/mixer/internal/proto/v2"
 	"github.com/datacommonsorg/mixer/internal/server/datasource"
@@ -90,6 +91,7 @@ func (sds *SpannerDataSource) Observation(ctx context.Context, req *pbv2.Observa
 	if req.Variable != nil {
 		// Variable expressions are not yet supported in Spanner.
 		if req.Variable.Expression != "" {
+			log.Printf("Received spanner request with variable expression: %s. Variable expressions are not yet supported in Spanner.", req.Variable.Expression)
 			return nil, nil
 		}
 		variables = req.Variable.Dcids

--- a/internal/server/spanner/datasource.go
+++ b/internal/server/spanner/datasource.go
@@ -77,7 +77,27 @@ func (sds *SpannerDataSource) Node(ctx context.Context, req *pbv2.NodeRequest) (
 
 // Observation retrieves observation data from Spanner.
 func (sds *SpannerDataSource) Observation(ctx context.Context, req *pbv2.ObservationRequest) (*pbv2.ObservationResponse, error) {
-	variables, entities, entityExpr := req.Variable.Dcids, req.Entity.Dcids, req.Entity.Expression
+	if req.Entity == nil {
+		return nil, fmt.Errorf("entity must be specified")
+	}
+
+	entities, entityExpr := req.Entity.Dcids, req.Entity.Expression
+	if len(entities) > 0 && entityExpr != "" {
+		return nil, fmt.Errorf("only one of entity.dcids and entity.expression should be specified")
+	}
+
+	variables := []string{}
+	if req.Variable != nil {
+		// Variable expressions are not yet supported in Spanner.
+		if req.Variable.Expression != "" {
+			return nil, nil
+		}
+		variables = req.Variable.Dcids
+	}
+	if entityExpr != "" && len(variables) == 0 {
+		return nil, fmt.Errorf("variable must be specified for entity.expression")
+	}
+
 	date := req.Date
 	var observations []*Observation
 	var err error

--- a/internal/server/spanner/dsutil.go
+++ b/internal/server/spanner/dsutil.go
@@ -253,7 +253,7 @@ func newObservationResponse(variable *pbv2.DcidOrExpression) *pbv2.ObservationRe
 		ByVariable: map[string]*pbv2.VariableObservation{},
 		Facets:     map[string]*pb.Facet{},
 	}
-	if variable == nil || variable.Expression != "" {
+	if variable == nil || len(variable.Dcids) == 0 {
 		return result
 	}
 
@@ -420,7 +420,7 @@ func observationsToOrderedFacets(observations []*Observation, includeObs bool) (
 		pvf, facetObs := observationToFacetObservation(obs, includeObs)
 
 		// Skip rows with no time series.
-		if pvf.ObsCount == 0 {
+		if pvf == nil {
 			continue
 		}
 
@@ -455,6 +455,10 @@ func observationToFacetObservation(observation *Observation, includeObs bool) (*
 		}
 
 		observations = append(observations, pointStat)
+	}
+
+	if len(observations) == 0 {
+		return nil, nil
 	}
 
 	facetObservation := &pbv2.FacetObservation{

--- a/internal/server/spanner/dsutil.go
+++ b/internal/server/spanner/dsutil.go
@@ -248,12 +248,16 @@ func observationsToObservationResponse(req *pbv2.ObservationRequest, observation
 	}
 }
 
-func newObservationResponse(variables []string) *pbv2.ObservationResponse {
+func newObservationResponse(variable *pbv2.DcidOrExpression) *pbv2.ObservationResponse {
 	result := &pbv2.ObservationResponse{
 		ByVariable: map[string]*pbv2.VariableObservation{},
 		Facets:     map[string]*pb.Facet{},
 	}
-	for _, variable := range variables {
+	if variable == nil || variable.Expression != "" {
+		return result
+	}
+
+	for _, variable := range variable.Dcids {
 		result.ByVariable[variable] = &pbv2.VariableObservation{
 			ByEntity: map[string]*pbv2.EntityObservation{},
 		}
@@ -278,13 +282,20 @@ func groupObservationsByVariableAndEntity(observations []*Observation) map[varia
 	return result
 }
 
-func generateObsResponse(variables []string, observations []*Observation, includeObs bool) *pbv2.ObservationResponse {
-	response := newObservationResponse(variables)
+func generateObsResponse(variable *pbv2.DcidOrExpression, observations []*Observation, includeObs bool) *pbv2.ObservationResponse {
+	response := newObservationResponse(variable)
 
 	variableEntityObs := groupObservationsByVariableAndEntity(observations)
 	for variableEntity, obs := range variableEntityObs {
 		orderedFacets, facets := observationsToOrderedFacets(obs, includeObs)
-		response.ByVariable[variableEntity.variable].ByEntity[variableEntity.entity] = &pbv2.EntityObservation{
+		variableObs, ok := response.ByVariable[variableEntity.variable]
+		if !ok {
+			variableObs = &pbv2.VariableObservation{
+				ByEntity: map[string]*pbv2.EntityObservation{},
+			}
+			response.ByVariable[variableEntity.variable] = variableObs
+		}
+		variableObs.ByEntity[variableEntity.entity] = &pbv2.EntityObservation{
 			OrderedFacets: orderedFacets,
 		}
 		for facetId, facet := range facets {
@@ -343,7 +354,7 @@ func mergeEntityOrderedFacets(byEntity map[string]*pbv2.EntityObservation, child
 }
 
 func obsToObsResponse(req *pbv2.ObservationRequest, observations []*Observation) *pbv2.ObservationResponse {
-	response := generateObsResponse(req.Variable.Dcids, observations, true /*includeObs*/)
+	response := generateObsResponse(req.Variable, observations, true /*includeObs*/)
 
 	// Attach all requested entity dcids to response.
 	if len(req.Entity.Dcids) > 0 {
@@ -361,30 +372,42 @@ func obsToObsResponse(req *pbv2.ObservationRequest, observations []*Observation)
 }
 
 func obsToFacetResponse(req *pbv2.ObservationRequest, observations []*Observation) *pbv2.ObservationResponse {
-	response := generateObsResponse(req.Variable.Dcids, observations, false /*includeObs*/)
+	response := generateObsResponse(req.Variable, observations, false /*includeObs*/)
 
 	if len(req.Entity.Dcids) > 0 {
 		return response
 	}
 
 	// Merge child places for entity expression.
-	mergedResponse := newObservationResponse(req.Variable.Dcids)
+	mergedResponse := newObservationResponse(req.Variable)
 	mergedResponse.Facets = response.Facets
 	childPlaces := getDistinctEntities(observations)
-	for variable, variableObs := range mergedResponse.ByVariable {
-		variableObs.ByEntity[ENTITY_PLACEHOLDER] = &pbv2.EntityObservation{}
-		initialVariableObs, ok := response.ByVariable[variable]
-		if ok {
-			variableObs.ByEntity[ENTITY_PLACEHOLDER].OrderedFacets = mergeEntityOrderedFacets(initialVariableObs.ByEntity, childPlaces)
+	for variable, initialVariableObs := range response.ByVariable {
+		variableObs, ok := mergedResponse.ByVariable[variable]
+		if !ok {
+			variableObs = &pbv2.VariableObservation{
+				ByEntity: map[string]*pbv2.EntityObservation{},
+			}
+			mergedResponse.ByVariable[variable] = variableObs
+		}
+		variableObs.ByEntity[ENTITY_PLACEHOLDER] = &pbv2.EntityObservation{
+			OrderedFacets: mergeEntityOrderedFacets(initialVariableObs.ByEntity, childPlaces),
 		}
 	}
 	return mergedResponse
 }
 
 func obsToExistenceResponse(req *pbv2.ObservationRequest, observations []*Observation) *pbv2.ObservationResponse {
-	response := newObservationResponse(req.Variable.Dcids)
+	response := newObservationResponse(req.Variable)
 	for _, obs := range observations {
-		response.ByVariable[obs.VariableMeasured].ByEntity[obs.ObservationAbout] = &pbv2.EntityObservation{}
+		variableObs, ok := response.ByVariable[obs.VariableMeasured]
+		if !ok {
+			variableObs = &pbv2.VariableObservation{
+				ByEntity: map[string]*pbv2.EntityObservation{},
+			}
+			response.ByVariable[obs.VariableMeasured] = variableObs
+		}
+		variableObs.ByEntity[obs.ObservationAbout] = &pbv2.EntityObservation{}
 	}
 	return response
 }

--- a/internal/server/spanner/golden/query/get_observations_entity.json
+++ b/internal/server/spanner/golden/query/get_observations_entity.json
@@ -1,0 +1,82 @@
+[
+  {
+    "VariableMeasured": "Count_HeatTemperatureEvent",
+    "ObservationAbout": "wikidataId/Q341968",
+    "Observations": {
+      "Observations": [
+        {
+          "Date": "2022-09",
+          "Value": "1"
+        },
+        {
+          "Date": "2022-10",
+          "Value": "2"
+        }
+      ]
+    },
+    "Provenance": "dc/base/TemperatureEvents_Agg",
+    "ObservationPeriod": "P1M",
+    "MeasurementMethod": "DataCommonsAggregate",
+    "Unit": "",
+    "ScalingFactor": "",
+    "ImportName": "TemperatureEvents_Agg",
+    "ProvenanceURL": "https://datacommons.org"
+  },
+  {
+    "VariableMeasured": "Count_HeatTemperatureEvent",
+    "ObservationAbout": "wikidataId/Q341968",
+    "Observations": {
+      "Observations": [
+        {
+          "Date": "2022",
+          "Value": "3"
+        }
+      ]
+    },
+    "Provenance": "dc/base/TemperatureEvents_Agg",
+    "ObservationPeriod": "P1Y",
+    "MeasurementMethod": "DataCommonsAggregate",
+    "Unit": "",
+    "ScalingFactor": "",
+    "ImportName": "TemperatureEvents_Agg",
+    "ProvenanceURL": "https://datacommons.org"
+  },
+  {
+    "VariableMeasured": "Count_Person",
+    "ObservationAbout": "wikidataId/Q341968",
+    "Observations": {
+      "Observations": [
+        {
+          "Date": "2016",
+          "Value": "653"
+        }
+      ]
+    },
+    "Provenance": "dc/base/WikidataPopulation",
+    "ObservationPeriod": "",
+    "MeasurementMethod": "WikidataPopulation",
+    "Unit": "",
+    "ScalingFactor": "",
+    "ImportName": "WikidataPopulation",
+    "ProvenanceURL": "https://www.wikidata.org/wiki/Wikidata:Main_Page"
+  },
+  {
+    "VariableMeasured": "Count_Person",
+    "ObservationAbout": "wikidataId/Q341968",
+    "Observations": {
+      "Observations": [
+        {
+          "Date": "2021",
+          "Value": "606"
+        }
+      ]
+    },
+    "Provenance": "dc/base/WikipediaStatsData",
+    "ObservationPeriod": "",
+    "MeasurementMethod": "Wikipedia",
+    "Unit": "",
+    "ScalingFactor": "",
+    "ImportName": "WikipediaStatsData",
+    "ProvenanceURL": "https://www.wikipedia.org"
+  }
+]

--- a/internal/server/spanner/query.go
+++ b/internal/server/spanner/query.go
@@ -169,16 +169,17 @@ func (sc *SpannerClient) GetNodeEdgesByID(ctx context.Context, ids []string, arc
 // GetObservations retrieves observations from Spanner given a list of variables and entities.
 func (sc *SpannerClient) GetObservations(ctx context.Context, variables []string, entities []string) ([]*Observation, error) {
 	var observations []*Observation
-	if len(variables) == 0 || len(entities) == 0 {
-		return observations, nil
-	}
 
 	stmt := spanner.Statement{
-		SQL: statements.getObsByVariableAndEntity,
+		SQL: statements.getObsByEntity,
 		Params: map[string]interface{}{
-			"variables": variables,
-			"entities":  entities,
+			"entities": entities,
 		},
+	}
+
+	if len(variables) > 0 {
+		stmt.SQL += statements.selectVariableDcids
+		stmt.Params["variables"] = variables
 	}
 
 	err := sc.queryAndCollect(

--- a/internal/server/spanner/statements.go
+++ b/internal/server/spanner/statements.go
@@ -43,8 +43,10 @@ var statements = struct {
 	applyOffset string
 	// Subquery to apply page limit.
 	applyLimit string
-	// Fetch Observations for variable+entity.
-	getObsByVariableAndEntity string
+	// Fetch Observations for entity dcids.
+	getObsByEntity string
+	// Filter by variable dcids.
+	selectVariableDcids string
 	// Fetch observations for variable + contained in place.
 	getObsByVariableAndContainedInPlace string
 	// Search nodes by name only.
@@ -235,7 +237,7 @@ var statements = struct {
 	applyLimit: fmt.Sprintf(`
 		LIMIT %d
 	`, PAGE_SIZE+1),
-	getObsByVariableAndEntity: `
+	getObsByEntity: `
 		SELECT
 			variable_measured,
 			observation_about,
@@ -247,10 +249,13 @@ var statements = struct {
 			COALESCE(scaling_factor, '') AS scaling_factor,
 			import_name,
 			provenance_url
-		FROM Observation
+		FROM 
+			Observation
 		WHERE
-			variable_measured IN UNNEST(@variables) AND
 			observation_about IN UNNEST(@entities)
+	`,
+	selectVariableDcids: `
+		AND variable_measured IN UNNEST(@variables)
 	`,
 	getObsByVariableAndContainedInPlace: `
 		SELECT

--- a/internal/server/v3/observation/golden/observation_test.go
+++ b/internal/server/v3/observation/golden/observation_test.go
@@ -201,6 +201,33 @@ func TestV3Observation(t *testing.T) {
 				},
 				goldenFile: "observations_str_val.json",
 			},
+			{
+				req: &pbv2.ObservationRequest{
+					Entity: &pbv2.DcidOrExpression{
+						Dcids: []string{"wikidataId/Q341968", "wikidataId/Q1764983"},
+					},
+					Select: []string{"entity", "variable"},
+				},
+				goldenFile: "observations_existence_entity.json",
+			},
+			{
+				req: &pbv2.ObservationRequest{
+					Entity: &pbv2.DcidOrExpression{
+						Dcids: []string{"wikidataId/Q341968", "wikidataId/Q1764983"},
+					},
+					Select: []string{"entity", "variable", "facet"},
+				},
+				goldenFile: "observations_facet_entity.json",
+			},
+			{
+				req: &pbv2.ObservationRequest{
+					Entity: &pbv2.DcidOrExpression{
+						Dcids: []string{"wikidataId/Q341968", "wikidataId/Q1764983"},
+					},
+					Select: []string{"entity", "variable", "date", "value"},
+				},
+				goldenFile: "observations_entity.json",
+			},
 		} {
 			goldenFile := c.goldenFile
 			resp, err := mixer.V3Observation(ctx, c.req)

--- a/internal/server/v3/observation/golden/observations_entity.json
+++ b/internal/server/v3/observation/golden/observations_entity.json
@@ -1,0 +1,125 @@
+{
+  "by_variable": {
+    "Count_HeatTemperatureEvent": {
+      "by_entity": {
+        "wikidataId/Q1764983": {},
+        "wikidataId/Q341968": {
+          "ordered_facets": [
+            {
+              "facet_id": "4010764369",
+              "observations": [
+                {
+                  "date": "2022-09",
+                  "value": 1
+                },
+                {
+                  "date": "2022-10",
+                  "value": 2
+                }
+              ],
+              "obs_count": 2,
+              "earliest_date": "2022-09",
+              "latest_date": "2022-10"
+            },
+            {
+              "facet_id": "2370098101",
+              "observations": [
+                {
+                  "date": "2022",
+                  "value": 3
+                }
+              ],
+              "obs_count": 1,
+              "earliest_date": "2022",
+              "latest_date": "2022"
+            }
+          ]
+        }
+      }
+    },
+    "Count_Person": {
+      "by_entity": {
+        "wikidataId/Q1764983": {
+          "ordered_facets": [
+            {
+              "facet_id": "1456184638",
+              "observations": [
+                {
+                  "date": "2021",
+                  "value": 366
+                }
+              ],
+              "obs_count": 1,
+              "earliest_date": "2021",
+              "latest_date": "2021"
+            },
+            {
+              "facet_id": "2458695583",
+              "observations": [
+                {
+                  "date": "2016",
+                  "value": 425
+                }
+              ],
+              "obs_count": 1,
+              "earliest_date": "2016",
+              "latest_date": "2016"
+            }
+          ]
+        },
+        "wikidataId/Q341968": {
+          "ordered_facets": [
+            {
+              "facet_id": "1456184638",
+              "observations": [
+                {
+                  "date": "2021",
+                  "value": 606
+                }
+              ],
+              "obs_count": 1,
+              "earliest_date": "2021",
+              "latest_date": "2021"
+            },
+            {
+              "facet_id": "2458695583",
+              "observations": [
+                {
+                  "date": "2016",
+                  "value": 653
+                }
+              ],
+              "obs_count": 1,
+              "earliest_date": "2016",
+              "latest_date": "2016"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "facets": {
+    "1456184638": {
+      "import_name": "WikipediaStatsData",
+      "provenance_url": "https://www.wikipedia.org",
+      "measurement_method": "Wikipedia"
+    },
+    "2370098101": {
+      "import_name": "TemperatureEvents_Agg",
+      "provenance_url": "https://datacommons.org",
+      "measurement_method": "DataCommonsAggregate",
+      "observation_period": "P1Y"
+    },
+    "2458695583": {
+      "import_name": "WikidataPopulation",
+      "provenance_url": "https://www.wikidata.org/wiki/Wikidata:Main_Page",
+      "measurement_method": "WikidataPopulation"
+    },
+    "4010764369": {
+      "import_name": "TemperatureEvents_Agg",
+      "provenance_url": "https://datacommons.org",
+      "measurement_method": "DataCommonsAggregate",
+      "observation_period": "P1M"
+    }
+  }
+}

--- a/internal/server/v3/observation/golden/observations_existence_entity.json
+++ b/internal/server/v3/observation/golden/observations_existence_entity.json
@@ -1,0 +1,15 @@
+{
+  "by_variable": {
+    "Count_HeatTemperatureEvent": {
+      "by_entity": {
+        "wikidataId/Q341968": {}
+      }
+    },
+    "Count_Person": {
+      "by_entity": {
+        "wikidataId/Q1764983": {},
+        "wikidataId/Q341968": {}
+      }
+    }
+  }
+}

--- a/internal/server/v3/observation/golden/observations_facet_entity.json
+++ b/internal/server/v3/observation/golden/observations_facet_entity.json
@@ -1,0 +1,84 @@
+{
+  "by_variable": {
+    "Count_HeatTemperatureEvent": {
+      "by_entity": {
+        "wikidataId/Q341968": {
+          "ordered_facets": [
+            {
+              "facet_id": "4010764369",
+              "obs_count": 2,
+              "earliest_date": "2022-09",
+              "latest_date": "2022-10"
+            },
+            {
+              "facet_id": "2370098101",
+              "obs_count": 1,
+              "earliest_date": "2022",
+              "latest_date": "2022"
+            }
+          ]
+        }
+      }
+    },
+    "Count_Person": {
+      "by_entity": {
+        "wikidataId/Q1764983": {
+          "ordered_facets": [
+            {
+              "facet_id": "1456184638",
+              "obs_count": 1,
+              "earliest_date": "2021",
+              "latest_date": "2021"
+            },
+            {
+              "facet_id": "2458695583",
+              "obs_count": 1,
+              "earliest_date": "2016",
+              "latest_date": "2016"
+            }
+          ]
+        },
+        "wikidataId/Q341968": {
+          "ordered_facets": [
+            {
+              "facet_id": "1456184638",
+              "obs_count": 1,
+              "earliest_date": "2021",
+              "latest_date": "2021"
+            },
+            {
+              "facet_id": "2458695583",
+              "obs_count": 1,
+              "earliest_date": "2016",
+              "latest_date": "2016"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "facets": {
+    "1456184638": {
+      "import_name": "WikipediaStatsData",
+      "provenance_url": "https://www.wikipedia.org",
+      "measurement_method": "Wikipedia"
+    },
+    "2370098101": {
+      "import_name": "TemperatureEvents_Agg",
+      "provenance_url": "https://datacommons.org",
+      "measurement_method": "DataCommonsAggregate",
+      "observation_period": "P1Y"
+    },
+    "2458695583": {
+      "import_name": "WikidataPopulation",
+      "provenance_url": "https://www.wikidata.org/wiki/Wikidata:Main_Page",
+      "measurement_method": "WikidataPopulation"
+    },
+    "4010764369": {
+      "import_name": "TemperatureEvents_Agg",
+      "provenance_url": "https://datacommons.org",
+      "measurement_method": "DataCommonsAggregate",
+      "observation_period": "P1M"
+    }
+  }
+}


### PR DESCRIPTION
This is for requests of the form /observation?entity.dcids=<> where no variable is specified, so essentially getting the variables for a place(s). 

Kara brought up that this is supported in V2, but we noticed it wasn't yet supported it in V3. In V2, this only works for existence and not with any date or facet filters (so it's a bit inconsistent). Here I added it everywhere, but can restrict it if needed as a follow up, along with some other query optimizations 

This PR also splits up some tests into different tests to avoid test timeouts 