### PR TITLE
Add defaults to node search queries

### DIFF
--- a/internal/server/spanner/golden/query/search_nodes_with_type.json
+++ b/internal/server/spanner/golden/query/search_nodes_with_type.json
@@ -1,7 +1,7 @@
 [
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_2_1_1_1_0_0",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Minimum wage that applies on a selected date of the year (see metadata for details), No, No",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_2_0_1_0_0_0",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Gross earnings (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, No, No",
     "Types": [
       "StatisticalVariable"
     ],
@@ -10,8 +10,8 @@
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_2_1_1_1_0_1",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Minimum wage that applies on a selected date of the year (see metadata for details), No, Yes",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_2_0_1_0_0_1",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Gross earnings (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, No, Yes",
     "Types": [
       "StatisticalVariable"
     ],
@@ -20,8 +20,8 @@
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_2_1_1_1_1_0",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Minimum wage that applies on a selected date of the year (see metadata for details), Yes, No",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_2_0_1_0_1_0",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Gross earnings (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, Yes, No",
     "Types": [
       "StatisticalVariable"
     ],
@@ -30,8 +30,8 @@
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_2_1_1_1_1_1",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Minimum wage that applies on a selected date of the year (see metadata for details), Yes, Yes",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_2_0_1_0_1_1",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Gross earnings (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, Yes, Yes",
     "Types": [
       "StatisticalVariable"
     ],
@@ -40,8 +40,8 @@
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_2_1_1_0_0_0",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, No, No",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_2_0_0_1_0_0",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Gross earnings (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), No, No",
     "Types": [
       "StatisticalVariable"
     ],
@@ -50,8 +50,8 @@
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_2_1_1_0_0_1",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, No, Yes",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_2_0_0_1_0_1",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Gross earnings (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), No, Yes",
     "Types": [
       "StatisticalVariable"
     ],
@@ -60,8 +60,8 @@
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_2_1_1_0_1_0",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, Yes, No",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_2_0_0_1_1_0",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Gross earnings (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), Yes, No",
     "Types": [
       "StatisticalVariable"
     ],
@@ -70,8 +70,8 @@
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_2_1_1_0_1_1",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, Yes, Yes",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_2_0_0_1_1_1",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Gross earnings (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), Yes, Yes",
     "Types": [
       "StatisticalVariable"
     ],
@@ -80,8 +80,8 @@
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_2_1_0_1_0_0",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), No, No",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_2_1_1_0_0_0",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, No, No",
     "Types": [
       "StatisticalVariable"
     ],
@@ -90,8 +90,8 @@
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_2_1_0_1_0_1",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), No, Yes",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_2_1_1_0_0_1",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, No, Yes",
     "Types": [
       "StatisticalVariable"
     ],
@@ -100,8 +100,8 @@
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_2_1_0_1_1_0",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), Yes, No",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_2_1_1_0_1_0",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, Yes, No",
     "Types": [
       "StatisticalVariable"
     ],
@@ -110,8 +110,8 @@
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_2_1_0_1_1_1",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), Yes, Yes",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_2_1_1_0_1_1",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, Yes, Yes",
     "Types": [
       "StatisticalVariable"
     ],
@@ -120,8 +120,8 @@
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_2_1_0_0_0_0",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Weighted average of minimum wage amounts throughout the calendar year, No, No",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_2_1_0_1_0_0",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), No, No",
     "Types": [
       "StatisticalVariable"
     ],
@@ -130,8 +130,8 @@
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_2_1_0_0_0_1",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Weighted average of minimum wage amounts throughout the calendar year, No, Yes",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_2_1_0_1_0_1",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), No, Yes",
     "Types": [
       "StatisticalVariable"
     ],
@@ -140,8 +140,8 @@
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_2_1_0_0_1_0",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Weighted average of minimum wage amounts throughout the calendar year, Yes, No",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_2_1_0_1_1_0",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), Yes, No",
     "Types": [
       "StatisticalVariable"
     ],
@@ -150,8 +150,8 @@
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_2_1_0_0_1_1",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Weighted average of minimum wage amounts throughout the calendar year, Yes, Yes",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_2_1_0_1_1_1",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), Yes, Yes",
     "Types": [
       "StatisticalVariable"
     ],
@@ -160,8 +160,8 @@
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_3_1_1_1_0_0",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the median wage, Net income (family level), All employees, expressed in full-time equivalent units, Minimum wage that applies on a selected date of the year (see metadata for details), No, No",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_3_0_1_0_0_0",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the median wage, Gross earnings (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, No, No",
     "Types": [
       "StatisticalVariable"
     ],
@@ -170,8 +170,8 @@
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_3_1_1_1_0_1",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the median wage, Net income (family level), All employees, expressed in full-time equivalent units, Minimum wage that applies on a selected date of the year (see metadata for details), No, Yes",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_3_0_1_0_0_1",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the median wage, Gross earnings (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, No, Yes",
     "Types": [
       "StatisticalVariable"
     ],
@@ -180,8 +180,8 @@
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_3_1_1_1_1_0",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the median wage, Net income (family level), All employees, expressed in full-time equivalent units, Minimum wage that applies on a selected date of the year (see metadata for details), Yes, No",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_3_0_1_0_1_0",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the median wage, Gross earnings (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, Yes, No",
     "Types": [
       "StatisticalVariable"
     ],
@@ -190,8 +190,8 @@
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_3_1_1_1_1_1",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the median wage, Net income (family level), All employees, expressed in full-time equivalent units, Minimum wage that applies on a selected date of the year (see metadata for details), Yes, Yes",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_3_0_1_0_1_1",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the median wage, Gross earnings (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, Yes, Yes",
     "Types": [
       "StatisticalVariable"
     ],

--- a/internal/server/spanner/golden/query/search_nodes_without_type.json
+++ b/internal/server/spanner/golden/query/search_nodes_without_type.json
@@ -10,8 +10,8 @@
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_2_1_1_1_0_0",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Minimum wage that applies on a selected date of the year (see metadata for details), No, No",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_2_0_1_0_0_0",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Gross earnings (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, No, No",
     "Types": [
       "StatisticalVariable"
     ],
@@ -20,8 +20,8 @@
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_2_1_1_1_0_1",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Minimum wage that applies on a selected date of the year (see metadata for details), No, Yes",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_2_0_1_0_0_1",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Gross earnings (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, No, Yes",
     "Types": [
       "StatisticalVariable"
     ],
@@ -30,8 +30,8 @@
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_2_1_1_1_1_0",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Minimum wage that applies on a selected date of the year (see metadata for details), Yes, No",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_2_0_1_0_1_0",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Gross earnings (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, Yes, No",
     "Types": [
       "StatisticalVariable"
     ],
@@ -40,8 +40,8 @@
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_2_1_1_1_1_1",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Minimum wage that applies on a selected date of the year (see metadata for details), Yes, Yes",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_2_0_1_0_1_1",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Gross earnings (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, Yes, Yes",
     "Types": [
       "StatisticalVariable"
     ],
@@ -50,8 +50,8 @@
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_2_1_1_0_0_0",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, No, No",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_2_0_0_1_0_0",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Gross earnings (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), No, No",
     "Types": [
       "StatisticalVariable"
     ],
@@ -60,8 +60,8 @@
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_2_1_1_0_0_1",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, No, Yes",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_2_0_0_1_0_1",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Gross earnings (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), No, Yes",
     "Types": [
       "StatisticalVariable"
     ],
@@ -70,8 +70,8 @@
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_2_1_1_0_1_0",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, Yes, No",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_2_0_0_1_1_0",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Gross earnings (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), Yes, No",
     "Types": [
       "StatisticalVariable"
     ],
@@ -80,8 +80,8 @@
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_2_1_1_0_1_1",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, Yes, Yes",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_2_0_0_1_1_1",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Gross earnings (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), Yes, Yes",
     "Types": [
       "StatisticalVariable"
     ],
@@ -90,8 +90,8 @@
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_2_1_0_1_0_0",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), No, No",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_2_1_1_0_0_0",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, No, No",
     "Types": [
       "StatisticalVariable"
     ],
@@ -100,8 +100,8 @@
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_2_1_0_1_0_1",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), No, Yes",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_2_1_1_0_0_1",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, No, Yes",
     "Types": [
       "StatisticalVariable"
     ],
@@ -110,8 +110,8 @@
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_2_1_0_1_1_0",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), Yes, No",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_2_1_1_0_1_0",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, Yes, No",
     "Types": [
       "StatisticalVariable"
     ],
@@ -120,8 +120,8 @@
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_2_1_0_1_1_1",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), Yes, Yes",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_2_1_1_0_1_1",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, Yes, Yes",
     "Types": [
       "StatisticalVariable"
     ],
@@ -130,8 +130,8 @@
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_2_1_0_0_0_0",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Weighted average of minimum wage amounts throughout the calendar year, No, No",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_2_1_0_1_0_0",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), No, No",
     "Types": [
       "StatisticalVariable"
     ],
@@ -140,8 +140,8 @@
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_2_1_0_0_0_1",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Weighted average of minimum wage amounts throughout the calendar year, No, Yes",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_2_1_0_1_0_1",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), No, Yes",
     "Types": [
       "StatisticalVariable"
     ],
@@ -150,8 +150,8 @@
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_2_1_0_0_1_0",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Weighted average of minimum wage amounts throughout the calendar year, Yes, No",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_2_1_0_1_1_0",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), Yes, No",
     "Types": [
       "StatisticalVariable"
     ],
@@ -160,8 +160,8 @@
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_2_1_0_0_1_1",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Weighted average of minimum wage amounts throughout the calendar year, Yes, Yes",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_2_1_0_1_1_1",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), Yes, Yes",
     "Types": [
       "StatisticalVariable"
     ],
@@ -170,8 +170,8 @@
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_3_1_1_1_0_0",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the median wage, Net income (family level), All employees, expressed in full-time equivalent units, Minimum wage that applies on a selected date of the year (see metadata for details), No, No",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_3_0_1_0_0_0",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the median wage, Gross earnings (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, No, No",
     "Types": [
       "StatisticalVariable"
     ],
@@ -180,8 +180,8 @@
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_3_1_1_1_0_1",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the median wage, Net income (family level), All employees, expressed in full-time equivalent units, Minimum wage that applies on a selected date of the year (see metadata for details), No, Yes",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_3_0_1_0_0_1",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the median wage, Gross earnings (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, No, Yes",
     "Types": [
       "StatisticalVariable"
     ],
@@ -190,8 +190,8 @@
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_3_1_1_1_1_0",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the median wage, Net income (family level), All employees, expressed in full-time equivalent units, Minimum wage that applies on a selected date of the year (see metadata for details), Yes, No",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_3_0_1_0_1_0",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the median wage, Gross earnings (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, Yes, No",
     "Types": [
       "StatisticalVariable"
     ],

--- a/internal/server/spanner/golden/query/search_object_values_with_query_and_type.json
+++ b/internal/server/spanner/golden/query/search_object_values_with_query_and_type.json
@@ -1,202 +1,202 @@
 [
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_2_1_1_1_0_0",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Minimum wage that applies on a selected date of the year (see metadata for details), No, No",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_2_0_1_0_0_0",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Gross earnings (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, No, No",
     "Types": [
       "StatisticalVariable"
     ],
     "MatchedPredicate": "name",
-    "MatchedObjectValue": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Minimum wage that applies on a selected date of the year (see metadata for details), No, No",
+    "MatchedObjectValue": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Gross earnings (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, No, No",
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_2_1_1_1_0_1",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Minimum wage that applies on a selected date of the year (see metadata for details), No, Yes",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_2_0_1_0_0_1",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Gross earnings (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, No, Yes",
     "Types": [
       "StatisticalVariable"
     ],
     "MatchedPredicate": "name",
-    "MatchedObjectValue": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Minimum wage that applies on a selected date of the year (see metadata for details), No, Yes",
+    "MatchedObjectValue": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Gross earnings (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, No, Yes",
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_2_1_1_1_1_0",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Minimum wage that applies on a selected date of the year (see metadata for details), Yes, No",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_2_0_1_0_1_0",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Gross earnings (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, Yes, No",
     "Types": [
       "StatisticalVariable"
     ],
     "MatchedPredicate": "name",
-    "MatchedObjectValue": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Minimum wage that applies on a selected date of the year (see metadata for details), Yes, No",
+    "MatchedObjectValue": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Gross earnings (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, Yes, No",
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_2_1_1_1_1_1",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Minimum wage that applies on a selected date of the year (see metadata for details), Yes, Yes",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_2_0_1_0_1_1",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Gross earnings (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, Yes, Yes",
     "Types": [
       "StatisticalVariable"
     ],
     "MatchedPredicate": "name",
-    "MatchedObjectValue": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Minimum wage that applies on a selected date of the year (see metadata for details), Yes, Yes",
+    "MatchedObjectValue": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Gross earnings (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, Yes, Yes",
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_2_1_1_0_0_0",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, No, No",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_2_0_0_1_0_0",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Gross earnings (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), No, No",
     "Types": [
       "StatisticalVariable"
     ],
     "MatchedPredicate": "name",
-    "MatchedObjectValue": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, No, No",
+    "MatchedObjectValue": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Gross earnings (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), No, No",
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_2_1_1_0_0_1",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, No, Yes",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_2_0_0_1_0_1",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Gross earnings (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), No, Yes",
     "Types": [
       "StatisticalVariable"
     ],
     "MatchedPredicate": "name",
-    "MatchedObjectValue": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, No, Yes",
+    "MatchedObjectValue": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Gross earnings (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), No, Yes",
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_2_1_1_0_1_0",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, Yes, No",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_2_0_0_1_1_0",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Gross earnings (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), Yes, No",
     "Types": [
       "StatisticalVariable"
     ],
     "MatchedPredicate": "name",
-    "MatchedObjectValue": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, Yes, No",
+    "MatchedObjectValue": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Gross earnings (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), Yes, No",
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_2_1_1_0_1_1",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, Yes, Yes",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_2_0_0_1_1_1",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Gross earnings (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), Yes, Yes",
     "Types": [
       "StatisticalVariable"
     ],
     "MatchedPredicate": "name",
-    "MatchedObjectValue": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, Yes, Yes",
+    "MatchedObjectValue": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Gross earnings (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), Yes, Yes",
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_2_1_0_1_0_0",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), No, No",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_2_1_1_0_0_0",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, No, No",
     "Types": [
       "StatisticalVariable"
     ],
     "MatchedPredicate": "name",
-    "MatchedObjectValue": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), No, No",
+    "MatchedObjectValue": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, No, No",
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_2_1_0_1_0_1",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), No, Yes",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_2_1_1_0_0_1",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, No, Yes",
     "Types": [
       "StatisticalVariable"
     ],
     "MatchedPredicate": "name",
-    "MatchedObjectValue": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), No, Yes",
+    "MatchedObjectValue": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, No, Yes",
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_2_1_0_1_1_0",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), Yes, No",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_2_1_1_0_1_0",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, Yes, No",
     "Types": [
       "StatisticalVariable"
     ],
     "MatchedPredicate": "name",
-    "MatchedObjectValue": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), Yes, No",
+    "MatchedObjectValue": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, Yes, No",
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_2_1_0_1_1_1",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), Yes, Yes",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_2_1_1_0_1_1",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, Yes, Yes",
     "Types": [
       "StatisticalVariable"
     ],
     "MatchedPredicate": "name",
-    "MatchedObjectValue": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), Yes, Yes",
+    "MatchedObjectValue": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, Yes, Yes",
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_2_1_0_0_0_0",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Weighted average of minimum wage amounts throughout the calendar year, No, No",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_2_1_0_1_0_0",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), No, No",
     "Types": [
       "StatisticalVariable"
     ],
     "MatchedPredicate": "name",
-    "MatchedObjectValue": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Weighted average of minimum wage amounts throughout the calendar year, No, No",
+    "MatchedObjectValue": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), No, No",
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_2_1_0_0_0_1",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Weighted average of minimum wage amounts throughout the calendar year, No, Yes",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_2_1_0_1_0_1",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), No, Yes",
     "Types": [
       "StatisticalVariable"
     ],
     "MatchedPredicate": "name",
-    "MatchedObjectValue": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Weighted average of minimum wage amounts throughout the calendar year, No, Yes",
+    "MatchedObjectValue": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), No, Yes",
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_2_1_0_0_1_0",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Weighted average of minimum wage amounts throughout the calendar year, Yes, No",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_2_1_0_1_1_0",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), Yes, No",
     "Types": [
       "StatisticalVariable"
     ],
     "MatchedPredicate": "name",
