### PR TITLE
Turn off SPARQL via Apigee and ESP configurations

### DIFF
--- a/deploy/apigee/target_endpoints/api.template.xml
+++ b/deploy/apigee/target_endpoints/api.template.xml
@@ -69,6 +69,9 @@
             ((proxy.pathsuffix MatchesPath "/v1/triples") OR (proxy.pathsuffix MatchesPath "/v1/triples/**")) OR
             ((proxy.pathsuffix MatchesPath "/v1/variables") OR (proxy.pathsuffix MatchesPath "/v1/variables/**")) OR
             (proxy.pathsuffix MatchesPath "/v2/sparql") OR
+            (proxy.pathsuffix MatchesPath "/v3/sparql") OR
+            (proxy.pathsuffix MatchesPath "/query") OR
+            (proxy.pathsuffix MatchesPath "/v1/query") OR
             (proxy.pathsuffix MatchesPath "/v1/recognize/entities") OR
           </Condition>
           <Name>block-deprecated-endpoints</Name>
@@ -106,7 +109,6 @@
               (proxy.pathsuffix MatchesPath "/node/property-labels") OR
               (proxy.pathsuffix MatchesPath "/node/property-values") OR
               (proxy.pathsuffix MatchesPath "/node/triples") OR
-              (proxy.pathsuffix MatchesPath "/query") OR
               (proxy.pathsuffix MatchesPath "/search") OR
               (proxy.pathsuffix MatchesPath "/stat/all") OR
               (proxy.pathsuffix MatchesPath "/stat/series") OR

--- a/esp/endpoints.yaml.tmpl
+++ b/esp/endpoints.yaml.tmpl
@@ -38,16 +38,11 @@ backend:
     # Default timeout for the ESP and mixer GRPC server.
     - selector: "datacommons.Mixer.*"
       deadline: 60
-    # Longer timeout for the Sparql endpoint.
-    - selector: "datacommons.Mixer.Query"
-      deadline: 300
 
 usage:
   rules:
   # V0 APIs can be called without an API Key.
   # This will be removed once the V0 users are fully migrated.
-  - selector: "datacommons.Mixer.Query"
-    allow_unregistered_calls: true
   - selector: "datacommons.Mixer.GetPropertyLabels"
     allow_unregistered_calls: true
   - selector: "datacommons.Mixer.GetPropertyValues"


### PR DESCRIPTION
These endpoints aren't being consumed anywhere in our repos (with exception of `api-r` and `tools` repos, which I don't believe we use anymore).