### PR TITLE
Update the disaster event query by splitting a single match to multiple matches

### DIFF
--- a/internal/server/spanner/golden/query_builder/get_event_collection_date.sql
+++ b/internal/server/spanner/golden/query_builder/get_event_collection_date.sql
@@ -1,5 +1,9 @@
 		@{force_join_order=true}
-		GRAPH DCGraph MATCH (event:Node)-[:Edge {predicate: 'affectedPlace', object_id: 'country/LBR'}]->(), (event)-[:Edge {predicate: 'typeOf', object_id: 'FireEvent'}]->(), (event)-[:Edge {predicate: 'startDate'}]->(dateNode:Node)
+		GRAPH DCGraph
+		MATCH (event:Node)-[:Edge {predicate: 'typeOf', object_id: 'FireEvent'}]->()
+		WITH DISTINCT event
+		MATCH (event:Node)-[:Edge {predicate: 'affectedPlace', object_id: 'country/LBR'}]->()
+		MATCH (event:Node)-[:Edge {predicate: 'startDate'}]->(dateNode:Node)
 		RETURN DISTINCT 
 			SUBSTR(dateNode.value, 1, 7) AS month
 		ORDER BY 

--- a/internal/server/spanner/golden/query_builder/get_event_collection_date_flood.sql
+++ b/internal/server/spanner/golden/query_builder/get_event_collection_date_flood.sql
@@ -1,5 +1,9 @@
 		@{force_join_order=true}
-		GRAPH DCGraph MATCH (event:Node)-[:Edge {predicate: 'affectedPlace', object_id: 'country/GBR'}]->(), (event)-[:Edge {predicate: 'typeOf', object_id: 'FloodEvent'}]->(), (event)-[:Edge {predicate: 'startDate'}]->(dateNode:Node)
+		GRAPH DCGraph
+		MATCH (event:Node)-[:Edge {predicate: 'typeOf', object_id: 'FloodEvent'}]->()
+		WITH DISTINCT event
+		MATCH (event:Node)-[:Edge {predicate: 'affectedPlace', object_id: 'country/GBR'}]->()
+		MATCH (event:Node)-[:Edge {predicate: 'startDate'}]->(dateNode:Node)
 		RETURN DISTINCT 
 			SUBSTR(dateNode.value, 1, 7) AS month
 		ORDER BY 

--- a/internal/server/spanner/golden/query_builder/get_event_collection_dcids.sql
+++ b/internal/server/spanner/golden/query_builder/get_event_collection_dcids.sql
@@ -1,8 +1,12 @@
 		@{force_join_order=true}
-		GRAPH DCGraph MATCH (event:Node)-[:Edge {predicate: 'affectedPlace', object_id: 'country/LBR'}]->(), (event)-[:Edge {predicate: 'typeOf', object_id: 'FireEvent'}]->(), (event)-[:Edge {predicate: 'startDate'}]->(dateNode:Node)
+		GRAPH DCGraph
+		MATCH (event:Node)-[:Edge {predicate: 'typeOf', object_id: 'FireEvent'}]->()
+		WITH DISTINCT event
+		MATCH (event:Node)-[:Edge {predicate: 'affectedPlace', object_id: 'country/LBR'}]->()
+		MATCH (event:Node)-[:Edge {predicate: 'startDate'}]->(dateNode:Node)
 		WHERE 
 			SUBSTR(dateNode.value, 1, 7) = '2020-10'
-		MATCH (event)-[magEdge:Edge {predicate: 'area'}]->()
+		MATCH (event:Node)-[magEdge:Edge {predicate: 'area'}]->()
 		RETURN DISTINCT 
 			event.subject_id AS dcid,
 			magEdge.object_id AS magnitude

--- a/internal/server/spanner/golden/query_builder/get_event_collection_dcids_heat.sql
+++ b/internal/server/spanner/golden/query_builder/get_event_collection_dcids_heat.sql
@@ -1,8 +1,12 @@
 		@{force_join_order=true}
