### PR TITLE
Fix the issue of null name field for extracting node

### DIFF
--- a/internal/server/spanner/golden/query_builder/get_node_edges_by_object_id.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_by_object_id.sql
@@ -7,7 +7,7 @@
 			e.provenance,
 			n.value,
 			n.bytes,
-			IFNULL(n.name, "") AS name,
+			IFNULL(n.name, '') AS name,
 			n.types
 		ORDER BY
 			subject_id,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_by_object_id.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_by_object_id.sql
@@ -7,7 +7,7 @@
 			e.provenance,
 			n.value,
 			n.bytes,
-			n.name,
+			IFNULL(n.name, "") AS name,
 			n.types
 		ORDER BY
 			subject_id,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_by_subject_id.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_by_subject_id.sql
@@ -7,7 +7,7 @@
 			e.provenance,
 			n.value,
 			n.bytes,
-			IFNULL(n.name, "") AS name,
+			IFNULL(n.name, '') AS name,
 			n.types
 		ORDER BY
 			subject_id,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_by_subject_id.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_by_subject_id.sql
@@ -7,7 +7,7 @@
 			e.provenance,
 			n.value,
 			n.bytes,
-			n.name,
+			IFNULL(n.name, "") AS name,
 			n.types
 		ORDER BY
 			subject_id,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_first_page.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_first_page.sql
@@ -9,7 +9,7 @@
 			e.provenance,
 			n.value,
 			n.bytes,
-			n.name,
+			IFNULL(n.name, "") AS name,
 			n.types
 		ORDER BY
 			subject_id,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_first_page.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_first_page.sql
@@ -9,7 +9,7 @@
 			e.provenance,
 			n.value,
 			n.bytes,
-			IFNULL(n.name, "") AS name,
+			IFNULL(n.name, '') AS name,
 			n.types
 		ORDER BY
 			subject_id,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_first_page_chain.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_first_page_chain.sql
@@ -15,7 +15,7 @@
 			'' AS provenance,
 			n.value,
 			n.bytes,
-			n.name,
+			IFNULL(n.name, "") AS name,
 			n.types
 		ORDER BY
 			subject_id,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_first_page_chain.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_first_page_chain.sql
@@ -15,7 +15,7 @@
 			'' AS provenance,
 			n.value,
 			n.bytes,
-			IFNULL(n.name, "") AS name,
+			IFNULL(n.name, '') AS name,
 			n.types
 		ORDER BY
 			subject_id,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_in_bracket_props.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_in_bracket_props.sql
@@ -9,7 +9,7 @@
 			e.provenance,
 			n.value,
 			n.bytes,
-			n.name,
+			IFNULL(n.name, "") AS name,
 			n.types
 		ORDER BY
 			subject_id,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_in_bracket_props.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_in_bracket_props.sql
@@ -9,7 +9,7 @@
 			e.provenance,
 			n.value,
 			n.bytes,
-			IFNULL(n.name, "") AS name,
+			IFNULL(n.name, '') AS name,
 			n.types
 		ORDER BY
 			subject_id,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_in_chain.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_in_chain.sql
@@ -15,7 +15,7 @@
 			'' AS provenance,
 			n.value,
 			n.bytes,
-			n.name,
+			IFNULL(n.name, "") AS name,
 			n.types
 		ORDER BY
 			subject_id,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_in_chain.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_in_chain.sql
@@ -15,7 +15,7 @@
 			'' AS provenance,
 			n.value,
 			n.bytes,
-			IFNULL(n.name, "") AS name,
+			IFNULL(n.name, '') AS name,
 			n.types
 		ORDER BY
 			subject_id,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_in_filter.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_in_filter.sql
@@ -23,7 +23,7 @@
 			provenance,
 			ANY_VALUE(n.value) AS value,
 			ANY_VALUE(n.bytes) AS bytes,
-			ANY_VALUE(n.name) AS name,
+			ANY_VALUE(IFNULL(n.name, "")) AS name,
 			ANY_VALUE(n.types) AS types
 		GROUP BY
 			subject_id,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_in_filter.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_in_filter.sql
@@ -23,7 +23,7 @@
 			provenance,
 			ANY_VALUE(n.value) AS value,
 			ANY_VALUE(n.bytes) AS bytes,
