### PR TITLE
filter observations from spanner for existence requests

### DIFF
--- a/internal/server/spanner/datasource.go
+++ b/internal/server/spanner/datasource.go
@@ -103,18 +103,19 @@ func (sds *SpannerDataSource) Observation(ctx context.Context, req *pbv2.Observa
 	date := req.Date
 	var observations []*Observation
 	var err error
+	filterObs := isExistenceRequest(req.Select)
 
 	if entityExpr != "" {
 		containedInPlace, err := v2.ParseContainedInPlace(entityExpr)
 		if err != nil {
 			return nil, fmt.Errorf("error getting observations (contained in): %v", err)
 		}
-		observations, err = sds.client.GetObservationsContainedInPlace(ctx, variables, containedInPlace, date)
+		observations, err = sds.client.GetObservationsContainedInPlace(ctx, variables, containedInPlace, date, filterObs)
 		if err != nil {
 			return nil, fmt.Errorf("error getting observations (contained in): %v", err)
 		}
 	} else {
-		observations, err = sds.client.GetObservations(ctx, variables, entities, date)
+		observations, err = sds.client.GetObservations(ctx, variables, entities, date, filterObs)
 		if err != nil {
 			return nil, fmt.Errorf("error getting observations: %v", err)
 		}

--- a/internal/server/spanner/golden/query/get_observations_entity.json
+++ b/internal/server/spanner/golden/query/get_observations_entity.json
@@ -3,7 +3,7 @@
     "VariableMeasured": "Count_HeatTemperatureEvent",
     "ObservationAbout": "wikidataId/Q341968",
     "Observations": {
-      "Observations": null
+      "Observations": []
     },
     "Provenance": "dc/base/TemperatureEvents_Agg",
     "ObservationPeriod": "P1M",
@@ -17,7 +17,7 @@
     "VariableMeasured": "Count_HeatTemperatureEvent",
     "ObservationAbout": "wikidataId/Q341968",
     "Observations": {
-      "Observations": null
+      "Observations": []
     },
     "Provenance": "dc/base/TemperatureEvents_Agg",
     "ObservationPeriod": "P1Y",
@@ -31,7 +31,7 @@
     "VariableMeasured": "Count_Person",
     "ObservationAbout": "wikidataId/Q341968",
     "Observations": {
-      "Observations": null
+      "Observations": []
     },
     "Provenance": "dc/base/WikidataPopulation",
     "ObservationPeriod": "",
@@ -45,7 +45,7 @@
     "VariableMeasured": "Count_Person",
     "ObservationAbout": "wikidataId/Q341968",
     "Observations": {
-      "Observations": null
+      "Observations": []
     },
     "Provenance": "dc/base/WikipediaStatsData",
     "ObservationPeriod": "",
@@ -59,7 +59,7 @@
     "VariableMeasured": "Max_Temperature",
     "ObservationAbout": "wikidataId/Q341968",
     "Observations": {
-      "Observations": null
+      "Observations": []
     },
     "Provenance": "dc/base/NOAA_EPA_Observed_Historical_Weather",
     "ObservationPeriod": "P1M",

--- a/internal/server/spanner/golden/query/get_observations_entity.json
+++ b/internal/server/spanner/golden/query/get_observations_entity.json
@@ -3,16 +3,7 @@
     "VariableMeasured": "Count_HeatTemperatureEvent",
     "ObservationAbout": "wikidataId/Q341968",
     "Observations": {
-      "Observations": [
-        {
-          "Date": "2022-09",
-          "Value": "1"
-        },
-        {
-          "Date": "2022-10",
-          "Value": "2"
-        }
-      ]
+      "Observations": null
     },
     "Provenance": "dc/base/TemperatureEvents_Agg",
     "ObservationPeriod": "P1M",
@@ -26,12 +17,7 @@
     "VariableMeasured": "Count_HeatTemperatureEvent",
     "ObservationAbout": "wikidataId/Q341968",
     "Observations": {
-      "Observations": [
-        {
-          "Date": "2022",
-          "Value": "3"
-        }
-      ]
+      "Observations": null
     },
     "Provenance": "dc/base/TemperatureEvents_Agg",
     "ObservationPeriod": "P1Y",
@@ -45,12 +31,7 @@
     "VariableMeasured": "Count_Person",
     "ObservationAbout": "wikidataId/Q341968",
     "Observations": {
-      "Observations": [
-        {
-          "Date": "2016",
-          "Value": "653"
-        }
-      ]
+      "Observations": null
     },
     "Provenance": "dc/base/WikidataPopulation",
     "ObservationPeriod": "",
@@ -64,12 +45,7 @@
     "VariableMeasured": "Count_Person",
     "ObservationAbout": "wikidataId/Q341968",
     "Observations": {
-      "Observations": [
-        {
-          "Date": "2021",
-          "Value": "606"
-        }
-      ]
+      "Observations": null
     },
     "Provenance": "dc/base/WikipediaStatsData",
     "ObservationPeriod": "",
@@ -78,5 +54,19 @@
     "ScalingFactor": "",
     "ImportName": "WikipediaStatsData",
     "ProvenanceURL": "https://www.wikipedia.org"
+  },
+  {
+    "VariableMeasured": "Max_Temperature",
+    "ObservationAbout": "wikidataId/Q341968",
+    "Observations": {
+      "Observations": null
+    },
+    "Provenance": "dc/base/NOAA_EPA_Observed_Historical_Weather",
+    "ObservationPeriod": "P1M",
+    "MeasurementMethod": "dcAggregate/NASAGSOD_NASAGHCN_EPA",
+    "Unit": "Celsius",
+    "ScalingFactor": "",
+    "ImportName": "NOAA_EPA_Observed_Historical_Weather",
+    "ProvenanceURL": "https://www.noaa.gov/"
   }
 ]

