### PR TITLE
Add BulkVariableGroupInfo to spanner data source

### DIFF
--- a/internal/server/handler_v2.go
+++ b/internal/server/handler_v2.go
@@ -652,15 +652,34 @@ func (s *Server) V2BulkVariableInfo(
 func (s *Server) V2BulkVariableGroupInfo(
 	ctx context.Context, in *pbv1.BulkVariableGroupInfoRequest,
 ) (*pbv1.BulkVariableGroupInfoResponse, error) {
+	if s.shouldDivertV2(ctx) {
+		return s.dispatcher.BulkVariableGroupInfo(ctx, in)
+	}
+
+	v2StartTime := time.Now()
+
 	// Use the V1 implementation for now.
-	resp, err := s.BulkVariableGroupInfo(ctx, in)
+	v2Resp, err := s.BulkVariableGroupInfo(ctx, in)
 	if err != nil {
 		return nil, err
 	}
 
-	convertV1ToV2BulkVariableGroupInfo(resp)
+	convertV1ToV2BulkVariableGroupInfo(v2Resp)
 
-	return resp, nil
+	v2Latency := time.Since(v2StartTime)
+
+	s.maybeMirrorV3(
+		ctx,
+		in,
+		v2Resp,
+		v2Latency,
+		func(ctx context.Context, req proto.Message) (proto.Message, error) {
+			return s.V3BulkVariableGroupInfo(ctx, req.(*pbv1.BulkVariableGroupInfoRequest))
+		},
+		GetV2BulkVariableGroupInfoCmpOpts(),
+	)
+
+	return v2Resp, nil
 }
 
 // resolveRouting determines whether to route to local and/or remote instances

--- a/internal/server/mirror.go
+++ b/internal/server/mirror.go
@@ -245,6 +245,12 @@ func GetV2BulkVariableInfoCmpOpts() []cmp.Option {
 	}
 }
 
+func GetV2BulkVariableGroupInfoCmpOpts() []cmp.Option {
+	return []cmp.Option{
+		protocmp.Transform(),
+	}
+}
+
 func GetV2EventCmpOpts() []cmp.Option {
 	return []cmp.Option{
 		protocmp.Transform(),

--- a/internal/server/spanner/datasource.go
+++ b/internal/server/spanner/datasource.go
@@ -606,6 +606,67 @@ func (sds *SpannerDataSource) handleEventCollection(ctx context.Context, req *pb
 }
 
 func (sds *SpannerDataSource) BulkVariableGroupInfo(ctx context.Context, req *pbv1.BulkVariableGroupInfoRequest) (*pbv1.BulkVariableGroupInfoResponse, error) {
-	// TODO: Update with implementation.
-	return &pbv1.BulkVariableGroupInfoResponse{}, nil
+	// Validate input.
+	if len(req.GetNodes()) == 0 {
+		return nil, status.Errorf(codes.InvalidArgument, "request must specify at least one node")
+	}
+	if len(req.GetNodes()) > 1 && (len(req.ConstrainedEntities) > 0 || req.NumEntitiesExistence > 0) {
+		return nil, status.Errorf(codes.InvalidArgument, "constrainedEntities and numEntitiesExistence can only be used when one node is specified")
+	}
+	if req.NumEntitiesExistence < 0 {
+		return nil, status.Errorf(codes.InvalidArgument, "numEntitiesExistence must be non-negative")
+	}
+	var svgs []string
+	for _, node := range req.GetNodes() {
+		if !strings.HasPrefix(node, prefixTopic) {
+			svgs = append(svgs, node)
+		}
+	}
+
+	// Unfiltered case.
+	if len(req.ConstrainedEntities) == 0 && req.NumEntitiesExistence == 0 {
+		svgInfo, err := sds.client.GetStatVarGroupNode(ctx, svgs)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "error getting StatVarGroupNode from Spanner: %v", err)
+		}
+		return svgInfoToBulkVariableGroupInfoResponse(svgInfo, req.GetNodes()), nil
+	}
+
+	var constrainedPlaces []string
+	var constrainedImport string
+	for _, constraint := range req.ConstrainedEntities {
+		if strings.HasPrefix(constraint, prefixDataset) || strings.HasPrefix(constraint, prefixSource) {
+			if constrainedImport != "" {
+				return nil, status.Errorf(codes.InvalidArgument, "only one import constraint can be specified")
+			}
+			constrainedImport = constraint
+		} else {
+			constrainedPlaces = append(constrainedPlaces, constraint)
+		}
+	}
+
+	// Filter Topic.
+	if strings.HasPrefix(req.GetNodes()[0], prefixTopic) {
+		count, err := sds.client.GetFilteredTopic(ctx, req.GetNodes()[0], constrainedPlaces, constrainedImport, int(req.NumEntitiesExistence))
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "error getting filtered topic count from Spanner: %v", err)
+		}
+		return &pbv1.BulkVariableGroupInfoResponse{
+			Data: []*pbv1.VariableGroupInfoResponse{
+				{
+					Node: req.GetNodes()[0],
+					Info: &pb.StatVarGroupNode{
+						DescendentStatVarCount: int32(count),
+					},
+				},
+			},
+		}, nil
+	}
+
+	// Filter StatVarGroup.
+	filteredSVGInfo, err := sds.client.GetFilteredStatVarGroupNode(ctx, svgs[0], constrainedPlaces, constrainedImport, int(req.NumEntitiesExistence))
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "error getting filtered StatVarGroupNode from Spanner: %v", err)
+	}
+	return filteredSVGInfoToBulkVariableGroupInfoResponse(filteredSVGInfo, req.GetNodes()[0]), nil
 }