-			ANY_VALUE(IFNULL(n.name, "")) AS name,
+			ANY_VALUE(IFNULL(n.name, '')) AS name,
 			ANY_VALUE(n.types) AS types
 		GROUP BY
 			subject_id,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_in_single_prop.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_in_single_prop.sql
@@ -9,7 +9,7 @@
 			e.provenance,
 			n.value,
 			n.bytes,
-			n.name,
+			IFNULL(n.name, "") AS name,
 			n.types
 		ORDER BY
 			subject_id,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_in_single_prop.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_in_single_prop.sql
@@ -9,7 +9,7 @@
 			e.provenance,
 			n.value,
 			n.bytes,
-			IFNULL(n.name, "") AS name,
+			IFNULL(n.name, '') AS name,
 			n.types
 		ORDER BY
 			subject_id,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_linked_contained_in_place.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_linked_contained_in_place.sql
@@ -21,7 +21,7 @@
 			provenance,
 			ANY_VALUE(n.value) AS value,
 			ANY_VALUE(n.bytes) AS bytes,
-			ANY_VALUE(IFNULL(n.name, "")) AS name,
+			ANY_VALUE(IFNULL(n.name, '')) AS name,
 			ANY_VALUE(n.types) AS types
 		GROUP BY
 			subject_id,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_linked_contained_in_place.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_linked_contained_in_place.sql
@@ -21,7 +21,7 @@
 			provenance,
 			ANY_VALUE(n.value) AS value,
 			ANY_VALUE(n.bytes) AS bytes,
-			ANY_VALUE(n.name) AS name,
+			ANY_VALUE(IFNULL(n.name, "")) AS name,
 			ANY_VALUE(n.types) AS types
 		GROUP BY
 			subject_id,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_malicious.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_malicious.sql
@@ -21,7 +21,7 @@
 			provenance,
 			ANY_VALUE(n.value) AS value,
 			ANY_VALUE(n.bytes) AS bytes,
-			ANY_VALUE(IFNULL(n.name, "")) AS name,
+			ANY_VALUE(IFNULL(n.name, '')) AS name,
 			ANY_VALUE(n.types) AS types
 		GROUP BY
 			subject_id,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_malicious.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_malicious.sql
@@ -21,7 +21,7 @@
 			provenance,
 			ANY_VALUE(n.value) AS value,
 			ANY_VALUE(n.bytes) AS bytes,
-			ANY_VALUE(n.name) AS name,
+			ANY_VALUE(IFNULL(n.name, "")) AS name,
 			ANY_VALUE(n.types) AS types
 		GROUP BY
 			subject_id,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_out_bracket_props.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_out_bracket_props.sql
@@ -9,7 +9,7 @@
 			e.provenance,
 			n.value,
 			n.bytes,
-			n.name,
+			IFNULL(n.name, "") AS name,
 			n.types
 		ORDER BY
 			subject_id,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_out_bracket_props.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_out_bracket_props.sql
@@ -9,7 +9,7 @@
 			e.provenance,
 			n.value,
 			n.bytes,
-			IFNULL(n.name, "") AS name,
+			IFNULL(n.name, '') AS name,
 			n.types
 		ORDER BY
 			subject_id,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_out_chain.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_out_chain.sql
@@ -15,7 +15,7 @@
 			'' AS provenance,
 			n.value,
 			n.bytes,
-			n.name,
+			IFNULL(n.name, "") AS name,
 			n.types
 		ORDER BY
 			subject_id,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_out_chain.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_out_chain.sql
@@ -15,7 +15,7 @@
 			'' AS provenance,
 			n.value,
 			n.bytes,
-			IFNULL(n.name, "") AS name,
+			IFNULL(n.name, '') AS name,
 			n.types
 		ORDER BY
 			subject_id,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_out_filter.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_out_filter.sql
@@ -23,7 +23,7 @@
 			provenance,
 			ANY_VALUE(n.value) AS value,
 			ANY_VALUE(n.bytes) AS bytes,
-			ANY_VALUE(n.name) AS name,
+			ANY_VALUE(IFNULL(n.name, "")) AS name,
 			ANY_VALUE(n.types) AS types
 		GROUP BY
 			subject_id,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_out_filter.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_out_filter.sql
@@ -23,7 +23,7 @@
 			provenance,
 			ANY_VALUE(n.value) AS value,
 			ANY_VALUE(n.bytes) AS bytes,
