### PR TITLE
Support multiple nodes with filtering for BulkVariableGroupInfo in spanner

### DIFF
--- a/internal/server/spanner/client.go
+++ b/internal/server/spanner/client.go
@@ -45,8 +45,8 @@ type SpannerClient interface {
 	Sparql(ctx context.Context, nodes []types.Node, queries []*types.Query, opts *types.QueryOptions) ([][]string, error)
 	GetProvenanceSummary(ctx context.Context, ids []string) (map[string]map[string]*pb.StatVarSummary_ProvenanceSummary, error)
 	GetStatVarGroupNode(ctx context.Context, nodes []string) ([]*StatVarGroupNode, error)
-	GetFilteredStatVarGroupNode(ctx context.Context, node string, constrainedPlaces []string, constrainedImport string, numEntitiesExistence int) (*FilteredStatVarGroupNode, error)
-	GetFilteredTopic(ctx context.Context, node string, constrainedPlaces []string, constrainedImport string, numEntitiesExistence int) (int, error)
+	GetFilteredStatVarGroupNode(ctx context.Context, nodes []string, constrainedPlaces []string, constrainedImport string, numEntitiesExistence int) (map[string]*FilteredStatVarGroupNode, error)
+	GetFilteredTopic(ctx context.Context, nodes []string, constrainedPlaces []string, constrainedImport string, numEntitiesExistence int) (map[string]int, error)
 	Id() string
 	Start()
 	Close()

--- a/internal/server/spanner/coordinate_resolve_test.go
+++ b/internal/server/spanner/coordinate_resolve_test.go
@@ -92,12 +92,12 @@ func (m *coordinateMockSpannerClient) GetStatVarGroupNode(ctx context.Context, n
 	return nil, nil
 }
 
-func (m *coordinateMockSpannerClient) GetFilteredStatVarGroupNode(ctx context.Context, node string, constrainedPlaces []string, constrainedImport string, numEntitiesExistence int) (*FilteredStatVarGroupNode, error) {
+func (m *coordinateMockSpannerClient) GetFilteredStatVarGroupNode(ctx context.Context, nodes []string, constrainedPlaces []string, constrainedImport string, numEntitiesExistence int) (map[string]*FilteredStatVarGroupNode, error) {
 	return nil, nil
 }
 
-func (m *coordinateMockSpannerClient) GetFilteredTopic(ctx context.Context, node string, constrainedPlaces []string, constrainedImport string, numEntitiesExistence int) (int, error) {
-	return 0, nil
+func (m *coordinateMockSpannerClient) GetFilteredTopic(ctx context.Context, nodes []string, constrainedPlaces []string, constrainedImport string, numEntitiesExistence int) (map[string]int, error) {
+	return nil, nil
 }
 
 func (m *coordinateMockSpannerClient) Id() string { return "mock" }

--- a/internal/server/spanner/datasource.go
+++ b/internal/server/spanner/datasource.go
@@ -593,17 +593,22 @@ func (sds *SpannerDataSource) BulkVariableGroupInfo(ctx context.Context, req *pb
 	if len(req.GetNodes()) == 0 {
 		return nil, status.Errorf(codes.InvalidArgument, "request must specify at least one node")
 	}
-	if len(req.GetNodes()) > 1 && (len(req.ConstrainedEntities) > 0 || req.NumEntitiesExistence > 0) {
-		return nil, status.Errorf(codes.InvalidArgument, "constrainedEntities and numEntitiesExistence can only be used when one node is specified")
-	}
 	if req.NumEntitiesExistence < 0 {
 		return nil, status.Errorf(codes.InvalidArgument, "numEntitiesExistence must be non-negative")
 	}
 	var svgs []string
+	var topics []string
 	for _, node := range req.GetNodes() {
-		if !strings.HasPrefix(node, prefixTopic) {
+		if strings.HasPrefix(node, prefixTopic) {
+			topics = append(topics, node)
+		} else if strings.HasPrefix(node, prefixSVG) {
 			svgs = append(svgs, node)
+		} else {
+			return nil, status.Errorf(codes.InvalidArgument, "node %s is not a valid StatVarGroup or Topic node", node)
 		}
+	}
+	if len(svgs) > 0 && len(topics) > 0 {
+		return nil, status.Errorf(codes.InvalidArgument, "cannot mix Topic and StatVarGroup nodes in request")
 	}
 
 	// Unfiltered case.
@@ -629,27 +634,18 @@ func (sds *SpannerDataSource) BulkVariableGroupInfo(ctx context.Context, req *pb
 	}
 
 	// Filter Topic.
-	if strings.HasPrefix(req.GetNodes()[0], prefixTopic) {
-		count, err := sds.client.GetFilteredTopic(ctx, req.GetNodes()[0], constrainedPlaces, constrainedImport, int(req.NumEntitiesExistence))
+	if len(topics) > 0 {
+		counts, err := sds.client.GetFilteredTopic(ctx, req.GetNodes(), constrainedPlaces, constrainedImport, int(req.NumEntitiesExistence))
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "error getting filtered topic count from Spanner: %v", err)
 		}
-		return &pbv1.BulkVariableGroupInfoResponse{
-			Data: []*pbv1.VariableGroupInfoResponse{
-				{
-					Node: req.GetNodes()[0],
-					Info: &pb.StatVarGroupNode{
-						DescendentStatVarCount: int32(count),
-					},
-				},
-			},
-		}, nil
+		return filteredTopicInfoToBulkVariableGroupInfoResponse(counts, topics), nil
 	}
 
 	// Filter StatVarGroup.
-	filteredSVGInfo, err := sds.client.GetFilteredStatVarGroupNode(ctx, svgs[0], constrainedPlaces, constrainedImport, int(req.NumEntitiesExistence))
+	filteredSVGInfo, err := sds.client.GetFilteredStatVarGroupNode(ctx, svgs, constrainedPlaces, constrainedImport, int(req.NumEntitiesExistence))
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "error getting filtered StatVarGroupNode from Spanner: %v", err)
 	}
-	return filteredSVGInfoToBulkVariableGroupInfoResponse(filteredSVGInfo, req.GetNodes()[0]), nil
+	return filteredSVGInfoToBulkVariableGroupInfoResponse(filteredSVGInfo), nil
 }

--- a/internal/server/spanner/dsutil.go
+++ b/internal/server/spanner/dsutil.go
@@ -731,7 +731,7 @@ func filteredTopicInfoToBulkVariableGroupInfoResponse(counts map[string]int, nod
 		})
 	}
 
-	// Sort response by SVG.
+	// Sort response by node.
 	slices.SortFunc(response.Data, func(a, b *pbv1.VariableGroupInfoResponse) int {
 		return strings.Compare(a.Node, b.Node)
 	})

