### PR TITLE
Deprecate more endpoints in apigee

### DIFF
--- a/deploy/apigee/target_endpoints/api.template.xml
+++ b/deploy/apigee/target_endpoints/api.template.xml
@@ -42,6 +42,7 @@
         </Step>
         <Step>
           <Condition>
+            ((proxy.pathsuffix MatchesPath "/bulk/stats") OR (proxy.pathsuffix MatchesPath "/bulk/stats/**")) OR
             (proxy.pathsuffix MatchesPath "/internal/bio") OR
             (proxy.pathsuffix MatchesPath "/internal/import-table") OR
             (proxy.pathsuffix MatchesPath "/node/places-in") OR
@@ -59,9 +60,15 @@
             (proxy.pathsuffix MatchesPath "/stat/value") OR
             (proxy.pathsuffix MatchesPath "/translate") OR
             (proxy.pathsuffix MatchesPath "/update-cache") OR
+            ((proxy.pathsuffix MatchesPath "/v1/bulk/info/place") OR (proxy.pathsuffix MatchesPath "/v1/bulk/info/place/**")) OR
+            ((proxy.pathsuffix MatchesPath "/v1/bulk/observation-dates/linked") OR (proxy.pathsuffix MatchesPath "/v1/bulk/observation-dates/linked/**")) OR
             (proxy.pathsuffix MatchesPath "/v1/bulk/observation-existence") OR
+            ((proxy.pathsuffix MatchesPath "/v1/bulk/observations/point") OR (proxy.pathsuffix MatchesPath "/v1/bulk/observations/point/**")) OR
             (proxy.pathsuffix MatchesPath "/v1/bulk/observations/point/linked") OR
+            ((proxy.pathsuffix MatchesPath "/v1/bulk/observations/series") OR (proxy.pathsuffix MatchesPath "/v1/bulk/observations/series/**")) OR
             ((proxy.pathsuffix MatchesPath "/v1/bulk/properties") OR (proxy.pathsuffix MatchesPath "/v1/bulk/properties/**")) OR
+            ((proxy.pathsuffix MatchesPath "/v1/bulk/property/values") OR (proxy.pathsuffix MatchesPath "/v1/bulk/property/values/**")) OR
+            ((proxy.pathsuffix MatchesPath "/v1/bulk/property/values/linked") OR (proxy.pathsuffix MatchesPath "/v1/bulk/property/values/linked/**")) OR
             ((proxy.pathsuffix MatchesPath "/v1/bulk/triples") OR (proxy.pathsuffix MatchesPath "/v1/bulk/triples/**")) OR
             (proxy.pathsuffix MatchesPath "/v1/bulk/variables") OR
             (proxy.pathsuffix MatchesPath "/v1/events") OR
@@ -70,20 +77,24 @@
             ((proxy.pathsuffix MatchesPath "/v1/info/place") OR (proxy.pathsuffix MatchesPath "/v1/info/place/**")) OR
             ((proxy.pathsuffix MatchesPath "/v1/info/variable") OR (proxy.pathsuffix MatchesPath "/v1/info/variable/**")) OR
             ((proxy.pathsuffix MatchesPath "/v1/info/variable-group") OR (proxy.pathsuffix MatchesPath "/v1/info/variable-group/**")) OR
-            ((proxy.pathsuffix MatchesPath "/v1/internal/page/bio") OR (proxy.pathsuffix MatchesPath "/v1/internal/page/bio/**"))
+            ((proxy.pathsuffix MatchesPath "/v1/internal/page/bio") OR (proxy.pathsuffix MatchesPath "/v1/internal/page/bio/**")) OR
+            ((proxy.pathsuffix MatchesPath "/v1/internal/page/place") OR (proxy.pathsuffix MatchesPath "/v1/internal/page/place/**")) OR
             ((proxy.pathsuffix MatchesPath "/v1/observations/point") OR (proxy.pathsuffix MatchesPath "/v1/observations/point/**")) OR
             ((proxy.pathsuffix MatchesPath "/v1/observations/series") OR (proxy.pathsuffix MatchesPath "/v1/observations/series/**")) OR
             (proxy.pathsuffix MatchesPath "/v1/observations/series/derived") OR
