### PR TITLE
[DCP Ingestion - No Downtime] Allow Mixer to startup if IngestionHistory is missing or empty

### DIFF
--- a/internal/server/spanner/query.go
+++ b/internal/server/spanner/query.go
@@ -770,7 +770,7 @@ func (sc *spannerDatabaseClient) fetchAndUpdateTimestamp(ctx context.Context) er
 	}
 
 	if warnMsg != "" {
-		slog.Warn(warnMsg + " Startup will proceed with strong reads.")
+		slog.Warn(warnMsg + " Falling back to strong reads.")
 		return nil
 	}
 
@@ -840,7 +840,6 @@ func (sc *spannerDatabaseClient) executeQuery(
 	if sc.useStaleReads {
 		ts, err := sc.getStalenessTimestamp()
 		if err != nil {
-			slog.Warn("Staleness timestamp not available. Falling back to StrongRead.", "error", err.Error())
 			return runQuery(spanner.StrongRead())
 		}
 		err = runQuery(spanner.ReadTimestamp(ts))

--- a/internal/server/spanner/query.go
+++ b/internal/server/spanner/query.go
@@ -760,9 +760,20 @@ func (sc *spannerDatabaseClient) fetchAndUpdateTimestamp(ctx context.Context) er
 	defer iter.Stop()
 
 	row, err := iter.Next()
+	
+	// Handle missing or empty table cases gracefully
+	var warnMsg string
 	if err == iterator.Done {
-		return fmt.Errorf("no valid rows found in IngestionHistory")
+		warnMsg = "No valid rows found in IngestionHistory."
+	} else if err != nil && spanner.ErrCode(err) == codes.NotFound {
+		warnMsg = "IngestionHistory table not found."
 	}
+
+	if warnMsg != "" {
+		slog.Warn(warnMsg + " Startup will proceed with strong reads.")
+		return nil
+	}
+
 	if err != nil {
 		if isTimeoutError(err) {
 			slog.ErrorContext(queryCtx, "Spanner timestamp polling timed out",
@@ -829,7 +840,8 @@ func (sc *spannerDatabaseClient) executeQuery(
 	if sc.useStaleReads {
 		ts, err := sc.getStalenessTimestamp()
 		if err != nil {
-			return err
+			slog.Warn("Staleness timestamp not available. Falling back to StrongRead.", "error", err.Error())
+			return runQuery(spanner.StrongRead())
 		}
 		err = runQuery(spanner.ReadTimestamp(ts))
 


### PR DESCRIPTION
This is step 1 in ensuring no downtime for DCP mid-ingestion. The DCP flow will deploy all infrastructure together, including a new Spanner instance/DB which may not have tables just yet. We do not want Mixer to fail to startup at this point, though we understand it would have no data to return. 

Once the table initialization script is run (process tbc), the IngestionHistory table will be created, and future imports will be written there. At this point, Stale reads will be enabled for CDC/DCP.

Legacy CDC customers will keep the flag disabled, while DCP customers wil enable Stale Reads. Both will be from the same stable image. 
Context: https://docs.google.com/document/d/1SELfRfNKnUZEvjZdRDN6V8feDhM848e6nnS7HqEPj8k/edit?resourcekey=0-sgcFjpIJQBftf8ssZxu4wg&tab=t.xzi0za7xd5sc