-			ANY_VALUE(IFNULL(n.name, "")) AS name,
+			ANY_VALUE(IFNULL(n.name, '')) AS name,
 			ANY_VALUE(n.types) AS types
 		GROUP BY
 			subject_id,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_out_single_prop.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_out_single_prop.sql
@@ -9,7 +9,7 @@
 			e.provenance,
 			n.value,
 			n.bytes,
-			n.name,
+			IFNULL(n.name, "") AS name,
 			n.types
 		ORDER BY
 			subject_id,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_out_single_prop.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_out_single_prop.sql
@@ -9,7 +9,7 @@
 			e.provenance,
 			n.value,
 			n.bytes,
-			IFNULL(n.name, "") AS name,
+			IFNULL(n.name, '') AS name,
 			n.types
 		ORDER BY
 			subject_id,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_second_page.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_second_page.sql
@@ -9,7 +9,7 @@
 			e.provenance,
 			n.value,
 			n.bytes,
-			n.name,
+			IFNULL(n.name, "") AS name,
 			n.types
 		ORDER BY
 			subject_id,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_second_page.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_second_page.sql
@@ -9,7 +9,7 @@
 			e.provenance,
 			n.value,
 			n.bytes,
-			IFNULL(n.name, "") AS name,
+			IFNULL(n.name, '') AS name,
 			n.types
 		ORDER BY
 			subject_id,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_second_page_chain.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_second_page_chain.sql
@@ -15,7 +15,7 @@
 			'' AS provenance,
 			n.value,
 			n.bytes,
-			n.name,
+			IFNULL(n.name, "") AS name,
 			n.types
 		ORDER BY
 			subject_id,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_second_page_chain.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_second_page_chain.sql
@@ -15,7 +15,7 @@
 			'' AS provenance,
 			n.value,
 			n.bytes,
-			IFNULL(n.name, "") AS name,
+			IFNULL(n.name, '') AS name,
 			n.types
 		ORDER BY
 			subject_id,

--- a/internal/server/spanner/statements.go
+++ b/internal/server/spanner/statements.go
@@ -233,7 +233,7 @@ var statements = struct {
 			provenance,
 			ANY_VALUE(n.value) AS value,
 			ANY_VALUE(n.bytes) AS bytes,
-			ANY_VALUE(IFNULL(n.name, "")) AS name,
+			ANY_VALUE(IFNULL(n.name, '')) AS name,
 			ANY_VALUE(n.types) AS types
 		GROUP BY
 			subject_id,

--- a/internal/server/spanner/statements.go
+++ b/internal/server/spanner/statements.go
@@ -193,7 +193,7 @@ var statements = struct {
 			e.provenance,
 			n.value,
 			n.bytes,
-			IFNULL(n.name, "") AS name,
+			IFNULL(n.name, '') AS name,
 			n.types
 		ORDER BY
 			subject_id,

--- a/internal/server/spanner/statements.go
+++ b/internal/server/spanner/statements.go
@@ -193,7 +193,7 @@ var statements = struct {
 			e.provenance,
 			n.value,
 			n.bytes,
-			n.name,
+			IFNULL(n.name, "") AS name,
 			n.types
 		ORDER BY
 			subject_id,
@@ -213,7 +213,7 @@ var statements = struct {
 			'' AS provenance,
 			n.value,
 			n.bytes,
-			n.name,
+			IFNULL(n.name, "") AS name,
 			n.types
 		ORDER BY
 			subject_id,
@@ -233,7 +233,7 @@ var statements = struct {
 			provenance,
 			ANY_VALUE(n.value) AS value,
 			ANY_VALUE(n.bytes) AS bytes,
-			ANY_VALUE(n.name) AS name,
+			ANY_VALUE(IFNULL(n.name, "")) AS name,
 			ANY_VALUE(n.types) AS types
 		GROUP BY
 			subject_id,

--- a/internal/server/spanner/statements.go
+++ b/internal/server/spanner/statements.go
@@ -213,7 +213,7 @@ var statements = struct {
 			'' AS provenance,
 			n.value,
 			n.bytes,
-			IFNULL(n.name, "") AS name,
+			IFNULL(n.name, '') AS name,
 			n.types
 		ORDER BY
 			subject_id,


### PR DESCRIPTION
This code fixes the disaster dashboard as the node extracted contains data without name field and causing parsing NULL to string