### PR TITLE
[Feature Flags] Fix Cloud Build trigger definition

### DIFF
--- a/build/ci/cloudbuild.deploy_flags.yaml
+++ b/build/ci/cloudbuild.deploy_flags.yaml
@@ -32,6 +32,8 @@ steps:
   # Run the flag deploy script
   - name: gcr.io/datcom-ci/full-env:${_FULL_ENV_VERSION}
     env:
+      # The deploy script looks for this variable to know whether it's running
+      # on Cloud Build. It prints a warning and asks for confirmation otherwise.
       - "BUILD_ID=${BUILD_ID}"
     entrypoint: "bash"
     args:

--- a/build/ci/cloudbuild.deploy_flags.yaml
+++ b/build/ci/cloudbuild.deploy_flags.yaml
@@ -25,17 +25,20 @@
 steps:
   # Ensure past commits are available so they can be used for validation
   - name: gcr.io/cloud-builders/git
-    args: ["fetch", "--unshallow"]
+    args:
+      - fetch
+      - "--unshallow"
 
   # Run the flag deploy script
   - name: gcr.io/datcom-ci/full-env:${_FULL_ENV_VERSION}
+    env:
+      - "BUILD_ID=${BUILD_ID}"
     entrypoint: "bash"
     args:
       - "-c"
       - |
         set -e
         ./deploy/featureflags/deploy_flags.sh deploy/featureflags "$_ENV"
-    waitFor: ["validate-feature-flags"]
 
 substitutions:
   _ENV: ""


### PR DESCRIPTION
- The deploy script looks for $BUILD_ID to know whether it's running on Cloud Build (it asks for confirmation otherwise)
- `validate-feature-flags` isn't a standalone step anymore, it's built into the deploy script