--- a/internal/server/spanner/dsutil.go
+++ b/internal/server/spanner/dsutil.go
@@ -893,7 +893,7 @@ func filteredSVGInfoToBulkVariableGroupInfoResponse(svgInfo map[string]*Filtered
 	for node, info := range svgInfo {
 		response.Data = append(response.Data, &pbv1.VariableGroupInfoResponse{
 			Node: node,
-			Info: filteredSingleSVGInfoToBulkVariableGroupInfoResponse(info, node),
+			Info: filteredSVGInfoToStatVarGroupNode(info, node),
 		})
 	}
 
@@ -903,8 +903,8 @@ func filteredSVGInfoToBulkVariableGroupInfoResponse(svgInfo map[string]*Filtered
 	return response
 }
 
-// filteredSingleSVGInfoToBulkVariableGroupInfoResponse converts a FilteredStatVarGroupNode info to a BulkVariableGroupInfoResponse.
-func filteredSingleSVGInfoToBulkVariableGroupInfoResponse(svgInfo *FilteredStatVarGroupNode, node string) *pb.StatVarGroupNode {
+// filteredSVGInfoToStatVarGroupNode converts a FilteredStatVarGroupNode info to a BulkVariableGroupInfoResponse.
+func filteredSVGInfoToStatVarGroupNode(svgInfo *FilteredStatVarGroupNode, node string) *pb.StatVarGroupNode {
 	svgNode := &pb.StatVarGroupNode{}
 	allChildren := map[string]bool{}
 

--- a/internal/server/spanner/dsutil.go
+++ b/internal/server/spanner/dsutil.go
@@ -717,6 +717,27 @@ func generateBulkVariableInfoResponse(variableInfo map[string]map[string]*pb.Sta
 	return response
 }
 
+func filteredTopicInfoToBulkVariableGroupInfoResponse(counts map[string]int, nodes []string) *pbv1.BulkVariableGroupInfoResponse {
+	response := &pbv1.BulkVariableGroupInfoResponse{
+		Data: make([]*pbv1.VariableGroupInfoResponse, 0, len(nodes)),
+	}
+
+	for node, count := range counts {
+		response.Data = append(response.Data, &pbv1.VariableGroupInfoResponse{
+			Node: node,
+			Info: &pb.StatVarGroupNode{
+				DescendentStatVarCount: int32(count),
+			},
+		})
+	}
+
+	// Sort response by SVG.
+	slices.SortFunc(response.Data, func(a, b *pbv1.VariableGroupInfoResponse) int {
+		return strings.Compare(a.Node, b.Node)
+	})
+	return response
+}
+
 // splitPascalCase splits a PascalCase string into separate words with spaces.
 func splitPascalCase(s string) string {
 	var builder strings.Builder
@@ -863,18 +884,28 @@ func svgInfoToBulkVariableGroupInfoResponse(svgInfo []*StatVarGroupNode, nodes [
 	return response
 }
 
-// filteredSVGInfoToBulkVariableGroupInfoResponse converts a list of FilteredStatVarGroupNode info to a BulkVariableGroupInfoResponse.
-func filteredSVGInfoToBulkVariableGroupInfoResponse(svgInfo *FilteredStatVarGroupNode, node string) *pbv1.BulkVariableGroupInfoResponse {
+// filteredSVGInfoToBulkVariableGroupInfoResponse converts a map of FilteredStatVarGroupNode info to a BulkVariableGroupInfoResponse.
+func filteredSVGInfoToBulkVariableGroupInfoResponse(svgInfo map[string]*FilteredStatVarGroupNode) *pbv1.BulkVariableGroupInfoResponse {
 	response := &pbv1.BulkVariableGroupInfoResponse{
-		Data: []*pbv1.VariableGroupInfoResponse{
-			{
-				Node: node,
-				Info: &pb.StatVarGroupNode{},
-			},
-		},
+		Data: []*pbv1.VariableGroupInfoResponse{},
 	}
 
-	svgNode := response.Data[0].Info
+	for node, info := range svgInfo {
+		response.Data = append(response.Data, &pbv1.VariableGroupInfoResponse{
+			Node: node,
+			Info: filteredSingleSVGInfoToBulkVariableGroupInfoResponse(info, node),
+		})
+	}
+
+	slices.SortFunc(response.Data, func(a, b *pbv1.VariableGroupInfoResponse) int {
+		return strings.Compare(a.Node, b.Node)
+	})
+	return response
+}
+
+// filteredSingleSVGInfoToBulkVariableGroupInfoResponse converts a FilteredStatVarGroupNode info to a BulkVariableGroupInfoResponse.
+func filteredSingleSVGInfoToBulkVariableGroupInfoResponse(svgInfo *FilteredStatVarGroupNode, node string) *pb.StatVarGroupNode {
+	svgNode := &pb.StatVarGroupNode{}
 	allChildren := map[string]bool{}
 
 	// Attach Child SVGs.
@@ -928,5 +959,5 @@ func filteredSVGInfoToBulkVariableGroupInfoResponse(svgInfo *FilteredStatVarGrou
 
 	sortSVGNode(svgNode)
 
-	return response
+	return svgNode
 }

--- a/internal/server/spanner/golden/datasource_test.go
+++ b/internal/server/spanner/golden/datasource_test.go
@@ -87,11 +87,11 @@ func (m *mockSpannerClient) GetEventCollection(ctx context.Context, req *pbv1.Ev
 func (m *mockSpannerClient) GetStatVarGroupNode(ctx context.Context, nodes []string) ([]*spanner.StatVarGroupNode, error) {
 	return nil, nil
 }
-func (m *mockSpannerClient) GetFilteredStatVarGroupNode(ctx context.Context, node string, constrainedPlaces []string, constrainedImport string, numEntitiesExistence int) (*spanner.FilteredStatVarGroupNode, error) {
+func (m *mockSpannerClient) GetFilteredStatVarGroupNode(ctx context.Context, nodes []string, constrainedPlaces []string, constrainedImport string, numEntitiesExistence int) (map[string]*spanner.FilteredStatVarGroupNode, error) {
 	return nil, nil
 }
-func (m *mockSpannerClient) GetFilteredTopic(ctx context.Context, node string, constrainedPlaces []string, constrainedImport string, numEntitiesExistence int) (int, error) {
-	return 0, nil
+func (m *mockSpannerClient) GetFilteredTopic(ctx context.Context, nodes []string, constrainedPlaces []string, constrainedImport string, numEntitiesExistence int) (map[string]int, error) {
+	return nil, nil
 }
 func (m *mockSpannerClient) Id() string { return "mock" }
 func (m *mockSpannerClient) Start()     {}

--- a/internal/server/spanner/golden/query/get_filtered_stat_var_group_node_import.json
+++ b/internal/server/spanner/golden/query/get_filtered_stat_var_group_node_import.json
@@ -1,514 +1,516 @@
 {
-  "SVGChild": [
-    {
-      "SubjectID": "Count_Company",
-      "Name": "",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "Count_Person",
-      "Name": "Total population",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "Count_Person_5To17Years_Poor",
-      "Name": "",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "Count_Person_AsAFractionOf_Count_Household",
-      "Name": "",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "Count_Person_InfrastructureProject_BrazilRuralDevelopmentProgram",
-      "Name": "",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "Count_Person_PerArea",
-      "Name": "Population Density",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "FertilityRate_Person_Female",
-      "Name": "Fertility rate of women",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "FertilityRate_Person_Female_AsAFractionOf_Count_Person_Female",
-      "Name": "Fertility rate (%)",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "GenderIncomeInequality_Person_15OrMoreYears_WithIncome",
-      "Name": "Income Inequality Between Men and Women of Working Age",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "GrowthRate_Count_Person",
-      "Name": "Population growth rate",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "IncrementalCount_Person",
-      "Name": "Population Change",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "LifeExpectancy_Person",
-      "Name": "Life Expectancy",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "Mean_Count_Person",
-      "Name": "Mean count of person",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "Mean_IncrementalCount_Person",
-      "Name": "Mean incremental count of person",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "Mean_MealCost_Person_FoodSecure",
-      "Name": "Average Meal Cost for Food Secure People",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "Median_Age_Person",
-      "Name": "Median age of population",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "Median_Income_Person",
-      "Name": "Median Income of a Population",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "dc/g/Child",
-      "Name": "Child",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Children",
-      "Name": "Children",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/CivicStructure",
-      "Name": "Civic Structure",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Commute",
-      "Name": "Commute",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Courthouse",
-      "Name": "Courthouse",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Demographics_Miscellaneous",
-      "Name": "Miscellaneous",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Food",
-      "Name": "Food",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/FoodBasket",
-      "Name": "Food Basket",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/House",
-      "Name": "House",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Household",
-      "Name": "Household",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Households",
-      "Name": "Households",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/ImmigrationAndCitizenship",
-      "Name": "Immigration and Citizenship",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Infant",
-      "Name": "Infant",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Language",
-      "Name": "Language",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/MaternalMortalityEvent",
-      "Name": "Maternal Mortality Event",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/MilitaryService",
-      "Name": "Military Service",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Mother",
-      "Name": "Mother",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/MunicipalWard",
-      "Name": "Municipal Ward",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/NonPregnantWoman",
-      "Name": "Non Pregnant Woman",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_Age",
-      "Name": "Person by Age",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_AgeGroupClassification",
-      "Name": "Person by Age Group Classification",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_BenefitProgram",
-      "Name": "Person by Benefit Program",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_BenefitsStatus",
-      "Name": "Person by Benefits Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_CarpoolOccupancy",
-      "Name": "Person by Carpool Occupancy",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_ChildrenStatus",
-      "Name": "Person by Children Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_CitizenshipStatus",
-      "Name": "Person by Citizenship Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_CommuteStartTime",
-      "Name": "Person by Commute Start Time",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_CommuteType",
-      "Name": "Person by Commute Type",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_ComparisonRegion",
-      "Name": "Person by Comparison Region",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_CrashInvolvement",
-      "Name": "Person by Crash Involvement",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_DateOfEntry",
-      "Name": "Person by Date of Entry",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_DeprivationDomain",
-      "Name": "Person by Deprivation Domain",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_DeviceUsed",
-      "Name": "Person by Device Used",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_DisabilityStatus",
-      "Name": "Person by Disability Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_Earnings",
-      "Name": "Person by Earnings",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_ElectronicGadgetUsed",
-      "Name": "Person by Electronic Gadget Used",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_Employer",
-      "Name": "Person by Employer",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_Ethnicity",
-      "Name": "Person by Ethnicity",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_Facilities",
-      "Name": "Person by Facilities",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_FoodSecurityStatus",
-      "Name": "Person by Food Security Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_Gender",
-      "Name": "Person by Gender",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_GovernmentId",
-      "Name": "Person by Government Id",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_GovernmentIdentifier",
-      "Name": "Person by Government Identifier",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_HealthInsurance",
-      "Name": "Person by Health Insurance",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_HouseholdIncome",
-      "Name": "Person by Household Income",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_HouseholdType",
-      "Name": "Person by Household Type",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_IdentityActivity",
-      "Name": "Person by Identity Activity",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_Income",
-      "Name": "Person by Income",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_IncomeStatus",
-      "Name": "Person by Income Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_InternetAccessStatus",
-      "Name": "Person by Internet Access Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_InternetUsageLocation",
-      "Name": "Person by Internet Usage Location",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_IsInternetUser",
-      "Name": "Person by Is Internet User",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_LaborForceStatus",
-      "Name": "Person by Labor Force Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_LiteracyStatus",
-      "Name": "Person by Literacy Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_MaritalStatus",
-      "Name": "Person by Marital Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_MemberStatus",
-      "Name": "Person by Member Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_NumberOfVehiclesInHousehold",
-      "Name": "Person by Number of Vehicles in Household",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_PlaceOfBirth",
-      "Name": "Person by Place of Birth",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_PlaceOfResidenceClassification",
-      "Name": "Person by Place of Residence Classification",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_PovertyStatus",
-      "Name": "Person by Poverty Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_Race",
-      "Name": "Person by Race",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_Religion",
-      "Name": "Person by Religion",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_ResidentStatus",
-      "Name": "Person by Resident Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_VehicleOccupantType",
-      "Name": "Person by Vehicle Occupant Type",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_VulnerabilityStatus",
-      "Name": "Person by Vulnerability Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Place_Facilities",
-      "Name": "Place by Facilities",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Place_PlaceOfResidenceClassification",
-      "Name": "Place by Place of Residence Classification",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Place_PlaceType",
-      "Name": "Place by Place Type",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Place_SocialCondition",
-      "Name": "Place by Social Condition",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Residence",
-      "Name": "Residence",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Vehicle",
-      "Name": "Vehicle",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/VehicleCrashIncident",
-      "Name": "Vehicle Crash Incident",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Village",
-      "Name": "Village",
-      "Predicate": "specializationOf"
-    }
-  ],
-  "ChildSV": [
-    {
-      "SubjectID": "Count_Person",
-      "Name": "Total population"
-    },
-    {
-      "SubjectID": "FertilityRate_Person_Female",
-      "Name": "Fertility rate of women"
-    },
-    {
-      "SubjectID": "GrowthRate_Count_Person",
-      "Name": "Population growth rate"
-    },
-    {
-      "SubjectID": "LifeExpectancy_Person",
-      "Name": "Life Expectancy"
-    }
-  ],
-  "ChildSVG": [
-    {
-      "SubjectID": "dc/g/Demographics",
-      "Name": "Demographics",
-      "DescendentStatVarCount": 1425
-    },
-    {
-      "SubjectID": "dc/g/Demographics_Miscellaneous",
-      "Name": "Miscellaneous",
-      "DescendentStatVarCount": 1385
-    },
-    {
-      "SubjectID": "dc/g/Person_Age",
-      "Name": "Person by Age",
-      "DescendentStatVarCount": 21
-    },
-    {
-      "SubjectID": "dc/g/Person_Gender",
-      "Name": "Person by Gender",
-      "DescendentStatVarCount": 23
-    },
-    {
-      "SubjectID": "dc/g/Person_IsInternetUser",
-      "Name": "Person by Is Internet User",
-      "DescendentStatVarCount": 1
-    },
-    {
-      "SubjectID": "dc/g/Person_LaborForceStatus",
-      "Name": "Person by Labor Force Status",
-      "DescendentStatVarCount": 5
-    },
-    {
-      "SubjectID": "dc/g/Person_PlaceOfResidenceClassification",
-      "Name": "Person by Place of Residence Classification",
-      "DescendentStatVarCount": 2
-    },
-    {
-      "SubjectID": "dc/g/Residence",
-      "Name": "Residence",
-      "DescendentStatVarCount": 3
-    }
-  ]
+  "dc/g/Demographics": {
+    "SVGChild": [
+      {
+        "SubjectID": "Count_Company",
+        "Name": "",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "Count_Person",
+        "Name": "Total population",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "Count_Person_5To17Years_Poor",
+        "Name": "",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "Count_Person_AsAFractionOf_Count_Household",
+        "Name": "",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "Count_Person_InfrastructureProject_BrazilRuralDevelopmentProgram",
+        "Name": "",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "Count_Person_PerArea",
+        "Name": "Population Density",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "FertilityRate_Person_Female",
+        "Name": "Fertility rate of women",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "FertilityRate_Person_Female_AsAFractionOf_Count_Person_Female",
+        "Name": "Fertility rate (%)",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "GenderIncomeInequality_Person_15OrMoreYears_WithIncome",
+        "Name": "Income Inequality Between Men and Women of Working Age",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "GrowthRate_Count_Person",
+        "Name": "Population growth rate",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "IncrementalCount_Person",
+        "Name": "Population Change",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "LifeExpectancy_Person",
+        "Name": "Life Expectancy",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "Mean_Count_Person",
+        "Name": "Mean count of person",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "Mean_IncrementalCount_Person",
+        "Name": "Mean incremental count of person",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "Mean_MealCost_Person_FoodSecure",
+        "Name": "Average Meal Cost for Food Secure People",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "Median_Age_Person",
+        "Name": "Median age of population",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "Median_Income_Person",
+        "Name": "Median Income of a Population",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "dc/g/Child",
+        "Name": "Child",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Children",
+        "Name": "Children",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/CivicStructure",
+        "Name": "Civic Structure",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Commute",
+        "Name": "Commute",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Courthouse",
+        "Name": "Courthouse",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Demographics_Miscellaneous",
+        "Name": "Miscellaneous",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Food",
+        "Name": "Food",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/FoodBasket",
+        "Name": "Food Basket",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/House",
+        "Name": "House",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Household",
+        "Name": "Household",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Households",
+        "Name": "Households",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/ImmigrationAndCitizenship",
+        "Name": "Immigration and Citizenship",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Infant",
+        "Name": "Infant",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Language",
+        "Name": "Language",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/MaternalMortalityEvent",
+        "Name": "Maternal Mortality Event",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/MilitaryService",
+        "Name": "Military Service",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Mother",
+        "Name": "Mother",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/MunicipalWard",
+        "Name": "Municipal Ward",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/NonPregnantWoman",
+        "Name": "Non Pregnant Woman",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_Age",
+        "Name": "Person by Age",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_AgeGroupClassification",
+        "Name": "Person by Age Group Classification",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_BenefitProgram",
+        "Name": "Person by Benefit Program",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_BenefitsStatus",
+        "Name": "Person by Benefits Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_CarpoolOccupancy",
+        "Name": "Person by Carpool Occupancy",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_ChildrenStatus",
+        "Name": "Person by Children Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_CitizenshipStatus",
+        "Name": "Person by Citizenship Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_CommuteStartTime",
+        "Name": "Person by Commute Start Time",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_CommuteType",
+        "Name": "Person by Commute Type",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_ComparisonRegion",
+        "Name": "Person by Comparison Region",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_CrashInvolvement",
+        "Name": "Person by Crash Involvement",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_DateOfEntry",
+        "Name": "Person by Date of Entry",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_DeprivationDomain",
+        "Name": "Person by Deprivation Domain",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_DeviceUsed",
+        "Name": "Person by Device Used",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_DisabilityStatus",
+        "Name": "Person by Disability Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_Earnings",
+        "Name": "Person by Earnings",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_ElectronicGadgetUsed",
+        "Name": "Person by Electronic Gadget Used",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_Employer",
+        "Name": "Person by Employer",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_Ethnicity",
+        "Name": "Person by Ethnicity",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_Facilities",
+        "Name": "Person by Facilities",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_FoodSecurityStatus",
+        "Name": "Person by Food Security Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_Gender",
+        "Name": "Person by Gender",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_GovernmentId",
+        "Name": "Person by Government Id",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_GovernmentIdentifier",
+        "Name": "Person by Government Identifier",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_HealthInsurance",
+        "Name": "Person by Health Insurance",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_HouseholdIncome",
+        "Name": "Person by Household Income",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_HouseholdType",
+        "Name": "Person by Household Type",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_IdentityActivity",
+        "Name": "Person by Identity Activity",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_Income",
+        "Name": "Person by Income",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_IncomeStatus",
+        "Name": "Person by Income Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_InternetAccessStatus",
+        "Name": "Person by Internet Access Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_InternetUsageLocation",
+        "Name": "Person by Internet Usage Location",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_IsInternetUser",
+        "Name": "Person by Is Internet User",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_LaborForceStatus",
+        "Name": "Person by Labor Force Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_LiteracyStatus",
+        "Name": "Person by Literacy Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_MaritalStatus",
+        "Name": "Person by Marital Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_MemberStatus",
+        "Name": "Person by Member Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_NumberOfVehiclesInHousehold",
+        "Name": "Person by Number of Vehicles in Household",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_PlaceOfBirth",
+        "Name": "Person by Place of Birth",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_PlaceOfResidenceClassification",
+        "Name": "Person by Place of Residence Classification",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_PovertyStatus",
+        "Name": "Person by Poverty Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_Race",
+        "Name": "Person by Race",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_Religion",
+        "Name": "Person by Religion",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_ResidentStatus",
+        "Name": "Person by Resident Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_VehicleOccupantType",
+        "Name": "Person by Vehicle Occupant Type",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_VulnerabilityStatus",
+        "Name": "Person by Vulnerability Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Place_Facilities",
+        "Name": "Place by Facilities",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Place_PlaceOfResidenceClassification",
+        "Name": "Place by Place of Residence Classification",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Place_PlaceType",
+        "Name": "Place by Place Type",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Place_SocialCondition",
+        "Name": "Place by Social Condition",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Residence",
+        "Name": "Residence",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Vehicle",
+        "Name": "Vehicle",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/VehicleCrashIncident",
+        "Name": "Vehicle Crash Incident",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Village",
+        "Name": "Village",
+        "Predicate": "specializationOf"
+      }
+    ],
+    "ChildSV": [
+      {
+        "SubjectID": "Count_Person",
+        "Name": "Total population"
+      },
+      {
+        "SubjectID": "FertilityRate_Person_Female",
+        "Name": "Fertility rate of women"
+      },
+      {
+        "SubjectID": "GrowthRate_Count_Person",
+        "Name": "Population growth rate"
+      },
+      {
+        "SubjectID": "LifeExpectancy_Person",
+        "Name": "Life Expectancy"
+      }
+    ],
+    "ChildSVG": [
+      {
+        "SubjectID": "dc/g/Demographics",
+        "Name": "Demographics",
+        "DescendentStatVarCount": 1425
+      },
+      {
+        "SubjectID": "dc/g/Demographics_Miscellaneous",
+        "Name": "Miscellaneous",
+        "DescendentStatVarCount": 1385
+      },
+      {
+        "SubjectID": "dc/g/Person_Age",
+        "Name": "Person by Age",
+        "DescendentStatVarCount": 21
+      },
+      {
+        "SubjectID": "dc/g/Person_Gender",
+        "Name": "Person by Gender",
+        "DescendentStatVarCount": 23
+      },
+      {
+        "SubjectID": "dc/g/Person_IsInternetUser",
+        "Name": "Person by Is Internet User",
+        "DescendentStatVarCount": 1
+      },
+      {
+        "SubjectID": "dc/g/Person_LaborForceStatus",
+        "Name": "Person by Labor Force Status",
+        "DescendentStatVarCount": 5
+      },
+      {
+        "SubjectID": "dc/g/Person_PlaceOfResidenceClassification",
+        "Name": "Person by Place of Residence Classification",
+        "DescendentStatVarCount": 2
+      },
+      {
+        "SubjectID": "dc/g/Residence",
+        "Name": "Residence",
+        "DescendentStatVarCount": 3
+      }
+    ]
+  }
 }

--- a/internal/server/spanner/golden/query/get_filtered_stat_var_group_node_num_entities_existence.json
+++ b/internal/server/spanner/golden/query/get_filtered_stat_var_group_node_num_entities_existence.json
@@ -1,528 +1,530 @@
 {
-  "SVGChild": [
-    {
-      "SubjectID": "Count_Company",
-      "Name": "",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "Count_Person",
-      "Name": "Total population",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "Count_Person_5To17Years_Poor",
-      "Name": "",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "Count_Person_AsAFractionOf_Count_Household",
-      "Name": "",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "Count_Person_InfrastructureProject_BrazilRuralDevelopmentProgram",
-      "Name": "",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "Count_Person_PerArea",
-      "Name": "Population Density",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "FertilityRate_Person_Female",
-      "Name": "Fertility rate of women",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "FertilityRate_Person_Female_AsAFractionOf_Count_Person_Female",
-      "Name": "Fertility rate (%)",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "GenderIncomeInequality_Person_15OrMoreYears_WithIncome",
-      "Name": "Income Inequality Between Men and Women of Working Age",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "GrowthRate_Count_Person",
-      "Name": "Population growth rate",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "IncrementalCount_Person",
-      "Name": "Population Change",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "LifeExpectancy_Person",
-      "Name": "Life Expectancy",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "Mean_Count_Person",
-      "Name": "Mean count of person",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "Mean_IncrementalCount_Person",
-      "Name": "Mean incremental count of person",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "Mean_MealCost_Person_FoodSecure",
-      "Name": "Average Meal Cost for Food Secure People",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "Median_Age_Person",
-      "Name": "Median age of population",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "Median_Income_Person",
-      "Name": "Median Income of a Population",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "dc/g/Child",
-      "Name": "Child",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Children",
-      "Name": "Children",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/CivicStructure",
-      "Name": "Civic Structure",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Commute",
-      "Name": "Commute",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Courthouse",
-      "Name": "Courthouse",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Demographics_Miscellaneous",
-      "Name": "Miscellaneous",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Food",
-      "Name": "Food",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/FoodBasket",
-      "Name": "Food Basket",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/House",
-      "Name": "House",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Household",
-      "Name": "Household",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Households",
-      "Name": "Households",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/ImmigrationAndCitizenship",
-      "Name": "Immigration and Citizenship",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Infant",
-      "Name": "Infant",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Language",
-      "Name": "Language",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/MaternalMortalityEvent",
-      "Name": "Maternal Mortality Event",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/MilitaryService",
-      "Name": "Military Service",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Mother",
-      "Name": "Mother",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/MunicipalWard",
-      "Name": "Municipal Ward",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/NonPregnantWoman",
-      "Name": "Non Pregnant Woman",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_Age",
-      "Name": "Person by Age",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_AgeGroupClassification",
-      "Name": "Person by Age Group Classification",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_BenefitProgram",
-      "Name": "Person by Benefit Program",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_BenefitsStatus",
-      "Name": "Person by Benefits Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_CarpoolOccupancy",
-      "Name": "Person by Carpool Occupancy",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_ChildrenStatus",
-      "Name": "Person by Children Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_CitizenshipStatus",
-      "Name": "Person by Citizenship Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_CommuteStartTime",
-      "Name": "Person by Commute Start Time",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_CommuteType",
-      "Name": "Person by Commute Type",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_ComparisonRegion",
-      "Name": "Person by Comparison Region",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_CrashInvolvement",
-      "Name": "Person by Crash Involvement",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_DateOfEntry",
-      "Name": "Person by Date of Entry",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_DeprivationDomain",
-      "Name": "Person by Deprivation Domain",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_DeviceUsed",
-      "Name": "Person by Device Used",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_DisabilityStatus",
-      "Name": "Person by Disability Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_Earnings",
-      "Name": "Person by Earnings",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_ElectronicGadgetUsed",
-      "Name": "Person by Electronic Gadget Used",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_Employer",
-      "Name": "Person by Employer",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_Ethnicity",
-      "Name": "Person by Ethnicity",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_Facilities",
-      "Name": "Person by Facilities",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_FoodSecurityStatus",
-      "Name": "Person by Food Security Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_Gender",
-      "Name": "Person by Gender",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_GovernmentId",
-      "Name": "Person by Government Id",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_GovernmentIdentifier",
-      "Name": "Person by Government Identifier",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_HealthInsurance",
-      "Name": "Person by Health Insurance",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_HouseholdIncome",
-      "Name": "Person by Household Income",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_HouseholdType",
-      "Name": "Person by Household Type",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_IdentityActivity",
-      "Name": "Person by Identity Activity",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_Income",
-      "Name": "Person by Income",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_IncomeStatus",
-      "Name": "Person by Income Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_InternetAccessStatus",
-      "Name": "Person by Internet Access Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_InternetUsageLocation",
-      "Name": "Person by Internet Usage Location",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_IsInternetUser",
-      "Name": "Person by Is Internet User",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_LaborForceStatus",
-      "Name": "Person by Labor Force Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_LiteracyStatus",
-      "Name": "Person by Literacy Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_MaritalStatus",
-      "Name": "Person by Marital Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_MemberStatus",
-      "Name": "Person by Member Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_NumberOfVehiclesInHousehold",
-      "Name": "Person by Number of Vehicles in Household",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_PlaceOfBirth",
-      "Name": "Person by Place of Birth",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_PlaceOfResidenceClassification",
-      "Name": "Person by Place of Residence Classification",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_PovertyStatus",
-      "Name": "Person by Poverty Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_Race",
-      "Name": "Person by Race",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_Religion",
-      "Name": "Person by Religion",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_ResidentStatus",
-      "Name": "Person by Resident Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_VehicleOccupantType",
-      "Name": "Person by Vehicle Occupant Type",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_VulnerabilityStatus",
-      "Name": "Person by Vulnerability Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Place_Facilities",
-      "Name": "Place by Facilities",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Place_PlaceOfResidenceClassification",
-      "Name": "Place by Place of Residence Classification",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Place_PlaceType",
-      "Name": "Place by Place Type",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Place_SocialCondition",
-      "Name": "Place by Social Condition",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Residence",
-      "Name": "Residence",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Vehicle",
-      "Name": "Vehicle",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/VehicleCrashIncident",
-      "Name": "Vehicle Crash Incident",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Village",
-      "Name": "Village",
-      "Predicate": "specializationOf"
-    }
-  ],
-  "ChildSV": [
-    {
-      "SubjectID": "Count_Person",
-      "Name": "Total population"
-    },
-    {
-      "SubjectID": "Count_Person_PerArea",
-      "Name": "Population Density"
-    },
-    {
-      "SubjectID": "FertilityRate_Person_Female",
-      "Name": "Fertility rate of women"
-    },
-    {
-      "SubjectID": "GrowthRate_Count_Person",
-      "Name": "Population growth rate"
-    },
-    {
-      "SubjectID": "LifeExpectancy_Person",
-      "Name": "Life Expectancy"
-    }
-  ],
-  "ChildSVG": [
-    {
-      "SubjectID": "dc/g/Demographics",
-      "Name": "Demographics",
-      "DescendentStatVarCount": 1228
-    },
-    {
-      "SubjectID": "dc/g/Demographics_Miscellaneous",
-      "Name": "Miscellaneous",
-      "DescendentStatVarCount": 1075
-    },
-    {
-      "SubjectID": "dc/g/Household",
-      "Name": "Household",
-      "DescendentStatVarCount": 1
-    },
-    {
-      "SubjectID": "dc/g/Person_Age",
-      "Name": "Person by Age",
-      "DescendentStatVarCount": 129
-    },
-    {
-      "SubjectID": "dc/g/Person_Gender",
-      "Name": "Person by Gender",
-      "DescendentStatVarCount": 85
-    },
-    {
-      "SubjectID": "dc/g/Person_IsInternetUser",
-      "Name": "Person by Is Internet User",
-      "DescendentStatVarCount": 1
-    },
-    {
-      "SubjectID": "dc/g/Person_LaborForceStatus",
-      "Name": "Person by Labor Force Status",
-      "DescendentStatVarCount": 5
-    },
-    {
-      "SubjectID": "dc/g/Person_PlaceOfResidenceClassification",
-      "Name": "Person by Place of Residence Classification",
-      "DescendentStatVarCount": 2
-    },
-    {
-      "SubjectID": "dc/g/Person_PovertyStatus",
-      "Name": "Person by Poverty Status",
-      "DescendentStatVarCount": 1
-    },
-    {
-      "SubjectID": "dc/g/Residence",
-      "Name": "Residence",
-      "DescendentStatVarCount": 3
-    }
-  ]
+  "dc/g/Demographics": {
+    "SVGChild": [
+      {
+        "SubjectID": "Count_Company",
+        "Name": "",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "Count_Person",
+        "Name": "Total population",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "Count_Person_5To17Years_Poor",
+        "Name": "",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "Count_Person_AsAFractionOf_Count_Household",
+        "Name": "",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "Count_Person_InfrastructureProject_BrazilRuralDevelopmentProgram",
+        "Name": "",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "Count_Person_PerArea",
+        "Name": "Population Density",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "FertilityRate_Person_Female",
+        "Name": "Fertility rate of women",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "FertilityRate_Person_Female_AsAFractionOf_Count_Person_Female",
+        "Name": "Fertility rate (%)",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "GenderIncomeInequality_Person_15OrMoreYears_WithIncome",
+        "Name": "Income Inequality Between Men and Women of Working Age",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "GrowthRate_Count_Person",
+        "Name": "Population growth rate",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "IncrementalCount_Person",
+        "Name": "Population Change",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "LifeExpectancy_Person",
+        "Name": "Life Expectancy",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "Mean_Count_Person",
+        "Name": "Mean count of person",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "Mean_IncrementalCount_Person",
+        "Name": "Mean incremental count of person",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "Mean_MealCost_Person_FoodSecure",
+        "Name": "Average Meal Cost for Food Secure People",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "Median_Age_Person",
+        "Name": "Median age of population",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "Median_Income_Person",
+        "Name": "Median Income of a Population",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "dc/g/Child",
+        "Name": "Child",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Children",
+        "Name": "Children",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/CivicStructure",
+        "Name": "Civic Structure",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Commute",
+        "Name": "Commute",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Courthouse",
+        "Name": "Courthouse",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Demographics_Miscellaneous",
+        "Name": "Miscellaneous",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Food",
+        "Name": "Food",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/FoodBasket",
+        "Name": "Food Basket",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/House",
+        "Name": "House",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Household",
+        "Name": "Household",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Households",
+        "Name": "Households",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/ImmigrationAndCitizenship",
+        "Name": "Immigration and Citizenship",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Infant",
+        "Name": "Infant",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Language",
+        "Name": "Language",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/MaternalMortalityEvent",
+        "Name": "Maternal Mortality Event",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/MilitaryService",
+        "Name": "Military Service",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Mother",
+        "Name": "Mother",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/MunicipalWard",
+        "Name": "Municipal Ward",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/NonPregnantWoman",
+        "Name": "Non Pregnant Woman",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_Age",
+        "Name": "Person by Age",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_AgeGroupClassification",
+        "Name": "Person by Age Group Classification",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_BenefitProgram",
+        "Name": "Person by Benefit Program",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_BenefitsStatus",
+        "Name": "Person by Benefits Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_CarpoolOccupancy",
+        "Name": "Person by Carpool Occupancy",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_ChildrenStatus",
+        "Name": "Person by Children Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_CitizenshipStatus",
+        "Name": "Person by Citizenship Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_CommuteStartTime",
+        "Name": "Person by Commute Start Time",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_CommuteType",
+        "Name": "Person by Commute Type",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_ComparisonRegion",
+        "Name": "Person by Comparison Region",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_CrashInvolvement",
+        "Name": "Person by Crash Involvement",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_DateOfEntry",
+        "Name": "Person by Date of Entry",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_DeprivationDomain",
+        "Name": "Person by Deprivation Domain",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_DeviceUsed",
+        "Name": "Person by Device Used",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_DisabilityStatus",
+        "Name": "Person by Disability Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_Earnings",
+        "Name": "Person by Earnings",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_ElectronicGadgetUsed",
+        "Name": "Person by Electronic Gadget Used",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_Employer",
+        "Name": "Person by Employer",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_Ethnicity",
+        "Name": "Person by Ethnicity",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_Facilities",
+        "Name": "Person by Facilities",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_FoodSecurityStatus",
+        "Name": "Person by Food Security Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_Gender",
+        "Name": "Person by Gender",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_GovernmentId",
+        "Name": "Person by Government Id",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_GovernmentIdentifier",
+        "Name": "Person by Government Identifier",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_HealthInsurance",
+        "Name": "Person by Health Insurance",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_HouseholdIncome",
+        "Name": "Person by Household Income",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_HouseholdType",
+        "Name": "Person by Household Type",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_IdentityActivity",
+        "Name": "Person by Identity Activity",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_Income",
+        "Name": "Person by Income",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_IncomeStatus",
+        "Name": "Person by Income Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_InternetAccessStatus",
+        "Name": "Person by Internet Access Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_InternetUsageLocation",
+        "Name": "Person by Internet Usage Location",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_IsInternetUser",
+        "Name": "Person by Is Internet User",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_LaborForceStatus",
+        "Name": "Person by Labor Force Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_LiteracyStatus",
+        "Name": "Person by Literacy Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_MaritalStatus",
+        "Name": "Person by Marital Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_MemberStatus",
+        "Name": "Person by Member Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_NumberOfVehiclesInHousehold",
+        "Name": "Person by Number of Vehicles in Household",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_PlaceOfBirth",
+        "Name": "Person by Place of Birth",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_PlaceOfResidenceClassification",
+        "Name": "Person by Place of Residence Classification",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_PovertyStatus",
+        "Name": "Person by Poverty Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_Race",
+        "Name": "Person by Race",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_Religion",
+        "Name": "Person by Religion",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_ResidentStatus",
+        "Name": "Person by Resident Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_VehicleOccupantType",
+        "Name": "Person by Vehicle Occupant Type",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_VulnerabilityStatus",
+        "Name": "Person by Vulnerability Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Place_Facilities",
+        "Name": "Place by Facilities",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Place_PlaceOfResidenceClassification",
+        "Name": "Place by Place of Residence Classification",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Place_PlaceType",
+        "Name": "Place by Place Type",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Place_SocialCondition",
+        "Name": "Place by Social Condition",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Residence",
+        "Name": "Residence",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Vehicle",
+        "Name": "Vehicle",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/VehicleCrashIncident",
+        "Name": "Vehicle Crash Incident",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Village",
+        "Name": "Village",
+        "Predicate": "specializationOf"
+      }
+    ],
+    "ChildSV": [
+      {
+        "SubjectID": "Count_Person",
+        "Name": "Total population"
+      },
+      {
+        "SubjectID": "Count_Person_PerArea",
+        "Name": "Population Density"
+      },
+      {
+        "SubjectID": "FertilityRate_Person_Female",
+        "Name": "Fertility rate of women"
+      },
+      {
+        "SubjectID": "GrowthRate_Count_Person",
+        "Name": "Population growth rate"
+      },
+      {
+        "SubjectID": "LifeExpectancy_Person",
+        "Name": "Life Expectancy"
+      }
+    ],
+    "ChildSVG": [
+      {
+        "SubjectID": "dc/g/Demographics",
+        "Name": "Demographics",
+        "DescendentStatVarCount": 1228
+      },
+      {
+        "SubjectID": "dc/g/Demographics_Miscellaneous",
+        "Name": "Miscellaneous",
+        "DescendentStatVarCount": 1075
+      },
+      {
+        "SubjectID": "dc/g/Household",
+        "Name": "Household",
+        "DescendentStatVarCount": 1
+      },
+      {
+        "SubjectID": "dc/g/Person_Age",
+        "Name": "Person by Age",
+        "DescendentStatVarCount": 129
+      },
+      {
+        "SubjectID": "dc/g/Person_Gender",
+        "Name": "Person by Gender",
+        "DescendentStatVarCount": 85
+      },
+      {
+        "SubjectID": "dc/g/Person_IsInternetUser",
+        "Name": "Person by Is Internet User",
+        "DescendentStatVarCount": 1
+      },
+      {
+        "SubjectID": "dc/g/Person_LaborForceStatus",
+        "Name": "Person by Labor Force Status",
+        "DescendentStatVarCount": 5
+      },
+      {
+        "SubjectID": "dc/g/Person_PlaceOfResidenceClassification",
+        "Name": "Person by Place of Residence Classification",
+        "DescendentStatVarCount": 2
+      },
+      {
+        "SubjectID": "dc/g/Person_PovertyStatus",
+        "Name": "Person by Poverty Status",
+        "DescendentStatVarCount": 1
+      },
+      {
+        "SubjectID": "dc/g/Residence",
+        "Name": "Residence",
+        "DescendentStatVarCount": 3
+      }
+    ]
+  }
 }

--- a/internal/server/spanner/golden/query/get_filtered_stat_var_group_node_place_import.json
+++ b/internal/server/spanner/golden/query/get_filtered_stat_var_group_node_place_import.json
@@ -1,514 +1,516 @@
 {
-  "SVGChild": [
-    {
-      "SubjectID": "Count_Company",
-      "Name": "",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "Count_Person",
-      "Name": "Total population",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "Count_Person_5To17Years_Poor",
-      "Name": "",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "Count_Person_AsAFractionOf_Count_Household",
-      "Name": "",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "Count_Person_InfrastructureProject_BrazilRuralDevelopmentProgram",
-      "Name": "",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "Count_Person_PerArea",
-      "Name": "Population Density",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "FertilityRate_Person_Female",
-      "Name": "Fertility rate of women",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "FertilityRate_Person_Female_AsAFractionOf_Count_Person_Female",
-      "Name": "Fertility rate (%)",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "GenderIncomeInequality_Person_15OrMoreYears_WithIncome",
-      "Name": "Income Inequality Between Men and Women of Working Age",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "GrowthRate_Count_Person",
-      "Name": "Population growth rate",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "IncrementalCount_Person",
-      "Name": "Population Change",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "LifeExpectancy_Person",
-      "Name": "Life Expectancy",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "Mean_Count_Person",
-      "Name": "Mean count of person",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "Mean_IncrementalCount_Person",
-      "Name": "Mean incremental count of person",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "Mean_MealCost_Person_FoodSecure",
-      "Name": "Average Meal Cost for Food Secure People",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "Median_Age_Person",
-      "Name": "Median age of population",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "Median_Income_Person",
-      "Name": "Median Income of a Population",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "dc/g/Child",
-      "Name": "Child",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Children",
-      "Name": "Children",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/CivicStructure",
-      "Name": "Civic Structure",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Commute",
-      "Name": "Commute",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Courthouse",
-      "Name": "Courthouse",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Demographics_Miscellaneous",
-      "Name": "Miscellaneous",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Food",
-      "Name": "Food",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/FoodBasket",
-      "Name": "Food Basket",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/House",
-      "Name": "House",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Household",
-      "Name": "Household",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Households",
-      "Name": "Households",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/ImmigrationAndCitizenship",
-      "Name": "Immigration and Citizenship",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Infant",
-      "Name": "Infant",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Language",
-      "Name": "Language",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/MaternalMortalityEvent",
-      "Name": "Maternal Mortality Event",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/MilitaryService",
-      "Name": "Military Service",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Mother",
-      "Name": "Mother",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/MunicipalWard",
-      "Name": "Municipal Ward",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/NonPregnantWoman",
-      "Name": "Non Pregnant Woman",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_Age",
-      "Name": "Person by Age",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_AgeGroupClassification",
-      "Name": "Person by Age Group Classification",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_BenefitProgram",
-      "Name": "Person by Benefit Program",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_BenefitsStatus",
-      "Name": "Person by Benefits Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_CarpoolOccupancy",
-      "Name": "Person by Carpool Occupancy",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_ChildrenStatus",
-      "Name": "Person by Children Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_CitizenshipStatus",
-      "Name": "Person by Citizenship Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_CommuteStartTime",
-      "Name": "Person by Commute Start Time",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_CommuteType",
-      "Name": "Person by Commute Type",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_ComparisonRegion",
-      "Name": "Person by Comparison Region",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_CrashInvolvement",
-      "Name": "Person by Crash Involvement",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_DateOfEntry",
-      "Name": "Person by Date of Entry",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_DeprivationDomain",
-      "Name": "Person by Deprivation Domain",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_DeviceUsed",
-      "Name": "Person by Device Used",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_DisabilityStatus",
-      "Name": "Person by Disability Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_Earnings",
-      "Name": "Person by Earnings",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_ElectronicGadgetUsed",
-      "Name": "Person by Electronic Gadget Used",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_Employer",
-      "Name": "Person by Employer",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_Ethnicity",
-      "Name": "Person by Ethnicity",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_Facilities",
-      "Name": "Person by Facilities",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_FoodSecurityStatus",
-      "Name": "Person by Food Security Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_Gender",
-      "Name": "Person by Gender",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_GovernmentId",
-      "Name": "Person by Government Id",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_GovernmentIdentifier",
-      "Name": "Person by Government Identifier",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_HealthInsurance",
-      "Name": "Person by Health Insurance",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_HouseholdIncome",
-      "Name": "Person by Household Income",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_HouseholdType",
-      "Name": "Person by Household Type",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_IdentityActivity",
-      "Name": "Person by Identity Activity",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_Income",
-      "Name": "Person by Income",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_IncomeStatus",
-      "Name": "Person by Income Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_InternetAccessStatus",
-      "Name": "Person by Internet Access Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_InternetUsageLocation",
-      "Name": "Person by Internet Usage Location",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_IsInternetUser",
-      "Name": "Person by Is Internet User",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_LaborForceStatus",
-      "Name": "Person by Labor Force Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_LiteracyStatus",
-      "Name": "Person by Literacy Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_MaritalStatus",
-      "Name": "Person by Marital Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_MemberStatus",
-      "Name": "Person by Member Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_NumberOfVehiclesInHousehold",
-      "Name": "Person by Number of Vehicles in Household",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_PlaceOfBirth",
-      "Name": "Person by Place of Birth",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_PlaceOfResidenceClassification",
-      "Name": "Person by Place of Residence Classification",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_PovertyStatus",
-      "Name": "Person by Poverty Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_Race",
-      "Name": "Person by Race",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_Religion",
-      "Name": "Person by Religion",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_ResidentStatus",
-      "Name": "Person by Resident Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_VehicleOccupantType",
-      "Name": "Person by Vehicle Occupant Type",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_VulnerabilityStatus",
-      "Name": "Person by Vulnerability Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Place_Facilities",
-      "Name": "Place by Facilities",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Place_PlaceOfResidenceClassification",
-      "Name": "Place by Place of Residence Classification",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Place_PlaceType",
-      "Name": "Place by Place Type",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Place_SocialCondition",
-      "Name": "Place by Social Condition",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Residence",
-      "Name": "Residence",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Vehicle",
-      "Name": "Vehicle",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/VehicleCrashIncident",
-      "Name": "Vehicle Crash Incident",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Village",
-      "Name": "Village",
-      "Predicate": "specializationOf"
-    }
-  ],
-  "ChildSV": [
-    {
-      "SubjectID": "Count_Person",
-      "Name": "Total population"
-    },
-    {
-      "SubjectID": "FertilityRate_Person_Female",
-      "Name": "Fertility rate of women"
-    },
-    {
-      "SubjectID": "GrowthRate_Count_Person",
-      "Name": "Population growth rate"
-    },
-    {
-      "SubjectID": "LifeExpectancy_Person",
-      "Name": "Life Expectancy"
-    }
-  ],
-  "ChildSVG": [
-    {
-      "SubjectID": "dc/g/Demographics",
-      "Name": "Demographics",
-      "DescendentStatVarCount": 1343
-    },
-    {
-      "SubjectID": "dc/g/Demographics_Miscellaneous",
-      "Name": "Miscellaneous",
-      "DescendentStatVarCount": 1303
-    },
-    {
-      "SubjectID": "dc/g/Person_Age",
-      "Name": "Person by Age",
-      "DescendentStatVarCount": 21
-    },
-    {
-      "SubjectID": "dc/g/Person_Gender",
-      "Name": "Person by Gender",
-      "DescendentStatVarCount": 23
-    },
-    {
-      "SubjectID": "dc/g/Person_IsInternetUser",
-      "Name": "Person by Is Internet User",
-      "DescendentStatVarCount": 1
-    },
-    {
-      "SubjectID": "dc/g/Person_LaborForceStatus",
-      "Name": "Person by Labor Force Status",
-      "DescendentStatVarCount": 5
-    },
-    {
-      "SubjectID": "dc/g/Person_PlaceOfResidenceClassification",
-      "Name": "Person by Place of Residence Classification",
-      "DescendentStatVarCount": 2
-    },
-    {
-      "SubjectID": "dc/g/Residence",
-      "Name": "Residence",
-      "DescendentStatVarCount": 3
-    }
-  ]
+  "dc/g/Demographics": {
+    "SVGChild": [
+      {
+        "SubjectID": "Count_Company",
+        "Name": "",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "Count_Person",
+        "Name": "Total population",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "Count_Person_5To17Years_Poor",
+        "Name": "",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "Count_Person_AsAFractionOf_Count_Household",
+        "Name": "",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "Count_Person_InfrastructureProject_BrazilRuralDevelopmentProgram",
+        "Name": "",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "Count_Person_PerArea",
+        "Name": "Population Density",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "FertilityRate_Person_Female",
+        "Name": "Fertility rate of women",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "FertilityRate_Person_Female_AsAFractionOf_Count_Person_Female",
+        "Name": "Fertility rate (%)",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "GenderIncomeInequality_Person_15OrMoreYears_WithIncome",
+        "Name": "Income Inequality Between Men and Women of Working Age",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "GrowthRate_Count_Person",
+        "Name": "Population growth rate",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "IncrementalCount_Person",
+        "Name": "Population Change",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "LifeExpectancy_Person",
+        "Name": "Life Expectancy",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "Mean_Count_Person",
+        "Name": "Mean count of person",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "Mean_IncrementalCount_Person",
+        "Name": "Mean incremental count of person",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "Mean_MealCost_Person_FoodSecure",
+        "Name": "Average Meal Cost for Food Secure People",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "Median_Age_Person",
+        "Name": "Median age of population",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "Median_Income_Person",
+        "Name": "Median Income of a Population",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "dc/g/Child",
+        "Name": "Child",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Children",
+        "Name": "Children",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/CivicStructure",
+        "Name": "Civic Structure",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Commute",
+        "Name": "Commute",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Courthouse",
+        "Name": "Courthouse",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Demographics_Miscellaneous",
+        "Name": "Miscellaneous",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Food",
+        "Name": "Food",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/FoodBasket",
+        "Name": "Food Basket",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/House",
+        "Name": "House",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Household",
+        "Name": "Household",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Households",
+        "Name": "Households",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/ImmigrationAndCitizenship",
+        "Name": "Immigration and Citizenship",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Infant",
+        "Name": "Infant",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Language",
+        "Name": "Language",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/MaternalMortalityEvent",
+        "Name": "Maternal Mortality Event",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/MilitaryService",
+        "Name": "Military Service",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Mother",
+        "Name": "Mother",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/MunicipalWard",
+        "Name": "Municipal Ward",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/NonPregnantWoman",
+        "Name": "Non Pregnant Woman",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_Age",
+        "Name": "Person by Age",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_AgeGroupClassification",
+        "Name": "Person by Age Group Classification",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_BenefitProgram",
+        "Name": "Person by Benefit Program",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_BenefitsStatus",
+        "Name": "Person by Benefits Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_CarpoolOccupancy",
+        "Name": "Person by Carpool Occupancy",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_ChildrenStatus",
+        "Name": "Person by Children Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_CitizenshipStatus",
+        "Name": "Person by Citizenship Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_CommuteStartTime",
+        "Name": "Person by Commute Start Time",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_CommuteType",
+        "Name": "Person by Commute Type",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_ComparisonRegion",
+        "Name": "Person by Comparison Region",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_CrashInvolvement",
+        "Name": "Person by Crash Involvement",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_DateOfEntry",
+        "Name": "Person by Date of Entry",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_DeprivationDomain",
+        "Name": "Person by Deprivation Domain",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_DeviceUsed",
+        "Name": "Person by Device Used",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_DisabilityStatus",
+        "Name": "Person by Disability Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_Earnings",
+        "Name": "Person by Earnings",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_ElectronicGadgetUsed",
+        "Name": "Person by Electronic Gadget Used",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_Employer",
+        "Name": "Person by Employer",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_Ethnicity",
+        "Name": "Person by Ethnicity",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_Facilities",
+        "Name": "Person by Facilities",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_FoodSecurityStatus",
+        "Name": "Person by Food Security Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_Gender",
+        "Name": "Person by Gender",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_GovernmentId",
+        "Name": "Person by Government Id",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_GovernmentIdentifier",
+        "Name": "Person by Government Identifier",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_HealthInsurance",
+        "Name": "Person by Health Insurance",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_HouseholdIncome",
+        "Name": "Person by Household Income",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_HouseholdType",
+        "Name": "Person by Household Type",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_IdentityActivity",
+        "Name": "Person by Identity Activity",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_Income",
+        "Name": "Person by Income",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_IncomeStatus",
+        "Name": "Person by Income Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_InternetAccessStatus",
+        "Name": "Person by Internet Access Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_InternetUsageLocation",
+        "Name": "Person by Internet Usage Location",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_IsInternetUser",
+        "Name": "Person by Is Internet User",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_LaborForceStatus",
+        "Name": "Person by Labor Force Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_LiteracyStatus",
+        "Name": "Person by Literacy Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_MaritalStatus",
+        "Name": "Person by Marital Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_MemberStatus",
+        "Name": "Person by Member Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_NumberOfVehiclesInHousehold",
+        "Name": "Person by Number of Vehicles in Household",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_PlaceOfBirth",
+        "Name": "Person by Place of Birth",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_PlaceOfResidenceClassification",
+        "Name": "Person by Place of Residence Classification",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_PovertyStatus",
+        "Name": "Person by Poverty Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_Race",
+        "Name": "Person by Race",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_Religion",
+        "Name": "Person by Religion",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_ResidentStatus",
+        "Name": "Person by Resident Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_VehicleOccupantType",
+        "Name": "Person by Vehicle Occupant Type",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_VulnerabilityStatus",
+        "Name": "Person by Vulnerability Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Place_Facilities",
+        "Name": "Place by Facilities",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Place_PlaceOfResidenceClassification",
+        "Name": "Place by Place of Residence Classification",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Place_PlaceType",
+        "Name": "Place by Place Type",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Place_SocialCondition",
+        "Name": "Place by Social Condition",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Residence",
+        "Name": "Residence",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Vehicle",
+        "Name": "Vehicle",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/VehicleCrashIncident",
+        "Name": "Vehicle Crash Incident",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Village",
+        "Name": "Village",
+        "Predicate": "specializationOf"
+      }
+    ],
+    "ChildSV": [
+      {
+        "SubjectID": "Count_Person",
+        "Name": "Total population"
+      },
+      {
+        "SubjectID": "FertilityRate_Person_Female",
+        "Name": "Fertility rate of women"
+      },
+      {
+        "SubjectID": "GrowthRate_Count_Person",
+        "Name": "Population growth rate"
+      },
+      {
+        "SubjectID": "LifeExpectancy_Person",
+        "Name": "Life Expectancy"
+      }
+    ],
+    "ChildSVG": [
+      {
+        "SubjectID": "dc/g/Demographics",
+        "Name": "Demographics",
+        "DescendentStatVarCount": 1343
+      },
+      {
+        "SubjectID": "dc/g/Demographics_Miscellaneous",
+        "Name": "Miscellaneous",
+        "DescendentStatVarCount": 1303
+      },
+      {
+        "SubjectID": "dc/g/Person_Age",
+        "Name": "Person by Age",
+        "DescendentStatVarCount": 21
+      },
+      {
+        "SubjectID": "dc/g/Person_Gender",
+        "Name": "Person by Gender",
+        "DescendentStatVarCount": 23
+      },
+      {
+        "SubjectID": "dc/g/Person_IsInternetUser",
+        "Name": "Person by Is Internet User",
+        "DescendentStatVarCount": 1
+      },
+      {
+        "SubjectID": "dc/g/Person_LaborForceStatus",
+        "Name": "Person by Labor Force Status",
+        "DescendentStatVarCount": 5
+      },
+      {
+        "SubjectID": "dc/g/Person_PlaceOfResidenceClassification",
+        "Name": "Person by Place of Residence Classification",
+        "DescendentStatVarCount": 2
+      },
+      {
+        "SubjectID": "dc/g/Residence",
+        "Name": "Residence",
+        "DescendentStatVarCount": 3
+      }
+    ]
+  }
 }

--- a/internal/server/spanner/golden/query/get_filtered_stat_var_group_node_places.json
+++ b/internal/server/spanner/golden/query/get_filtered_stat_var_group_node_places.json
@@ -1,705 +1,769 @@
 {
-  "SVGChild": [
-    {
-      "SubjectID": "Count_Company",
-      "Name": "",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "Count_Person",
-      "Name": "Total population",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "Count_Person_5To17Years_Poor",
-      "Name": "",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "Count_Person_AsAFractionOf_Count_Household",
-      "Name": "",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "Count_Person_InfrastructureProject_BrazilRuralDevelopmentProgram",
-      "Name": "",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "Count_Person_PerArea",
-      "Name": "Population Density",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "FertilityRate_Person_Female",
-      "Name": "Fertility rate of women",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "FertilityRate_Person_Female_AsAFractionOf_Count_Person_Female",
-      "Name": "Fertility rate (%)",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "GenderIncomeInequality_Person_15OrMoreYears_WithIncome",
-      "Name": "Income Inequality Between Men and Women of Working Age",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "GrowthRate_Count_Person",
-      "Name": "Population growth rate",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "IncrementalCount_Person",
-      "Name": "Population Change",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "LifeExpectancy_Person",
-      "Name": "Life Expectancy",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "Mean_Count_Person",
-      "Name": "Mean count of person",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "Mean_IncrementalCount_Person",
-      "Name": "Mean incremental count of person",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "Mean_MealCost_Person_FoodSecure",
-      "Name": "Average Meal Cost for Food Secure People",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "Median_Age_Person",
-      "Name": "Median age of population",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "Median_Income_Person",
-      "Name": "Median Income of a Population",
-      "Predicate": "memberOf"
-    },
-    {
-      "SubjectID": "dc/g/Child",
-      "Name": "Child",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Children",
-      "Name": "Children",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/CivicStructure",
-      "Name": "Civic Structure",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Commute",
-      "Name": "Commute",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Courthouse",
-      "Name": "Courthouse",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Demographics_Miscellaneous",
-      "Name": "Miscellaneous",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Food",
-      "Name": "Food",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/FoodBasket",
-      "Name": "Food Basket",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/House",
-      "Name": "House",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Household",
-      "Name": "Household",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Households",
-      "Name": "Households",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/ImmigrationAndCitizenship",
-      "Name": "Immigration and Citizenship",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Infant",
-      "Name": "Infant",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Language",
-      "Name": "Language",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/MaternalMortalityEvent",
-      "Name": "Maternal Mortality Event",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/MilitaryService",
-      "Name": "Military Service",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Mother",
-      "Name": "Mother",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/MunicipalWard",
-      "Name": "Municipal Ward",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/NonPregnantWoman",
-      "Name": "Non Pregnant Woman",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_Age",
-      "Name": "Person by Age",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_AgeGroupClassification",
-      "Name": "Person by Age Group Classification",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_BenefitProgram",
-      "Name": "Person by Benefit Program",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_BenefitsStatus",
-      "Name": "Person by Benefits Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_CarpoolOccupancy",
-      "Name": "Person by Carpool Occupancy",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_ChildrenStatus",
-      "Name": "Person by Children Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_CitizenshipStatus",
-      "Name": "Person by Citizenship Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_CommuteStartTime",
-      "Name": "Person by Commute Start Time",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_CommuteType",
-      "Name": "Person by Commute Type",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_ComparisonRegion",
-      "Name": "Person by Comparison Region",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_CrashInvolvement",
-      "Name": "Person by Crash Involvement",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_DateOfEntry",
-      "Name": "Person by Date of Entry",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_DeprivationDomain",
-      "Name": "Person by Deprivation Domain",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_DeviceUsed",
-      "Name": "Person by Device Used",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_DisabilityStatus",
-      "Name": "Person by Disability Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_Earnings",
-      "Name": "Person by Earnings",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_ElectronicGadgetUsed",
-      "Name": "Person by Electronic Gadget Used",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_Employer",
-      "Name": "Person by Employer",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_Ethnicity",
-      "Name": "Person by Ethnicity",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_Facilities",
-      "Name": "Person by Facilities",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_FoodSecurityStatus",
-      "Name": "Person by Food Security Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_Gender",
-      "Name": "Person by Gender",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_GovernmentId",
-      "Name": "Person by Government Id",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_GovernmentIdentifier",
-      "Name": "Person by Government Identifier",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_HealthInsurance",
-      "Name": "Person by Health Insurance",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_HouseholdIncome",
-      "Name": "Person by Household Income",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_HouseholdType",
-      "Name": "Person by Household Type",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_IdentityActivity",
-      "Name": "Person by Identity Activity",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_Income",
-      "Name": "Person by Income",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_IncomeStatus",
-      "Name": "Person by Income Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_InternetAccessStatus",
-      "Name": "Person by Internet Access Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_InternetUsageLocation",
-      "Name": "Person by Internet Usage Location",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_IsInternetUser",
-      "Name": "Person by Is Internet User",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_LaborForceStatus",
-      "Name": "Person by Labor Force Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_LiteracyStatus",
-      "Name": "Person by Literacy Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_MaritalStatus",
-      "Name": "Person by Marital Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_MemberStatus",
-      "Name": "Person by Member Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_NumberOfVehiclesInHousehold",
-      "Name": "Person by Number of Vehicles in Household",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_PlaceOfBirth",
-      "Name": "Person by Place of Birth",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_PlaceOfResidenceClassification",
-      "Name": "Person by Place of Residence Classification",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_PovertyStatus",
-      "Name": "Person by Poverty Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_Race",
-      "Name": "Person by Race",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_Religion",
-      "Name": "Person by Religion",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_ResidentStatus",
-      "Name": "Person by Resident Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_VehicleOccupantType",
-      "Name": "Person by Vehicle Occupant Type",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Person_VulnerabilityStatus",
-      "Name": "Person by Vulnerability Status",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Place_Facilities",
-      "Name": "Place by Facilities",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Place_PlaceOfResidenceClassification",
-      "Name": "Place by Place of Residence Classification",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Place_PlaceType",
-      "Name": "Place by Place Type",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Place_SocialCondition",
-      "Name": "Place by Social Condition",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Residence",
-      "Name": "Residence",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Vehicle",
-      "Name": "Vehicle",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/VehicleCrashIncident",
-      "Name": "Vehicle Crash Incident",
-      "Predicate": "specializationOf"
-    },
-    {
-      "SubjectID": "dc/g/Village",
-      "Name": "Village",
-      "Predicate": "specializationOf"
-    }
-  ],
-  "ChildSV": [
-    {
-      "SubjectID": "Count_Person",
-      "Name": "Total population"
-    },
-    {
-      "SubjectID": "Count_Person_PerArea",
-      "Name": "Population Density"
-    },
-    {
-      "SubjectID": "FertilityRate_Person_Female",
-      "Name": "Fertility rate of women"
-    },
-    {
-      "SubjectID": "GenderIncomeInequality_Person_15OrMoreYears_WithIncome",
-      "Name": "Income Inequality Between Men and Women of Working Age"
-    },
-    {
-      "SubjectID": "GrowthRate_Count_Person",
-      "Name": "Population growth rate"
-    },
-    {
-      "SubjectID": "LifeExpectancy_Person",
-      "Name": "Life Expectancy"
-    },
-    {
-      "SubjectID": "Median_Age_Person",
-      "Name": "Median age of population"
-    },
-    {
-      "SubjectID": "Median_Income_Person",
-      "Name": "Median Income of a Population"
-    }
-  ],
-  "ChildSVG": [
-    {
-      "SubjectID": "dc/g/Commute",
-      "Name": "Commute",
-      "DescendentStatVarCount": 191
-    },
-    {
-      "SubjectID": "dc/g/Demographics",
-      "Name": "Demographics",
-      "DescendentStatVarCount": 34401
-    },
-    {
-      "SubjectID": "dc/g/Demographics_Miscellaneous",
-      "Name": "Miscellaneous",
-      "DescendentStatVarCount": 1303
-    },
-    {
-      "SubjectID": "dc/g/Household",
-      "Name": "Household",
-      "DescendentStatVarCount": 3335
-    },
-    {
-      "SubjectID": "dc/g/ImmigrationAndCitizenship",
-      "Name": "Immigration and Citizenship",
-      "DescendentStatVarCount": 2689
-    },
-    {
-      "SubjectID": "dc/g/Language",
-      "Name": "Language",
-      "DescendentStatVarCount": 498
-    },
-    {
-      "SubjectID": "dc/g/MilitaryService",
-      "Name": "Military Service",
-      "DescendentStatVarCount": 2353
-    },
-    {
-      "SubjectID": "dc/g/Person_Age",
-      "Name": "Person by Age",
-      "DescendentStatVarCount": 20811
-    },
-    {
-      "SubjectID": "dc/g/Person_BenefitsStatus",
-      "Name": "Person by Benefits Status",
-      "DescendentStatVarCount": 7
-    },
-    {
-      "SubjectID": "dc/g/Person_CarpoolOccupancy",
-      "Name": "Person by Carpool Occupancy",
-      "DescendentStatVarCount": 9
-    },
-    {
-      "SubjectID": "dc/g/Person_ChildrenStatus",
-      "Name": "Person by Children Status",
-      "DescendentStatVarCount": 7
-    },
-    {
-      "SubjectID": "dc/g/Person_CitizenshipStatus",
-      "Name": "Person by Citizenship Status",
-      "DescendentStatVarCount": 735
-    },
-    {
-      "SubjectID": "dc/g/Person_CommuteStartTime",
-      "Name": "Person by Commute Start Time",
-      "DescendentStatVarCount": 30
-    },
-    {
-      "SubjectID": "dc/g/Person_CommuteType",
-      "Name": "Person by Commute Type",
-      "DescendentStatVarCount": 102
-    },
-    {
-      "SubjectID": "dc/g/Person_CrashInvolvement",
-      "Name": "Person by Crash Involvement",
-      "DescendentStatVarCount": 4
-    },
-    {
-      "SubjectID": "dc/g/Person_DateOfEntry",
-      "Name": "Person by Date of Entry",
-      "DescendentStatVarCount": 236
-    },
-    {
-      "SubjectID": "dc/g/Person_DisabilityStatus",
-      "Name": "Person by Disability Status",
-      "DescendentStatVarCount": 544
-    },
-    {
-      "SubjectID": "dc/g/Person_Earnings",
-      "Name": "Person by Earnings",
-      "DescendentStatVarCount": 139
-    },
-    {
-      "SubjectID": "dc/g/Person_ElectronicGadgetUsed",
-      "Name": "Person by Electronic Gadget Used",
-      "DescendentStatVarCount": 406
-    },
-    {
-      "SubjectID": "dc/g/Person_Ethnicity",
-      "Name": "Person by Ethnicity",
-      "DescendentStatVarCount": 1343
-    },
-    {
-      "SubjectID": "dc/g/Person_Gender",
-      "Name": "Person by Gender",
-      "DescendentStatVarCount": 18032
-    },
-    {
-      "SubjectID": "dc/g/Person_HealthInsurance",
-      "Name": "Person by Health Insurance",
-      "DescendentStatVarCount": 1292
-    },
-    {
-      "SubjectID": "dc/g/Person_HouseholdIncome",
-      "Name": "Person by Household Income",
-      "DescendentStatVarCount": 40
-    },
-    {
-      "SubjectID": "dc/g/Person_HouseholdType",
-      "Name": "Person by Household Type",
-      "DescendentStatVarCount": 462
-    },
-    {
-      "SubjectID": "dc/g/Person_Income",
-      "Name": "Person by Income",
-      "DescendentStatVarCount": 1092
-    },
-    {
-      "SubjectID": "dc/g/Person_IncomeStatus",
-      "Name": "Person by Income Status",
-      "DescendentStatVarCount": 549
-    },
-    {
-      "SubjectID": "dc/g/Person_InternetUsageLocation",
-      "Name": "Person by Internet Usage Location",
-      "DescendentStatVarCount": 406
-    },
-    {
-      "SubjectID": "dc/g/Person_IsInternetUser",
-      "Name": "Person by Is Internet User",
-      "DescendentStatVarCount": 407
-    },
-    {
-      "SubjectID": "dc/g/Person_LaborForceStatus",
-      "Name": "Person by Labor Force Status",
-      "DescendentStatVarCount": 2678
-    },
-    {
-      "SubjectID": "dc/g/Person_LiteracyStatus",
-      "Name": "Person by Literacy Status",
-      "DescendentStatVarCount": 216
-    },
-    {
-      "SubjectID": "dc/g/Person_MaritalStatus",
-      "Name": "Person by Marital Status",
-      "DescendentStatVarCount": 509
-    },
-    {
-      "SubjectID": "dc/g/Person_MemberStatus",
-      "Name": "Person by Member Status",
-      "DescendentStatVarCount": 96
-    },
-    {
-      "SubjectID": "dc/g/Person_NumberOfVehiclesInHousehold",
-      "Name": "Person by Number of Vehicles in Household",
-      "DescendentStatVarCount": 12
-    },
-    {
-      "SubjectID": "dc/g/Person_PlaceOfBirth",
-      "Name": "Person by Place of Birth",
-      "DescendentStatVarCount": 1940
-    },
-    {
-      "SubjectID": "dc/g/Person_PlaceOfResidenceClassification",
-      "Name": "Person by Place of Residence Classification",
-      "DescendentStatVarCount": 1995
-    },
-    {
-      "SubjectID": "dc/g/Person_PovertyStatus",
-      "Name": "Person by Poverty Status",
-      "DescendentStatVarCount": 1042
-    },
-    {
-      "SubjectID": "dc/g/Person_Race",
-      "Name": "Person by Race",
-      "DescendentStatVarCount": 17853
-    },
-    {
-      "SubjectID": "dc/g/Person_Religion",
-      "Name": "Person by Religion",
-      "DescendentStatVarCount": 1872
-    },
-    {
-      "SubjectID": "dc/g/Person_ResidentStatus",
-      "Name": "Person by Resident Status",
-      "DescendentStatVarCount": 376
-    },
-    {
-      "SubjectID": "dc/g/Person_VehicleOccupantType",
-      "Name": "Person by Vehicle Occupant Type",
-      "DescendentStatVarCount": 4
-    },
-    {
-      "SubjectID": "dc/g/Residence",
-      "Name": "Residence",
-      "DescendentStatVarCount": 3184
-    },
-    {
-      "SubjectID": "dc/g/Vehicle",
-      "Name": "Vehicle",
-      "DescendentStatVarCount": 5
-    },
-    {
-      "SubjectID": "dc/g/VehicleCrashIncident",
-      "Name": "Vehicle Crash Incident",
-      "DescendentStatVarCount": 100
-    }
-  ]
+  "dc/g/Agriculture": {
+    "SVGChild": [
+      {
+        "SubjectID": "Count_Person_5OrLessMeter_Rural_AsAFractionOf_Count_Person",
+        "Name": "",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "dc/g/Agriculture_Miscellaneous",
+        "Name": "Miscellaneous",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Farm",
+        "Name": "Farm",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/FarmInventory",
+        "Name": "Farm Inventory",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_EconomicSector",
+        "Name": "Person by Economic Sector",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_OwnershipStatus",
+        "Name": "Person by Ownership Status",
+        "Predicate": "specializationOf"
+      }
+    ],
+    "ChildSV": null,
+    "ChildSVG": [
+      {
+        "SubjectID": "dc/g/Agriculture",
+        "Name": "Agriculture",
+        "DescendentStatVarCount": 199
+      },
+      {
+        "SubjectID": "dc/g/Agriculture_Miscellaneous",
+        "Name": "Miscellaneous",
+        "DescendentStatVarCount": 41
+      },
+      {
+        "SubjectID": "dc/g/Farm",
+        "Name": "Farm",
+        "DescendentStatVarCount": 122
+      },
+      {
+        "SubjectID": "dc/g/FarmInventory",
+        "Name": "Farm Inventory",
+        "DescendentStatVarCount": 28
+      },
+      {
+        "SubjectID": "dc/g/Person_OwnershipStatus",
+        "Name": "Person by Ownership Status",
+        "DescendentStatVarCount": 8
+      }
+    ]
+  },
+  "dc/g/Demographics": {
+    "SVGChild": [
+      {
+        "SubjectID": "Count_Company",
+        "Name": "",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "Count_Person",
+        "Name": "Total population",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "Count_Person_5To17Years_Poor",
+        "Name": "",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "Count_Person_AsAFractionOf_Count_Household",
+        "Name": "",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "Count_Person_InfrastructureProject_BrazilRuralDevelopmentProgram",
+        "Name": "",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "Count_Person_PerArea",
+        "Name": "Population Density",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "FertilityRate_Person_Female",
+        "Name": "Fertility rate of women",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "FertilityRate_Person_Female_AsAFractionOf_Count_Person_Female",
+        "Name": "Fertility rate (%)",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "GenderIncomeInequality_Person_15OrMoreYears_WithIncome",
+        "Name": "Income Inequality Between Men and Women of Working Age",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "GrowthRate_Count_Person",
+        "Name": "Population growth rate",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "IncrementalCount_Person",
+        "Name": "Population Change",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "LifeExpectancy_Person",
+        "Name": "Life Expectancy",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "Mean_Count_Person",
+        "Name": "Mean count of person",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "Mean_IncrementalCount_Person",
+        "Name": "Mean incremental count of person",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "Mean_MealCost_Person_FoodSecure",
+        "Name": "Average Meal Cost for Food Secure People",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "Median_Age_Person",
+        "Name": "Median age of population",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "Median_Income_Person",
+        "Name": "Median Income of a Population",
+        "Predicate": "memberOf"
+      },
+      {
+        "SubjectID": "dc/g/Child",
+        "Name": "Child",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Children",
+        "Name": "Children",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/CivicStructure",
+        "Name": "Civic Structure",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Commute",
+        "Name": "Commute",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Courthouse",
+        "Name": "Courthouse",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Demographics_Miscellaneous",
+        "Name": "Miscellaneous",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Food",
+        "Name": "Food",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/FoodBasket",
+        "Name": "Food Basket",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/House",
+        "Name": "House",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Household",
+        "Name": "Household",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Households",
+        "Name": "Households",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/ImmigrationAndCitizenship",
+        "Name": "Immigration and Citizenship",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Infant",
+        "Name": "Infant",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Language",
+        "Name": "Language",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/MaternalMortalityEvent",
+        "Name": "Maternal Mortality Event",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/MilitaryService",
+        "Name": "Military Service",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Mother",
+        "Name": "Mother",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/MunicipalWard",
+        "Name": "Municipal Ward",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/NonPregnantWoman",
+        "Name": "Non Pregnant Woman",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_Age",
+        "Name": "Person by Age",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_AgeGroupClassification",
+        "Name": "Person by Age Group Classification",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_BenefitProgram",
+        "Name": "Person by Benefit Program",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_BenefitsStatus",
+        "Name": "Person by Benefits Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_CarpoolOccupancy",
+        "Name": "Person by Carpool Occupancy",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_ChildrenStatus",
+        "Name": "Person by Children Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_CitizenshipStatus",
+        "Name": "Person by Citizenship Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_CommuteStartTime",
+        "Name": "Person by Commute Start Time",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_CommuteType",
+        "Name": "Person by Commute Type",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_ComparisonRegion",
+        "Name": "Person by Comparison Region",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_CrashInvolvement",
+        "Name": "Person by Crash Involvement",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_DateOfEntry",
+        "Name": "Person by Date of Entry",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_DeprivationDomain",
+        "Name": "Person by Deprivation Domain",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_DeviceUsed",
+        "Name": "Person by Device Used",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_DisabilityStatus",
+        "Name": "Person by Disability Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_Earnings",
+        "Name": "Person by Earnings",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_ElectronicGadgetUsed",
+        "Name": "Person by Electronic Gadget Used",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_Employer",
+        "Name": "Person by Employer",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_Ethnicity",
+        "Name": "Person by Ethnicity",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_Facilities",
+        "Name": "Person by Facilities",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_FoodSecurityStatus",
+        "Name": "Person by Food Security Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_Gender",
+        "Name": "Person by Gender",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_GovernmentId",
+        "Name": "Person by Government Id",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_GovernmentIdentifier",
+        "Name": "Person by Government Identifier",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_HealthInsurance",
+        "Name": "Person by Health Insurance",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_HouseholdIncome",
+        "Name": "Person by Household Income",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_HouseholdType",
+        "Name": "Person by Household Type",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_IdentityActivity",
+        "Name": "Person by Identity Activity",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_Income",
+        "Name": "Person by Income",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_IncomeStatus",
+        "Name": "Person by Income Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_InternetAccessStatus",
+        "Name": "Person by Internet Access Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_InternetUsageLocation",
+        "Name": "Person by Internet Usage Location",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_IsInternetUser",
+        "Name": "Person by Is Internet User",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_LaborForceStatus",
+        "Name": "Person by Labor Force Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_LiteracyStatus",
+        "Name": "Person by Literacy Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_MaritalStatus",
+        "Name": "Person by Marital Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_MemberStatus",
+        "Name": "Person by Member Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_NumberOfVehiclesInHousehold",
+        "Name": "Person by Number of Vehicles in Household",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_PlaceOfBirth",
+        "Name": "Person by Place of Birth",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_PlaceOfResidenceClassification",
+        "Name": "Person by Place of Residence Classification",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_PovertyStatus",
+        "Name": "Person by Poverty Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_Race",
+        "Name": "Person by Race",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_Religion",
+        "Name": "Person by Religion",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_ResidentStatus",
+        "Name": "Person by Resident Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_VehicleOccupantType",
+        "Name": "Person by Vehicle Occupant Type",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Person_VulnerabilityStatus",
+        "Name": "Person by Vulnerability Status",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Place_Facilities",
+        "Name": "Place by Facilities",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Place_PlaceOfResidenceClassification",
+        "Name": "Place by Place of Residence Classification",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Place_PlaceType",
+        "Name": "Place by Place Type",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Place_SocialCondition",
+        "Name": "Place by Social Condition",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Residence",
+        "Name": "Residence",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Vehicle",
+        "Name": "Vehicle",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/VehicleCrashIncident",
+        "Name": "Vehicle Crash Incident",
+        "Predicate": "specializationOf"
+      },
+      {
+        "SubjectID": "dc/g/Village",
+        "Name": "Village",
+        "Predicate": "specializationOf"
+      }
+    ],
+    "ChildSV": [
+      {
+        "SubjectID": "Count_Person",
+        "Name": "Total population"
+      },
+      {
+        "SubjectID": "Count_Person_PerArea",
+        "Name": "Population Density"
+      },
+      {
+        "SubjectID": "FertilityRate_Person_Female",
+        "Name": "Fertility rate of women"
+      },
+      {
+        "SubjectID": "GenderIncomeInequality_Person_15OrMoreYears_WithIncome",
+        "Name": "Income Inequality Between Men and Women of Working Age"
+      },
+      {
+        "SubjectID": "GrowthRate_Count_Person",
+        "Name": "Population growth rate"
+      },
+      {
+        "SubjectID": "LifeExpectancy_Person",
+        "Name": "Life Expectancy"
+      },
+      {
+        "SubjectID": "Median_Age_Person",
+        "Name": "Median age of population"
+      },
+      {
+        "SubjectID": "Median_Income_Person",
+        "Name": "Median Income of a Population"
+      }
+    ],
+    "ChildSVG": [
+      {
+        "SubjectID": "dc/g/Commute",
+        "Name": "Commute",
+        "DescendentStatVarCount": 191
+      },
+      {
+        "SubjectID": "dc/g/Demographics",
+        "Name": "Demographics",
+        "DescendentStatVarCount": 34401
+      },
+      {
+        "SubjectID": "dc/g/Demographics_Miscellaneous",
+        "Name": "Miscellaneous",
+        "DescendentStatVarCount": 1303
+      },
+      {
+        "SubjectID": "dc/g/Household",
+        "Name": "Household",
+        "DescendentStatVarCount": 3335
+      },
+      {
+        "SubjectID": "dc/g/ImmigrationAndCitizenship",
+        "Name": "Immigration and Citizenship",
+        "DescendentStatVarCount": 2689
+      },
+      {
+        "SubjectID": "dc/g/Language",
+        "Name": "Language",
+        "DescendentStatVarCount": 498
+      },
+      {
+        "SubjectID": "dc/g/MilitaryService",
+        "Name": "Military Service",
+        "DescendentStatVarCount": 2353
+      },
+      {
+        "SubjectID": "dc/g/Person_Age",
+        "Name": "Person by Age",
+        "DescendentStatVarCount": 20811
+      },
+      {
+        "SubjectID": "dc/g/Person_BenefitsStatus",
+        "Name": "Person by Benefits Status",
+        "DescendentStatVarCount": 7
+      },
+      {
+        "SubjectID": "dc/g/Person_CarpoolOccupancy",
+        "Name": "Person by Carpool Occupancy",
+        "DescendentStatVarCount": 9
+      },
+      {
+        "SubjectID": "dc/g/Person_ChildrenStatus",
+        "Name": "Person by Children Status",
+        "DescendentStatVarCount": 7
+      },
+      {
+        "SubjectID": "dc/g/Person_CitizenshipStatus",
+        "Name": "Person by Citizenship Status",
+        "DescendentStatVarCount": 735
+      },
+      {
+        "SubjectID": "dc/g/Person_CommuteStartTime",
+        "Name": "Person by Commute Start Time",
+        "DescendentStatVarCount": 30
+      },
+      {
+        "SubjectID": "dc/g/Person_CommuteType",
+        "Name": "Person by Commute Type",
+        "DescendentStatVarCount": 102
+      },
+      {
+        "SubjectID": "dc/g/Person_CrashInvolvement",
+        "Name": "Person by Crash Involvement",
+        "DescendentStatVarCount": 4
+      },
+      {
+        "SubjectID": "dc/g/Person_DateOfEntry",
+        "Name": "Person by Date of Entry",
+        "DescendentStatVarCount": 236
+      },
+      {
+        "SubjectID": "dc/g/Person_DisabilityStatus",
+        "Name": "Person by Disability Status",
+        "DescendentStatVarCount": 544
+      },
+      {
+        "SubjectID": "dc/g/Person_Earnings",
+        "Name": "Person by Earnings",
+        "DescendentStatVarCount": 139
+      },
+      {
+        "SubjectID": "dc/g/Person_ElectronicGadgetUsed",
+        "Name": "Person by Electronic Gadget Used",
+        "DescendentStatVarCount": 406
+      },
+      {
+        "SubjectID": "dc/g/Person_Ethnicity",
+        "Name": "Person by Ethnicity",
+        "DescendentStatVarCount": 1343
+      },
+      {
+        "SubjectID": "dc/g/Person_Gender",
+        "Name": "Person by Gender",
+        "DescendentStatVarCount": 18032
+      },
+      {
+        "SubjectID": "dc/g/Person_HealthInsurance",
+        "Name": "Person by Health Insurance",
+        "DescendentStatVarCount": 1292
+      },
+      {
+        "SubjectID": "dc/g/Person_HouseholdIncome",
+        "Name": "Person by Household Income",
+        "DescendentStatVarCount": 40
+      },
+      {
+        "SubjectID": "dc/g/Person_HouseholdType",
+        "Name": "Person by Household Type",
+        "DescendentStatVarCount": 462
+      },
+      {
+        "SubjectID": "dc/g/Person_Income",
+        "Name": "Person by Income",
+        "DescendentStatVarCount": 1092
+      },
+      {
+        "SubjectID": "dc/g/Person_IncomeStatus",
+        "Name": "Person by Income Status",
+        "DescendentStatVarCount": 549
+      },
+      {
+        "SubjectID": "dc/g/Person_InternetUsageLocation",
+        "Name": "Person by Internet Usage Location",
+        "DescendentStatVarCount": 406
+      },
+      {
+        "SubjectID": "dc/g/Person_IsInternetUser",
+        "Name": "Person by Is Internet User",
+        "DescendentStatVarCount": 407
+      },
+      {
+        "SubjectID": "dc/g/Person_LaborForceStatus",
+        "Name": "Person by Labor Force Status",
+        "DescendentStatVarCount": 2678
+      },
+      {
+        "SubjectID": "dc/g/Person_LiteracyStatus",
+        "Name": "Person by Literacy Status",
+        "DescendentStatVarCount": 216
+      },
+      {
+        "SubjectID": "dc/g/Person_MaritalStatus",
+        "Name": "Person by Marital Status",
+        "DescendentStatVarCount": 509
+      },
+      {
+        "SubjectID": "dc/g/Person_MemberStatus",
+        "Name": "Person by Member Status",
+        "DescendentStatVarCount": 96
+      },
+      {
+        "SubjectID": "dc/g/Person_NumberOfVehiclesInHousehold",
+        "Name": "Person by Number of Vehicles in Household",
+        "DescendentStatVarCount": 12
+      },
+      {
+        "SubjectID": "dc/g/Person_PlaceOfBirth",
+        "Name": "Person by Place of Birth",
+        "DescendentStatVarCount": 1940
+      },
+      {
+        "SubjectID": "dc/g/Person_PlaceOfResidenceClassification",
+        "Name": "Person by Place of Residence Classification",
+        "DescendentStatVarCount": 1995
+      },
+      {
+        "SubjectID": "dc/g/Person_PovertyStatus",
+        "Name": "Person by Poverty Status",
+        "DescendentStatVarCount": 1042
+      },
+      {
+        "SubjectID": "dc/g/Person_Race",
+        "Name": "Person by Race",
+        "DescendentStatVarCount": 17853
+      },
+      {
+        "SubjectID": "dc/g/Person_Religion",
+        "Name": "Person by Religion",
+        "DescendentStatVarCount": 1872
+      },
+      {
+        "SubjectID": "dc/g/Person_ResidentStatus",
+        "Name": "Person by Resident Status",
+        "DescendentStatVarCount": 376
+      },
+      {
+        "SubjectID": "dc/g/Person_VehicleOccupantType",
+        "Name": "Person by Vehicle Occupant Type",
+        "DescendentStatVarCount": 4
+      },
+      {
+        "SubjectID": "dc/g/Residence",
+        "Name": "Residence",
+        "DescendentStatVarCount": 3184
+      },
+      {
+        "SubjectID": "dc/g/Vehicle",
+        "Name": "Vehicle",
+        "DescendentStatVarCount": 5
+      },
+      {
+        "SubjectID": "dc/g/VehicleCrashIncident",
+        "Name": "Vehicle Crash Incident",
+        "DescendentStatVarCount": 100
+      }
+    ]
+  }
 }

--- a/internal/server/spanner/golden/query/get_filtered_topic_places.json
+++ b/internal/server/spanner/golden/query/get_filtered_topic_places.json
@@ -1,1 +1,3 @@
-13
+{
+  "dc/topic/Demographics": 13
+}

--- a/internal/server/spanner/golden/query/get_filtered_topic_places_multiple_topics.json
+++ b/internal/server/spanner/golden/query/get_filtered_topic_places_multiple_topics.json
@@ -1,0 +1,4 @@
+{
+  "dc/topic/Demographics": 13,
+  "dc/topic/Economy": 86
+}

--- a/internal/server/spanner/golden/query_builder/get_filtered_topic_places_multiple_topics.sql
+++ b/internal/server/spanner/golden/query_builder/get_filtered_topic_places_multiple_topics.sql
@@ -9,6 +9,6 @@
 				GROUP BY variable_measured
 			) o ON o.variable_measured = e.subject_id
 		WHERE e.predicate = 'linkedMember'
-			AND e.object_id = 'dc/topic/Demographics'
+			AND e.object_id IN ('dc/topic/Demographics','dc/topic/Economy')
 		GROUP BY
 			e.object_id

--- a/internal/server/spanner/golden/query_builder_test.go
+++ b/internal/server/spanner/golden/query_builder_test.go
@@ -218,6 +218,18 @@ func TestGetFilteredSVGChildren(t *testing.T) {
 	}
 }
 
+func TestGetFilteredTopicChildren(t *testing.T) {
+	t.Parallel()
+
+	for _, c := range getFilteredTopicTestCases {
+		goldenFile := c.golden + ".sql"
+
+		runQueryBuilderGoldenTest(t, goldenFile, func(ctx context.Context) (interface{}, error) {
+			return spanner.GetFilteredTopicChildrenQuery(c.nodes, c.constrainedPlaces, c.constrainedImport, c.numEntitiesExistence), nil
+		})
+	}
+}
+
 func TestGetTermEmbeddingQuery(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/spanner/golden/query_cases_test.go
+++ b/internal/server/spanner/golden/query_cases_test.go
@@ -585,14 +585,6 @@ var getFilteredSVGChildrenTestCases = []struct {
 		numEntitiesExistence: 2,
 		golden:               "get_filtered_svg_num_entities_existence",
 	},
-	{
-		template:             "Topic",
-		node:                 "dc/topic/Demographics",
-		constrainedPlaces:    []string{"country/CAN", "country/IND"},
-		constrainedImport:    "",
-		numEntitiesExistence: 1,
-		golden:               "get_filtered_topic_places",
-	},
 }
 
 var embeddingFromQueryTestCases = []struct {
@@ -610,11 +602,11 @@ var embeddingFromQueryTestCases = []struct {
 }
 
 var vectorSearchNodeTestCases = []struct {
-	limit       int
-	embeddings  []float64
-	numLeaves   int
-	threshold   float64
-	golden      string
+	limit      int
+	embeddings []float64
+	numLeaves  int
+	threshold  float64
+	golden     string
 }{
 	{
 		limit:      5,
@@ -622,38 +614,38 @@ var vectorSearchNodeTestCases = []struct {
 		numLeaves:  20,
 		threshold:  0.6,
 		golden:     "vector_search_node",
-   },
+	},
 }
 var getFilteredStatVarGroupNodeTestCases = []struct {
-	node                 string
+	nodes                []string
 	constrainedPlaces    []string
 	constrainedImport    string
 	numEntitiesExistence int
 	golden               string
 }{
 	{
-		node:                 "dc/g/Demographics",
+		nodes:                []string{"dc/g/Demographics", "dc/g/Agriculture"},
 		constrainedPlaces:    []string{"country/USA", "country/IND"},
 		constrainedImport:    "",
 		numEntitiesExistence: 1,
 		golden:               "get_filtered_stat_var_group_node_places",
 	},
 	{
-		node:                 "dc/g/Demographics",
+		nodes:                []string{"dc/g/Demographics"},
 		constrainedPlaces:    []string{},
 		constrainedImport:    "dc/s/WorldBank",
 		numEntitiesExistence: 1,
 		golden:               "get_filtered_stat_var_group_node_import",
 	},
 	{
-		node:                 "dc/g/Demographics",
+		nodes:                []string{"dc/g/Demographics"},
 		constrainedPlaces:    []string{"country/USA", "country/IND"},
 		constrainedImport:    "dc/s/WorldBank",
 		numEntitiesExistence: 1,
 		golden:               "get_filtered_stat_var_group_node_place_import",
 	},
 	{
-		node:                 "dc/g/Demographics",
+		nodes:                []string{"dc/g/Demographics"},
 		constrainedPlaces:    []string{"country/USA", "country/IND", "country/CAN"},
 		constrainedImport:    "",
 		numEntitiesExistence: 2,
@@ -662,17 +654,24 @@ var getFilteredStatVarGroupNodeTestCases = []struct {
 }
 
 var getFilteredTopicTestCases = []struct {
-	node                 string
+	nodes                []string
 	constrainedPlaces    []string
 	constrainedImport    string
 	numEntitiesExistence int
 	golden               string
 }{
 	{
-		node:                 "dc/topic/Demographics",
+		nodes:                []string{"dc/topic/Demographics"},
 		constrainedPlaces:    []string{"country/CAN", "country/IND"},
 		constrainedImport:    "",
 		numEntitiesExistence: 1,
 		golden:               "get_filtered_topic_places",
+	},
+	{
+		nodes:                []string{"dc/topic/Demographics", "dc/topic/Economy"},
+		constrainedPlaces:    []string{"country/CAN", "country/IND"},
+		constrainedImport:    "",
+		numEntitiesExistence: 1,
+		golden:               "get_filtered_topic_places_multiple_topics",
 	},
 }

--- a/internal/server/spanner/golden/query_test.go
+++ b/internal/server/spanner/golden/query_test.go
@@ -320,7 +320,7 @@ func TestGetFilteredStatVarGroupNode(t *testing.T) {
 		goldenFile := c.golden + ".json"
 
 		runQueryGoldenTest(t, goldenFile, func(ctx context.Context) (interface{}, error) {
-			actual, err := client.GetFilteredStatVarGroupNode(ctx, c.node, c.constrainedPlaces, c.constrainedImport, c.numEntitiesExistence)
+			actual, err := client.GetFilteredStatVarGroupNode(ctx, c.nodes, c.constrainedPlaces, c.constrainedImport, c.numEntitiesExistence)
 			if err != nil {
 				return nil, err
 			}
@@ -342,7 +342,7 @@ func TestGetFilteredTopic(t *testing.T) {
 		goldenFile := c.golden + ".json"
 
 		runQueryGoldenTest(t, goldenFile, func(ctx context.Context) (interface{}, error) {
-			return client.GetFilteredTopic(ctx, c.node, c.constrainedPlaces, c.constrainedImport, c.numEntitiesExistence)
+			return client.GetFilteredTopic(ctx, c.nodes, c.constrainedPlaces, c.constrainedImport, c.numEntitiesExistence)
 		})
 	}
 }
@@ -441,14 +441,16 @@ func sortStatVarGroupNode(results []*spanner.StatVarGroupNode) {
 }
 
 // sortFilteredStatVarGroupNode sorts the children of a FilteredStatVarGroupNode by subject_id to ensure deterministic order in tests.
-func sortFilteredStatVarGroupNode(results *spanner.FilteredStatVarGroupNode) {
-	sort.Slice(results.SVGChild, func(i, j int) bool {
-		return results.SVGChild[i].SubjectID < results.SVGChild[j].SubjectID
-	})
-	sort.Slice(results.ChildSV, func(i, j int) bool {
-		return results.ChildSV[i].SubjectID < results.ChildSV[j].SubjectID
-	})
-	sort.Slice(results.ChildSVG, func(i, j int) bool {
-		return results.ChildSVG[i].SubjectID < results.ChildSVG[j].SubjectID
-	})
+func sortFilteredStatVarGroupNode(results map[string]*spanner.FilteredStatVarGroupNode) {
+	for _, node := range results {
+		sort.Slice(node.SVGChild, func(i, j int) bool {
+			return node.SVGChild[i].SubjectID < node.SVGChild[j].SubjectID
+		})
+		sort.Slice(node.ChildSV, func(i, j int) bool {
+			return node.ChildSV[i].SubjectID < node.ChildSV[j].SubjectID
+		})
+		sort.Slice(node.ChildSVG, func(i, j int) bool {
+			return node.ChildSVG[i].SubjectID < node.ChildSVG[j].SubjectID
+		})
+	}
 }

--- a/internal/server/spanner/query.go
+++ b/internal/server/spanner/query.go
@@ -655,6 +655,7 @@ func (sc *spannerDatabaseClient) VectorSearchQuery(ctx context.Context, limit in
 	)
 	return results, err
 }
+
 // GetStatVarGroupNode fetches StatVarGroupNode info from Spanner.
 func (sc *spannerDatabaseClient) GetStatVarGroupNode(ctx context.Context, nodes []string) ([]*StatVarGroupNode, error) {
 	var svgNodes []*StatVarGroupNode
@@ -680,8 +681,43 @@ func (sc *spannerDatabaseClient) GetStatVarGroupNode(ctx context.Context, nodes 
 	return svgNodes, nil
 }
 
-// GetFilteredStatVarGroupNode fetches the relevant info to build a filtered StatVarGroupNode from Spanner.
-func (sc *spannerDatabaseClient) GetFilteredStatVarGroupNode(ctx context.Context, node string, constrainedPlaces []string, constrainedImport string, numEntitiesExistence int) (*FilteredStatVarGroupNode, error) {
+// GetFilteredStatVarGroupNode fetches filtered StatVarGroupNode info from Spanner based on constrained places and import, and number of entities existence.
+func (sc *spannerDatabaseClient) GetFilteredStatVarGroupNode(ctx context.Context, nodes []string, constrainedPlaces []string, constrainedImport string, numEntitiesExistence int) (map[string]*FilteredStatVarGroupNode, error) {
+	response := map[string]*FilteredStatVarGroupNode{}
+	errGroup, errCtx := errgroup.WithContext(ctx)
+
+	type nodeResult struct {
+		node string
+		resp *FilteredStatVarGroupNode
+	}
+	resps := make(chan nodeResult, len(nodes))
+
+	for _, node := range nodes {
+		node := node
+		errGroup.Go(func() error {
+			resp, err := sc.getSingleFilteredStatVarGroupNode(errCtx, node, constrainedPlaces, constrainedImport, numEntitiesExistence)
+			if err != nil {
+				return fmt.Errorf("error fetching filtered StatVarGroupNode for node %s: %w", node, err)
+			}
+			resps <- nodeResult{node: node, resp: resp}
+			return nil
+		})
+	}
+
+	if err := errGroup.Wait(); err != nil {
+		return nil, err
+	}
+	close(resps)
+
+	for res := range resps {
+		response[res.node] = res.resp
+	}
+
+	return response, nil
+}
+
+// getSingleFilteredStatVarGroupNode fetches the relevant info to build a single filtered StatVarGroupNode from Spanner.
+func (sc *spannerDatabaseClient) getSingleFilteredStatVarGroupNode(ctx context.Context, node string, constrainedPlaces []string, constrainedImport string, numEntitiesExistence int) (*FilteredStatVarGroupNode, error) {
 	filteredStatVarGroupNode := &FilteredStatVarGroupNode{}
 	errGroup, errCtx := errgroup.WithContext(ctx)
 	svgChildChan := make(chan []*SVGChild, 1)
@@ -764,24 +800,33 @@ func (sc *spannerDatabaseClient) GetFilteredStatVarGroupNode(ctx context.Context
 }
 
 // GetFilteredTopic fetches the relevant info to build a filtered Topic response from Spanner.
-func (sc *spannerDatabaseClient) GetFilteredTopic(ctx context.Context, node string, constrainedPlaces []string, constrainedImport string, numEntitiesExistence int) (int, error) {
-	stmt := GetFilteredSVGChildrenQuery(templateTopic, node, constrainedPlaces, constrainedImport, numEntitiesExistence)
+func (sc *spannerDatabaseClient) GetFilteredTopic(ctx context.Context, nodes []string, constrainedPlaces []string, constrainedImport string, numEntitiesExistence int) (map[string]int, error) {
+	counts := make(map[string]int, len(nodes))
+	for _, node := range nodes {
+		counts[node] = 0
+	}
+
+	stmt := GetFilteredTopicChildrenQuery(nodes, constrainedPlaces, constrainedImport, numEntitiesExistence)
 	rows, err := queryDynamic(ctx, sc, *stmt)
 	if err != nil {
-		return 0, err
+		return counts, err
 	}
 	if len(rows) == 0 {
 		// No child SVs.
-		return 0, nil
+		return counts, nil
 	}
-	if len(rows[0]) == 0 {
-		return 0, fmt.Errorf("malformed response when fetching count of Topic children")
+	for _, row := range rows {
+		if len(row) != 2 {
+			return counts, fmt.Errorf("malformed response when fetching count of Topic children")
+		}
+		parent := row[0]
+		count, err := strconv.Atoi(row[1])
+		if err != nil {
+			return counts, fmt.Errorf("error converting Topic children count to int")
+		}
+		counts[parent] = count
 	}
-	count, err := strconv.Atoi(rows[0][0])
-	if err != nil {
-		return 0, fmt.Errorf("error converting Topic children count to int")
-	}
-	return count, nil
+	return counts, nil
 }
 
 // fetchAndUpdateTimestamp queries Spanner and updates the timestamp.

--- a/internal/server/spanner/query.go
+++ b/internal/server/spanner/query.go
@@ -681,7 +681,7 @@ func (sc *spannerDatabaseClient) GetStatVarGroupNode(ctx context.Context, nodes 
 	return svgNodes, nil
 }
 
-// GetFilteredStatVarGroupNode fetches filtered StatVarGroupNode info from Spanner based on constrained places and import, and number of entities existence.
+// GetFilteredStatVarGroupNode fetches filtered StatVarGroupNode info from Spanner.
 func (sc *spannerDatabaseClient) GetFilteredStatVarGroupNode(ctx context.Context, nodes []string, constrainedPlaces []string, constrainedImport string, numEntitiesExistence int) (map[string]*FilteredStatVarGroupNode, error) {
 	response := map[string]*FilteredStatVarGroupNode{}
 	errGroup, errCtx := errgroup.WithContext(ctx)

--- a/internal/server/spanner/query.go
+++ b/internal/server/spanner/query.go
@@ -71,6 +71,9 @@ const (
 	predName               = "name"
 	predUrl                = "url"
 	predDomain             = "domain"
+
+	// Maximum number of concurrent goroutines for fetching filtered StatVarGroupNode info.
+	maxConcurrentFilteredSVGGoroutines = 10
 )
 
 // GetNodeProps retrieves node properties from Spanner given a list of IDs and a direction and returns a map.
@@ -685,6 +688,7 @@ func (sc *spannerDatabaseClient) GetStatVarGroupNode(ctx context.Context, nodes 
 func (sc *spannerDatabaseClient) GetFilteredStatVarGroupNode(ctx context.Context, nodes []string, constrainedPlaces []string, constrainedImport string, numEntitiesExistence int) (map[string]*FilteredStatVarGroupNode, error) {
 	response := map[string]*FilteredStatVarGroupNode{}
 	errGroup, errCtx := errgroup.WithContext(ctx)
+	errGroup.SetLimit(maxConcurrentFilteredSVGGoroutines) // Limit the number of concurrent goroutines to avoid overwhelming Spanner with too many requests.
 
 	type nodeResult struct {
 		node string
@@ -807,25 +811,29 @@ func (sc *spannerDatabaseClient) GetFilteredTopic(ctx context.Context, nodes []s
 	}
 
 	stmt := GetFilteredTopicChildrenQuery(nodes, constrainedPlaces, constrainedImport, numEntitiesExistence)
-	rows, err := queryDynamic(ctx, sc, *stmt)
+	err := sc.executeQuery(ctx, *stmt, func(iter *spanner.RowIterator) error {
+		for {
+			row, err := iter.Next()
+			if err == iterator.Done {
+				break
+			}
+			if err != nil {
+				return err
+			}
+
+			var parent string
+			var count int64
+			if err := row.Columns(&parent, &count); err != nil {
+				return fmt.Errorf("error reading row for filtered Topic children count: %w", err)
+			}
+			counts[parent] = int(count)
+		}
+		return nil
+	})
 	if err != nil {
 		return counts, err
 	}
-	if len(rows) == 0 {
-		// No child SVs.
-		return counts, nil
-	}
-	for _, row := range rows {
-		if len(row) != 2 {
-			return counts, fmt.Errorf("malformed response when fetching count of Topic children")
-		}
-		parent := row[0]
-		count, err := strconv.Atoi(row[1])
-		if err != nil {
-			return counts, fmt.Errorf("error converting Topic children count to int")
-		}
-		counts[parent] = count
-	}
+
 	return counts, nil
 }
 

--- a/internal/server/spanner/query_builder.go
+++ b/internal/server/spanner/query_builder.go
@@ -56,8 +56,6 @@ const (
 	templateSV = "SV"
 	// Template for fetching child SVGs
 	templateSVG = "SVG"
-	// Template for fetching children of a Topic
-	templateTopic = "Topic"
 	// isPartOf predicate
 	predicateIsPartOf = "isPartOf"
 	// source predicate
@@ -441,12 +439,9 @@ func GetSVGChildrenQuery(node string) *spanner.Statement {
 	}
 }
 
-// GetFilteredSVGChildren returns a query to get children for a given stat var group filtered by constrained entities and existence threshold.
-func GetFilteredSVGChildrenQuery(template string, node string, constrainedPlaces []string, constrainedImport string, numEntitiesExistence int) *spanner.Statement {
-	params := map[string]interface{}{
-		"node":                 node,
-		"numEntitiesExistence": numEntitiesExistence,
-	}
+// filterDescentStatVarsQuery returns a subquery to filter descendent stat vars for a given variable group or topic based on constrained entities and existence threshold.
+func filterDescentStatVarsQuery(constrainedPlaces []string, constrainedImport string, numEntitiesExistence int) *spanner.Statement {
+	var params = map[string]interface{}{}
 
 	var entityFilter string
 	var distinct string
@@ -473,19 +468,41 @@ func GetFilteredSVGChildrenQuery(template string, node string, constrainedPlaces
 		params["numEntitiesExistence"] = numEntitiesExistence
 	}
 
+	return &spanner.Statement{
+		SQL:    fmt.Sprintf(statements.filterDescendentStatVars, entityFilter, numFilter),
+		Params: params,
+	}
+}
+
+// GetFilteredSVGChildren returns a query to get children for a given stat var group filtered by constrained entities and existence threshold.
+func GetFilteredSVGChildrenQuery(template string, node string, constrainedPlaces []string, constrainedImport string, numEntitiesExistence int) *spanner.Statement {
+	subquery := filterDescentStatVarsQuery(constrainedPlaces, constrainedImport, numEntitiesExistence)
+	subquery.Params["node"] = node
+
 	var baseStatement string
 	switch template {
 	case templateSV:
 		baseStatement = statements.getFilteredChildSVs
 	case templateSVG:
 		baseStatement = statements.getFilteredChildSVGs
-	case templateTopic:
-		baseStatement = statements.getFilteredTopic
 	}
 
 	return &spanner.Statement{
-		SQL:    fmt.Sprintf(baseStatement, entityFilter, numFilter),
-		Params: params,
+		SQL:    fmt.Sprintf(baseStatement, subquery.SQL),
+		Params: subquery.Params,
+	}
+}
+
+// GetFilteredTopicChildren returns a query to get children for given topics filtered by constrained entities and existence threshold.
+func GetFilteredTopicChildrenQuery(nodes []string, constrainedPlaces []string, constrainedImport string, numEntitiesExistence int) *spanner.Statement {
+	subquery := filterDescentStatVarsQuery(constrainedPlaces, constrainedImport, numEntitiesExistence)
+
+	nodeFilter, nodeVal := getParamStatement("node", nodes)
+	subquery.Params["node"] = nodeVal
+
+	return &spanner.Statement{
+		SQL:    fmt.Sprintf(statements.getFilteredTopic, subquery.SQL, nodeFilter),
+		Params: subquery.Params,
 	}
 }
 

--- a/internal/server/spanner/query_builder.go
+++ b/internal/server/spanner/query_builder.go
@@ -444,7 +444,7 @@ func filterDescentStatVarsQuery(constrainedPlaces []string, constrainedImport st
 	var params = map[string]interface{}{}
 
 	var entityFilter string
-	var distinct string
+	distinct := "observation_about"
 	if constrainedImport != "" {
 		entityFilter = statements.filterDescendentStatVarsByImport
 		params["predicate"] = getImportFilterPredicate(constrainedImport)
@@ -459,7 +459,6 @@ func filterDescentStatVarsQuery(constrainedPlaces []string, constrainedImport st
 			entityFilter = entityFilter + "\n\t\t\t\t\t" + sqlAnd + " " + fmt.Sprintf(statements.selectEntityDcids, placeFilter)
 		}
 		params["places"] = placeVal
-		distinct = "observation_about"
 	}
 
 	var numFilter string

--- a/internal/server/spanner/statements.go
+++ b/internal/server/spanner/statements.go
@@ -109,6 +109,8 @@ var statements = struct {
 	getFilteredChildSVs string
 	// Fetch filtered count of descendent stat vars for a given topic.
 	getFilteredTopic string
+	// Filter descendent stat vars.
+	filterDescendentStatVars string
 	// Filter descendent stat vars by import.
 	filterDescendentStatVarsByImport string
 	// Filter descendent stat vars by num_entities_existences.
@@ -443,11 +445,7 @@ var statements = struct {
 			SELECT
 				e.subject_id AS subject_id
 			FROM Edge e
-			JOIN@{JOIN_TYPE=HASH_JOIN} (
-				SELECT variable_measured
-				FROM Observation %[1]s
-				GROUP BY variable_measured%[2]s
-			) o ON o.variable_measured = e.subject_id
+			%s
 			WHERE e.subject_id IN (
 				SELECT DISTINCT subject_id
 				FROM Edge
@@ -468,11 +466,7 @@ var statements = struct {
 				e.object_id AS subject_id,
 				COUNT(e.subject_id) AS descendent_stat_var_count
 			FROM Edge e
-			JOIN@{JOIN_TYPE=HASH_JOIN} (
-				SELECT variable_measured
-				FROM Observation %[1]s
-				GROUP BY variable_measured%[2]s
-			) o ON o.variable_measured = e.subject_id
+			%s
 			WHERE e.predicate = 'linkedMemberOf'
 				AND e.object_id IN (
 					SELECT DISTINCT subject_id
@@ -487,17 +481,19 @@ var statements = struct {
 		) e_counts
 			ON n.subject_id = e_counts.subject_id`,
 	getFilteredTopic: `		SELECT
+			e.object_id AS subject_id,
 			COUNT(e.subject_id) AS descendent_stat_var_count
 		FROM Edge@{FORCE_INDEX=InEdge} e
-		JOIN@{JOIN_TYPE=HASH_JOIN} (
-			SELECT variable_measured
-			FROM Observation %[1]s
-			GROUP BY variable_measured%[2]s
-		) o ON o.variable_measured = e.subject_id
+		%[1]s
 		WHERE e.predicate = 'linkedMember'
-			AND e.object_id = @node
+			AND e.object_id %[2]s
 		GROUP BY
 			e.object_id`,
+	filterDescendentStatVars: `JOIN@{JOIN_TYPE=HASH_JOIN} (
+				SELECT variable_measured
+				FROM Observation %[1]s
+				GROUP BY variable_measured%[2]s
+			) o ON o.variable_measured = e.subject_id`,
 	filterDescendentStatVarsByImport: `
 				JOIN Edge@{FORCE_INDEX=InEdge} e1
 				ON import_name = SUBSTR(e1.subject_id, 9)

--- a/internal/server/v3/bulk_variable_group_info/bulk_variable_group_info_filtered_svg.json
+++ b/internal/server/v3/bulk_variable_group_info/bulk_variable_group_info_filtered_svg.json
@@ -1,6 +1,47 @@
 {
   "data": [
     {
+      "node": "dc/g/Agriculture",
+      "info": {
+        "absoluteName": "Agriculture",
+        "childStatVars": [
+          {
+            "id": "Count_Person_5OrLessMeter_Rural_AsAFractionOf_Count_Person"
+          }
+        ],
+        "childStatVarGroups": [
+          {
+            "id": "dc/g/Person_EconomicSector",
+            "specializedEntity": "Economic Sector",
+            "displayName": "Person by Economic Sector"
+          },
+          {
+            "id": "dc/g/Farm",
+            "specializedEntity": "Farm",
+            "displayName": "Farm"
+          },
+          {
+            "id": "dc/g/FarmInventory",
+            "specializedEntity": "Farm Inventory",
+            "displayName": "Farm Inventory",
+            "descendentStatVarCount": 4
+          },
+          {
+            "id": "dc/g/Agriculture_Miscellaneous",
+            "specializedEntity": "Miscellaneous",
+            "displayName": "Miscellaneous",
+            "descendentStatVarCount": 16
+          },
+          {
+            "id": "dc/g/Person_OwnershipStatus",
+            "specializedEntity": "Ownership Status",
+            "displayName": "Person by Ownership Status"
+          }
+        ],
+        "descendentStatVarCount": 20
+      }
+    },
+    {
       "node": "dc/g/Environment",
       "info": {
         "absoluteName": "Environment",

--- a/internal/server/v3/bulk_variable_group_info/bulk_variable_group_info_filtered_topic.json
+++ b/internal/server/v3/bulk_variable_group_info/bulk_variable_group_info_filtered_topic.json
@@ -5,6 +5,12 @@
       "info": {
         "descendentStatVarCount": 2
       }
+    },
+    {
+      "node": "dc/topic/Economy",
+      "info": {
+        "descendentStatVarCount": 10
+      }
     }
   ]
 }

--- a/internal/server/v3/bulk_variable_group_info/bulk_variable_group_info_test.go
+++ b/internal/server/v3/bulk_variable_group_info/bulk_variable_group_info_test.go
@@ -51,7 +51,7 @@ func TestV3BulkVariableGroupInfo(t *testing.T) {
 			},
 			{
 				&pbv1.BulkVariableGroupInfoRequest{
-					Nodes:                []string{"dc/g/Environment"},
+					Nodes:                []string{"dc/g/Environment", "dc/g/Agriculture"},
 					ConstrainedEntities:  []string{"country/USA", "country/IND", "country/CAN"},
 					NumEntitiesExistence: 2,
 				},
@@ -59,7 +59,7 @@ func TestV3BulkVariableGroupInfo(t *testing.T) {
 			},
 			{
 				&pbv1.BulkVariableGroupInfoRequest{
-					Nodes:               []string{"dc/topic/Demographics"},
+					Nodes:               []string{"dc/topic/Demographics", "dc/topic/Economy"},
 					ConstrainedEntities: []string{"dc/s/WorldBank"},
 				},
 				"bulk_variable_group_info_filtered_topic.json",


### PR DESCRIPTION
Website requires this, so adding this functionality

For topic filtering, it's fast enough to directly request multiple nodes at once within the same query
For svg filtering, the queries are much more complex and it's hard to come up with efficient plans for multiple parent nodes, so I'm currently just doing parallel requests