--- a/internal/server/spanner/dsutil.go
+++ b/internal/server/spanner/dsutil.go
@@ -24,6 +24,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"unicode"
 
 	pb "github.com/datacommonsorg/mixer/internal/proto"
 	pbv1 "github.com/datacommonsorg/mixer/internal/proto/v1"
@@ -713,5 +714,220 @@ func generateBulkVariableInfoResponse(variableInfo map[string]map[string]*pb.Sta
 	slices.SortFunc(response.Data, func(a, b *pbv1.VariableInfoResponse) int {
 		return strings.Compare(a.Node, b.Node)
 	})
+	return response
+}
+
+// splitPascalCase splits a PascalCase string into separate words with spaces.
+func splitPascalCase(s string) string {
+	var builder strings.Builder
+
+	// Pre-allocate memory.
+	builder.Grow(len(s) + 5)
+
+	runes := []rune(s)
+	for i, r := range runes {
+		if i > 0 {
+			prev := runes[i-1]
+
+			// Rule 1: Lowercase to Uppercase (e.g., "m" -> "I")
+			isLowerToUpper := unicode.IsLower(prev) && unicode.IsUpper(r)
+
+			// Rule 2: Acronym boundary (e.g., "X" -> "M" -> "L")
+			isAcronym := unicode.IsUpper(prev) && unicode.IsUpper(r) &&
+				i+1 < len(runes) && unicode.IsLower(runes[i+1])
+
+			// Rule 3: Letter to Number (e.g., "s" -> "6")
+			isLetterToDigit := unicode.IsLetter(prev) && unicode.IsDigit(r)
+
+			// Rule 4: Number to Letter (e.g., "5" -> "Y")
+			isDigitToLetter := unicode.IsDigit(prev) && unicode.IsLetter(r)
+
+			// If any of our boundaries are met, insert a space
+			if isLowerToUpper || isAcronym || isLetterToDigit || isDigitToLetter {
+				builder.WriteRune(' ')
+			}
+		}
+		builder.WriteRune(r)
+	}
+
+	return builder.String()
+}
+
+// processSvgId removes the SVG prefix up through the population type and splits into pvs.
+func processSvgId(svg string) []string {
+	var trimmed string
+	_, after, found := strings.Cut(svg, "_")
+	if found {
+		trimmed = after
+	} else {
+		trimmed = strings.TrimPrefix(svg, prefixSVG)
+	}
+
+	return strings.FieldsFunc(trimmed, func(r rune) bool {
+		return r == '_' || r == '-'
+	})
+}
+
+// isCuratedHierarchy checks if the SVG is part of a curated hierarchy, which have different naming conventions that do not follow the standard specialization pattern.
+func isCuratedHierarchy(svg string) bool {
+	return strings.HasPrefix(svg, "dc/g/UN") || strings.HasPrefix(svg, "dc/g/SDG")
+}
+
+// getSpecializedEntity returns the specialized entity for a child SVG given its parent SVG.
+func getSpecializedEntity(parent, child, childName string) string {
+	if !strings.Contains(child, "_") || isCuratedHierarchy(child) { // Child is likely curated.
+		return childName
+	}
+	parentParts := processSvgId(parent)
+	childParts := processSvgId(child)
+
+	for i := 0; i < len(parentParts) && i < len(childParts); i++ {
+		if parentParts[i] != childParts[i] {
+			return splitPascalCase(childParts[i])
+		}
+	}
+
+	return splitPascalCase(childParts[len(childParts)-1])
+}
+
+// sortSVGNode sorts the child SVGs and SVs of a StatVarGroupNode. Child SVGs are sorted by specialized entity, with special handling for curated hierarchies, and child SVs are sorted by display name.
+func sortSVGNode(node *pb.StatVarGroupNode) {
+	sort.Slice(node.ChildStatVarGroups, func(i, j int) bool {
+		// Use numeric sorting for special groups.
+		if isCuratedHierarchy(node.ChildStatVarGroups[i].Id) {
+			iName := strings.Split(node.ChildStatVarGroups[i].SpecializedEntity, ":")[0]
+			jName := strings.Split(node.ChildStatVarGroups[j].SpecializedEntity, ":")[0]
+			iNum, err1 := strconv.Atoi(iName)
+			jNum, err2 := strconv.Atoi(jName)
+			if err1 == nil && err2 == nil {
+				return iNum < jNum
+			}
+			// Fall back to string comparison if numeric parsing fails.
+		}
+		return node.ChildStatVarGroups[i].SpecializedEntity < node.ChildStatVarGroups[j].SpecializedEntity
+	})
+	sort.Slice(node.ChildStatVars, func(i, j int) bool {
+		return node.ChildStatVars[i].DisplayName < node.ChildStatVars[j].DisplayName
+	})
+}
+
+// svgInfoToBulkVariableGroupInfoResponse converts a list of StatVarGroupNode info to a BulkVariableGroupInfoResponse.
+func svgInfoToBulkVariableGroupInfoResponse(svgInfo []*StatVarGroupNode, nodes []string) *pbv1.BulkVariableGroupInfoResponse {
+	response := &pbv1.BulkVariableGroupInfoResponse{
+		Data: make([]*pbv1.VariableGroupInfoResponse, 0, len(nodes)),
+	}
+
+	nodeToSVG := map[string]*pb.StatVarGroupNode{}
+	for _, node := range nodes {
+		nodeToSVG[node] = &pb.StatVarGroupNode{}
+	}
+	for _, row := range svgInfo {
+		// We are trimming excess quotes to help with sorting.
+		// TODO: This should really be handled at ingestion time instead.
+		name := strings.Trim(row.Name, "\"")
+		svgNode := nodeToSVG[row.SVG]
+		if row.DescendentStatVarCount >= 0 { // Child SVG.
+			if row.SubjectID == row.SVG { // Self.
+				svgNode.AbsoluteName = name
+				svgNode.DescendentStatVarCount = int32(row.DescendentStatVarCount)
+				continue
+			}
+			childSVG := &pb.StatVarGroupNode_ChildSVG{
+				Id:                     row.SubjectID,
+				SpecializedEntity:      getSpecializedEntity(row.SVG, row.SubjectID, name),
+				DisplayName:            name,
+				DescendentStatVarCount: int32(row.DescendentStatVarCount),
+			}
+			svgNode.ChildStatVarGroups = append(svgNode.ChildStatVarGroups, childSVG)
+		} else { // Child SV.
+			childSV := &pb.StatVarGroupNode_ChildSV{
+				Id:          row.SubjectID,
+				DisplayName: name,
+				HasData:     row.HasData,
+			}
+			svgNode.ChildStatVars = append(svgNode.ChildStatVars, childSV)
+		}
+	}
+
+	// Sort results.
+	for node, svgNode := range nodeToSVG {
+		sortSVGNode(svgNode)
+		response.Data = append(response.Data, &pbv1.VariableGroupInfoResponse{
+			Node: node,
+			Info: nodeToSVG[node],
+		})
+	}
+	slices.SortFunc(response.Data, func(a, b *pbv1.VariableGroupInfoResponse) int {
+		return strings.Compare(a.Node, b.Node)
+	})
+	return response
+}
+
+// filteredSVGInfoToBulkVariableGroupInfoResponse converts a list of FilteredStatVarGroupNode info to a BulkVariableGroupInfoResponse.
+func filteredSVGInfoToBulkVariableGroupInfoResponse(svgInfo *FilteredStatVarGroupNode, node string) *pbv1.BulkVariableGroupInfoResponse {
+	response := &pbv1.BulkVariableGroupInfoResponse{
+		Data: []*pbv1.VariableGroupInfoResponse{
+			{
+				Node: node,
+				Info: &pb.StatVarGroupNode{},
+			},
+		},
+	}
+
+	svgNode := response.Data[0].Info
+	allChildren := map[string]bool{}
+
+	// Attach Child SVGs.
+	for _, row := range svgInfo.ChildSVG {
+		name := strings.Trim(row.Name, "\"")
+		if row.SubjectID == node { // Self.
+			svgNode.AbsoluteName = name
+			svgNode.DescendentStatVarCount = int32(row.DescendentStatVarCount)
+			continue
+		}
+		svgNode.ChildStatVarGroups = append(svgNode.ChildStatVarGroups, &pb.StatVarGroupNode_ChildSVG{
+			Id:                     row.SubjectID,
+			SpecializedEntity:      getSpecializedEntity(node, row.SubjectID, name),
+			DisplayName:            name,
+			DescendentStatVarCount: int32(row.DescendentStatVarCount),
+		})
+		allChildren[row.SubjectID] = true
+	}
+
+	// Attach Child SVs.
+	for _, row := range svgInfo.ChildSV {
+		name := strings.Trim(row.Name, "\"")
+		svgNode.ChildStatVars = append(svgNode.ChildStatVars, &pb.StatVarGroupNode_ChildSV{
+			Id:          row.SubjectID,
+			DisplayName: name,
+			HasData:     true,
+		})
+		allChildren[row.SubjectID] = true
+	}
+
+	// Attach missing children.
+	for _, row := range svgInfo.SVGChild {
+		if _, ok := allChildren[row.SubjectID]; ok {
+			continue
+		}
+		name := strings.Trim(row.Name, "\"")
+		switch row.Predicate {
+		case predicateSpecializationOf:
+			svgNode.ChildStatVarGroups = append(svgNode.ChildStatVarGroups, &pb.StatVarGroupNode_ChildSVG{
+				Id:                row.SubjectID,
+				SpecializedEntity: getSpecializedEntity(node, row.SubjectID, row.Name),
+				DisplayName:       row.Name,
+			})
+		case predicateMemberOf:
+			svgNode.ChildStatVars = append(svgNode.ChildStatVars, &pb.StatVarGroupNode_ChildSV{
+				Id:          row.SubjectID,
+				DisplayName: name,
+				HasData:     false,
+			})
+		}
+	}
+
+	sortSVGNode(svgNode)
+
 	return response
 }

