### PR TITLE
Replace log.Println with slog for structured logging

### DIFF
--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -1,0 +1,12 @@
+package log
+
+import (
+	"log/slog"
+	"os"
+)
+
+// SetUpLogger sets up a logger.
+func SetUpLogger() {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{AddSource: true}))
+	slog.SetDefault(logger)
+}

--- a/internal/server/v2/facet/contained_in.go
+++ b/internal/server/v2/facet/contained_in.go
@@ -16,7 +16,7 @@ package facet
 
 import (
 	"context"
-	"log"
+	"log/slog"
 	"net/http"
 	"sort"
 
@@ -172,7 +172,7 @@ func btContainedInFacet(
 				totalSeries,
 			)
 		}
-		log.Println("Fetch series cache in contained-in observation query")
+		slog.Info("Fetch series cache in contained-in observation query")
 		// When date doesn't matter, use SeriesFacet to get the facets for the
 		// child places
 		if queryDate == "" || queryDate == shared.LATEST {

--- a/internal/server/v2/observation/contained_in.go
+++ b/internal/server/v2/observation/contained_in.go
@@ -17,7 +17,7 @@ package observation
 
 import (
 	"context"
-	"log"
+	"log/slog"
 	"net/http"
 	"sort"
 
@@ -143,7 +143,7 @@ func FetchContainedIn(
 					totalSeries,
 				)
 			}
-			log.Println("Fetch series cache in contained-in observation query")
+			slog.Info("Fetch series cache in contained-in observation query")
 			directResp, err := FetchDirectBT(
 				ctx,
 				store.BtGroup,

--- a/test/http_memprof/http_memprof.go
+++ b/test/http_memprof/http_memprof.go
@@ -20,6 +20,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -188,7 +189,7 @@ func writeResultsToCsv(results []*MemoryProfileResult, outputPath string) {
 }
 
 func main() {
-	log.SetFlags(log.LstdFlags | log.Lshortfile)
+	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, nil)))
 
 	flag.Parse()
 
@@ -229,7 +230,7 @@ func main() {
 			log.Fatalf("Could not connect to %s: timed out. Last state: %s", *grpcAddr, s)
 		}
 	}
-	log.Println("Connected to gRPC succesfully")
+	slog.Info("Connected to gRPC succesfully")
 
 	//nolint:errcheck // TODO: Fix pre-existing issue and remove comment.
 	defer conn.Close()

--- a/test/setup.go
+++ b/test/setup.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"log"
+	"log/slog"
 	"net"
 	"os"
 	"path"
@@ -298,11 +299,11 @@ func UpdateGolden(v interface{}, root, fname string) {
 	encoder.SetIndent("", "  ")
 	err := encoder.Encode(v)
 	if err != nil {
-		log.Printf("could not encode golden response %v", err)
+		slog.Warn("could not encode golden response", "err", err)
 	}
 	if os.WriteFile(
 		path.Join(root, fname), bytes.TrimRight(buf.Bytes(), "\n"), 0644) != nil {
-		log.Printf("could not write golden files to %s", fname)
+		slog.Warn("could not write golden files to", "err", err)
 	}
 }
 
@@ -316,18 +317,18 @@ func UpdateProtoGolden(
 	// Use encoding/json to get stable output.
 	data, err := marshaller.Marshal(resp)
 	if err != nil {
-		log.Printf("marshaller.Marshal(%s) = %s", fname, err)
+		slog.Warn("marshaller.Marshal()", "err", err)
 		return
 	}
 	var rm json.RawMessage = data
 	jsonByte, err := json.MarshalIndent(rm, "", "  ")
 	if err != nil {
-		log.Printf("json.MarshalIndent(%s) = %s", fname, err)
+		slog.Warn("json.MarshalIndent()", "err", err)
 		return
 	}
 	err = os.WriteFile(path.Join(root, fname), jsonByte, 0644)
 	if err != nil {
-		log.Printf("os.WriteFile(%s) = %s", fname, err)
+		slog.Warn("os.WriteFile", "err", err)
 	}
 }
 
@@ -377,7 +378,7 @@ func ReadGolden(goldenDir string, goldenFile string) (string, error) {
 // If not enabled, it returns nil.
 func NewSpannerClient() *spanner.SpannerClient {
 	if !EnableSpannerGraph {
-		log.Println("Spanner graph not enabled.")
+		slog.Info("Spanner graph not enabled.")
 		return nil
 	}
 	_, filename, _, _ := runtime.Caller(0)


### PR DESCRIPTION
Replaced all instances of `log.Println` with the `slog` structured logging library for info and warning level log messages.

Reasons to do this:
- log.Println has error severity when ingested by GCP, so datcom-mixer logs appear to be full of errors from e.g. the "Mixer ready to serve" statement.
- Structured logging is [recommended by GCP](https://cloud.google.com/stackdriver/docs/instrumentation/choose-approach#containers) for use with GKE
  - `slog` in particular is [recommended for Golang](https://cloud.google.com/stackdriver/docs/instrumentation/choose-approach#logging-frameworks)

Steps:
- Introduced a new `internal/log/log.go` file to centralize logger setup.
- Updated `cmd/main.go`, `internal/server/v2/facet/contained_in.go`, `internal/server/v2/observation/contained_in.go`, `test/http_memprof/http_memprof.go`, and `test/setup.go` to use `slog.Info` and `slog.Warn` instead of `log.Println`.
- Configured the logger to include source file and line number information.