### PR TITLE
Enable metrics in mixer autopush

### DIFF
--- a/deploy/helm_charts/envs/mixer_autopush.yaml
+++ b/deploy/helm_charts/envs/mixer_autopush.yaml
@@ -6,6 +6,7 @@ mixer:
   useSpannerGraph: true
   useRedis: true
   enableV3: true
+  enableOtlp: true
 
 ingress:
   enabled: true


### PR DESCRIPTION
After deployment:
- The Google-built OTLP collector should be running in datcom-mixer-autopush
- The autopush mixer should be pushing metrics to it
- These metrics should be discoverable in Cloud Monitoring