### PR TITLE
Remove definition clearing from the v1 to v2 wrapper functionality

### DIFF
--- a/internal/server/handler_v2.go
+++ b/internal/server/handler_v2.go
@@ -558,7 +558,6 @@ func convertV1ToV2BulkVariableGroupInfo(resp *pbv1.BulkVariableGroupInfoResponse
 		for _, childSV := range info.GetInfo().GetChildStatVars() {
 			childSV.SearchName = ""
 			childSV.SearchNames = nil
-			childSV.Definition = ""
 		}
 	}
 }

--- a/internal/server/v2/bulk_variable_group_info/bulk_variable_group_info.json
+++ b/internal/server/v2/bulk_variable_group_info/bulk_variable_group_info.json
@@ -7,7 +7,8 @@
         "childStatVars": [
           {
             "id": "Count_Person_5OrLessMeter_Rural_AsAFractionOf_Count_Person",
-            "displayName": "Population: 5 Meter or Less, Rural (Per Capita)"
+            "displayName": "Population: 5 Meter or Less, Rural (Per Capita)",
+            "definition": "md=Count_Person,mp=count,pt=Person,elevation=MeterUpto5,placeOfResidenceClassification=Rural"
           }
         ],
         "childStatVarGroups": [
@@ -52,11 +53,13 @@
           {
             "id": "Count_HousingUnit",
             "displayName": "Housing Units",
+            "definition": "mp=count,pt=HousingUnit",
             "hasData": true
           },
           {
             "id": "Monthly_Median_GrossRent_HousingUnit",
             "displayName": "Median Monthly Gross Rent of Housing Unit",
+            "definition": "mq=Monthly,st=medianValue,mp=grossRent,pt=HousingUnit",
             "hasData": true
           }
         ],


### PR DESCRIPTION
## Issue

[b/507063871](https://b.corp.google.com/issues/507063871)

## Description

Now that Spanner (and therefore the `v2` endpoints) will be providing the definition in the `bulk/info/variable-group` endpoint, the non-diverted `v2` version of the endpoint now returns the definition.

The corresponding goldens are updated as well.