### PR TITLE
Include Docker in the deploy-tool image

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -15,7 +15,10 @@
 # Build docker image used in Cloud Build for deployment.
 # This image contains "gcloud", "kubectl", "yq" and "helm"
 
+FROM docker:stable AS docker-cli
 FROM google/cloud-sdk:slim
+
+COPY --from=docker-cli /usr/local/bin/docker /usr/bin/docker
 
 RUN apt-get update && \
     apt-get install -y kubectl gettext-base google-cloud-sdk-gke-gcloud-auth-plugin && \


### PR DESCRIPTION
While it wasn't in the previous config, the previously pushed version of the image did have Docker. This inclusion is required for Custom DC autopush deployments.