+            ((proxy.pathsuffix MatchesPath "/v1/place/ranking") OR (proxy.pathsuffix MatchesPath "/v1/place/ranking/**")) OR
             (proxy.pathsuffix MatchesPath "/v1/place/stat-vars/union") OR
             (proxy.pathsuffix MatchesPath "/v1/properties") OR (proxy.pathsuffix MatchesPath "/v1/properties/**") OR
             (proxy.pathsuffix MatchesPath "/v1/property/values") OR (proxy.pathsuffix MatchesPath "/v1/property/values/**") OR
             (proxy.pathsuffix MatchesPath "/v1/query") OR
             (proxy.pathsuffix MatchesPath "/v1/recognize/entities") OR
+            ((proxy.pathsuffix MatchesPath "/v1/recon/entity/resolve") OR (proxy.pathsuffix MatchesPath "/v1/recon/entity/resolve/**")) OR
+            ((proxy.pathsuffix MatchesPath "/v1/recon/resolve/coordinate") OR (proxy.pathsuffix MatchesPath "/v1/recon/resolve/coordinate/**")) OR
             (proxy.pathsuffix MatchesPath "/v1/stat/date/within-place") OR
             ((proxy.pathsuffix MatchesPath "/v1/triples") OR (proxy.pathsuffix MatchesPath "/v1/triples/**")) OR
             ((proxy.pathsuffix MatchesPath "/v1/variables") OR (proxy.pathsuffix MatchesPath "/v1/variables/**")) OR
             (proxy.pathsuffix MatchesPath "/v2/sparql") OR
-            (proxy.pathsuffix MatchesPath "/v3/sparql") OR
+            (proxy.pathsuffix MatchesPath "/v3/sparql")
           </Condition>
           <Name>block-deprecated-endpoints</Name>
         </Step>
@@ -115,12 +126,6 @@
           <Condition>
             <!-- List of endpoints that do NOT require a key -->
             !(
-              (proxy.pathsuffix MatchesPath "/bulk/stats") OR
-              (proxy.pathsuffix MatchesPath "/search") OR
-              (proxy.pathsuffix MatchesPath "/v1/place/ranking") OR
-              (proxy.pathsuffix MatchesPath "/v1/place/related") OR
-              (proxy.pathsuffix MatchesPath "/v1/recon/entity/resolve") OR
-              (proxy.pathsuffix MatchesPath "/v1/recon/resolve/coordinate") OR
               (proxy.pathsuffix MatchesPath "/v1/recon/resolve/id") OR
               (proxy.pathsuffix MatchesPath "/v1/variable/search") OR
               <!-- /v2/resolve is public ONLY for legacy requests (no 'resolver' param). -->

--- a/deploy/apigee/target_endpoints/api.template.xml
+++ b/deploy/apigee/target_endpoints/api.template.xml
@@ -82,7 +82,7 @@
             ((proxy.pathsuffix MatchesPath "/v1/observations/point") OR (proxy.pathsuffix MatchesPath "/v1/observations/point/**")) OR
             ((proxy.pathsuffix MatchesPath "/v1/observations/series") OR (proxy.pathsuffix MatchesPath "/v1/observations/series/**")) OR
             (proxy.pathsuffix MatchesPath "/v1/observations/series/derived") OR
-            ((proxy.pathsuffix MatchesPath "/v1/place/ranking") OR (proxy.pathsuffix MatchesPath "/v1/place/ranking/**")) OR
+            ((proxy.pathsuffix MatchesPath "/v1/place/related") OR (proxy.pathsuffix MatchesPath "/v1/place/related/**")) OR
             (proxy.pathsuffix MatchesPath "/v1/place/stat-vars/union") OR
             (proxy.pathsuffix MatchesPath "/v1/properties") OR (proxy.pathsuffix MatchesPath "/v1/properties/**") OR
             (proxy.pathsuffix MatchesPath "/v1/property/values") OR (proxy.pathsuffix MatchesPath "/v1/property/values/**") OR


### PR DESCRIPTION
As part of the v0/v1 migration, this PR adds endpoints that have previously been deprecated to the apigee config so that users get a deprecation message when attempting to use those endpoints.

Furthermore, it fixes a bug where the trailing ORs were mismatched, that caused intermittent deployment issues.