### PR TITLE
Do not use GROUP_CONCAT when fetching entity variables

### DIFF
--- a/internal/sqldb/statements.go
+++ b/internal/sqldb/statements.go
@@ -226,10 +226,9 @@ var statements = struct {
 			AND t2.object_id IN (:parentPlaces);
 	`,
 	getEntityVariables: `
-		SELECT entity, GROUP_CONCAT(DISTINCT variable) variables
+		SELECT DISTINCT entity, variable
 		FROM observations 
-		WHERE entity in (:entities)
-		GROUP BY entity;
+		WHERE entity in (:entities);
 	`,
 	getAllEntitiesAndVariables: `
 		SELECT DISTINCT entity, variable


### PR DESCRIPTION
* `GROUP_CONCAT` was returning truncated results which caused issues with entities with a high number of variables
* See https://issuetracker.google.com/issues/443752806 for more details
* This PR updates the sql query to not use `GROUP_CONCAT`.