### PR TITLE
Improve Apigee deployment script robustness

### DIFF
--- a/deploy/apigee/README.md
+++ b/deploy/apigee/README.md
@@ -31,6 +31,7 @@
    - Proxy structure config `envs/$ENV_NAME.yaml`
    - Proxy variable substitution values `./$ENV_NAME.env`. Use a temp value for PSC host IP if you haven't created an endpoint attachment yet. Other values should have been noted during previous steps.
    - Apigee + load balancer Terraform `terraform/$ENV_NAME/*`
+1. **IMPORTANT**: Manually edit `terraform/$ENV_NAME/terraform.tf` to configure the `bucket` for the GCS backend. This bucket stores the Terraform state. The recommended format is `$HOST_PROJECT_ID-tf`.
 1. Create a destination in Secret Manager for your `./$ENV_NAME.env` file. For example, for the file nonprod.env, you would run `gcloud secrets create nonprod-env --project=<project_id from YAML> --data-file=nonprod.env`
 1. Configure references to resources created by Apigee one-click provisioning:
    - Set tfvars `apigee_lb_url_map_name` from `gcloud compute url-maps list`.

--- a/deploy/apigee/deploy_apigee.sh
+++ b/deploy/apigee/deploy_apigee.sh
@@ -174,7 +174,7 @@ function terraform_plan_and_maybe_apply() {
   fi
 
   while true; do
-    read -p "Proceed to apply the plan? (y/N)" yn
+    read -p "Proceed to apply the plan? (y/n)" yn
     case $yn in
     [Yy]*)
       terraform_cmd "apply $PLAN_FILE"


### PR DESCRIPTION
- Use a plan file to guarantee that the changes applied are always the ones that were previewed
- Check that tfstate is read from a bucket with the expected name
  - Document that the bucket name should be updated when setting up a new Apigee organization