### PR TITLE
Add deployment flag for spanner-only setup

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -93,6 +93,7 @@ var (
 	httpProfilePort   = flag.Int("httpprof_port", 0, "Port to serve HTTP profiles from")
 	foldRemoteRootSvg = flag.Bool("fold_remote_root_svg", false, "Whether to fold root SVG from remote mixer")
 	// Spanner Graph
+	useSpannerGraph  = flag.Bool("use_spanner_graph", false, "Use Cloud Spanner Graph as database.")
 	spannerGraphInfo = flag.String("spanner_graph_info", "", "Yaml formatted text containing information for Spanner Graph.")
 	// Redis.
 	useRedis  = flag.Bool("use_redis", false, "Use Redis cache.")
@@ -138,6 +139,10 @@ func main() {
 	slog.Info("Created feature flags")
 
 	ctx := context.Background()
+
+	// The new Spanner-based backend can be enabled either by a server config flag (for stable configuration) or a feature flag (for experimental configuration).
+	// After launch, only the server config should be used.
+	shouldUseSpannerGraph := *useSpannerGraph || flags.UseSpannerGraph
 
 	credentials, err := google.FindDefaultCredentials(ctx, compute.ComputeScope)
 	if err == nil && credentials.ProjectID != "" {
@@ -192,7 +197,7 @@ func main() {
 
 	// Spanner Graph.
 	var spannerClient spanner.SpannerClient
-	if flags.UseSpannerGraph {
+	if shouldUseSpannerGraph {
 		var err error
 		spannerClient, err = spanner.NewSpannerClient(ctx, *spannerGraphInfo, flags.SpannerGraphDatabase)
 		if err != nil {
@@ -286,7 +291,7 @@ func main() {
 	// Create remote data source here but don't add it to sources yet since we want it to be the last source added.
 	// TODO: clean up how we create and add data sources.
 	var remoteDataSource datasource.DataSource
-	if flags.UseSpannerGraph && *remoteMixerDomain != "" {
+	if shouldUseSpannerGraph && *remoteMixerDomain != "" {
 		remoteClient, err := remote.NewRemoteClient(metadata)
 		if err != nil {
 			slog.Error("Failed to create remote client", "error", err)
@@ -334,13 +339,15 @@ func main() {
 	}
 
 	// SQL Data Source
-	if flags.UseSpannerGraph && sqldb.IsConnected(&sqlClient) {
+	if shouldUseSpannerGraph && sqldb.IsConnected(&sqlClient) {
 		var ds datasource.DataSource = sqldb.NewSQLDataSource(&sqlClient, remoteDataSource)
 		sources = append(sources, ds)
 	}
 
 	// Store
-	if len(tables) == 0 && *remoteMixerDomain == "" && !sqldb.IsConnected(&sqlClient) {
+	// An empty store is allowed *only* when there's a stable Spanner configuration.
+	// In particular, feature-flag-enabled Spanner configurations should still require Bigtable as a fallback.
+	if len(tables) == 0 && *remoteMixerDomain == "" && !sqldb.IsConnected(&sqlClient) && !*useSpannerGraph {
 		slog.Error("No bigtables or remote mixer domain or sql database are provided")
 		os.Exit(1)
 	}
@@ -393,8 +400,8 @@ func main() {
 
 	// Processors
 	processors := []*dispatcher.Processor{}
-	if flags.UseSpannerGraph {
-	slog.Info("New backend enabled, setting up processors")
+	if shouldUseSpannerGraph {
+		slog.Info("New backend enabled, setting up processors")
 		// Mixer in-memory cache.
 		dataSourceCache, err := cache.NewDataSourceCache(ctx, dataSources, cacheOptions)
 		if err != nil {
@@ -431,7 +438,7 @@ func main() {
 	dispatcher := dispatcher.NewDispatcher(processors, dataSources)
 
 	// Create server object
-	mixerServer := server.NewMixerServer(store, metadata, c, mapsClient, dispatcher, flags, *writeUsageLogs, *embeddingsServerURL, *resolveEmbeddingsIndexes)
+	mixerServer := server.NewMixerServer(store, metadata, c, mapsClient, dispatcher, flags, *writeUsageLogs, *embeddingsServerURL, *resolveEmbeddingsIndexes, *useSpannerGraph)
 	pbs.RegisterMixerServer(srv, mixerServer)
 
 	// Subscribe to branch cache update

--- a/deploy/featureflags/local.yaml
+++ b/deploy/featureflags/local.yaml
@@ -1,6 +1,0 @@
-flags:
-  EnableV3: true
-  V3MirrorFraction: 1.0
-  UseSpannerGraph: true
-  UseStaleReads: true
-  V2DivertFraction: 1.0

--- a/deploy/helm_charts/mixer/templates/deployment.yaml
+++ b/deploy/helm_charts/mixer/templates/deployment.yaml
@@ -188,6 +188,7 @@ spec:
               {{- if eq $.Values.mixer.foldRemoteRootSvg true }}
               --fold_remote_root_svg=true \
               {{- end }}
+              --use_spanner_graph={{ $.Values.mixer.useSpannerGraph }} \
               --spanner_graph_info="${SPANNER_GRAPH_INFO}" \
               --use_redis={{ $.Values.mixer.redis.enabled }} \
               --redis_info="${REDIS_INFO}" \

--- a/deploy/helm_charts/mixer/values.yaml
+++ b/deploy/helm_charts/mixer/values.yaml
@@ -41,6 +41,7 @@ mixer:
   useBranchBigtable: true
   useCustomBigtable: false
   useBigquery: true
+  useSpannerGraph: false
   foldRemoteRootSvg: false
   # Comma separated embeddings indexes for resolving indicators.
   resolveEmbeddingsIndexes: "base_uae_mem"

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -137,6 +137,10 @@ Additionally, to use a database other than the default in `spanner_graph_info.ya
 export MIXER_API_KEY=<YOUR API KEY>
 ./run_server.sh \
     --feature_flags_path=$PWD/deploy/featureflags/local.yaml \
+    --use_base_bigtable=false \
+    --use_branch_bigtable=false \
+    --use_bigquery=false \
+    --use_spanner_graph=true \
     --spanner_graph_info="$(cat deploy/storage/spanner_graph_info.yaml)" 
 ```
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -55,6 +55,8 @@ type Server struct {
 	writeUsageLogs           bool
 	embeddingsServerURL      string
 	resolveEmbeddingsIndexes string
+	// Whether to use dispatcher flow with Spanner as a default datasource.
+	useSpannerGraph bool
 }
 
 func (s *Server) updateBranchTable(ctx context.Context, branchTableName string) error {
@@ -161,6 +163,7 @@ func NewMixerServer(
 	writeUsageLogs bool,
 	embeddingsServerURL string,
 	resolveEmbeddingsIndexes string,
+	useSpannerGraph bool,
 ) *Server {
 	s := &Server{
 		store:                    store,
@@ -173,6 +176,7 @@ func NewMixerServer(
 		writeUsageLogs:           writeUsageLogs,
 		embeddingsServerURL:      embeddingsServerURL,
 		resolveEmbeddingsIndexes: resolveEmbeddingsIndexes,
+		useSpannerGraph:          useSpannerGraph,
 	}
 	s.cachedata.Store(cachedata)
 	return s
@@ -180,6 +184,10 @@ func NewMixerServer(
 
 // shouldDivertV2 returns true if the request should be diverted to the dispatcher.
 func (s *Server) shouldDivertV2(ctx context.Context) bool {
+	if s.useSpannerGraph {
+		return true
+	}
+
 	fraction := s.flags.V2DivertFraction
 	if fraction <= 0 {
 		return false

--- a/test/setup.go
+++ b/test/setup.go
@@ -283,7 +283,8 @@ func newClient(
 		return nil, func() {}, err
 	}
 	// Create mixer server. writeUsageLogs is false by default for tests but is directly tested in handler_v2_test.go
-	mixerServer := server.NewMixerServer(mixerStore, metadata, cachedata, mapsClient, dispatcher, flags, false, "", "")
+	// useSpannerGraph is also false by default while the legacy implementation remains, but is tested directly by V3 APIs.
+	mixerServer := server.NewMixerServer(mixerStore, metadata, cachedata, mapsClient, dispatcher, flags, false, "", "", false)
 	srv := grpc.NewServer()
 	pbs.RegisterMixerServer(srv, mixerServer)
 	reflection.Register(srv)


### PR DESCRIPTION
Adds a deployment flag "use_spanner_graph" to enable all spanner features, including dispatcher+datasource flow with spanner as a default datasource.

This is equivalent to setting the feature flags UseSpannerGraph = true and V2DivertFraction = 1.0, but can be used for stable configurations (in particular when disabling Bigtable and BigQuery)

This is to create a stable configuration for dev to help validate the eventual setup (and could also be used for DCP setup)

This should *not* be used for experimental configurations which do not have spanner fully enabled yet and/or still rely on BT/BQ, including all autopush/staging/prod envs 