### PR TITLE
Don't use filter queries when numEntitiesExistence is nonzero but there are no constraints for BulkVariableGroupInfo

### DIFF
--- a/internal/server/spanner/datasource.go
+++ b/internal/server/spanner/datasource.go
@@ -612,7 +612,7 @@ func (sds *SpannerDataSource) BulkVariableGroupInfo(ctx context.Context, req *pb
 	}
 
 	// Unfiltered case.
-	if len(req.ConstrainedEntities) == 0 && req.NumEntitiesExistence == 0 {
+	if len(req.ConstrainedEntities) == 0 {
 		svgInfo, err := sds.client.GetStatVarGroupNode(ctx, svgs)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "error getting StatVarGroupNode from Spanner: %v", err)


### PR DESCRIPTION
The API does not restrict setting numEntitiesExistence, however it only should be applied to specified constrainedEntities as defined in the proto definition https://github.com/datacommonsorg/mixer/blob/fa750085693afca5716f9ca992975bd497d5c01c/proto/v1/info.proto#L82-L84

So when constrainedEntities is empty, even for nonzero numEntitiesExistence, we should use the optimized non-filter query and ignore the numEntitiesExistence