--- a/internal/server/spanner/golden/query_test.go
+++ b/internal/server/spanner/golden/query_test.go
@@ -348,6 +348,7 @@ func TestGetObservations(t *testing.T) {
 		variables  []string
 		entities   []string
 		date       string
+		filterObs  bool
 		goldenFile string
 	}{
 		{
@@ -357,6 +358,7 @@ func TestGetObservations(t *testing.T) {
 		},
 		{
 			entities:   []string{"wikidataId/Q341968"},
+			filterObs:  true,
 			goldenFile: "get_observations_entity.json",
 		},
 		{
@@ -372,7 +374,7 @@ func TestGetObservations(t *testing.T) {
 			goldenFile: "get_observations_date.json",
 		},
 	} {
-		actual, err := client.GetObservations(ctx, c.variables, c.entities, c.date)
+		actual, err := client.GetObservations(ctx, c.variables, c.entities, c.date, c.filterObs)
 
 		if err != nil {
 			t.Fatalf("GetObservations error (%v): %v", c.goldenFile, err)
@@ -417,6 +419,7 @@ func TestGetObservationsContainedInPlace(t *testing.T) {
 		variables        []string
 		containedInPlace *v2.ContainedInPlace
 		date             string
+		filterObs        bool
 		goldenFile       string
 	}{
 		{
@@ -437,7 +440,7 @@ func TestGetObservationsContainedInPlace(t *testing.T) {
 			goldenFile:       "get_observations_contained_in_date.json",
 		},
 	} {
-		actual, err := client.GetObservationsContainedInPlace(ctx, c.variables, c.containedInPlace, c.date)
+		actual, err := client.GetObservationsContainedInPlace(ctx, c.variables, c.containedInPlace, c.date, c.filterObs)
 
 		if err != nil {
 			t.Fatalf("GetObservations error (%v): %v", c.goldenFile, err)

--- a/internal/server/spanner/model.go
+++ b/internal/server/spanner/model.go
@@ -73,6 +73,7 @@ func (ts *TimeSeries) DecodeSpanner(val interface{}) (err error) {
 	if !ok {
 		return fmt.Errorf("failed to decode TimeSeries: (%v)", val)
 	}
+	ts.Observations = []*DateValue{}
 	for _, v := range listVal.Values {
 		var data map[string]string
 		err := json.Unmarshal([]byte(v.GetStringValue()), &data)

--- a/internal/server/spanner/query.go
+++ b/internal/server/spanner/query.go
@@ -167,7 +167,7 @@ func (sc *SpannerClient) GetNodeEdgesByID(ctx context.Context, ids []string, arc
 }
 
 // GetObservations retrieves observations from Spanner given a list of variables and entities.
-func (sc *SpannerClient) GetObservations(ctx context.Context, variables []string, entities []string, date string) ([]*Observation, error) {
+func (sc *SpannerClient) GetObservations(ctx context.Context, variables []string, entities []string, date string, filterObs bool) ([]*Observation, error) {
 	var observations []*Observation
 	if len(entities) == 0 {
 		return nil, fmt.Errorf("entity must be specified")
@@ -175,7 +175,7 @@ func (sc *SpannerClient) GetObservations(ctx context.Context, variables []string
 
 	err := sc.queryAndCollect(
 		ctx,
-		buildBaseObsStatement(variables, entities, date),
+		buildBaseObsStatement(variables, entities, date, filterObs),
 		func() interface{} {
 			return &Observation{}
 		},
@@ -192,13 +192,13 @@ func (sc *SpannerClient) GetObservations(ctx context.Context, variables []string
 }
 
 // GetObservationsContainedInPlace retrieves observations from Spanner given a list of variables and an entity expression.
-func (sc *SpannerClient) GetObservationsContainedInPlace(ctx context.Context, variables []string, containedInPlace *v2.ContainedInPlace, date string) ([]*Observation, error) {
+func (sc *SpannerClient) GetObservationsContainedInPlace(ctx context.Context, variables []string, containedInPlace *v2.ContainedInPlace, date string, filterObs bool) ([]*Observation, error) {
 	var observations []*Observation
 	if len(variables) == 0 || containedInPlace == nil {
 		return observations, nil
 	}
 
-	stmt := buildBaseObsStatement(variables, []string{} /*entities*/, date)
+	stmt := buildBaseObsStatement(variables, []string{} /*entities*/, date, filterObs)
 	stmt.SQL = fmt.Sprintf(statements.getObsByVariableAndContainedInPlace, stmt.SQL)
 	stmt.Params["ancestor"] = containedInPlace.Ancestor
 	stmt.Params["childPlaceType"] = containedInPlace.ChildPlaceType

--- a/internal/server/spanner/statements.go
+++ b/internal/server/spanner/statements.go
@@ -43,12 +43,18 @@ var statements = struct {
 	applyOffset string
 	// Subquery to apply page limit.
 	applyLimit string
-	// Fetch all Observations.
-	getAllObs string
-	// Fetch latest Observations.
-	getLatestObs string
+	// Fetch Observations.
+	getObs string
 	// Fetch Observations for a specific date.
 	getDateObs string
+	// Subquery to return all Observations.
+	allObs string
+	// Subquery to return the latest Observations.
+	latestObs string
+	// Subquery to return Observations for a specific date.
+	dateObs string
+	// Subquery to return empty Observations.
+	emptyObs string
 	// Filter by variable dcids.
 	selectVariableDcids string
 	// Filter by entity dcids.
@@ -245,26 +251,11 @@ var statements = struct {
 	applyLimit: fmt.Sprintf(`
 		LIMIT %d
 	`, PAGE_SIZE+1),
-	getAllObs: `
+	getObs: `
 		SELECT
 			variable_measured,
 			observation_about,
-			observations,
-			provenance,
-			COALESCE(observation_period, '') AS observation_period,
-			COALESCE(measurement_method, '') AS measurement_method,
-			COALESCE(unit, '') AS unit,
-			COALESCE(scaling_factor, '') AS scaling_factor,
-			import_name,
-			provenance_url
-		FROM 
-			Observation
-	`,
-	getLatestObs: `
-		SELECT
-			variable_measured,
-			observation_about,
-			observations[ARRAY_LENGTH(observations)-1] AS observations,
+			%s,
 			provenance,
 			COALESCE(observation_period, '') AS observation_period,
 			COALESCE(measurement_method, '') AS measurement_method,
@@ -279,7 +270,7 @@ var statements = struct {
 		SELECT
 			variable_measured,
 			observation_about,
-			obs AS observations,
+			%s,
 			provenance,
 			COALESCE(observation_period, '') AS observation_period,
 			COALESCE(measurement_method, '') AS measurement_method,
@@ -290,6 +281,18 @@ var statements = struct {
 		FROM 
 			Observation,
 			UNNEST(observations) as obs
+	`,
+	allObs: `
+		observations
+	`,
+	latestObs: `
+		[observations[ARRAY_LENGTH(observations)-1]] AS observations
+	`,
+	dateObs: `
+		[obs] AS observations
+	`,
+	emptyObs: `
+		ARRAY<JSON>[] AS observations
 	`,
 	selectVariableDcids: `
 		variable_measured IN UNNEST(@variables)

--- a/internal/server/v3/observation/golden/observation_test.go
+++ b/internal/server/v3/observation/golden/observation_test.go
@@ -222,7 +222,7 @@ func TestV3Observation(t *testing.T) {
 			{
 				req: &pbv2.ObservationRequest{
 					Entity: &pbv2.DcidOrExpression{
-						Dcids: []string{"wikidataId/Q341968", "wikidataId/Q1764983"},
+						Dcids: []string{"wikidataId/Q4671576", "wikidataId/Q1764983"},
 					},
 					Select: []string{"entity", "variable", "date", "value"},
 				},

--- a/internal/server/v3/observation/golden/observations_entity.json
+++ b/internal/server/v3/observation/golden/observations_entity.json
@@ -1,37 +1,147 @@
 {
   "by_variable": {
-    "Count_HeatTemperatureEvent": {
+    "Area_FloodEvent": {
       "by_entity": {
         "wikidataId/Q1764983": {},
-        "wikidataId/Q341968": {
+        "wikidataId/Q4671576": {
           "ordered_facets": [
             {
-              "facet_id": "4010764369",
+              "facet_id": "1286017793",
               "observations": [
                 {
-                  "date": "2022-09",
-                  "value": 1
+                  "date": "2023-11",
+                  "value": 23.937
                 },
                 {
-                  "date": "2022-10",
-                  "value": 2
+                  "date": "2023-12",
+                  "value": 8.163
                 }
               ],
               "obs_count": 2,
-              "earliest_date": "2022-09",
-              "latest_date": "2022-10"
+              "earliest_date": "2023-11",
+              "latest_date": "2023-12"
             },
             {
-              "facet_id": "2370098101",
+              "facet_id": "767211349",
               "observations": [
                 {
-                  "date": "2022",
-                  "value": 3
+                  "date": "2023",
+                  "value": 32.099
                 }
               ],
               "obs_count": 1,
-              "earliest_date": "2022",
+              "earliest_date": "2023",
+              "latest_date": "2023"
+            }
+          ]
+        }
+      }
+    },
+    "Count_FireEvent": {
+      "by_entity": {
+        "wikidataId/Q1764983": {},
+        "wikidataId/Q4671576": {
+          "ordered_facets": [
+            {
+              "facet_id": "3641880131",
+              "observations": [
+                {
+                  "date": "2012-09",
+                  "value": 1
+                },
+                {
+                  "date": "2013-07",
+                  "value": 1
+                },
+                {
+                  "date": "2016-07",
+                  "value": 1
+                },
+                {
+                  "date": "2018-10",
+                  "value": 1
+                },
+                {
+                  "date": "2020-04",
+                  "value": 1
+                },
+                {
+                  "date": "2022-02",
+                  "value": 1
+                }
+              ],
+              "obs_count": 6,
+              "earliest_date": "2012-09",
+              "latest_date": "2022-02"
+            },
+            {
+              "facet_id": "992801983",
+              "observations": [
+                {
+                  "date": "2012",
+                  "value": 1
+                },
+                {
+                  "date": "2013",
+                  "value": 1
+                },
+                {
+                  "date": "2016",
+                  "value": 1
+                },
+                {
+                  "date": "2018",
+                  "value": 1
+                },
+                {
+                  "date": "2020",
+                  "value": 1
+                },
+                {
+                  "date": "2022",
+                  "value": 1
+                }
+              ],
+              "obs_count": 6,
+              "earliest_date": "2012",
               "latest_date": "2022"
+            }
+          ]
+        }
+      }
+    },
+    "Count_FloodEvent": {
+      "by_entity": {
+        "wikidataId/Q1764983": {},
+        "wikidataId/Q4671576": {
+          "ordered_facets": [
+            {
+              "facet_id": "2074204934",
+              "observations": [
+                {
+                  "date": "2023-11",
+                  "value": 1
+                },
+                {
+                  "date": "2023-12",
+                  "value": 1
+                }
+              ],
+              "obs_count": 2,
+              "earliest_date": "2023-11",
+              "latest_date": "2023-12"
+            },
+            {
+              "facet_id": "2646326466",
+              "observations": [
+                {
+                  "date": "2023",
+                  "value": 1
+                }
+              ],
+              "obs_count": 1,
+              "earliest_date": "2023",
+              "latest_date": "2023"
             }
           ]
         }
@@ -67,31 +177,19 @@
             }
           ]
         },
-        "wikidataId/Q341968": {
+        "wikidataId/Q4671576": {
           "ordered_facets": [
             {
               "facet_id": "1456184638",
               "observations": [
                 {
                   "date": "2021",
-                  "value": 606
+                  "value": 494
                 }
               ],
               "obs_count": 1,
               "earliest_date": "2021",
               "latest_date": "2021"
-            },
-            {
-              "facet_id": "2458695583",
-              "observations": [
-                {
-                  "date": "2016",
-                  "value": 653
-                }
-              ],
-              "obs_count": 1,
-              "earliest_date": "2016",
-              "latest_date": "2016"
             }
           ]
         }
@@ -99,27 +197,49 @@
     }
   },
   "facets": {
+    "1286017793": {
+      "import_name": "DynamicWorld_FloodEvents_Places_AutoRefresh",
+      "provenance_url": "https://developers.google.com/earth-engine/datasets/catalog/GOOGLE_DYNAMICWORLD_V1",
+      "observation_period": "P1M",
+      "unit": "SquareKilometer"
+    },
     "1456184638": {
       "import_name": "WikipediaStatsData",
       "provenance_url": "https://www.wikipedia.org",
       "measurement_method": "Wikipedia"
     },
-    "2370098101": {
-      "import_name": "TemperatureEvents_Agg",
-      "provenance_url": "https://datacommons.org",
-      "measurement_method": "DataCommonsAggregate",
-      "observation_period": "P1Y"
+    "2074204934": {
+      "import_name": "DynamicWorld_FloodEvents_Places_AutoRefresh",
+      "provenance_url": "https://developers.google.com/earth-engine/datasets/catalog/GOOGLE_DYNAMICWORLD_V1",
+      "observation_period": "P1M"
     },
     "2458695583": {
       "import_name": "WikidataPopulation",
       "provenance_url": "https://www.wikidata.org/wiki/Wikidata:Main_Page",
       "measurement_method": "WikidataPopulation"
     },
-    "4010764369": {
-      "import_name": "TemperatureEvents_Agg",
-      "provenance_url": "https://datacommons.org",
+    "2646326466": {
+      "import_name": "DynamicWorld_FloodEvents_Places_AutoRefresh",
+      "provenance_url": "https://developers.google.com/earth-engine/datasets/catalog/GOOGLE_DYNAMICWORLD_V1",
+      "observation_period": "P1Y"
+    },
+    "3641880131": {
+      "import_name": "NASA_VIIRSActiveFiresEvents_Agg",
+      "provenance_url": "https://firms.modaps.eosdis.nasa.gov/active_fire/",
       "measurement_method": "DataCommonsAggregate",
       "observation_period": "P1M"
+    },
+    "767211349": {
+      "import_name": "DynamicWorld_FloodEvents_Places_AutoRefresh",
+      "provenance_url": "https://developers.google.com/earth-engine/datasets/catalog/GOOGLE_DYNAMICWORLD_V1",
+      "observation_period": "P1Y",
+      "unit": "SquareKilometer"
+    },
+    "992801983": {
+      "import_name": "NASA_VIIRSActiveFiresEvents_Agg",
+      "provenance_url": "https://firms.modaps.eosdis.nasa.gov/active_fire/",
+      "measurement_method": "DataCommonsAggregate",
+      "observation_period": "P1Y"
     }
   }
 }

--- a/internal/server/v3/observation/golden/observations_existence_entity.json
+++ b/internal/server/v3/observation/golden/observations_existence_entity.json
@@ -10,6 +10,11 @@
         "wikidataId/Q1764983": {},
         "wikidataId/Q341968": {}
       }
+    },
+    "Max_Temperature": {
+      "by_entity": {
+        "wikidataId/Q341968": {}
+      }
     }
   }
 }

--- a/internal/server/v3/observation/golden/observations_facet_entity.json
+++ b/internal/server/v3/observation/golden/observations_facet_entity.json
@@ -55,6 +55,20 @@
           ]
         }
       }
+    },
+    "Max_Temperature": {
+      "by_entity": {
+        "wikidataId/Q341968": {
+          "ordered_facets": [
+            {
+              "facet_id": "3083194648",
+              "obs_count": 1437,
+              "earliest_date": "1902-06",
+              "latest_date": "2024-03"
+            }
+          ]
+        }
+      }
     }
   },
   "facets": {
@@ -73,6 +87,13 @@
       "import_name": "WikidataPopulation",
       "provenance_url": "https://www.wikidata.org/wiki/Wikidata:Main_Page",
       "measurement_method": "WikidataPopulation"
+    },
+    "3083194648": {
+      "import_name": "NOAA_EPA_Observed_Historical_Weather",
+      "provenance_url": "https://www.noaa.gov/",
+      "measurement_method": "dcAggregate/NASAGSOD_NASAGHCN_EPA",
+      "observation_period": "P1M",
+      "unit": "Celsius"
     },
     "4010764369": {
       "import_name": "TemperatureEvents_Agg",


### PR DESCRIPTION
This is to make the results from spanner smaller for existence requests that don't need them 

(note: some of the tests got updated with some temperature data since I added it to the test instance, but that's unrelated to this change)