### PR TITLE
Pass timeout deadline in mirrored context

### DIFF
--- a/internal/server/mirror.go
+++ b/internal/server/mirror.go
@@ -81,12 +81,12 @@ func (s *Server) mirrorV3(
 		v3WaitGroup.Add(1)
 	}
 
-	var mirrorTimeout time.Duration
+	var mirrorDeadline time.Time
 	if deadline, ok := ctx.Deadline(); ok {
-		mirrorTimeout = time.Until(deadline)
+		mirrorDeadline = deadline
 	} else {
 		slog.Warn("Original context has no deadline; using default API timeout", "timeout", spanner.ApiTimeout.String())
-		mirrorTimeout = spanner.ApiTimeout
+		mirrorDeadline = time.Now().Add(spanner.ApiTimeout)
 	}
 
 	// This is run in a separate goroutine to not block the response to the original
@@ -97,10 +97,10 @@ func (s *Server) mirrorV3(
 		}
 		// Create a new context for this goroutine, so it does not get canceled
 		// with the original request.
-		baseMirrorCtx := metrics.NewContext(ctx)
+		baseMirrorCtx := metrics.NewContext(context.WithoutCancel(ctx))
 
-		// Re-apply the timeout to the detached context
-		mirrorCtx, cancel := context.WithTimeout(baseMirrorCtx, mirrorTimeout)
+		// Re-apply the deadline to the detached context
+		mirrorCtx, cancel := context.WithDeadline(baseMirrorCtx, mirrorDeadline)
 		defer cancel()
 
 		// First call, without skipping cache