--- a/internal/server/spanner/dsutil.go
+++ b/internal/server/spanner/dsutil.go
@@ -915,14 +915,13 @@ func filteredSVGInfoToBulkVariableGroupInfoResponse(svgInfo *FilteredStatVarGrou
 		case predicateSpecializationOf:
 			svgNode.ChildStatVarGroups = append(svgNode.ChildStatVarGroups, &pb.StatVarGroupNode_ChildSVG{
 				Id:                row.SubjectID,
-				SpecializedEntity: getSpecializedEntity(node, row.SubjectID, row.Name),
-				DisplayName:       row.Name,
+				SpecializedEntity: getSpecializedEntity(node, row.SubjectID, name),
+				DisplayName:       name,
 			})
 		case predicateMemberOf:
 			svgNode.ChildStatVars = append(svgNode.ChildStatVars, &pb.StatVarGroupNode_ChildSV{
 				Id:          row.SubjectID,
 				DisplayName: name,
-				HasData:     false,
 			})
 		}
 	}

--- a/internal/server/spanner/query_builder.go
+++ b/internal/server/spanner/query_builder.go
@@ -62,6 +62,18 @@ const (
 	predicateIsPartOf = "isPartOf"
 	// source predicate
 	predicateSource = "source"
+	// memberOf predicate
+	predicateMemberOf = "memberOf"
+	// specializationOf predicate
+	predicateSpecializationOf = "specializationOf"
+	// Dataset dcid prefix
+	prefixDataset = "dc/d/"
+	// Source dcid prefix
+	prefixSource = "dc/s/"
+	// Topic dcid prefix
+	prefixTopic = "dc/topic/"
+	// StatVarGroup dcid prefix
+	prefixSVG = "dc/g/"
 )
 
 func GetCompletionTimestampQuery() *spanner.Statement {
@@ -535,7 +547,7 @@ func getParamStatement(param string, inputs []string) (string, interface{}) {
 
 // getImportFilterPredicate returns the appropriate filter predicate for a given filter entity.
 func getImportFilterPredicate(entity string) string {
-	if strings.HasPrefix(entity, "dc/d/") {
+	if strings.HasPrefix(entity, prefixDataset) {
 		return predicateIsPartOf
 	}
 	return predicateSource

--- a/internal/server/v3/bulk_variable_group_info/bulk_variable_group_info_filtered_svg.json
+++ b/internal/server/v3/bulk_variable_group_info/bulk_variable_group_info_filtered_svg.json
@@ -1,1 +1,131 @@
-{}
+{
+  "data": [
+    {
+      "node": "dc/g/Environment",
+      "info": {
+        "absoluteName": "Environment",
+        "childStatVars": [
+          {
+            "id": "Mean_WindDirection"
+          },
+          {
+            "id": "Mean_PalmerDroughtSeverityIndex",
+            "displayName": "Mean Palmer Drought Severity Index (PDSI)"
+          }
+        ],
+        "childStatVarGroups": [
+          {
+            "id": "dc/g/Place_AreaType",
+            "specializedEntity": "Area Type",
+            "displayName": "Place by Area Type"
+          },
+          {
+            "id": "dc/g/Atmosphere",
+            "specializedEntity": "Atmosphere",
+            "displayName": "Atmosphere"
+          },
+          {
+            "id": "dc/g/BodyOfWater",
+            "specializedEntity": "Body of Water",
+            "displayName": "Body of Water"
+          },
+          {
+            "id": "dc/g/Disasters",
+            "specializedEntity": "Disasters",
+            "displayName": "Disasters",
+            "descendentStatVarCount": 22
+          },
+          {
+            "id": "dc/g/Emissions",
+            "specializedEntity": "Emissions",
+            "displayName": "Emissions",
+            "descendentStatVarCount": 246
+          },
+          {
+            "id": "dc/g/LandCover",
+            "specializedEntity": "Land Cover",
+            "displayName": "Land Cover"
+          },
+          {
+            "id": "dc/g/Environment_Miscellaneous",
+            "specializedEntity": "Miscellaneous",
+            "displayName": "Miscellaneous",
+            "descendentStatVarCount": 85
+          },
+          {
+            "id": "dc/g/NaturalHazardImpact",
+            "specializedEntity": "Natural Hazard Impact",
+            "displayName": "Natural Hazard Impact"
+          },
+          {
+            "id": "dc/g/Household_NumberOfVehicles",
+            "specializedEntity": "Number Of Vehicles",
+            "displayName": "Household by Number of Vehicles"
+          },
+          {
+            "id": "dc/g/PollutedSites",
+            "specializedEntity": "Polluted Sites",
+            "displayName": "Polluted Sites"
+          },
+          {
+            "id": "dc/g/SeaBodyOfWater",
+            "specializedEntity": "Sea Body of Water",
+            "displayName": "Sea Body of Water"
+          },
+          {
+            "id": "dc/g/Household_TransportationType",
+            "specializedEntity": "Transportation Type",
+            "displayName": "Household by Transportation Type"
+          },
+          {
+            "id": "dc/g/WasteGenerated",
+            "specializedEntity": "Waste Generated",
+            "displayName": "Waste Generated"
+          },
+          {
+            "id": "dc/g/Person_WasteTreatmentType",
+            "specializedEntity": "Waste Treatment Type",
+            "displayName": "Person by Waste Treatment Type",
+            "descendentStatVarCount": 7
+          },
+          {
+            "id": "dc/g/Water",
+            "specializedEntity": "Water",
+            "displayName": "Water"
+          },
+          {
+            "id": "dc/g/Person_WaterTreatmentLevel",
+            "specializedEntity": "Water Treatment Level",
+            "displayName": "Person by Water Treatment Level",
+            "descendentStatVarCount": 4
+          },
+          {
+            "id": "dc/g/Person_WaterTreatmentStatus",
+            "specializedEntity": "Water Treatment Status",
+            "displayName": "Person by Water Treatment Status",
+            "descendentStatVarCount": 6
+          },
+          {
+            "id": "dc/g/Person_WaterTreatmentSystem",
+            "specializedEntity": "Water Treatment System",
+            "displayName": "Person by Water Treatment System",
+            "descendentStatVarCount": 7
+          },
+          {
+            "id": "dc/g/Person_WaterTreatmentType",
+            "specializedEntity": "Water Treatment Type",
+            "displayName": "Person by Water Treatment Type",
+            "descendentStatVarCount": 6
+          },
+          {
+            "id": "dc/g/Weather",
+            "specializedEntity": "Weather",
+            "displayName": "Weather",
+            "descendentStatVarCount": 735
+          }
+        ],
+        "descendentStatVarCount": 1095
+      }
+    }
+  ]
+}

--- a/internal/server/v3/bulk_variable_group_info/bulk_variable_group_info_filtered_topic.json
+++ b/internal/server/v3/bulk_variable_group_info/bulk_variable_group_info_filtered_topic.json
@@ -1,1 +1,10 @@
-{}
+{
+  "data": [
+    {
+      "node": "dc/topic/Demographics",
+      "info": {
+        "descendentStatVarCount": 2
+      }
+    }
+  ]
+}

--- a/internal/server/v3/bulk_variable_group_info/bulk_variable_group_info_stat_var_group_node.json
+++ b/internal/server/v3/bulk_variable_group_info/bulk_variable_group_info_stat_var_group_node.json
@@ -1,1 +1,160 @@
-{}
+{
+  "data": [
+    {
+      "node": "dc/g/Agriculture",
+      "info": {
+        "absoluteName": "Agriculture",
+        "childStatVars": [
+          {
+            "id": "Count_Person_5OrLessMeter_Rural_AsAFractionOf_Count_Person",
+            "hasData": true
+          }
+        ],
+        "childStatVarGroups": [
+          {
+            "id": "dc/g/Person_EconomicSector",
+            "specializedEntity": "Economic Sector",
+            "displayName": "Person by Economic Sector",
+            "descendentStatVarCount": 702
+          },
+          {
+            "id": "dc/g/Farm",
+            "specializedEntity": "Farm",
+            "displayName": "Farm",
+            "descendentStatVarCount": 132
+          },
+          {
+            "id": "dc/g/FarmInventory",
+            "specializedEntity": "Farm Inventory",
+            "displayName": "Farm Inventory",
+            "descendentStatVarCount": 81
+          },
+          {
+            "id": "dc/g/Agriculture_Miscellaneous",
+            "specializedEntity": "Miscellaneous",
+            "displayName": "Miscellaneous",
+            "descendentStatVarCount": 41
+          },
+          {
+            "id": "dc/g/Person_OwnershipStatus",
+            "specializedEntity": "Ownership Status",
+            "displayName": "Person by Ownership Status",
+            "descendentStatVarCount": 8
+          }
+        ],
+        "descendentStatVarCount": 965
+      }
+    },
+    {
+      "node": "dc/g/SDG",
+      "info": {
+        "absoluteName": "Sustainable Development Goals",
+        "childStatVarGroups": [
+          {
+            "id": "dc/g/SDG_1",
+            "specializedEntity": "1: No Poverty",
+            "displayName": "1: No Poverty",
+            "descendentStatVarCount": 131
+          },
+          {
+            "id": "dc/g/SDG_2",
+            "specializedEntity": "2: Zero Hunger",
+            "displayName": "2: Zero Hunger",
+            "descendentStatVarCount": 75
+          },
+          {
+            "id": "dc/g/SDG_3",
+            "specializedEntity": "3: Good Health and Well-being",
+            "displayName": "3: Good Health and Well-being",
+            "descendentStatVarCount": 152
+          },
+          {
+            "id": "dc/g/SDG_4",
+            "specializedEntity": "4: Quality Education",
+            "displayName": "4: Quality Education",
+            "descendentStatVarCount": 918
+          },
+          {
+            "id": "dc/g/SDG_5",
+            "specializedEntity": "5: Gender Equality",
+            "displayName": "5: Gender Equality",
+            "descendentStatVarCount": 401
+          },
+          {
+            "id": "dc/g/SDG_6",
+            "specializedEntity": "6: Clean Water and Sanitation",
+            "displayName": "6: Clean Water and Sanitation",
+            "descendentStatVarCount": 94
+          },
+          {
+            "id": "dc/g/SDG_7",
+            "specializedEntity": "7: Affordable and Clean Energy",
+            "displayName": "7: Affordable and Clean Energy",
+            "descendentStatVarCount": 23
+          },
+          {
+            "id": "dc/g/SDG_8",
+            "specializedEntity": "8: Decent Work and Economic Growth",
+            "displayName": "8: Decent Work and Economic Growth",
+            "descendentStatVarCount": 277
+          },
+          {
+            "id": "dc/g/SDG_9",
+            "specializedEntity": "9: Industry, Innovation and Infrastructure",
+            "displayName": "9: Industry, Innovation and Infrastructure",
+            "descendentStatVarCount": 30
+          },
+          {
+            "id": "dc/g/SDG_10",
+            "specializedEntity": "10: Reduced Inequality",
+            "displayName": "10: Reduced Inequality",
+            "descendentStatVarCount": 696
+          },
+          {
+            "id": "dc/g/SDG_11",
+            "specializedEntity": "11: Sustainable Cities and Communities",
+            "displayName": "11: Sustainable Cities and Communities",
+            "descendentStatVarCount": 52
+          },
+          {
+            "id": "dc/g/SDG_12",
+            "specializedEntity": "12: Responsible Consumption and Production",
+            "displayName": "12: Responsible Consumption and Production",
+            "descendentStatVarCount": 202
+          },
+          {
+            "id": "dc/g/SDG_13",
+            "specializedEntity": "13: Climate Action",
+            "displayName": "13: Climate Action",
+            "descendentStatVarCount": 66
+          },
+          {
+            "id": "dc/g/SDG_14",
+            "specializedEntity": "14: Life Below Water",
+            "displayName": "14: Life Below Water",
+            "descendentStatVarCount": 319
+          },
+          {
+            "id": "dc/g/SDG_15",
+            "specializedEntity": "15: Life on Land",
+            "displayName": "15: Life on Land",
+            "descendentStatVarCount": 165
+          },
+          {
+            "id": "dc/g/SDG_16",
+            "specializedEntity": "16: Peace and Justice Strong Institutions",
+            "displayName": "16: Peace and Justice Strong Institutions",
+            "descendentStatVarCount": 1439
+          },
+          {
+            "id": "dc/g/SDG_17",
+            "specializedEntity": "17: Partnerships to achieve the Goal",
+            "displayName": "17: Partnerships to achieve the Goal",
+            "descendentStatVarCount": 135
+          }
+        ],
+        "descendentStatVarCount": 4625
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This PR wires up the spanner implementation for BulkVariableGroupInfo for V3, including setting up V2 mirroring/diversion

Since we do not currently store specializedEntity in the graph, we are computing these on the fly. I did a best effort pass to try and get most of the top level SVG names decent, but these are highly curated in prophet, so really these should be part of the graph (though deferring to the larger discussion on what to do about SVG generation going forward). During testing, we can evaluate if additional curation is required and refine as needed. 

Performance really varies: requests can take anywhere from ~1s to >30s depending on both the complexity of the request and the server queue delay (ie the same request can have different latency on retries). (This might be a good candidate for some sort of prewarming, at least for top levels, or we can reevaluate if there's an efficient way to do this via federation.)

There are also a few discrepancies due to potential data bugs
- Some SVs are missing names in the Node table despite having name Edges. So for now we are returning empty names
- Some SV names are extra quoted. I removed these in the post processing, but ideally these can be fixed in ingestion

This also fixes some bugs with the existing implementation as now we can truly do a global aggregation :) 
- Base SVG info is for all imports, not just schema
- Base descendant counts are across all imports, not just the largest
- Entity thresholds compute a set intersection, not just nth largest