### PR TITLE
Deprecate v1/properties and v1/property/values in Apigee

### DIFF
--- a/deploy/apigee/target_endpoints/api.template.xml
+++ b/deploy/apigee/target_endpoints/api.template.xml
@@ -74,9 +74,9 @@
             ((proxy.pathsuffix MatchesPath "/v1/observations/point") OR (proxy.pathsuffix MatchesPath "/v1/observations/point/**")) OR
             ((proxy.pathsuffix MatchesPath "/v1/observations/series") OR (proxy.pathsuffix MatchesPath "/v1/observations/series/**")) OR
             (proxy.pathsuffix MatchesPath "/v1/observations/series/derived") OR
+            (proxy.pathsuffix MatchesPath "/v1/place/stat-vars/union") OR
             (proxy.pathsuffix MatchesPath "/v1/properties") OR (proxy.pathsuffix MatchesPath "/v1/properties/**") OR
             (proxy.pathsuffix MatchesPath "/v1/property/values") OR (proxy.pathsuffix MatchesPath "/v1/property/values/**") OR
-            (proxy.pathsuffix MatchesPath "/v1/place/stat-vars/union") OR
             (proxy.pathsuffix MatchesPath "/v1/query") OR
             (proxy.pathsuffix MatchesPath "/v1/recognize/entities") OR
             (proxy.pathsuffix MatchesPath "/v1/stat/date/within-place") OR

--- a/deploy/apigee/target_endpoints/api.template.xml
+++ b/deploy/apigee/target_endpoints/api.template.xml
@@ -74,6 +74,8 @@
             ((proxy.pathsuffix MatchesPath "/v1/observations/point") OR (proxy.pathsuffix MatchesPath "/v1/observations/point/**")) OR
             ((proxy.pathsuffix MatchesPath "/v1/observations/series") OR (proxy.pathsuffix MatchesPath "/v1/observations/series/**")) OR
             (proxy.pathsuffix MatchesPath "/v1/observations/series/derived") OR
+            (proxy.pathsuffix MatchesPath "/v1/properties") OR (proxy.pathsuffix MatchesPath "/v1/properties/**") OR
+            (proxy.pathsuffix MatchesPath "/v1/property/values") OR (proxy.pathsuffix MatchesPath "/v1/property/values/**") OR
             (proxy.pathsuffix MatchesPath "/v1/place/stat-vars/union") OR
             (proxy.pathsuffix MatchesPath "/v1/query") OR
             (proxy.pathsuffix MatchesPath "/v1/recognize/entities") OR


### PR DESCRIPTION
As part of the v0/v1 migration, this PR deprecates the v1/properties and v1/property/values endpoints via Apigee.

Tested with a test deployment to "nonprod", and verified staging.api.datacommons.org/v1/properties/* and staging.api.datacommons.org/v1/property/values/* gives a deprecation notice instead of returning values.