### PR TITLE
Consolidate EnableV3 flag into UseSpannerGraph

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -394,7 +394,7 @@ func main() {
 	// Processors
 	processors := []*dispatcher.Processor{}
 	if flags.UseSpannerGraph {
-		slog.Info("V3 enabled, setting up processors")
+	slog.Info("New backend enabled, setting up processors")
 		// Mixer in-memory cache.
 		dataSourceCache, err := cache.NewDataSourceCache(ctx, dataSources, cacheOptions)
 		if err != nil {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -192,7 +192,7 @@ func main() {
 
 	// Spanner Graph.
 	var spannerClient spanner.SpannerClient
-	if flags.EnableV3 && flags.UseSpannerGraph {
+	if flags.UseSpannerGraph {
 		var err error
 		spannerClient, err = spanner.NewSpannerClient(ctx, *spannerGraphInfo, flags.SpannerGraphDatabase)
 		if err != nil {
@@ -286,7 +286,7 @@ func main() {
 	// Create remote data source here but don't add it to sources yet since we want it to be the last source added.
 	// TODO: clean up how we create and add data sources.
 	var remoteDataSource datasource.DataSource
-	if flags.EnableV3 && *remoteMixerDomain != "" {
+	if flags.UseSpannerGraph && *remoteMixerDomain != "" {
 		remoteClient, err := remote.NewRemoteClient(metadata)
 		if err != nil {
 			slog.Error("Failed to create remote client", "error", err)
@@ -334,7 +334,7 @@ func main() {
 	}
 
 	// SQL Data Source
-	if flags.EnableV3 && sqldb.IsConnected(&sqlClient) {
+	if flags.UseSpannerGraph && sqldb.IsConnected(&sqlClient) {
 		var ds datasource.DataSource = sqldb.NewSQLDataSource(&sqlClient, remoteDataSource)
 		sources = append(sources, ds)
 	}
@@ -393,7 +393,7 @@ func main() {
 
 	// Processors
 	processors := []*dispatcher.Processor{}
-	if flags.EnableV3 {
+	if flags.UseSpannerGraph {
 		slog.Info("V3 enabled, setting up processors")
 		// Mixer in-memory cache.
 		dataSourceCache, err := cache.NewDataSourceCache(ctx, dataSources, cacheOptions)

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -124,7 +124,6 @@ export DB_PASS=<password>
 
 Enabling Spanner Graph requires the following feature flags to be set:
 
-- `EnableV3: true`
 - `UseSpannerGraph: true`
 
 These are currently set in `local.yaml`.

--- a/internal/featureflags/featureflags.go
+++ b/internal/featureflags/featureflags.go
@@ -25,10 +25,12 @@ import (
 // Container for feature flag values.
 type Flags struct {
 	// Enable datasources in V3 API.
+	// Deprecated in favor of UseSpannerGraph.
+	// TODO: Clean up flag once code changes roll out.
 	EnableV3 bool `yaml:"EnableV3"`
 	// Fraction of V2 API requests to mirror to V3. Value from 0 to 1.0.
 	V3MirrorFraction float64 `yaml:"V3MirrorFraction"`
-	// Use Google Spanner as a database.
+	// Enabled new Spanner-based dispatcher/datasource backend.
 	UseSpannerGraph bool `yaml:"UseSpannerGraph"`
 	// Spanner Graph database for Spanner DataSource.
 	// This is temporarily loaded from flags vs spanner_graph_info.yaml.
@@ -63,11 +65,11 @@ func (f *Flags) validateFlagValues() error {
 	if f.V3MirrorFraction < 0 || f.V3MirrorFraction > 1.0 {
 		return fmt.Errorf("V3MirrorFraction must be between 0 and 1.0, got %f", f.V3MirrorFraction)
 	}
-	if f.V3MirrorFraction > 0 && !f.EnableV3 {
-		return fmt.Errorf("V3MirrorFraction > 0 requires EnableV3 to be true")
+	if f.V3MirrorFraction > 0 && !f.UseSpannerGraph {
+		return fmt.Errorf("V3MirrorFraction > 0 requires UseSpannerGraph to be true")
 	}
-	if f.SpannerGraphDatabase != "" && (!f.UseSpannerGraph || !f.EnableV3) {
-		return fmt.Errorf("using SpannerGraphDatabase requires UseSpannerGraph and EnableV3 to be true")
+	if f.SpannerGraphDatabase != "" && !f.UseSpannerGraph {
+		return fmt.Errorf("using SpannerGraphDatabase requires UseSpannerGraph to be true")
 	}
 	if f.UseStaleReads && !f.UseSpannerGraph {
 		return fmt.Errorf("UseStaleReads requires UseSpannerGraph to be true")
@@ -75,8 +77,8 @@ func (f *Flags) validateFlagValues() error {
 	if f.V2DivertFraction < 0 || f.V2DivertFraction > 1.0 {
 		return fmt.Errorf("V2DivertFraction must be between 0 and 1.0, got %f", f.V2DivertFraction)
 	}
-	if f.V2DivertFraction > 0 && !f.EnableV3 {
-		return fmt.Errorf("V2DivertFraction > 0 requires EnableV3 to be true")
+	if f.V2DivertFraction > 0 && !f.UseSpannerGraph {
+		return fmt.Errorf("V2DivertFraction > 0 requires UseSpannerGraph to be true")
 	}
 	return nil
 }

--- a/internal/featureflags/featureflags_test.go
+++ b/internal/featureflags/featureflags_test.go
@@ -128,7 +128,7 @@ flags:
 			wantErr: true,
 		},
 		{
-			name: "validation error - mirror without v3",
+			name: "validation error - mirror without spanner graph",
 			fileContent: `
 flags:
   UseSpannerGraph: false

--- a/internal/featureflags/featureflags_test.go
+++ b/internal/featureflags/featureflags_test.go
@@ -28,7 +28,7 @@ import (
 // Example usage:
 //
 //	want: expectedFlags(func(f *Flags) {
-//		f.EnableV3 = true
+//		f.UseSpannerGraph = true
 //	}),
 func expectedFlags(mods ...func(*Flags)) *Flags {
 	f := setDefaultValues()
@@ -53,7 +53,7 @@ func TestNewFlags(t *testing.T) {
 		},
 		{
 			name:        "invalid yaml",
-			fileContent: "flags: \n  EnableV3: true\n V3MirrorFraction: 0.5", // bad indentation
+			fileContent: "flags: \n  UseSpannerGraph: true\n V3MirrorFraction: 0.5", // bad indentation
 			want:        nil,
 			wantErr:     true,
 		},
@@ -61,10 +61,10 @@ func TestNewFlags(t *testing.T) {
 			name: "partial flags",
 			fileContent: `
 flags:
-  EnableV3: true
+  UseSpannerGraph: true
 `,
 			want: expectedFlags(func(f *Flags) {
-				f.EnableV3 = true
+				f.UseSpannerGraph = true
 			}),
 			wantErr: false,
 		},
@@ -72,11 +72,11 @@ flags:
 			name: "all flags",
 			fileContent: `
 flags:
-  EnableV3: true
+  UseSpannerGraph: true
   V3MirrorFraction: 0.7
 `,
 			want: expectedFlags(func(f *Flags) {
-				f.EnableV3 = true
+				f.UseSpannerGraph = true
 				f.V3MirrorFraction = 0.7
 			}),
 			wantErr: false,
@@ -88,11 +88,11 @@ clusters:
   - projects/datcom-website-prod/locations/us-central1/clusters/website-us-central1
   - projects/datcom-website-prod/locations/us-west1/clusters/website-us-west1
 flags:
-  EnableV3: true
+  UseSpannerGraph: true
   V3MirrorFraction: 0.7
 `,
 			want: expectedFlags(func(f *Flags) {
-				f.EnableV3 = true
+				f.UseSpannerGraph = true
 				f.V3MirrorFraction = 0.7
 			}),
 			wantErr: false,
@@ -111,7 +111,7 @@ clusters:
 			name: "validation error - fraction too high",
 			fileContent: `
 flags:
-  EnableV3: true
+  UseSpannerGraph: true
   V3MirrorFraction: 1.1
 `,
 			want:    nil,
@@ -121,7 +121,7 @@ flags:
 			name: "validation error - fraction too low",
 			fileContent: `
 flags:
-  EnableV3: true
+  UseSpannerGraph: true
   V3MirrorFraction: -0.1
 `,
 			want:    nil,
@@ -131,7 +131,7 @@ flags:
 			name: "validation error - mirror without v3",
 			fileContent: `
 flags:
-  EnableV3: false
+  UseSpannerGraph: false
   V3MirrorFraction: 0.5
 `,
 			want:    nil,

--- a/internal/server/v3/bulk_variable_group_info/bulk_variable_group_info_test.go
+++ b/internal/server/v3/bulk_variable_group_info/bulk_variable_group_info_test.go
@@ -94,7 +94,7 @@ func TestV3BulkVariableGroupInfo(t *testing.T) {
 	}
 	if err := test.TestDriver(
 		"V3BulkVariableGroupInfo",
-		&test.TestOption{UseSpannerGraph: true, EnableV3: true},
+		&test.TestOption{UseSpannerGraph: true},
 		testSuite,
 	); err != nil {
 		t.Errorf("TestDriver() = %s", err)

--- a/internal/server/v3/bulk_variable_info/golden/bulk_variable_info_test.go
+++ b/internal/server/v3/bulk_variable_info/golden/bulk_variable_info_test.go
@@ -79,7 +79,7 @@ func TestV3BulkVariableInfo(t *testing.T) {
 	}
 	if err := test.TestDriver(
 		"V3BulkVariableInfo",
-		&test.TestOption{UseSpannerGraph: true, EnableV3: true},
+		&test.TestOption{UseSpannerGraph: true},
 		testSuite,
 	); err != nil {
 		t.Errorf("TestDriver() = %s", err)

--- a/internal/server/v3/node/golden/node_test.go
+++ b/internal/server/v3/node/golden/node_test.go
@@ -153,7 +153,7 @@ func TestV3Node(t *testing.T) {
 	}
 	if err := test.TestDriver(
 		"TestV3Node",
-		&test.TestOption{UseSQLite: true, UseSpannerGraph: true, EnableV3: true},
+		&test.TestOption{UseSQLite: true, UseSpannerGraph: true},
 		testSuite,
 	); err != nil {
 		t.Errorf("TestDriver() for TestV3Node = %s", err)
@@ -228,7 +228,7 @@ func TestV3NodePagination(t *testing.T) {
 	}
 	if err := test.TestDriver(
 		"TestV3NodePagination",
-		&test.TestOption{UseSQLite: true, UseSpannerGraph: true, EnableV3: true},
+		&test.TestOption{UseSQLite: true, UseSpannerGraph: true},
 		testSuite,
 	); err != nil {
 		t.Errorf("TestDriver() for TestV3NodePagination = %s", err)

--- a/internal/server/v3/nodesearch/golden/node_search_test.go
+++ b/internal/server/v3/nodesearch/golden/node_search_test.go
@@ -92,7 +92,7 @@ func TestV3NodeSearch(t *testing.T) {
 	}
 	if err := test.TestDriver(
 		"TestV3NodeSearch",
-		&test.TestOption{UseSQLite: true, UseSpannerGraph: true, EnableV3: true},
+		&test.TestOption{UseSQLite: true, UseSpannerGraph: true},
 		testSuite,
 	); err != nil {
 		t.Errorf("TestDriver() for TestV3NodeSearch = %s", err)

--- a/internal/server/v3/observation/golden/observation_test.go
+++ b/internal/server/v3/observation/golden/observation_test.go
@@ -282,7 +282,7 @@ func TestV3Observation(t *testing.T) {
 	}
 	if err := test.TestDriver(
 		"TestV3Observation",
-		&test.TestOption{UseSQLite: true, UseSpannerGraph: true, EnableV3: true, UseStatisticalCalculation: true},
+		&test.TestOption{UseSQLite: true, UseSpannerGraph: true, UseStatisticalCalculation: true},
 		testSuite,
 	); err != nil {
 		t.Errorf("TestDriver() for TestV3Observation = %s", err)

--- a/internal/server/v3/resolve/golden/resolve_test.go
+++ b/internal/server/v3/resolve/golden/resolve_test.go
@@ -113,7 +113,7 @@ func TestV3Resolve(t *testing.T) {
 	}
 	if err := test.TestDriver(
 		"TestV3Resolve",
-		&test.TestOption{UseSQLite: true, UseSpannerGraph: true, EnableV3: true},
+		&test.TestOption{UseSQLite: true, UseSpannerGraph: true},
 		testSuite,
 	); err != nil {
 		t.Errorf("TestDriver() for TestV3Resolve = %s", err)

--- a/internal/server/v3/sparql/golden/sparql_test.go
+++ b/internal/server/v3/sparql/golden/sparql_test.go
@@ -82,7 +82,7 @@ func TestV3Sparql(t *testing.T) {
 	}
 	if err := test.TestDriver(
 		"TestV3Sparql",
-		&test.TestOption{UseSQLite: true, UseSpannerGraph: true, EnableV3: true},
+		&test.TestOption{UseSQLite: true, UseSpannerGraph: true},
 		testSuite,
 	); err != nil {
 		t.Errorf("TestDriver() for TestV3Sparql = %s", err)

--- a/test/setup.go
+++ b/test/setup.go
@@ -60,7 +60,6 @@ type TestOption struct {
 	UseSQLite                 bool
 	UseStatisticalCalculation bool
 	UseSpannerGraph           bool
-	EnableV3                  bool
 	RemoteMixerDomain         string
 }
 
@@ -89,7 +88,7 @@ const (
 
 // Setup creates local server and client.
 func Setup(option ...*TestOption) (pbs.MixerClient, func(), error) {
-	fetchSVG, searchSVG, useCustomTable, useSQLite, useStatisticalCalculation, useSpannerGraph, enableV3, remoteMixerDomain := false, false, false, false, false, false, false, ""
+	fetchSVG, searchSVG, useCustomTable, useSQLite, useStatisticalCalculation, useSpannerGraph, remoteMixerDomain := false, false, false, false, false, false, ""
 	var cacheOptions cache.CacheOptions
 	if len(option) == 1 {
 		fetchSVG = option[0].FetchSVG
@@ -102,7 +101,6 @@ func Setup(option ...*TestOption) (pbs.MixerClient, func(), error) {
 		cacheOptions.SearchSVG = searchSVG
 		cacheOptions.CacheSVFormula = useStatisticalCalculation
 		useSpannerGraph = option[0].UseSpannerGraph
-		enableV3 = option[0].EnableV3
 		remoteMixerDomain = option[0].RemoteMixerDomain
 	}
 	return setupInternal(
@@ -113,7 +111,6 @@ func Setup(option ...*TestOption) (pbs.MixerClient, func(), error) {
 		useCustomTable,
 		useSQLite,
 		useSpannerGraph,
-		enableV3,
 		cacheOptions,
 		remoteMixerDomain,
 	)
@@ -121,7 +118,7 @@ func Setup(option ...*TestOption) (pbs.MixerClient, func(), error) {
 
 func setupInternal(
 	bigqueryVersionFile, baseBigtableInfoYaml, testBigtableInfoYaml, mcfPath string,
-	useCustomTable, useSQLite, useSpannerGraph, enableV3 bool,
+	useCustomTable, useSQLite, useSpannerGraph bool,
 	cacheOptions cache.CacheOptions,
 	remoteMixerDomain string,
 ) (pbs.MixerClient, func(), error) {
@@ -136,7 +133,7 @@ func setupInternal(
 	var spannerDataSource datasource.DataSource
 	var spannerClient spanner.SpannerClient
 	var spannerCleanup = func() {}
-	if enableV3 && useSpannerGraph {
+	if useSpannerGraph {
 		spannerClient = NewSpannerClient()
 		if spannerClient != nil {
 			spannerCleanup = spannerClient.Close
@@ -173,7 +170,7 @@ func setupInternal(
 		if err != nil {
 			log.Fatalf("SQL database validation failed: %v", err)
 		}
-		if enableV3 {
+		if useSpannerGraph {
 			var ds datasource.DataSource = sqldb.NewSQLDataSource(&sqlClient, spannerDataSource)
 			sources = append(sources, ds)
 		}
@@ -205,7 +202,7 @@ func setupInternal(
 	}
 
 	var remoteDataSource datasource.DataSource
-	if enableV3 && remoteMixerDomain != "" {
+	if useSpannerGraph && remoteMixerDomain != "" {
 		remoteClient, err := remote.NewRemoteClient(metadata)
 		if err != nil {
 			log.Fatalf("Failed to create remote client: %v", err)
@@ -221,7 +218,7 @@ func setupInternal(
 	dataSources := datasources.NewDataSources(sources, remoteDataSource)
 	// Processors
 	processors := []*dispatcher.Processor{}
-	if enableV3 {
+	if useSpannerGraph {
 		// Mixer in-memory cache.
 		dataSourceCache, err := cache.NewDataSourceCache(ctx, dataSources, cacheOptions)
 		if err != nil {


### PR DESCRIPTION
This PR updates the new backend flow to be gated by a single flag, UseSpannerGraph

This will enable the dispatcher/datasource framework in addition to adding spanner as the primary datasource