### PR TITLE
Add Spanner performance test CLI tool

### DIFF
--- a/internal/server/spanner/client_selector.go
+++ b/internal/server/spanner/client_selector.go
@@ -98,6 +98,15 @@ func useNormalizedSchema(ctx context.Context) bool {
 	return false
 }
 
+// shouldLogSQL checks whether to log the full interpolated SQL query based on request header.
+func shouldLogSQL(ctx context.Context) bool {
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		headers := md.Get(util.XLogSQL)
+		return len(headers) > 0 && headers[0] == "true"
+	}
+	return false
+}
+
 // logNormalizedInvocation logs that the normalized schema was invoked for a method with custom arguments.
 func logNormalizedInvocation(methodName string, args ...any) {
 	fullArgs := append([]any{"method", methodName}, args...)

--- a/internal/server/spanner/client_selector.go
+++ b/internal/server/spanner/client_selector.go
@@ -107,6 +107,14 @@ func shouldLogSQL(ctx context.Context) bool {
 	return false
 }
 
+// getSchemaName returns the name of the schema being used based on context.
+func getSchemaName(ctx context.Context) string {
+	if useNormalizedSchema(ctx) {
+		return "Normalized"
+	}
+	return "Legacy"
+}
+
 // logNormalizedInvocation logs that the normalized schema was invoked for a method with custom arguments.
 func logNormalizedInvocation(methodName string, args ...any) {
 	fullArgs := append([]any{"method", methodName}, args...)

--- a/internal/server/spanner/golden/query_builder_test.go
+++ b/internal/server/spanner/golden/query_builder_test.go
@@ -16,10 +16,8 @@ package golden
 
 import (
 	"context"
-	"fmt"
 	"path"
 	"runtime"
-	"strings"
 	"testing"
 
 	cloudSpanner "cloud.google.com/go/spanner"
@@ -266,7 +264,7 @@ func runQueryBuilderGoldenTest(t *testing.T, goldenFile string, fn goldenTestFun
 	if err != nil {
 		t.Fatalf("test function error (%v): %v", goldenFile, err)
 	}
-	interpolated := interpolateSQL(actual.(*cloudSpanner.Statement))
+	interpolated := spanner.InterpolateSQL(actual.(*cloudSpanner.Statement))
 
 	if test.GenerateGolden {
 		err := test.WriteGolden(interpolated, goldenDir, goldenFile)
@@ -287,40 +285,4 @@ func runQueryBuilderGoldenTest(t *testing.T, goldenFile string, fn goldenTestFun
 	}
 }
 
-// Replace params with values in SQL. ONLY FOR TESTS.
-func interpolateSQL(stmt *cloudSpanner.Statement) string {
-	sqlString := stmt.SQL
-	for key, value := range stmt.Params {
-		placeholder := "@" + key
-		var formattedValue string
 
-		switch v := value.(type) {
-		case string:
-			formattedValue = fmt.Sprintf("'%s'", strings.ReplaceAll(v, "'", "''"))
-		case []string:
-			// For UNNEST, represent the array as a comma-separated list
-			// enclosed in parentheses or brackets for clarity.
-			var quotedValues []string
-			for _, s := range v {
-				quotedValues = append(quotedValues, fmt.Sprintf("'%s'", strings.ReplaceAll(s, "'", "''")))
-			}
-			formattedValue = "(" + strings.Join(quotedValues, ",") + ")"
-			// Need to handle both UNNEST(@key) and @key
-			sqlString = strings.ReplaceAll(sqlString, "IN UNNEST("+placeholder+")", "IN "+formattedValue)
-			placeholder = "@" + key // Ensure we don't mess up UNNEST replacement
-			formattedValue = "[" + strings.Join(quotedValues, ",") + "]"
-		case []float64:
-			var stringValues []string
-			for _, f := range v {
-				stringValues = append(stringValues, fmt.Sprintf("%v", f))
-			}
-			formattedValue = "[" + strings.Join(stringValues, ",") + "]"
-		// ... add more cases for int64, float64, bool, etc.
-		default:
-			// Catch-all for other types
-			formattedValue = fmt.Sprintf("%v", v)
-		}
-		sqlString = strings.ReplaceAll(sqlString, placeholder, formattedValue)
-	}
-	return sqlString
-}

--- a/internal/server/spanner/query.go
+++ b/internal/server/spanner/query.go
@@ -17,6 +17,7 @@ package spanner
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -919,6 +920,14 @@ func (sc *spannerDatabaseClient) executeQuery(
 			interpolatedSQL := InterpolateSQL(&stmt)
 			schema := getSchemaName(queryCtx)
 			fmt.Printf("\n=== [%s] Spanner Query (Took %v) ===\n", schema, duration)
+			fmt.Println("[Parameterized Query]")
+			for k, v := range stmt.Params {
+				jsonVal, _ := json.Marshal(v)
+				fmt.Printf("SET @%s = %s;\n", k, string(jsonVal))
+			}
+			fmt.Println()
+			fmt.Println(stmt.SQL)
+			fmt.Println("\n[Interpolated Query]")
 			fmt.Println(interpolatedSQL)
 			fmt.Println("================================================")
 		}

--- a/internal/server/spanner/query.go
+++ b/internal/server/spanner/query.go
@@ -909,9 +909,19 @@ func (sc *spannerDatabaseClient) executeQuery(
 
 	runQuery := func(tb spanner.TimestampBound) error {
 		metrics.RecordSpannerQuery(queryCtx)
+		startTime := time.Now()
 		iter := sc.client.Single().WithTimestampBound(tb).Query(queryCtx, stmt)
 		defer iter.Stop()
 		err := handleRows(iter)
+		duration := time.Since(startTime)
+
+		if shouldLogSQL(queryCtx) {
+			interpolatedSQL := InterpolateSQL(&stmt)
+			slog.InfoContext(queryCtx, "Spanner query",
+				"sql", interpolatedSQL,
+				"duration_seconds", duration.Seconds(),
+			)
+		}
 
 		// Log slow Spanner queries that timed out.
 		if isTimeoutError(err) {

--- a/internal/server/spanner/query.go
+++ b/internal/server/spanner/query.go
@@ -917,10 +917,10 @@ func (sc *spannerDatabaseClient) executeQuery(
 
 		if shouldLogSQL(queryCtx) {
 			interpolatedSQL := InterpolateSQL(&stmt)
-			slog.InfoContext(queryCtx, "Spanner query",
-				"sql", interpolatedSQL,
-				"duration_seconds", duration.Seconds(),
-			)
+			schema := getSchemaName(queryCtx)
+			fmt.Printf("\n=== [%s] Spanner Query (Took %v) ===\n", schema, duration)
+			fmt.Println(interpolatedSQL)
+			fmt.Println("================================================")
 		}
 
 		// Log slow Spanner queries that timed out.

--- a/internal/server/spanner/sql_util.go
+++ b/internal/server/spanner/sql_util.go
@@ -1,0 +1,61 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spanner
+
+import (
+	"fmt"
+	"strings"
+
+	cloudSpanner "cloud.google.com/go/spanner"
+)
+
+// InterpolateSQL replaces params with values in SQL.
+// This is primarily used for debugging and testing to see the final query.
+func InterpolateSQL(stmt *cloudSpanner.Statement) string {
+	sqlString := stmt.SQL
+	for key, value := range stmt.Params {
+		placeholder := "@" + key
+		var formattedValue string
+
+		switch v := value.(type) {
+		case string:
+			formattedValue = fmt.Sprintf("'%s'", strings.ReplaceAll(v, "'", "''"))
+		case []string:
+			// For UNNEST, represent the array as a comma-separated list
+			// enclosed in parentheses or brackets for clarity.
+			var quotedValues []string
+			for _, s := range v {
+				quotedValues = append(quotedValues, fmt.Sprintf("'%s'", strings.ReplaceAll(s, "'", "''")))
+			}
+			formattedValue = "(" + strings.Join(quotedValues, ",") + ")"
+			// Need to handle both UNNEST(@key) and @key
+			sqlString = strings.ReplaceAll(sqlString, "IN UNNEST("+placeholder+")", "IN "+formattedValue)
+			placeholder = "@" + key // Ensure we don't mess up UNNEST replacement
+			formattedValue = "[" + strings.Join(quotedValues, ",") + "]"
+		case []float64:
+			var stringValues []string
+			for _, f := range v {
+				stringValues = append(stringValues, fmt.Sprintf("%v", f))
+			}
+			formattedValue = "[" + strings.Join(stringValues, ",") + "]"
+		// ... add more cases for int64, float64, bool, etc.
+		default:
+			// Catch-all for other types
+			formattedValue = fmt.Sprintf("%v", v)
+		}
+		sqlString = strings.ReplaceAll(sqlString, placeholder, formattedValue)
+	}
+	return sqlString
+}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -147,6 +147,9 @@ const (
 	// Whether to use normalized Spanner schema.
 	// To use, set header "X-Use-Normalized-Schema: true"
 	XUseNormalizedSchema = "X-Use-Normalized-Schema"
+	// Whether to log the full interpolated SQL query.
+	// To use, set header "X-Log-SQL: true"
+	XLogSQL = "X-Log-SQL"
 )
 
 // ZipAndEncode compresses the given content using gzip and encodes it in base64

--- a/tools/perf_test/README.md
+++ b/tools/perf_test/README.md
@@ -1,0 +1,37 @@
+# Performance Test Tool
+
+This CLI tool is designed to compare the performance of the legacy and normalized Spanner schemas for key observation APIs in Data Commons Mixer.
+
+## Objective
+To measure and compare the execution time of queries in both schemas in parallel, helping to identify performance bottlenecks.
+
+## How to Run
+
+### Examples
+
+#### 1. Test GetObservations
+```bash
+go run tools/perf_test/main.go -method=GetObservations -variables=Count_Person,Count_Household,Fake_54321 -entities=geoId/06,geoId/08
+```
+
+#### 2. Test CheckVariableExistence
+```bash
+go run tools/perf_test/main.go -method=CheckVariableExistence -variables=Count_Person,Count_Household,Fake_24680 -entities=geoId/06,geoId/08
+```
+
+#### 3. Test GetObservationsContainedInPlace
+```bash
+go run tools/perf_test/main.go -method=GetObservationsContainedInPlace -variables=Count_Person,Count_Household,Fake_13579 -ancestor=geoId/10 -child_type=County
+```
+
+## Flags
+- `-method`: The method to test (e.g., `GetObservations`, `CheckVariableExistence`, `GetObservationsContainedInPlace`).
+- `-variables`: Comma-separated list of variable DCIDs. Add a fake variable (e.g., `Fake_$RANDOM`) to bypass Spanner query cache.
+- `-entities`: Comma-separated list of entity DCIDs.
+- `-ancestor`: Ancestor place DCID for contained-in queries.
+- `-child_type`: Child place type for contained-in queries.
+- `-config`: Path to Spanner graph info YAML (defaults to `deploy/storage/spanner_graph_info.yaml`).
+
+## Notes
+- The tool automatically injects headers to bypass Mixer cache and force logging of the query string.
+- It runs both schemas in parallel by default and reports execution times for each.

--- a/tools/perf_test/main.go
+++ b/tools/perf_test/main.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/datacommonsorg/mixer/internal/server/spanner"
 	v2 "github.com/datacommonsorg/mixer/internal/server/v2"
@@ -130,7 +129,7 @@ func initSpannerClient(ctx context.Context, configPath string) (spanner.SpannerC
 	return spanner.NewSpannerClient(ctx, string(yamlFile), "")
 }
 
-// runParallelTest runs two operations in parallel and compares their execution time.
+// runParallelTest runs two operations in parallel and injects metadata headers.
 // It injects X-Log-SQL=true for both, and X-Use-Normalized-Schema=true for the second operation.
 func runParallelTest(
 	ctx context.Context,
@@ -140,7 +139,6 @@ func runParallelTest(
 	var wg sync.WaitGroup
 	wg.Add(2)
 
-	var time1, time2 time.Duration
 	var err1, err2 error
 
 	// Run Operation 1 (Legacy usually)
@@ -148,9 +146,7 @@ func runParallelTest(
 		defer wg.Done()
 		// Inject X-Log-SQL to see the query
 		c1 := metadata.NewIncomingContext(ctx, metadata.Pairs(util.XLogSQL, "true"))
-		start := time.Now()
 		err1 = op1(c1)
-		time1 = time.Since(start)
 	}()
 
 	// Run Operation 2 (Normalized usually)
@@ -161,23 +157,21 @@ func runParallelTest(
 			util.XLogSQL, "true",
 			util.XUseNormalizedSchema, "true",
 		))
-		start := time.Now()
 		err2 = op2(c2)
-		time2 = time.Since(start)
 	}()
 
 	wg.Wait()
 
-	fmt.Println("\n=== Performance Results ===")
+	fmt.Println("\n=== Execution Status ===")
 	if err1 != nil {
 		fmt.Printf("%s: Failed with error: %v\n", name1, err1)
 	} else {
-		fmt.Printf("%s: Took %v\n", name1, time1)
+		fmt.Printf("%s: Succeeded\n", name1)
 	}
 
 	if err2 != nil {
 		fmt.Printf("%s: Failed with error: %v\n", name2, err2)
 	} else {
-		fmt.Printf("%s: Took %v\n", name2, time2)
+		fmt.Printf("%s: Succeeded\n", name2)
 	}
 }

--- a/tools/perf_test/main.go
+++ b/tools/perf_test/main.go
@@ -1,0 +1,183 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"log/slog"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/datacommonsorg/mixer/internal/server/spanner"
+	v2 "github.com/datacommonsorg/mixer/internal/server/v2"
+	"github.com/datacommonsorg/mixer/internal/util"
+	"google.golang.org/grpc/metadata"
+)
+
+var (
+	method    = flag.String("method", "GetObservations", "Method to test: GetObservations, CheckVariableExistence, GetObservationsContainedInPlace, GetSdmxObservations")
+	variables = flag.String("variables", "", "Comma-separated list of variables")
+	entities  = flag.String("entities", "", "Comma-separated list of entities")
+	ancestor  = flag.String("ancestor", "", "Ancestor place for contained-in queries")
+	childType = flag.String("child_type", "", "Child place type for contained-in queries")
+	config    = flag.String("config", "deploy/storage/spanner_graph_info.yaml", "Path to spanner graph info yaml")
+)
+
+func main() {
+	flag.Parse()
+
+	if err := validateInputs(*method, *variables, *entities, *ancestor, *childType); err != nil {
+		log.Fatal(err)
+	}
+
+	ctx := context.Background()
+	client, err := initSpannerClient(ctx, *config)
+	if err != nil {
+		log.Fatalf("Failed to initialize Spanner client: %v", err)
+	}
+	defer client.Close()
+
+	vars := strings.Split(*variables, ",")
+	ents := strings.Split(*entities, ",")
+	if *entities == "" {
+		ents = []string{}
+	}
+
+	// Setup logging to Info by default, but enable extraction via header.
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo})))
+
+	switch *method {
+	case "GetObservations":
+		runParallelTest(ctx, "Legacy", client, func(c context.Context) error {
+			_, err := client.GetObservations(c, vars, ents)
+			return err
+		}, "Normalized", client, func(c context.Context) error {
+			_, err := client.GetObservations(c, vars, ents)
+			return err
+		})
+	case "CheckVariableExistence":
+		runParallelTest(ctx, "Legacy", client, func(c context.Context) error {
+			_, err := client.CheckVariableExistence(c, vars, ents)
+			return err
+		}, "Normalized", client, func(c context.Context) error {
+			_, err := client.CheckVariableExistence(c, vars, ents)
+			return err
+		})
+	case "GetObservationsContainedInPlace":
+		runParallelTest(ctx, "Legacy", client, func(c context.Context) error {
+			_, err := client.GetObservationsContainedInPlace(c, vars, &v2.ContainedInPlace{
+				Ancestor:       *ancestor,
+				ChildPlaceType: *childType,
+			})
+			return err
+		}, "Normalized", client, func(c context.Context) error {
+			_, err := client.GetObservationsContainedInPlace(c, vars, &v2.ContainedInPlace{
+				Ancestor:       *ancestor,
+				ChildPlaceType: *childType,
+			})
+			return err
+		})
+	default:
+		log.Fatalf("Unsupported method: %s", *method)
+	}
+}
+
+// validateInputs ensures that the required flags are provided for the selected method.
+func validateInputs(method string, variables string, entities string, ancestor string, childType string) error {
+	switch method {
+	case "GetObservations", "CheckVariableExistence":
+		if variables == "" {
+			return fmt.Errorf("at least one variable is required for method %s", method)
+		}
+	case "GetObservationsContainedInPlace":
+		if variables == "" || ancestor == "" || childType == "" {
+			return fmt.Errorf("variables, ancestor, and child_type are required for method %s", method)
+		}
+	// TODO: Support GetSdmxObservations later.
+	// case "GetSdmxObservations":
+	default:
+		return fmt.Errorf("unsupported method: %s", method)
+	}
+	return nil
+}
+
+// initSpannerClient reads the config and initializes the Spanner client.
+func initSpannerClient(ctx context.Context, configPath string) (spanner.SpannerClient, error) {
+	yamlFile, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read config file: %w", err)
+	}
+
+	// We reuse the logic from client.go by passing the YAML string directly.
+	// The client.go NewSpannerClient expects the YAML content.
+	return spanner.NewSpannerClient(ctx, string(yamlFile), "")
+}
+
+// runParallelTest runs two operations in parallel and compares their execution time.
+// It injects X-Log-SQL=true for both, and X-Use-Normalized-Schema=true for the second operation.
+func runParallelTest(
+	ctx context.Context,
+	name1 string, client1 spanner.SpannerClient, op1 func(context.Context) error,
+	name2 string, client2 spanner.SpannerClient, op2 func(context.Context) error,
+) {
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	var time1, time2 time.Duration
+	var err1, err2 error
+
+	// Run Operation 1 (Legacy usually)
+	go func() {
+		defer wg.Done()
+		// Inject X-Log-SQL to see the query
+		c1 := metadata.NewIncomingContext(ctx, metadata.Pairs(util.XLogSQL, "true"))
+		start := time.Now()
+		err1 = op1(c1)
+		time1 = time.Since(start)
+	}()
+
+	// Run Operation 2 (Normalized usually)
+	go func() {
+		defer wg.Done()
+		// Inject X-Log-SQL and X-Use-Normalized-Schema
+		c2 := metadata.NewIncomingContext(ctx, metadata.Pairs(
+			util.XLogSQL, "true",
+			util.XUseNormalizedSchema, "true",
+		))
+		start := time.Now()
+		err2 = op2(c2)
+		time2 = time.Since(start)
+	}()
+
+	wg.Wait()
+
+	fmt.Println("\n=== Performance Results ===")
+	if err1 != nil {
+		fmt.Printf("%s: Failed with error: %v\n", name1, err1)
+	} else {
+		fmt.Printf("%s: Took %v\n", name1, time1)
+	}
+
+	if err2 != nil {
+		fmt.Printf("%s: Failed with error: %v\n", name2, err2)
+	} else {
+		fmt.Printf("%s: Took %v\n", name2, time2)
+	}
+}


### PR DESCRIPTION
* Create a CLI tool to compare performance of legacy and normalized Spanner schemas in parallel.
* Move SQL interpolation logic to a shared utility file for use in non-test code.
* Add header-based trigger to log full interpolated SQL queries and execution times.