### PR TITLE
Add /v2/bulk/info/variable-group to svg service group

### DIFF
--- a/deploy/helm_charts/mixer/values.yaml
+++ b/deploy/helm_charts/mixer/values.yaml
@@ -431,6 +431,7 @@ serviceGroups:
       - "/v1/info/variable-group/*"
       - "/v1/variable/*"
       - "/v1/bulk/info/variable-group"
+      - "/v2/bulk/info/variable-group"
     replicas: 1
     resources:
       memoryRequest: "8G"


### PR DESCRIPTION
Right now the endpoint just wraps v1 so also needs cacheSVG to populate RawSvgs