### PR TITLE
Add use_bigquery to deployment.yaml to allow per environment overrides

### DIFF
--- a/deploy/helm_charts/mixer/templates/deployment.yaml
+++ b/deploy/helm_charts/mixer/templates/deployment.yaml
@@ -180,6 +180,7 @@ spec:
               --use_base_bigtable={{ $.Values.mixer.useBaseBigtable }} \
               --use_custom_bigtable={{ $.Values.mixer.useCustomBigtable }} \
               --use_branch_bigtable={{ $.Values.mixer.useBranchBigtable }} \
+              --use_bigquery={{ $.Values.mixer.useBigQuery }} \
               {{- if eq $.Values.mixer.bigqueryOnly true }}
               --bigquery_only=true \
               {{- end }}

--- a/deploy/helm_charts/mixer/templates/deployment.yaml
+++ b/deploy/helm_charts/mixer/templates/deployment.yaml
@@ -180,7 +180,7 @@ spec:
               --use_base_bigtable={{ $.Values.mixer.useBaseBigtable }} \
               --use_custom_bigtable={{ $.Values.mixer.useCustomBigtable }} \
               --use_branch_bigtable={{ $.Values.mixer.useBranchBigtable }} \
-              --use_bigquery={{ $.Values.mixer.useBigQuery }} \
+              --use_bigquery={{ $.Values.mixer.useBigquery }} \
               {{- if eq $.Values.mixer.bigqueryOnly true }}
               --bigquery_only=true \
               {{- end }}

--- a/deploy/helm_charts/mixer/values.yaml
+++ b/deploy/helm_charts/mixer/values.yaml
@@ -40,6 +40,7 @@ mixer:
   useBaseBigtable: true
   useBranchBigtable: true
   useCustomBigtable: false
+  useBigQuery: true
   foldRemoteRootSvg: false
   cacheSVFormula: false
   # Comma separated embeddings indexes for resolving indicators.

--- a/deploy/helm_charts/mixer/values.yaml
+++ b/deploy/helm_charts/mixer/values.yaml
@@ -40,7 +40,7 @@ mixer:
   useBaseBigtable: true
   useBranchBigtable: true
   useCustomBigtable: false
-  useBigQuery: true
+  useBigquery: true
   foldRemoteRootSvg: false
   cacheSVFormula: false
   # Comma separated embeddings indexes for resolving indicators.


### PR DESCRIPTION
Right now the configuration flag to enable BigQuery in mixer is set to default true
https://github.com/datacommonsorg/mixer/blob/40e895a7cb7fa4ec16deb61db58a2dcad6df4179/cmd/main.go#L65

To disable on spanner-based environments, this PR adds the flag to deployment.yaml with a default value of true, so each environment can configure the flag separately

This will be used to disable BigQuery on website dev while validating spanner backed website