-    "MatchedObjectValue": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Weighted average of minimum wage amounts throughout the calendar year, Yes, No",
+    "MatchedObjectValue": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), Yes, No",
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_2_1_0_0_1_1",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Weighted average of minimum wage amounts throughout the calendar year, Yes, Yes",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_2_1_0_1_1_1",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), Yes, Yes",
     "Types": [
       "StatisticalVariable"
     ],
     "MatchedPredicate": "name",
-    "MatchedObjectValue": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Weighted average of minimum wage amounts throughout the calendar year, Yes, Yes",
+    "MatchedObjectValue": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), Yes, Yes",
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_3_1_1_1_0_0",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the median wage, Net income (family level), All employees, expressed in full-time equivalent units, Minimum wage that applies on a selected date of the year (see metadata for details), No, No",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_3_0_1_0_0_0",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the median wage, Gross earnings (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, No, No",
     "Types": [
       "StatisticalVariable"
     ],
     "MatchedPredicate": "name",
-    "MatchedObjectValue": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the median wage, Net income (family level), All employees, expressed in full-time equivalent units, Minimum wage that applies on a selected date of the year (see metadata for details), No, No",
+    "MatchedObjectValue": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the median wage, Gross earnings (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, No, No",
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_3_1_1_1_0_1",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the median wage, Net income (family level), All employees, expressed in full-time equivalent units, Minimum wage that applies on a selected date of the year (see metadata for details), No, Yes",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_3_0_1_0_0_1",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the median wage, Gross earnings (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, No, Yes",
     "Types": [
       "StatisticalVariable"
     ],
     "MatchedPredicate": "name",
-    "MatchedObjectValue": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the median wage, Net income (family level), All employees, expressed in full-time equivalent units, Minimum wage that applies on a selected date of the year (see metadata for details), No, Yes",
+    "MatchedObjectValue": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the median wage, Gross earnings (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, No, Yes",
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_3_1_1_1_1_0",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the median wage, Net income (family level), All employees, expressed in full-time equivalent units, Minimum wage that applies on a selected date of the year (see metadata for details), Yes, No",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_3_0_1_0_1_0",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the median wage, Gross earnings (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, Yes, No",
     "Types": [
       "StatisticalVariable"
     ],
     "MatchedPredicate": "name",
-    "MatchedObjectValue": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the median wage, Net income (family level), All employees, expressed in full-time equivalent units, Minimum wage that applies on a selected date of the year (see metadata for details), Yes, No",
+    "MatchedObjectValue": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the median wage, Gross earnings (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, Yes, No",
     "Score": 0
   },
   {
-    "SubjectID": "oecd/IMW_1EARNERC2C_3_1_1_1_1_1",
-    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the median wage, Net income (family level), All employees, expressed in full-time equivalent units, Minimum wage that applies on a selected date of the year (see metadata for details), Yes, Yes",
+    "SubjectID": "oecd/IMW_2EARNERC2C_MIN_3_0_1_0_1_1",
+    "Name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the median wage, Gross earnings (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, Yes, Yes",
     "Types": [
       "StatisticalVariable"
     ],
     "MatchedPredicate": "name",
-    "MatchedObjectValue": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the median wage, Net income (family level), All employees, expressed in full-time equivalent units, Minimum wage that applies on a selected date of the year (see metadata for details), Yes, Yes",
+    "MatchedObjectValue": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the median wage, Gross earnings (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, Yes, Yes",
     "Score": 0
   }
 ]

--- a/internal/server/spanner/statements.go
+++ b/internal/server/spanner/statements.go
@@ -334,7 +334,11 @@ var statements = struct {
 		MATCH (n:Node)
 		WHERE 
 			SEARCH(n.name_tokenlist, @query)
-		RETURN n.subject_id, n.name, n.types, SCORE(n.name_tokenlist, @query, enhance_query => TRUE) AS score 
+		RETURN 
+			n.subject_id, 
+			COALESCE(n.name, '') AS name,
+			COALESCE(n.types, []) AS types, 
+			SCORE(n.name_tokenlist, @query, enhance_query => TRUE) AS score 
 		ORDER BY score + IF(n.name = @query, 1, 0) DESC, n.name ASC
 		LIMIT %d
 	`, merger.MAX_SEARCH_RESULTS),
@@ -344,7 +348,11 @@ var statements = struct {
 		WHERE 
 			SEARCH(n.name_tokenlist, @query)
 			AND ARRAY_INCLUDES_ANY(n.types, @types)
-		RETURN n.subject_id, n.name, n.types, SCORE(n.name_tokenlist, @query, enhance_query => TRUE) AS score
+		RETURN 
+			n.subject_id, 
+			COALESCE(n.name, '') AS name, 
+			COALESCE(n.types, []) AS types, 
+			SCORE(n.name_tokenlist, @query, enhance_query => TRUE) AS score
 		ORDER BY score + IF(n.name = @query, 1, 0) DESC, n.name ASC
 		LIMIT %d
 	`, merger.MAX_SEARCH_RESULTS),
@@ -353,8 +361,14 @@ var statements = struct {
 		MATCH -[e:Edge 
 			WHERE e.predicate IN UNNEST(@predicates) AND SEARCH(e.object_value_tokenlist, @query)
 		]->(n:Node %s)
-		RETURN n.subject_id, n.name, n.types, e.predicate AS predicate, e.object_value AS object_value, SCORE(e.object_value_tokenlist, @query, enhance_query => TRUE) AS score
-		ORDER BY score + IF(e.object_value = @query, 1, 0) + IF(REGEXP_CONTAINS(n.subject_id, @query), 0.5, 0) desc, n.name ASC
+		RETURN 
+			n.subject_id, 
+			COALESCE(n.name, '') AS name, 
+			COALESCE(n.types, []) AS types, 
+			e.predicate AS predicate, 
+			e.object_value AS object_value, 
+			SCORE(e.object_value_tokenlist, @query, enhance_query => TRUE) AS score
+		ORDER BY score + IF(e.object_value = @query, 1, 0) + IF(REGEXP_CONTAINS(n.subject_id, @query), 0.5, 0) DESC, n.name ASC
 		LIMIT %d
 	`,
 	filterTypes: `WHERE ARRAY_INCLUDES_ANY(n.types, @types)`,

--- a/internal/server/v3/nodesearch/golden/node_search_with_query_and_type.json
+++ b/internal/server/v3/nodesearch/golden/node_search_with_query_and_type.json
@@ -2,262 +2,262 @@
   "results": [
     {
       "node": {
-        "name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Minimum wage that applies on a selected date of the year (see metadata for details), No, No",
+        "name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Gross earnings (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, No, No",
         "types": [
           "StatisticalVariable"
         ],
-        "dcid": "oecd/IMW_1EARNERC2C_2_1_1_1_0_0"
+        "dcid": "oecd/IMW_2EARNERC2C_MIN_2_0_1_0_0_0"
       },
       "match": {
         "property": "name",
-        "value": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Minimum wage that applies on a selected date of the year (see metadata for details), No, No"
+        "value": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Gross earnings (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, No, No"
       }
     },
     {
       "node": {
-        "name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Minimum wage that applies on a selected date of the year (see metadata for details), No, Yes",
+        "name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Gross earnings (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, No, Yes",
         "types": [
           "StatisticalVariable"
         ],
-        "dcid": "oecd/IMW_1EARNERC2C_2_1_1_1_0_1"
+        "dcid": "oecd/IMW_2EARNERC2C_MIN_2_0_1_0_0_1"
       },
       "match": {
         "property": "name",
-        "value": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Minimum wage that applies on a selected date of the year (see metadata for details), No, Yes"
+        "value": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Gross earnings (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, No, Yes"
       }
     },
     {
       "node": {
-        "name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Minimum wage that applies on a selected date of the year (see metadata for details), Yes, No",
+        "name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Gross earnings (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, Yes, No",
         "types": [
           "StatisticalVariable"
         ],
-        "dcid": "oecd/IMW_1EARNERC2C_2_1_1_1_1_0"
+        "dcid": "oecd/IMW_2EARNERC2C_MIN_2_0_1_0_1_0"
       },
       "match": {
         "property": "name",
-        "value": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Minimum wage that applies on a selected date of the year (see metadata for details), Yes, No"
+        "value": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Gross earnings (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, Yes, No"
       }
     },
     {
       "node": {
-        "name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Minimum wage that applies on a selected date of the year (see metadata for details), Yes, Yes",
+        "name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Gross earnings (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, Yes, Yes",
         "types": [
           "StatisticalVariable"
         ],
-        "dcid": "oecd/IMW_1EARNERC2C_2_1_1_1_1_1"
+        "dcid": "oecd/IMW_2EARNERC2C_MIN_2_0_1_0_1_1"
       },
       "match": {
         "property": "name",
-        "value": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Minimum wage that applies on a selected date of the year (see metadata for details), Yes, Yes"
+        "value": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Gross earnings (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, Yes, Yes"
       }
     },
     {
       "node": {
-        "name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, No, No",
+        "name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Gross earnings (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), No, No",
         "types": [
           "StatisticalVariable"
         ],
-        "dcid": "oecd/IMW_1EARNERC2C_2_1_1_0_0_0"
+        "dcid": "oecd/IMW_2EARNERC2C_MIN_2_0_0_1_0_0"
       },
       "match": {
         "property": "name",
-        "value": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, No, No"
+        "value": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Gross earnings (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), No, No"
       }
     },
     {
       "node": {
-        "name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, No, Yes",
+        "name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Gross earnings (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), No, Yes",
         "types": [
           "StatisticalVariable"
         ],
-        "dcid": "oecd/IMW_1EARNERC2C_2_1_1_0_0_1"
+        "dcid": "oecd/IMW_2EARNERC2C_MIN_2_0_0_1_0_1"
       },
       "match": {
         "property": "name",
-        "value": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, No, Yes"
+        "value": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Gross earnings (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), No, Yes"
       }
     },
     {
       "node": {
-        "name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, Yes, No",
+        "name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Gross earnings (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), Yes, No",
         "types": [
           "StatisticalVariable"
         ],
-        "dcid": "oecd/IMW_1EARNERC2C_2_1_1_0_1_0"
+        "dcid": "oecd/IMW_2EARNERC2C_MIN_2_0_0_1_1_0"
       },
       "match": {
         "property": "name",
-        "value": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, Yes, No"
+        "value": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Gross earnings (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), Yes, No"
       }
     },
     {
       "node": {
-        "name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, Yes, Yes",
+        "name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Gross earnings (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), Yes, Yes",
         "types": [
           "StatisticalVariable"
         ],
-        "dcid": "oecd/IMW_1EARNERC2C_2_1_1_0_1_1"
+        "dcid": "oecd/IMW_2EARNERC2C_MIN_2_0_0_1_1_1"
       },
       "match": {
         "property": "name",
-        "value": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, Yes, Yes"
+        "value": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Gross earnings (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), Yes, Yes"
       }
     },
     {
       "node": {
-        "name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), No, No",
+        "name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, No, No",
         "types": [
           "StatisticalVariable"
         ],
-        "dcid": "oecd/IMW_1EARNERC2C_2_1_0_1_0_0"
+        "dcid": "oecd/IMW_2EARNERC2C_MIN_2_1_1_0_0_0"
       },
       "match": {
         "property": "name",
-        "value": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), No, No"
+        "value": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, No, No"
       }
     },
     {
       "node": {
-        "name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), No, Yes",
+        "name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, No, Yes",
         "types": [
           "StatisticalVariable"
         ],
-        "dcid": "oecd/IMW_1EARNERC2C_2_1_0_1_0_1"
+        "dcid": "oecd/IMW_2EARNERC2C_MIN_2_1_1_0_0_1"
       },
       "match": {
         "property": "name",
-        "value": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), No, Yes"
+        "value": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, No, Yes"
       }
     },
     {
       "node": {
-        "name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), Yes, No",
+        "name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, Yes, No",
         "types": [
           "StatisticalVariable"
         ],
-        "dcid": "oecd/IMW_1EARNERC2C_2_1_0_1_1_0"
+        "dcid": "oecd/IMW_2EARNERC2C_MIN_2_1_1_0_1_0"
       },
       "match": {
         "property": "name",
-        "value": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), Yes, No"
+        "value": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, Yes, No"
       }
     },
     {
       "node": {
-        "name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), Yes, Yes",
+        "name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, Yes, Yes",
         "types": [
           "StatisticalVariable"
         ],
-        "dcid": "oecd/IMW_1EARNERC2C_2_1_0_1_1_1"
+        "dcid": "oecd/IMW_2EARNERC2C_MIN_2_1_1_0_1_1"
       },
       "match": {
         "property": "name",
-        "value": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), Yes, Yes"
+        "value": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, Yes, Yes"
       }
     },
     {
       "node": {
-        "name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Weighted average of minimum wage amounts throughout the calendar year, No, No",
+        "name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), No, No",
         "types": [
           "StatisticalVariable"
         ],
-        "dcid": "oecd/IMW_1EARNERC2C_2_1_0_0_0_0"
+        "dcid": "oecd/IMW_2EARNERC2C_MIN_2_1_0_1_0_0"
       },
       "match": {
         "property": "name",
-        "value": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Weighted average of minimum wage amounts throughout the calendar year, No, No"
+        "value": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), No, No"
       }
     },
     {
       "node": {
-        "name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Weighted average of minimum wage amounts throughout the calendar year, No, Yes",
+        "name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), No, Yes",
         "types": [
           "StatisticalVariable"
         ],
-        "dcid": "oecd/IMW_1EARNERC2C_2_1_0_0_0_1"
+        "dcid": "oecd/IMW_2EARNERC2C_MIN_2_1_0_1_0_1"
       },
       "match": {
         "property": "name",
-        "value": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Weighted average of minimum wage amounts throughout the calendar year, No, Yes"
+        "value": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), No, Yes"
       }
     },
     {
       "node": {
-        "name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Weighted average of minimum wage amounts throughout the calendar year, Yes, No",
+        "name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), Yes, No",
         "types": [
           "StatisticalVariable"
         ],
-        "dcid": "oecd/IMW_1EARNERC2C_2_1_0_0_1_0"
+        "dcid": "oecd/IMW_2EARNERC2C_MIN_2_1_0_1_1_0"
       },
       "match": {
         "property": "name",
-        "value": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Weighted average of minimum wage amounts throughout the calendar year, Yes, No"
+        "value": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), Yes, No"
       }
     },
     {
       "node": {
-        "name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Weighted average of minimum wage amounts throughout the calendar year, Yes, Yes",
+        "name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), Yes, Yes",
         "types": [
           "StatisticalVariable"
         ],
-        "dcid": "oecd/IMW_1EARNERC2C_2_1_0_0_1_1"
+        "dcid": "oecd/IMW_2EARNERC2C_MIN_2_1_0_1_1_1"
       },
       "match": {
         "property": "name",
-        "value": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Weighted average of minimum wage amounts throughout the calendar year, Yes, Yes"
+        "value": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the average wage, Net income (family level), Full-time employees working in ISIC sectors C-K (see metadata for details), Minimum wage that applies on a selected date of the year (see metadata for details), Yes, Yes"
       }
     },
     {
       "node": {
-        "name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the median wage, Net income (family level), All employees, expressed in full-time equivalent units, Minimum wage that applies on a selected date of the year (see metadata for details), No, No",
+        "name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the median wage, Gross earnings (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, No, No",
         "types": [
           "StatisticalVariable"
         ],
-        "dcid": "oecd/IMW_1EARNERC2C_3_1_1_1_0_0"
+        "dcid": "oecd/IMW_2EARNERC2C_MIN_3_0_1_0_0_0"
       },
       "match": {
         "property": "name",
-        "value": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the median wage, Net income (family level), All employees, expressed in full-time equivalent units, Minimum wage that applies on a selected date of the year (see metadata for details), No, No"
+        "value": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the median wage, Gross earnings (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, No, No"
       }
     },
     {
       "node": {
-        "name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the median wage, Net income (family level), All employees, expressed in full-time equivalent units, Minimum wage that applies on a selected date of the year (see metadata for details), No, Yes",
+        "name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the median wage, Gross earnings (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, No, Yes",
         "types": [
           "StatisticalVariable"
         ],
-        "dcid": "oecd/IMW_1EARNERC2C_3_1_1_1_0_1"
+        "dcid": "oecd/IMW_2EARNERC2C_MIN_3_0_1_0_0_1"
       },
       "match": {
         "property": "name",
-        "value": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the median wage, Net income (family level), All employees, expressed in full-time equivalent units, Minimum wage that applies on a selected date of the year (see metadata for details), No, Yes"
+        "value": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the median wage, Gross earnings (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, No, Yes"
       }
     },
     {
       "node": {
-        "name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the median wage, Net income (family level), All employees, expressed in full-time equivalent units, Minimum wage that applies on a selected date of the year (see metadata for details), Yes, No",
+        "name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the median wage, Gross earnings (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, Yes, No",
         "types": [
           "StatisticalVariable"
         ],
-        "dcid": "oecd/IMW_1EARNERC2C_3_1_1_1_1_0"
+        "dcid": "oecd/IMW_2EARNERC2C_MIN_3_0_1_0_1_0"
       },
       "match": {
         "property": "name",
-        "value": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the median wage, Net income (family level), All employees, expressed in full-time equivalent units, Minimum wage that applies on a selected date of the year (see metadata for details), Yes, No"
+        "value": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the median wage, Gross earnings (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, Yes, No"
       }
     },
     {
       "node": {
-        "name": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the median wage, Net income (family level), All employees, expressed in full-time equivalent units, Minimum wage that applies on a selected date of the year (see metadata for details), Yes, Yes",
+        "name": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the median wage, Gross earnings (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, Yes, Yes",
         "types": [
           "StatisticalVariable"
         ],
-        "dcid": "oecd/IMW_1EARNERC2C_3_1_1_1_1_1"
+        "dcid": "oecd/IMW_2EARNERC2C_MIN_3_0_1_0_1_1"
       },
       "match": {
         "property": "name",
-        "value": "Incomes of minimum wage earners: Couple with 2 children - partner is out of work, Family income, divided by the income of an otherwise identical family working at the median wage, Net income (family level), All employees, expressed in full-time equivalent units, Minimum wage that applies on a selected date of the year (see metadata for details), Yes, Yes"
+        "value": "Incomes of minimum wage earners: Couple with 2 children - partner's earnings: Minimum Wage, Family income, divided by the income of an otherwise identical family working at the median wage, Gross earnings (family level), All employees, expressed in full-time equivalent units, Weighted average of minimum wage amounts throughout the calendar year, Yes, Yes"
       }
     }
   ]


### PR DESCRIPTION
This is to fix the broken "series" query

Also regenerates some goldens since it looks like the order was updated (unrelated to this change, possibly due to indexing) 