--- a/internal/server/mirror.go
+++ b/internal/server/mirror.go
@@ -26,6 +26,7 @@ import (
 	"github.com/datacommonsorg/mixer/internal/metrics"
 	pb "github.com/datacommonsorg/mixer/internal/proto"
 	pbv2 "github.com/datacommonsorg/mixer/internal/proto/v2"
+	"github.com/datacommonsorg/mixer/internal/server/spanner"
 	"github.com/datacommonsorg/mixer/internal/util"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -79,6 +80,15 @@ func (s *Server) mirrorV3(
 	if v3WaitGroup != nil {
 		v3WaitGroup.Add(1)
 	}
+
+	var mirrorTimeout time.Duration
+	if deadline, ok := ctx.Deadline(); ok {
+		mirrorTimeout = time.Until(deadline)
+	} else {
+		slog.Warn("Original context has no deadline; using default API timeout", "timeout", spanner.ApiTimeout.String())
+		mirrorTimeout = spanner.ApiTimeout
+	}
+
 	// This is run in a separate goroutine to not block the response to the original
 	// request.
 	go func() {
@@ -87,7 +97,11 @@ func (s *Server) mirrorV3(
 		}
 		// Create a new context for this goroutine, so it does not get canceled
 		// with the original request.
-		mirrorCtx := metrics.NewContext(ctx)
+		baseMirrorCtx := metrics.NewContext(ctx)
+
+		// Re-apply the timeout to the detached context
+		mirrorCtx, cancel := context.WithTimeout(baseMirrorCtx, mirrorTimeout)
+		defer cancel()
 
 		// First call, without skipping cache
 		s.doMirror(mirrorCtx, originalReq, originalResp, originalLatency, v3Call, cmpOpts, false /* skipCache */)
@@ -115,11 +129,9 @@ func (s *Server) doMirror(
 	v3StartTime := time.Now()
 	var v3Resp proto.Message
 	var v3Err error
-	var v3Ctx context.Context
+	v3Ctx := ctx
 	if skipCache {
-		v3Ctx = metadata.NewIncomingContext(context.Background(), metadata.Pairs(string(util.XSkipCache), "true"))
-	} else {
-		v3Ctx = context.Background()
+		v3Ctx = metadata.NewIncomingContext(v3Ctx, metadata.Pairs(string(util.XSkipCache), "true"))
 	}
 	v3Resp, v3Err = v3Call(v3Ctx, reqClone)
 	v3Latency := time.Since(v3StartTime)

--- a/internal/server/mirror_test.go
+++ b/internal/server/mirror_test.go
@@ -638,7 +638,6 @@ func TestMaybeMirrorV3_SlowQueryLogging(t *testing.T) {
 }
 
 func TestMirrorV3_FallsBackToDefaultDeadline(t *testing.T) {
-	// 1. Pass a context intentionally lacking a deadline
 	ctx := context.Background()
 
 	s := &Server{

--- a/internal/server/mirror_test.go
+++ b/internal/server/mirror_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/datacommonsorg/mixer/internal/metrics"
 	pb "github.com/datacommonsorg/mixer/internal/proto"
 	pbv2 "github.com/datacommonsorg/mixer/internal/proto/v2"
+	"github.com/datacommonsorg/mixer/internal/server/spanner"
 	"github.com/datacommonsorg/mixer/internal/util"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/sdk/metric"
@@ -62,7 +63,9 @@ func setUpSlogCapture() (*bytes.Buffer, func()) {
 }
 
 func TestMaybeMirrorV3_Percentage(t *testing.T) {
-	ctx := context.Background()
+	baseCtx := context.Background()
+	ctx, cancel := context.WithTimeout(baseCtx, 5*time.Second)
+	defer cancel()
 	req := &pbv2.NodeRequest{
 		Nodes: []string{"test"},
 	}
@@ -128,7 +131,8 @@ func TestMaybeMirrorV3_Percentage(t *testing.T) {
 }
 
 func TestMaybeMirrorV3_IgnoreSubsequentPages(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
 	s := &Server{
 		flags: &featureflags.Flags{
 			V3MirrorFraction: 1.0, // Mirroring is on
@@ -153,7 +157,8 @@ func TestMaybeMirrorV3_IgnoreSubsequentPages(t *testing.T) {
 }
 
 func TestMaybeMirrorV3_LatencyMetric(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
 	s := &Server{
 		flags: &featureflags.Flags{
 			V3MirrorFraction: 1.0, // Mirroring is on
@@ -210,7 +215,8 @@ func TestMaybeMirrorV3_LatencyMetric(t *testing.T) {
 }
 
 func TestMaybeMirrorV3_ObservationResponseMismatch(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
 	s := &Server{
 		flags: &featureflags.Flags{
 			V3MirrorFraction: 1.0, // Mirroring is on
@@ -286,7 +292,8 @@ func TestMaybeMirrorV3_ObservationResponseMismatch(t *testing.T) {
 }
 
 func TestMaybeMirrorV3_NodeResponseMismatch(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
 	s := &Server{
 		flags: &featureflags.Flags{
 			V3MirrorFraction: 1.0, // Mirroring is on
@@ -343,7 +350,8 @@ func TestMaybeMirrorV3_NodeResponseMismatch(t *testing.T) {
 }
 
 func TestMaybeMirrorV3_ResponseMatch(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
 	s := &Server{
 		flags: &featureflags.Flags{
 			V3MirrorFraction: 1.0, // Mirroring is on
@@ -415,7 +423,8 @@ func TestMaybeMirrorV3_ResponseMatch(t *testing.T) {
 }
 
 func TestMaybeMirrorV3_V3Error(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
 	s := &Server{
 		flags: &featureflags.Flags{
 			V3MirrorFraction: 1.0, // Mirroring is on
@@ -482,7 +491,8 @@ func TestMaybeMirrorV3_V3Error(t *testing.T) {
 }
 
 func TestMaybeMirrorV3_NodeIgnoresNextTokenMismatch(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
 	s := &Server{
 		flags: &featureflags.Flags{
 			V3MirrorFraction: 1.0, // Mirroring is on
@@ -517,7 +527,8 @@ func TestMaybeMirrorV3_NodeIgnoresNextTokenMismatch(t *testing.T) {
 }
 
 func TestMaybeMirrorV3_ObservationIgnoresFacetIdsAndMapOrder(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
 	s := &Server{
 		flags: &featureflags.Flags{
 			V3MirrorFraction: 1.0, // Mirroring is on
@@ -588,7 +599,8 @@ func TestMaybeMirrorV3_ObservationIgnoresFacetIdsAndMapOrder(t *testing.T) {
 }
 
 func TestMaybeMirrorV3_SlowQueryLogging(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
 	s := &Server{
 		flags: &featureflags.Flags{
 			V3MirrorFraction: 1.0,
@@ -622,5 +634,57 @@ func TestMaybeMirrorV3_SlowQueryLogging(t *testing.T) {
 
 	if !strings.Contains(logOutput, "latencyDiff") {
 		t.Errorf("Log should contain the latencyDiff value. Got: %q", logOutput)
+	}
+}
+
+func TestMirrorV3_FallsBackToDefaultDeadline(t *testing.T) {
+	// 1. Pass a context intentionally lacking a deadline
+	ctx := context.Background()
+
+	s := &Server{
+		flags: &featureflags.Flags{
+			V3MirrorFraction: 1.0, // Ensure mirroring is enabled
+		},
+	}
+
+	req := &pbv2.NodeRequest{}
+	resp := &pbv2.NodeResponse{}
+
+	var mirrorWg sync.WaitGroup
+
+	callCount := 0
+	var mu sync.Mutex
+	startTime := time.Now()
+
+	v3Call := func(v3Ctx context.Context, req proto.Message) (proto.Message, error) {
+		mu.Lock()
+		callCount++
+		mu.Unlock()
+
+		// Assert the deadline exists
+		deadline, ok := v3Ctx.Deadline()
+		if !ok {
+			t.Errorf("Expected context to have a fallback deadline, but it had none")
+			return &pbv2.NodeResponse{}, nil
+		}
+
+		// Assert the deadline is roughly equal to spanner.ApiTimeout
+		expectedDeadline := startTime.Add(spanner.ApiTimeout)
+
+		// Calculate the difference between the actual deadline and our expected deadline.
+		// We allow a small 1-second buffer because time.Now() inside mirrorV3
+		// will be slightly later than our startTime.
+		diff := deadline.Sub(expectedDeadline)
+		if diff < -time.Second || diff > time.Second {
+			t.Errorf("Fallback deadline is outside expected bounds. Got %v, expected ~%v", deadline, expectedDeadline)
+		}
+
+		return &pbv2.NodeResponse{}, nil
+	}
+
+	s.mirrorV3(ctx, req, resp, 0, v3Call, GetV2NodeCmpOpts(), &mirrorWg)
+	mirrorWg.Wait()
+	if callCount != 2 {
+		t.Errorf("Expected v3Call to be executed exactly 2 times, got %d", callCount)
 	}
 }

--- a/internal/server/spanner/query.go
+++ b/internal/server/spanner/query.go
@@ -58,7 +58,7 @@ const (
 	timestampPollingTimeout = 10 * time.Second
 
 	// Default timeout for API requests.
-	apiTimeout = 60 * time.Second
+	ApiTimeout = 60 * time.Second
 
 	// Special edge predicates.
 	predAffectedPlace      = "affectedPlace"
@@ -675,8 +675,8 @@ func (sc *spannerDatabaseClient) executeQuery(
 	} else {
 		// Fallback if the parent context surprisingly has no deadline.
 		// Using the default API timeout.
-		slog.Warn("Parent context has no deadline; using default API timeout", "timeout", apiTimeout.String())
-		timeout = apiTimeout
+		slog.Warn("Parent context has no deadline; using default API timeout", "timeout", ApiTimeout.String())
+		timeout = ApiTimeout
 	}
 	queryCtx, cancel = context.WithTimeout(ctx, timeout)
 	defer cancel()

--- a/internal/server/spanner/query.go
+++ b/internal/server/spanner/query.go
@@ -668,17 +668,15 @@ func (sc *spannerDatabaseClient) executeQuery(
 ) error {
 	var queryCtx context.Context
 	var cancel context.CancelFunc
-	var timeout time.Duration
 
-	if deadline, ok := ctx.Deadline(); ok {
-		timeout = time.Until(deadline)
+	if _, ok := ctx.Deadline(); ok {
+		queryCtx, cancel = context.WithCancel(ctx)
 	} else {
 		// Fallback if the parent context surprisingly has no deadline.
 		// Using the default API timeout.
 		slog.Warn("Parent context has no deadline; using default API timeout", "timeout", ApiTimeout.String())
-		timeout = ApiTimeout
+		queryCtx, cancel = context.WithTimeout(ctx, ApiTimeout)
 	}
-	queryCtx, cancel = context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	runQuery := func(tb spanner.TimestampBound) error {
@@ -691,7 +689,6 @@ func (sc *spannerDatabaseClient) executeQuery(
 		if isTimeoutError(err) {
 			slog.ErrorContext(queryCtx, "Spanner query timed out",
 				"sql", stmt.SQL,
-				"timeout", timeout.String(),
 				"error", err.Error(),
 			)
 		}


### PR DESCRIPTION
Previously we were creating a new context for mirrored requests so were not keeping the original timeout deadline. Since a majority of our traffic is still mirrored, we were almost always falling back to the default timeout. 

This PR updates the mirrored context to include the original timeout