### PR TITLE
Add query hint to observation queries

### DIFF
--- a/internal/server/spanner/golden/query_builder/get_observations.sql
+++ b/internal/server/spanner/golden/query_builder/get_observations.sql
@@ -11,7 +11,7 @@
 			is_dc_aggregate,
 			facet_id
 		FROM 
-			Observation
+			Observation@{FORCE_INDEX=_BASE_TABLE}
 		WHERE
 			variable_measured = 'AirPollutant_Cancer_Risk'
 			AND observation_about IN ('geoId/01001','geoId/02013')

--- a/internal/server/spanner/golden/query_builder/get_observations_contained_in.sql
+++ b/internal/server/spanner/golden/query_builder/get_observations_contained_in.sql
@@ -32,7 +32,7 @@
 			is_dc_aggregate,
 			facet_id
 		FROM 
-			Observation
+			Observation@{FORCE_INDEX=_BASE_TABLE}
 		WHERE
 			variable_measured IN ('Count_Person','Median_Age_Person'))obs
 		ON 

--- a/internal/server/spanner/golden/query_builder/get_observations_entity.sql
+++ b/internal/server/spanner/golden/query_builder/get_observations_entity.sql
@@ -11,6 +11,6 @@
 			is_dc_aggregate,
 			facet_id
 		FROM 
-			Observation
+			Observation@{FORCE_INDEX=_BASE_TABLE}
 		WHERE
 			observation_about = 'wikidataId/Q341968'

--- a/internal/server/spanner/statements.go
+++ b/internal/server/spanner/statements.go
@@ -245,7 +245,7 @@ var statements = struct {
 			is_dc_aggregate,
 			facet_id
 		FROM 
-			Observation`,
+			Observation@{FORCE_INDEX=_BASE_TABLE}`,
 	selectVariableDcids: `variable_measured %s`,
 	selectEntityDcids:   `observation_about %s`,
 	getObsByVariableAndContainedInPlace: `		SELECT


### PR DESCRIPTION
This is to help query optimizer pick a better plan - in this case base table is better than using other indexes