### PR TITLE
Add logging for unexpected cachedata access

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -92,9 +92,6 @@ var (
 	// Serve live profiles of the process (CPU, memory, etc.) over HTTP on this port
 	httpProfilePort   = flag.Int("httpprof_port", 0, "Port to serve HTTP profiles from")
 	foldRemoteRootSvg = flag.Bool("fold_remote_root_svg", false, "Whether to fold root SVG from remote mixer")
-	// Cache map of SV dcid to list of inputPropertyExpressions for StatisticalCalculations
-	// TODO: Test Custom DC and set to true after release
-	cacheSVFormula = flag.Bool("cache_sv_formula", false, "Whether to cache SV -> inputPropertyExpresions for StatisticalCaclulations.")
 	// Spanner Graph
 	spannerGraphInfo = flag.String("spanner_graph_info", "", "Yaml formatted text containing information for Spanner Graph.")
 	// Redis.
@@ -362,7 +359,7 @@ func main() {
 		FetchSVG:       *cacheSVG,
 		SearchSVG:      *cacheSVG,
 		CacheSQL:       sqldb.IsConnected(&store.SQLClient),
-		CacheSVFormula: *cacheSVFormula,
+		CacheSVFormula: flags.UseStatisticalCalculation,
 	}
 	c, err := cache.NewCache(ctx, store, cacheOptions, metadata)
 	if err != nil {
@@ -424,8 +421,11 @@ func main() {
 		slog.Info("After Redis setup")
 
 		// Calculation Processor
-		var calculationProcessor dispatcher.Processor = observation.NewCalculationProcessor(dataSources, dataSourceCache.SVFormula(ctx))
-		processors = append(processors, &calculationProcessor)
+		if flags.UseStatisticalCalculation {
+			var calculationProcessor dispatcher.Processor = observation.NewCalculationProcessor(dataSources, dataSourceCache.SVFormula(ctx))
+			processors = append(processors, &calculationProcessor)
+
+		}
 		slog.Info("After calculation processor setup")
 	}
 

--- a/deploy/helm_charts/envs/mixer_autopush.yaml
+++ b/deploy/helm_charts/envs/mixer_autopush.yaml
@@ -9,7 +9,6 @@ mixer:
   serviceName: autopush.api.datacommons.org
   project: datcom-mixer-autopush
   cluster_prefix: mixer
-  cacheSVFormula: true
   redis:
     enabled: true
     configFile: |

--- a/deploy/helm_charts/mixer/templates/deployment.yaml
+++ b/deploy/helm_charts/mixer/templates/deployment.yaml
@@ -188,9 +188,6 @@ spec:
               {{- if eq $.Values.mixer.foldRemoteRootSvg true }}
               --fold_remote_root_svg=true \
               {{- end }}
-              {{- if eq $.Values.mixer.cacheSVFormula true }}
-              --cache_sv_formula=true \
-              {{- end }}
               --spanner_graph_info="${SPANNER_GRAPH_INFO}" \
               --use_redis={{ $.Values.mixer.redis.enabled }} \
               --redis_info="${REDIS_INFO}" \

--- a/deploy/helm_charts/mixer/values.yaml
+++ b/deploy/helm_charts/mixer/values.yaml
@@ -42,7 +42,6 @@ mixer:
   useCustomBigtable: false
   useBigquery: true
   foldRemoteRootSvg: false
-  cacheSVFormula: false
   # Comma separated embeddings indexes for resolving indicators.
   resolveEmbeddingsIndexes: "base_uae_mem"
   redis:

--- a/internal/featureflags/featureflags.go
+++ b/internal/featureflags/featureflags.go
@@ -40,18 +40,21 @@ type Flags struct {
 	EnableEmbeddingsResolver bool `yaml:"EnableEmbeddingsResolver"`
 	// Fraction of V2 API requests to divert to the new dispatcher backend. Value from 0 to 1.0.
 	V2DivertFraction float64 `yaml:"V2DivertFraction"`
+	// Use inputPropertyExpressions for StatisticalCalculations to fill observation holes.
+	UseStatisticalCalculation bool `yaml:"UseStatisticalCalculation"`
 }
 
 // setDefaultValues creates a new Flags struct with default values.
 func setDefaultValues() *Flags {
 	return &Flags{
-		EnableV3:                 false,
-		V3MirrorFraction:         0.0,
-		UseSpannerGraph:          false,
-		SpannerGraphDatabase:     "",
-		UseStaleReads:            false,
-		EnableEmbeddingsResolver: true,
-		V2DivertFraction:         0.0,
+		EnableV3:                  false,
+		V3MirrorFraction:          0.0,
+		UseSpannerGraph:           false,
+		SpannerGraphDatabase:      "",
+		UseStaleReads:             false,
+		EnableEmbeddingsResolver:  true,
+		V2DivertFraction:          0.0,
+		UseStatisticalCalculation: false,
 	}
 }
 

--- a/internal/server/cache/cache.go
+++ b/internal/server/cache/cache.go
@@ -66,7 +66,7 @@ type Cache struct {
 
 func (c *Cache) ParentSvgs(ctx context.Context) map[string][]string {
 	if !c.options.FetchSVG {
-		slog.Warn("Unexpected access to uninitialized Cache ParentSvgs")
+		slog.Warn("Unexpected access to uninitialized Cache.ParentSvgs")
 	}
 	metrics.RecordCachedataRead(ctx, "parent_svgs")
 	return c.parentSvgs
@@ -74,7 +74,7 @@ func (c *Cache) ParentSvgs(ctx context.Context) map[string][]string {
 
 func (c *Cache) RawSvgs(ctx context.Context) map[string]*pb.StatVarGroupNode {
 	if !c.options.FetchSVG {
-		slog.Warn("Unexpected access to uninitialized RawSvgs")
+		slog.Warn("Unexpected access to uninitialized Cache.RawSvgs")
 	}
 	metrics.RecordCachedataRead(ctx, "raw_svgs")
 	return c.rawSvgs
@@ -82,7 +82,7 @@ func (c *Cache) RawSvgs(ctx context.Context) map[string]*pb.StatVarGroupNode {
 
 func (c *Cache) BlocklistSvgs(ctx context.Context) map[string]struct{} {
 	if !c.options.FetchSVG {
-		slog.Warn("Unexpected access to uninitialized BlocklistSvgs")
+		slog.Warn("Unexpected access to uninitialized Cache.BlocklistSvgs")
 	}
 	metrics.RecordCachedataRead(ctx, "blocklist_svgs")
 	return c.blocklistSvgs
@@ -90,7 +90,7 @@ func (c *Cache) BlocklistSvgs(ctx context.Context) map[string]struct{} {
 
 func (c *Cache) SvgSearchIndex(ctx context.Context) *resource.SearchIndex {
 	if !c.options.SearchSVG {
-		slog.Warn("Unexpected access to uninitialized SvgSearchIndex")
+		slog.Warn("Unexpected access to uninitialized Cache.SvgSearchIndex")
 	}
 	metrics.RecordCachedataRead(ctx, "svg_search_index")
 	return c.svgSearchIndex
@@ -98,7 +98,7 @@ func (c *Cache) SvgSearchIndex(ctx context.Context) *resource.SearchIndex {
 
 func (c *Cache) SQLProvenances(ctx context.Context) map[string]*pb.Facet {
 	if !c.options.CacheSQL {
-		slog.Warn("Unexpected access to uninitialized SQLProvenances")
+		slog.Warn("Unexpected access to uninitialized Cache.SQLProvenances")
 	}
 	metrics.RecordCachedataRead(ctx, "sql_provenances")
 	return c.sqlProvenances
@@ -106,7 +106,7 @@ func (c *Cache) SQLProvenances(ctx context.Context) map[string]*pb.Facet {
 
 func (c *Cache) SQLExistenceMap(ctx context.Context) map[util.EntityVariable]struct{} {
 	if !c.options.CacheSQL {
-		slog.Warn("Unexpected access to uninitialized SQLExistenceMap")
+		slog.Warn("Unexpected access to uninitialized Cache.SQLExistenceMap")
 	}
 	metrics.RecordCachedataRead(ctx, "sql_existence_map")
 	return c.sqlExistenceMap
@@ -114,7 +114,7 @@ func (c *Cache) SQLExistenceMap(ctx context.Context) map[util.EntityVariable]str
 
 func (c *Cache) SVFormula(ctx context.Context) map[string][]string {
 	if !c.options.CacheSVFormula {
-		slog.Warn("Unexpected access to uninitialized SVFormula")
+		slog.Warn("Unexpected access to uninitialized Cache.SVFormula")
 	}
 	metrics.RecordCachedataRead(ctx, "sv_formulas")
 	return c.svFormulas

--- a/internal/server/cache/cache.go
+++ b/internal/server/cache/cache.go
@@ -65,36 +65,57 @@ type Cache struct {
 }
 
 func (c *Cache) ParentSvgs(ctx context.Context) map[string][]string {
+	if !c.options.FetchSVG {
+		slog.Warn("Unexpected access to uninitialized Cache ParentSvgs")
+	}
 	metrics.RecordCachedataRead(ctx, "parent_svgs")
 	return c.parentSvgs
 }
 
 func (c *Cache) RawSvgs(ctx context.Context) map[string]*pb.StatVarGroupNode {
+	if !c.options.FetchSVG {
+		slog.Warn("Unexpected access to uninitialized RawSvgs")
+	}
 	metrics.RecordCachedataRead(ctx, "raw_svgs")
 	return c.rawSvgs
 }
 
 func (c *Cache) BlocklistSvgs(ctx context.Context) map[string]struct{} {
+	if !c.options.FetchSVG {
+		slog.Warn("Unexpected access to uninitialized BlocklistSvgs")
+	}
 	metrics.RecordCachedataRead(ctx, "blocklist_svgs")
 	return c.blocklistSvgs
 }
 
 func (c *Cache) SvgSearchIndex(ctx context.Context) *resource.SearchIndex {
+	if !c.options.SearchSVG {
+		slog.Warn("Unexpected access to uninitialized SvgSearchIndex")
+	}
 	metrics.RecordCachedataRead(ctx, "svg_search_index")
 	return c.svgSearchIndex
 }
 
 func (c *Cache) SQLProvenances(ctx context.Context) map[string]*pb.Facet {
+	if !c.options.CacheSQL {
+		slog.Warn("Unexpected access to uninitialized SQLProvenances")
+	}
 	metrics.RecordCachedataRead(ctx, "sql_provenances")
 	return c.sqlProvenances
 }
 
 func (c *Cache) SQLExistenceMap(ctx context.Context) map[util.EntityVariable]struct{} {
+	if !c.options.CacheSQL {
+		slog.Warn("Unexpected access to uninitialized SQLExistenceMap")
+	}
 	metrics.RecordCachedataRead(ctx, "sql_existence_map")
 	return c.sqlExistenceMap
 }
 
 func (c *Cache) SVFormula(ctx context.Context) map[string][]string {
+	if !c.options.CacheSVFormula {
+		slog.Warn("Unexpected access to uninitialized SVFormula")
+	}
 	metrics.RecordCachedataRead(ctx, "sv_formulas")
 	return c.svFormulas
 }

--- a/internal/server/count/count.go
+++ b/internal/server/count/count.go
@@ -146,6 +146,10 @@ func Count(
 	if err != nil {
 		return nil, err
 	}
+	if !cachedata.Options().CacheSVFormula {
+		return result, err
+	}
+
 	// Check for count for computed observations.
 	// Use counts of formula variables as a heuristic.
 	for _, svOrSvg := range svOrSvgs {

--- a/internal/server/v2/observation/golden/calculation_test.go
+++ b/internal/server/v2/observation/golden/calculation_test.go
@@ -135,7 +135,7 @@ func TestCalculation(t *testing.T) {
 	}
 	if err := test.TestDriver(
 		"TestCalculation",
-		&test.TestOption{UseSQLite: true, CacheSVFormula: true},
+		&test.TestOption{UseSQLite: true, UseStatisticalCalculation: true},
 		testSuite,
 	); err != nil {
 		t.Errorf("TestDriver() for TestCalculation = %s", err)
@@ -222,7 +222,7 @@ func TestCalculationForObsCollection(t *testing.T) {
 	}
 	if err := test.TestDriver(
 		"TestCalculationForObsCollection",
-		&test.TestOption{UseSQLite: true, CacheSVFormula: true},
+		&test.TestOption{UseSQLite: true, UseStatisticalCalculation: true},
 		testSuite,
 	); err != nil {
 		t.Errorf("TestDriver() for TestCalculationForObsCollection = %s", err)

--- a/internal/server/v2/observation/golden/existence_test.go
+++ b/internal/server/v2/observation/golden/existence_test.go
@@ -92,7 +92,7 @@ func TestExistence(t *testing.T) {
 	}
 	if err := test.TestDriver(
 		"Observation(existence)",
-		&test.TestOption{FetchSVG: true, UseSQLite: true, CacheSVFormula: true},
+		&test.TestOption{FetchSVG: true, UseSQLite: true, UseStatisticalCalculation: true},
 		testSuite,
 	); err != nil {
 		t.Errorf("TestDriver() = %s", err)

--- a/internal/server/v3/observation/golden/observation_test.go
+++ b/internal/server/v3/observation/golden/observation_test.go
@@ -282,7 +282,7 @@ func TestV3Observation(t *testing.T) {
 	}
 	if err := test.TestDriver(
 		"TestV3Observation",
-		&test.TestOption{UseSQLite: true, UseSpannerGraph: true, EnableV3: true, CacheSVFormula: true},
+		&test.TestOption{UseSQLite: true, UseSpannerGraph: true, EnableV3: true, UseStatisticalCalculation: true},
 		testSuite,
 	); err != nil {
 		t.Errorf("TestDriver() for TestV3Observation = %s", err)

--- a/test/setup.go
+++ b/test/setup.go
@@ -54,14 +54,14 @@ import (
 
 // TestOption holds the options for integration test.
 type TestOption struct {
-	FetchSVG          bool
-	SearchSVG         bool
-	UseCustomTable    bool
-	UseSQLite         bool
-	CacheSVFormula    bool
-	UseSpannerGraph   bool
-	EnableV3          bool
-	RemoteMixerDomain string
+	FetchSVG                  bool
+	SearchSVG                 bool
+	UseCustomTable            bool
+	UseSQLite                 bool
+	UseStatisticalCalculation bool
+	UseSpannerGraph           bool
+	EnableV3                  bool
+	RemoteMixerDomain         string
 }
 
 var (
@@ -89,18 +89,18 @@ const (
 
 // Setup creates local server and client.
 func Setup(option ...*TestOption) (pbs.MixerClient, func(), error) {
-	fetchSVG, searchSVG, useCustomTable, useSQLite, cacheSVFormula, useSpannerGraph, enableV3, remoteMixerDomain := false, false, false, false, false, false, false, ""
+	fetchSVG, searchSVG, useCustomTable, useSQLite, useStatisticalCalculation, useSpannerGraph, enableV3, remoteMixerDomain := false, false, false, false, false, false, false, ""
 	var cacheOptions cache.CacheOptions
 	if len(option) == 1 {
 		fetchSVG = option[0].FetchSVG
 		searchSVG = option[0].SearchSVG
 		useCustomTable = option[0].UseCustomTable
 		useSQLite = option[0].UseSQLite
-		cacheSVFormula = option[0].CacheSVFormula
+		useStatisticalCalculation = option[0].UseStatisticalCalculation
 		cacheOptions.CacheSQL = useSQLite
 		cacheOptions.FetchSVG = fetchSVG
 		cacheOptions.SearchSVG = searchSVG
-		cacheOptions.CacheSVFormula = cacheSVFormula
+		cacheOptions.CacheSVFormula = useStatisticalCalculation
 		useSpannerGraph = option[0].UseSpannerGraph
 		enableV3 = option[0].EnableV3
 		remoteMixerDomain = option[0].RemoteMixerDomain


### PR DESCRIPTION
Motivated by recent issue with /v2/bulk/info/variable-group which was not correctly accessing RawSvgs

Logs whenever a cache field is accessed without it being initialized

As part of this change, updates Cache.svFormulas to be gated before access and adds a feature flag to enable StatisticalCalculation features (vs using cache options)

