### PR TITLE
Fix OTLP collector deployment process

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -17,12 +17,15 @@
 
 FROM google/cloud-sdk:slim
 
-RUN \
-    apt-get install kubectl && \
+RUN apt-get update && \
+    apt-get install -y kubectl gettext-base google-cloud-sdk-gke-gcloud-auth-plugin && \
     curl -L https://github.com/mikefarah/yq/releases/download/v4.27.3/yq_linux_386 -o /usr/bin/yq && \
     chmod +x /usr/bin/yq && \
     curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && \
     chmod 700 get_helm.sh && \
     ./get_helm.sh && \
+    rm get_helm.sh && \
     mv /usr/local/bin/helm /usr/bin/helm && \
-    chmod +x /usr/bin/helm
+    chmod +x /usr/bin/helm && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
- Make sure `envsubst` and GKE creds are available in the deploy tool image
- Print gcloud perms commands if they don't work