### PR TITLE
Enable spanner, disable BT/BQ for dev

### DIFF
--- a/deploy/helm_charts/envs/mixer_dev.yaml
+++ b/deploy/helm_charts/envs/mixer_dev.yaml
@@ -7,6 +7,10 @@ mixer:
   hostProject: datcom-mixer-dev-316822
   serviceName: dev.api.datacommons.org
   cluster_prefix: mixer
+  useBaseBigtable: false
+  useBranchBigtable: false
+  useBigquery: false
+  useSpannerGraph: true
   redis:
     enabled: true
     configFile: |


### PR DESCRIPTION
Enable spanner-only setup on dev (ie new spanner backend, without BT or BQ)

Follow up to https://github.com/datacommonsorg/mixer/pull/1865