### PR TITLE
Revert /v2/bulk/info/variable-group to match v1

### DIFF
--- a/internal/server/handler_v2.go
+++ b/internal/server/handler_v2.go
@@ -652,34 +652,7 @@ func (s *Server) V2BulkVariableInfo(
 func (s *Server) V2BulkVariableGroupInfo(
 	ctx context.Context, in *pbv1.BulkVariableGroupInfoRequest,
 ) (*pbv1.BulkVariableGroupInfoResponse, error) {
-	if s.shouldDivertV2(ctx) {
-		return s.dispatcher.BulkVariableGroupInfo(ctx, in)
-	}
-
-	v2StartTime := time.Now()
-
-	// Use the V1 implementation for now.
-	v2Resp, err := s.BulkVariableGroupInfo(ctx, in)
-	if err != nil {
-		return nil, err
-	}
-
-	convertV1ToV2BulkVariableGroupInfo(v2Resp)
-
-	v2Latency := time.Since(v2StartTime)
-
-	s.maybeMirrorV3(
-		ctx,
-		in,
-		v2Resp,
-		v2Latency,
-		func(ctx context.Context, req proto.Message) (proto.Message, error) {
-			return s.V3BulkVariableGroupInfo(ctx, req.(*pbv1.BulkVariableGroupInfoRequest))
-		},
-		GetV2BulkVariableGroupInfoCmpOpts(),
-	)
-
-	return v2Resp, nil
+	return s.BulkVariableGroupInfo(ctx, in)
 }
 
 // resolveRouting determines whether to route to local and/or remote instances
@@ -708,22 +681,5 @@ func resolveRouting(target, remoteMixerDomain string) (bool, bool, error) {
 		return true, false, nil
 	default:
 		return true, true, nil
-	}
-}
-
-// convertV1ToV2BulkVariableGroupInfo converts a V1 BulkVariableGroupInfoResponse to the V2 version.
-func convertV1ToV2BulkVariableGroupInfo(resp *pbv1.BulkVariableGroupInfoResponse) {
-	// The new response will not contain all legacy V1 fields.
-	// To ensure the new response is sufficient, clear all legacy fields until swapping over to the new backend.
-	for _, info := range resp.GetData() {
-		if info.GetInfo() == nil {
-			continue
-		}
-		info.Info.ParentStatVarGroups = nil
-		for _, childSV := range info.GetInfo().GetChildStatVars() {
-			childSV.SearchName = ""
-			childSV.SearchNames = nil
-			childSV.Definition = ""
-		}
 	}
 }

--- a/internal/server/mirror.go
+++ b/internal/server/mirror.go
@@ -245,12 +245,6 @@ func GetV2BulkVariableInfoCmpOpts() []cmp.Option {
 	}
 }
 
-func GetV2BulkVariableGroupInfoCmpOpts() []cmp.Option {
-	return []cmp.Option{
-		protocmp.Transform(),
-	}
-}
-
 func GetV2EventCmpOpts() []cmp.Option {
 	return []cmp.Option{
 		protocmp.Transform(),

--- a/internal/server/v2/bulk_variable_group_info/bulk_variable_group_info.json
+++ b/internal/server/v2/bulk_variable_group_info/bulk_variable_group_info.json
@@ -7,7 +7,11 @@
         "childStatVars": [
           {
             "id": "Count_Person_5OrLessMeter_Rural_AsAFractionOf_Count_Person",
-            "displayName": "Population: 5 Meter or Less, Rural (Per Capita)"
+            "searchNames": [
+              "Population Count of Person With Elevation is 5 Meter or Less, Place of Residence Classification is Rural (Per Capita)"
+            ],
+            "displayName": "Population: 5 Meter or Less, Rural (Per Capita)",
+            "definition": "md=Count_Person,mp=count,pt=Person,elevation=MeterUpto5,placeOfResidenceClassification=Rural"
           }
         ],
         "childStatVarGroups": [
@@ -41,7 +45,10 @@
             "descendentStatVarCount": 8
           }
         ],
-        "descendentStatVarCount": 174
+        "descendentStatVarCount": 174,
+        "parentStatVarGroups": [
+          "dc/g/Root"
+        ]
       }
     },
     {
@@ -51,12 +58,21 @@
         "childStatVars": [
           {
             "id": "Count_HousingUnit",
+            "searchNames": [
+              "Count of Housing Unit",
+              "Housing Units"
+            ],
             "displayName": "Housing Units",
+            "definition": "mp=count,pt=HousingUnit",
             "hasData": true
           },
           {
             "id": "Monthly_Median_GrossRent_HousingUnit",
+            "searchNames": [
+              "Median Monthly Gross Rent of Housing Unit"
+            ],
             "displayName": "Median Monthly Gross Rent of Housing Unit",
+            "definition": "mq=Monthly,st=medianValue,mp=grossRent,pt=HousingUnit",
             "hasData": true
           }
         ],
@@ -230,7 +246,10 @@
             "descendentStatVarCount": 16
           }
         ],
-        "descendentStatVarCount": 511
+        "descendentStatVarCount": 511,
+        "parentStatVarGroups": [
+          "dc/g/Root"
+        ]
       }
     }
   ]


### PR DESCRIPTION
This PR makes the v2 BulkInfoVariableGroup call exactly the v1 implementation with no mirroring or diversion to spanner. This is to help test and isolate the issue with the endpoint and unblock autopush website which uses the v2 endpoint