### PR TITLE
Fix statements for filtered edges to group by and dedup

### DIFF
--- a/internal/server/spanner/golden/query_builder/get_node_edges_in_filter.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_in_filter.sql
@@ -21,10 +21,15 @@
 		  	subject_id,
 			predicate,
 			provenance,
-			n.value,
-			n.bytes,
-			n.name,
-			n.types
+			ANY_VALUE(n.value) AS value,
+			ANY_VALUE(n.bytes) AS bytes,
+			ANY_VALUE(n.name) AS name,
+			ANY_VALUE(n.types) AS types
+		GROUP BY
+			subject_id,
+			predicate,
+			object_id,
+			provenance
 		ORDER BY
 			subject_id,
 			predicate,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_linked_contained_in_place.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_linked_contained_in_place.sql
@@ -19,10 +19,15 @@
 		  	subject_id,
 			predicate,
 			provenance,
-			n.value,
-			n.bytes,
-			n.name,
-			n.types
+			ANY_VALUE(n.value) AS value,
+			ANY_VALUE(n.bytes) AS bytes,
+			ANY_VALUE(n.name) AS name,
+			ANY_VALUE(n.types) AS types
+		GROUP BY
+			subject_id,
+			predicate,
+			object_id,
+			provenance
 		ORDER BY
 			subject_id,
 			predicate,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_malicious.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_malicious.sql
@@ -19,10 +19,15 @@
 		  	subject_id,
 			predicate,
 			provenance,
-			n.value,
-			n.bytes,
-			n.name,
-			n.types
+			ANY_VALUE(n.value) AS value,
+			ANY_VALUE(n.bytes) AS bytes,
+			ANY_VALUE(n.name) AS name,
+			ANY_VALUE(n.types) AS types
+		GROUP BY
+			subject_id,
+			predicate,
+			object_id,
+			provenance
 		ORDER BY
 			subject_id,
 			predicate,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_out_filter.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_out_filter.sql
@@ -21,10 +21,15 @@
 		  	subject_id,
 			predicate,
 			provenance,
-			n.value,
-			n.bytes,
-			n.name,
-			n.types
+			ANY_VALUE(n.value) AS value,
+			ANY_VALUE(n.bytes) AS bytes,
+			ANY_VALUE(n.name) AS name,
+			ANY_VALUE(n.types) AS types
+		GROUP BY
+			subject_id,
+			predicate,
+			object_id,
+			provenance
 		ORDER BY
 			subject_id,
 			predicate,

--- a/internal/server/spanner/statements.go
+++ b/internal/server/spanner/statements.go
@@ -231,10 +231,15 @@ var statements = struct {
 		  	subject_id,
 			predicate,
 			provenance,
-			n.value,
-			n.bytes,
-			n.name,
-			n.types
+			ANY_VALUE(n.value) AS value,
+			ANY_VALUE(n.bytes) AS bytes,
+			ANY_VALUE(n.name) AS name,
+			ANY_VALUE(n.types) AS types
+		GROUP BY
+			subject_id,
+			predicate,
+			object_id,
+			provenance
 		ORDER BY
 			subject_id,
 			predicate,


### PR DESCRIPTION
This change modifies the GQL code to do a group by in the end of the graph.

This removes the duplication generated when triggering the n:Node - [filter] condition

and in the meanwhile avoid calling distinct in the middle of the graph which causes 20s latency