### PR TITLE
Update SkipCache behavior

### DIFF
--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -146,6 +146,31 @@ exposes the http mixer service at `localhost:8081`.
 envoy -l warning --config-path esp/envoy-config.yaml
 ```
 
+## Running Redis locally
+
+Mixer can use Redis as a cache. To run Redis locally for development and connect mixer to it:
+
+1. Install Redis and start a Redis server. On MacOS, you can use Homebrew:
+
+```bash
+brew install redis
+redis-server
+```
+
+2.  Start mixer with `go run cmd/main.go` as described above and add the following flags:
+
+```bash
+--enable_v3=true \
+--use_redis=true \
+--redis_info="$(cat <<EOF
+instances:
+  - host: "127.0.0.1"
+    port: "6379"
+EOF
+)"
+```
+
+
 ## Update Go package dependencies
 
 To view possible updates:

--- a/internal/server/mirror.go
+++ b/internal/server/mirror.go
@@ -106,7 +106,7 @@ func (s *Server) doMirror(
 	var v3Err error
 	var v3Ctx context.Context
 	if skipCache {
-		v3Ctx = metadata.NewOutgoingContext(context.Background(), metadata.Pairs(string(util.XSkipCache), "true"))
+		v3Ctx = metadata.NewIncomingContext(context.Background(), metadata.Pairs(string(util.XSkipCache), "true"))
 	} else {
 		v3Ctx = context.Background()
 	}

--- a/internal/server/redis/processor.go
+++ b/internal/server/redis/processor.go
@@ -52,7 +52,11 @@ func (processor *CacheProcessor) PreProcess(rc *dispatcher.RequestContext) (disp
 	return dispatcher.Continue, nil
 }
 
+// Stores the returned response in Redis if caching is enabled for the request.
 func (processor *CacheProcessor) PostProcess(rc *dispatcher.RequestContext) (dispatcher.Outcome, error) {
+	if skipCache(rc.Context) {
+		return dispatcher.Continue, nil
+	}
 	if rc.CurrentResponse != nil {
 		if err := processor.client.CacheResponse(rc.Context, rc.OriginalRequest, rc.CurrentResponse); err != nil {
 			// Log the error but continue processing.


### PR DESCRIPTION
- When mirroring requests to V3 and setting the SkipCache header, set it on incoming instead of outgoing context so it will actually be read by CacheProcessor.
- If SkipCache is set, also skip storing the response in the cache during post-processing
- Document how to run and connect to Redis locally