-		GRAPH DCGraph MATCH (event:Node)-[:Edge {predicate: 'affectedPlace', object_id: 'geoId/37'}]->(), (event)-[:Edge {predicate: 'typeOf', object_id: 'HeatTemperatureEvent'}]->(), (event)-[:Edge {predicate: 'startDate'}]->(dateNode:Node)
+		GRAPH DCGraph
+		MATCH (event:Node)-[:Edge {predicate: 'typeOf', object_id: 'HeatTemperatureEvent'}]->()
+		WITH DISTINCT event
+		MATCH (event:Node)-[:Edge {predicate: 'affectedPlace', object_id: 'geoId/37'}]->()
+		MATCH (event:Node)-[:Edge {predicate: 'startDate'}]->(dateNode:Node)
 		WHERE 
 			SUBSTR(dateNode.value, 1, 7) = '2022-01'
-		MATCH (event)-[magEdge:Edge {predicate: 'differenceTemperature'}]->()
+		MATCH (event:Node)-[magEdge:Edge {predicate: 'differenceTemperature'}]->()
 		RETURN DISTINCT 
 			event.subject_id AS dcid,
 			magEdge.object_id AS magnitude

--- a/internal/server/spanner/statements.go
+++ b/internal/server/spanner/statements.go
@@ -347,22 +347,34 @@ var statements = struct {
 			type = @type
 			AND key %s`,
 	getEventCollectionDate: `		@{force_join_order=true}
-		GRAPH DCGraph MATCH (event:Node)-[:Edge {predicate: 'affectedPlace', object_id: @placeID}]->(), (event)-[:Edge {predicate: 'typeOf', object_id: @eventType}]->(), (event)-[:Edge {predicate: 'startDate'}]->(dateNode:Node)
+		GRAPH DCGraph
+		MATCH (event:Node)-[:Edge {predicate: 'typeOf', object_id: @eventType}]->()
+		WITH DISTINCT event
+		MATCH (event:Node)-[:Edge {predicate: 'affectedPlace', object_id: @placeID}]->()
+		MATCH (event:Node)-[:Edge {predicate: 'startDate'}]->(dateNode:Node)
 		RETURN DISTINCT 
 			SUBSTR(dateNode.value, 1, 7) AS month
 		ORDER BY 
 			month`,
 	getEventCollectionDcids: `		@{force_join_order=true}
-		GRAPH DCGraph MATCH (event:Node)-[:Edge {predicate: 'affectedPlace', object_id: @placeID}]->(), (event)-[:Edge {predicate: 'typeOf', object_id: @eventType}]->(), (event)-[:Edge {predicate: 'startDate'}]->(dateNode:Node)
+		GRAPH DCGraph
+		MATCH (event:Node)-[:Edge {predicate: 'typeOf', object_id: @eventType}]->()
+		WITH DISTINCT event
+		MATCH (event:Node)-[:Edge {predicate: 'affectedPlace', object_id: @placeID}]->()
+		MATCH (event:Node)-[:Edge {predicate: 'startDate'}]->(dateNode:Node)
 		WHERE 
 			SUBSTR(dateNode.value, 1, 7) = @date
 		RETURN DISTINCT 
 			event.subject_id AS dcid`,
 	getEventCollectionDcidsWithMagnitude: `		@{force_join_order=true}
-		GRAPH DCGraph MATCH (event:Node)-[:Edge {predicate: 'affectedPlace', object_id: @placeID}]->(), (event)-[:Edge {predicate: 'typeOf', object_id: @eventType}]->(), (event)-[:Edge {predicate: 'startDate'}]->(dateNode:Node)
+		GRAPH DCGraph
+		MATCH (event:Node)-[:Edge {predicate: 'typeOf', object_id: @eventType}]->()
+		WITH DISTINCT event
+		MATCH (event:Node)-[:Edge {predicate: 'affectedPlace', object_id: @placeID}]->()
+		MATCH (event:Node)-[:Edge {predicate: 'startDate'}]->(dateNode:Node)
 		WHERE 
 			SUBSTR(dateNode.value, 1, 7) = @date
-		MATCH (event)-[magEdge:Edge {predicate: @magnitudeProp}]->()
+		MATCH (event:Node)-[magEdge:Edge {predicate: @magnitudeProp}]->()
 		RETURN DISTINCT 
 			event.subject_id AS dcid,
 			magEdge.object_id AS magnitude`,


### PR DESCRIPTION
This change update the node edge match from multiple conditions in a single match

to a match on disaster event first that reduces the number of node to match in later stage and then do matches on other conditions

This reduces py client time from 20s to 2s 