### PR TITLE
Add a new statement to filter the nodes/DCIDs by node types

### DIFF
--- a/internal/server/spanner/client.go
+++ b/internal/server/spanner/client.go
@@ -51,6 +51,7 @@ type SpannerClient interface {
 	GetFilteredTopic(ctx context.Context, nodes []string, constrainedPlaces []string, constrainedImport string, numEntitiesExistence int) (map[string]int, error)
 	VectorSearchQuery(ctx context.Context, tableName string, limit int, embeddings []float64, numLeaves int, threshold float64, nodeTypes []string) ([]*VectorSearchResult, error)
 	GetTermEmbeddingQuery(ctx context.Context, modelName, searchLabel, taskType string) ([]float64, error)
+	FilterNodesByType(ctx context.Context, nodes []string, typeFilter string) ([]string, error)
 	GetSdmxObservations(ctx context.Context, req *pb.SdmxDataQuery) (*pb.SdmxDataResult, error)
 	Id() string
 	Start()

--- a/internal/server/spanner/client.go
+++ b/internal/server/spanner/client.go
@@ -51,7 +51,7 @@ type SpannerClient interface {
 	GetFilteredTopic(ctx context.Context, nodes []string, constrainedPlaces []string, constrainedImport string, numEntitiesExistence int) (map[string]int, error)
 	VectorSearchQuery(ctx context.Context, tableName string, limit int, embeddings []float64, numLeaves int, threshold float64, nodeTypes []string) ([]*VectorSearchResult, error)
 	GetTermEmbeddingQuery(ctx context.Context, modelName, searchLabel, taskType string) ([]float64, error)
-	FilterNodesByType(ctx context.Context, nodes []string, typeFilter string) ([]string, error)
+	FilterNodesByTypes(ctx context.Context, nodes []string, typeFilters []string) (map[string][]string, error)
 	GetSdmxObservations(ctx context.Context, req *pb.SdmxDataQuery) (*pb.SdmxDataResult, error)
 	Id() string
 	Start()

--- a/internal/server/spanner/coordinate_resolve_test.go
+++ b/internal/server/spanner/coordinate_resolve_test.go
@@ -114,6 +114,10 @@ func (m *coordinateMockSpannerClient) GetTermEmbeddingQuery(ctx context.Context,
 	return m.embeddingsRes, nil
 }
 
+func (m *coordinateMockSpannerClient) FilterNodesByType(ctx context.Context, nodes []string, typeFilter string) ([]string, error) {
+	return nil, nil
+}
+
 func (m *coordinateMockSpannerClient) Id() string { return "mock" }
 func (m *coordinateMockSpannerClient) Start()     {}
 func (m *coordinateMockSpannerClient) Close()     {}

--- a/internal/server/spanner/coordinate_resolve_test.go
+++ b/internal/server/spanner/coordinate_resolve_test.go
@@ -114,7 +114,7 @@ func (m *coordinateMockSpannerClient) GetTermEmbeddingQuery(ctx context.Context,
 	return m.embeddingsRes, nil
 }
 
-func (m *coordinateMockSpannerClient) FilterNodesByType(ctx context.Context, nodes []string, typeFilter string) ([]string, error) {
+func (m *coordinateMockSpannerClient) FilterNodesByTypes(ctx context.Context, nodes []string, typeFilters []string) (map[string][]string, error) {
 	return nil, nil
 }
 

--- a/internal/server/spanner/datasource.go
+++ b/internal/server/spanner/datasource.go
@@ -711,33 +711,26 @@ func (sds *SpannerDataSource) BulkVariableGroupInfo(ctx context.Context, req *pb
 	if req.NumEntitiesExistence < 0 {
 		return nil, status.Errorf(codes.InvalidArgument, "numEntitiesExistence must be non-negative")
 	}
-	var dbSvgs, topics []string
-	g, errCtx := errgroup.WithContext(ctx)
-	g.SetLimit(2)
-	g.Go(func() error {
-		var err error
-		dbSvgs, err = sds.client.FilterNodesByType(errCtx, req.GetNodes(), "StatVarGroup")
-		return err
-	})
-	g.Go(func() error {
-		var err error
-		topics, err = sds.client.FilterNodesByType(errCtx, req.GetNodes(), "Topic")
-		return err
-	})
-	if err := g.Wait(); err != nil {
+	nodeToTypes, err := sds.client.FilterNodesByTypes(ctx, req.GetNodes(), []string{"StatVarGroup", "Topic"})
+	if err != nil {
 		return nil, status.Errorf(codes.Internal, "error filtering nodes: %v", err)
 	}
 
 	foundNodes := map[string]bool{}
 	var svgs []string
-	for _, node := range dbSvgs {
+	var topics []string
+
+	for node, matchedTypes := range nodeToTypes {
 		foundNodes[node] = true
-		if _, ok := svgGroupInfoExclusionList[node]; !ok {
-			svgs = append(svgs, node)
+		for _, t := range matchedTypes {
+			if t == "StatVarGroup" {
+				if _, ok := svgGroupInfoExclusionList[node]; !ok {
+					svgs = append(svgs, node)
+				}
+			} else if t == "Topic" {
+				topics = append(topics, node)
+			}
 		}
-	}
-	for _, node := range topics {
-		foundNodes[node] = true
 	}
 
 	invalidNodeMap := map[string]bool{}

--- a/internal/server/spanner/datasource.go
+++ b/internal/server/spanner/datasource.go
@@ -717,23 +717,25 @@ func (sds *SpannerDataSource) BulkVariableGroupInfo(ctx context.Context, req *pb
 	}
 
 	foundNodes := map[string]bool{}
+	invalidNodeMap := map[string]bool{}
 	var svgs []string
 	var topics []string
 
 	for node, matchedTypes := range nodeToTypes {
 		foundNodes[node] = true
 		for _, t := range matchedTypes {
-			if t == "StatVarGroup" {
-				if _, ok := svgGroupInfoExclusionList[node]; !ok {
+			switch t {
+			case "StatVarGroup":
+				if _, ok := svgGroupInfoExclusionList[node]; ok {
+					invalidNodeMap[node] = true
+				} else {
 					svgs = append(svgs, node)
 				}
-			} else if t == "Topic" {
+			case "Topic":
 				topics = append(topics, node)
 			}
 		}
 	}
-
-	invalidNodeMap := map[string]bool{}
 	for _, node := range req.GetNodes() {
 		if !foundNodes[node] {
 			invalidNodeMap[node] = true
@@ -802,15 +804,6 @@ func filterVariableGroupInfo(data []*pbv1.VariableGroupInfoResponse, invalidNode
 	filteredData := make([]*pbv1.VariableGroupInfoResponse, 0, len(data)+len(invalidNodes))
 
 	for _, item := range data {
-		// Respect API contract: keep the node identifier but clear the info object.
-		if _, ok := svgGroupInfoExclusionList[item.GetNode()]; ok {
-			filteredData = append(filteredData, &pbv1.VariableGroupInfoResponse{
-				Node: item.GetNode(),
-				Info: &pb.StatVarGroupNode{},
-			})
-			continue
-		}
-
 		itemToAppend := item
 		needsModification := false
 

--- a/internal/server/spanner/datasource.go
+++ b/internal/server/spanner/datasource.go
@@ -711,17 +711,29 @@ func (sds *SpannerDataSource) BulkVariableGroupInfo(ctx context.Context, req *pb
 	if req.NumEntitiesExistence < 0 {
 		return nil, status.Errorf(codes.InvalidArgument, "numEntitiesExistence must be non-negative")
 	}
+	dbSvgs, err := sds.client.FilterNodesByType(ctx, req.GetNodes(), "StatVarGroup")
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "error filtering svgs: %v", err)
+	}
+	topics, err := sds.client.FilterNodesByType(ctx, req.GetNodes(), "Topic")
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "error filtering topics: %v", err)
+	}
+
+	foundNodes := map[string]bool{}
 	var svgs []string
-	var topics []string
+	for _, node := range dbSvgs {
+		foundNodes[node] = true
+		if _, ok := svgGroupInfoExclusionList[node]; !ok {
+			svgs = append(svgs, node)
+		}
+	}
+	for _, node := range topics {
+		foundNodes[node] = true
+	}
+
 	for _, node := range req.GetNodes() {
-		if strings.HasPrefix(node, prefixTopic) {
-			topics = append(topics, node)
-		} else if strings.HasPrefix(node, prefixSVG) {
-			// Exclude hidden nodes from the database query
-			if _, ok := svgGroupInfoExclusionList[node]; !ok {
-				svgs = append(svgs, node)
-			}
-		} else {
+		if !foundNodes[node] {
 			return nil, status.Errorf(codes.InvalidArgument, "node %s is not a valid StatVarGroup or Topic node", node)
 		}
 	}

--- a/internal/server/spanner/datasource.go
+++ b/internal/server/spanner/datasource.go
@@ -711,13 +711,21 @@ func (sds *SpannerDataSource) BulkVariableGroupInfo(ctx context.Context, req *pb
 	if req.NumEntitiesExistence < 0 {
 		return nil, status.Errorf(codes.InvalidArgument, "numEntitiesExistence must be non-negative")
 	}
-	dbSvgs, err := sds.client.FilterNodesByType(ctx, req.GetNodes(), "StatVarGroup")
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "error filtering svgs: %v", err)
-	}
-	topics, err := sds.client.FilterNodesByType(ctx, req.GetNodes(), "Topic")
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "error filtering topics: %v", err)
+	var dbSvgs, topics []string
+	g, errCtx := errgroup.WithContext(ctx)
+	g.SetLimit(2)
+	g.Go(func() error {
+		var err error
+		dbSvgs, err = sds.client.FilterNodesByType(errCtx, req.GetNodes(), "StatVarGroup")
+		return err
+	})
+	g.Go(func() error {
+		var err error
+		topics, err = sds.client.FilterNodesByType(errCtx, req.GetNodes(), "Topic")
+		return err
+	})
+	if err := g.Wait(); err != nil {
+		return nil, status.Errorf(codes.Internal, "error filtering nodes: %v", err)
 	}
 
 	foundNodes := map[string]bool{}
@@ -732,10 +740,15 @@ func (sds *SpannerDataSource) BulkVariableGroupInfo(ctx context.Context, req *pb
 		foundNodes[node] = true
 	}
 
+	invalidNodeMap := map[string]bool{}
 	for _, node := range req.GetNodes() {
 		if !foundNodes[node] {
-			return nil, status.Errorf(codes.InvalidArgument, "node %s is not a valid StatVarGroup or Topic node", node)
+			invalidNodeMap[node] = true
 		}
+	}
+	var invalidNodes []string
+	for node := range invalidNodeMap {
+		invalidNodes = append(invalidNodes, node)
 	}
 	if len(svgs) > 0 && len(topics) > 0 {
 		return nil, status.Errorf(codes.InvalidArgument, "cannot mix Topic and StatVarGroup nodes in request")
@@ -747,8 +760,8 @@ func (sds *SpannerDataSource) BulkVariableGroupInfo(ctx context.Context, req *pb
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "error getting StatVarGroupNode from Spanner: %v", err)
 		}
-		resp := svgInfoToBulkVariableGroupInfoResponse(svgInfo, req.GetNodes())
-		resp.Data = filterVariableGroupInfo(resp.GetData())
+		resp := svgInfoToBulkVariableGroupInfoResponse(svgInfo, svgs)
+		resp.Data = filterVariableGroupInfo(resp.GetData(), invalidNodes)
 		return resp, nil
 	}
 
@@ -772,7 +785,7 @@ func (sds *SpannerDataSource) BulkVariableGroupInfo(ctx context.Context, req *pb
 			return nil, status.Errorf(codes.Internal, "error getting filtered topic count from Spanner: %v", err)
 		}
 		resp := filteredTopicInfoToBulkVariableGroupInfoResponse(counts, topics)
-		resp.Data = filterVariableGroupInfo(resp.GetData())
+		resp.Data = filterVariableGroupInfo(resp.GetData(), invalidNodes)
 		return resp, nil
 	}
 
@@ -782,7 +795,7 @@ func (sds *SpannerDataSource) BulkVariableGroupInfo(ctx context.Context, req *pb
 		return nil, status.Errorf(codes.Internal, "error getting filtered StatVarGroupNode from Spanner: %v", err)
 	}
 	resp := filteredSVGInfoToBulkVariableGroupInfoResponse(filteredSVGInfo)
-	resp.Data = filterVariableGroupInfo(resp.GetData())
+	resp.Data = filterVariableGroupInfo(resp.GetData(), invalidNodes)
 	return resp, nil
 }
 
@@ -791,9 +804,9 @@ func (sds *SpannerDataSource) SdmxData(ctx context.Context, req *pb.SdmxDataQuer
 	return sds.client.GetSdmxObservations(ctx, req)
 }
 
-// filterVariableGroupInfo filters out excluded SVGs from the response data.
-func filterVariableGroupInfo(data []*pbv1.VariableGroupInfoResponse) []*pbv1.VariableGroupInfoResponse {
-	filteredData := make([]*pbv1.VariableGroupInfoResponse, 0, len(data))
+// filterVariableGroupInfo filters out excluded SVGs from the response data and appends invalid nodes.
+func filterVariableGroupInfo(data []*pbv1.VariableGroupInfoResponse, invalidNodes []string) []*pbv1.VariableGroupInfoResponse {
+	filteredData := make([]*pbv1.VariableGroupInfoResponse, 0, len(data)+len(invalidNodes))
 
 	for _, item := range data {
 		// Respect API contract: keep the node identifier but clear the info object.
@@ -837,5 +850,13 @@ func filterVariableGroupInfo(data []*pbv1.VariableGroupInfoResponse) []*pbv1.Var
 
 		filteredData = append(filteredData, itemToAppend)
 	}
+
+	for _, node := range invalidNodes {
+		filteredData = append(filteredData, &pbv1.VariableGroupInfoResponse{
+			Node: node,
+			Info: &pb.StatVarGroupNode{},
+		})
+	}
+
 	return filteredData
 }

--- a/internal/server/spanner/golden/datasource_test.go
+++ b/internal/server/spanner/golden/datasource_test.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"path"
 	"runtime"
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/datacommonsorg/mixer/internal/maps"
@@ -38,6 +40,7 @@ type mockSpannerClient struct {
 	resolveByIDRes            map[string][]string
 	getNodeEdgesRes           map[string][]*spanner.Edge
 	checkVariableExistenceRes [][]string
+	filterNodesByTypeRes      map[string][]string
 }
 
 func (m *mockSpannerClient) GetNodeProps(ctx context.Context, ids []string, out bool) (map[string][]*spanner.Property, error) {
@@ -76,7 +79,14 @@ func (m *mockSpannerClient) GetTermEmbeddingQuery(ctx context.Context, modelName
 	return nil, nil
 }
 func (m *mockSpannerClient) FilterNodesByType(ctx context.Context, nodes []string, typeFilter string) ([]string, error) {
-	return nil, nil
+	res := []string{}
+	allowedNodes := m.filterNodesByTypeRes[typeFilter]
+	for _, node := range nodes {
+		if slices.Contains(allowedNodes, node) {
+			res = append(res, node)
+		}
+	}
+	return res, nil
 }
 func (m *mockSpannerClient) VectorSearchQuery(ctx context.Context, tableName string, limit int, embeddings []float64, numLeaves int, threshold float64, nodeTypes []string) ([]*spanner.VectorSearchResult, error) {
 	return nil, nil
@@ -494,5 +504,58 @@ func TestSpannerObservation(t *testing.T) {
 		if diff := cmp.Diff(got, &want, cmpOpts); diff != "" {
 			t.Errorf("%s: %v payload mismatch:\n%v", c.desc, c.goldenFile, diff)
 		}
+	}
+}
+
+func TestBulkVariableGroupInfo_Filtering(t *testing.T) {
+	ctx := context.Background()
+
+	// Setup mock to return specific nodes for specific types
+	client := &mockSpannerClient{
+		filterNodesByTypeRes: map[string][]string{
+			"StatVarGroup": {"dc/g/Demographics", "WHO/Root"},
+			"Topic":        {"dc/topic/Demographics"},
+		},
+	}
+	ds := spanner.NewSpannerDataSource(client, nil, nil, false)
+
+	// Test Case 1: Valid SVGs including WHO/Root
+	req1 := &pbv1.BulkVariableGroupInfoRequest{
+		Nodes: []string{"dc/g/Demographics", "WHO/Root"},
+	}
+	_, err := ds.BulkVariableGroupInfo(ctx, req1)
+	// We expect no error here regarding node validation
+	if err != nil && strings.Contains(err.Error(), "is not a valid StatVarGroup") {
+		t.Errorf("Expected WHO/Root to be valid, got error: %v", err)
+	}
+
+	// Test Case 2: Invalid node (neither SVG nor Topic) should return empty result without duplication
+	req2 := &pbv1.BulkVariableGroupInfoRequest{
+		Nodes: []string{"InvalidNode", "InvalidNode"},
+	}
+	resp, err := ds.BulkVariableGroupInfo(ctx, req2)
+	if err != nil {
+		t.Errorf("Expected no error for InvalidNode, got: %v", err)
+	}
+	count := 0
+	for _, data := range resp.GetData() {
+		if data.Node == "InvalidNode" {
+			count++
+			if data.Info != nil && (data.Info.AbsoluteName != "" || len(data.Info.ChildStatVars) > 0) {
+				t.Errorf("Expected empty result for InvalidNode, got: %v", data.Info)
+			}
+		}
+	}
+	if count != 1 {
+		t.Errorf("Expected exactly one InvalidNode in response, got: %d", count)
+	}
+
+	// Test Case 3: Mixed nodes (Topics and SVGs)
+	req3 := &pbv1.BulkVariableGroupInfoRequest{
+		Nodes: []string{"dc/g/Demographics", "dc/topic/Demographics"},
+	}
+	_, err = ds.BulkVariableGroupInfo(ctx, req3)
+	if err == nil || !strings.Contains(err.Error(), "cannot mix Topic and StatVarGroup nodes") {
+		t.Errorf("Expected error for mixed nodes, got: %v", err)
 	}
 }

--- a/internal/server/spanner/golden/datasource_test.go
+++ b/internal/server/spanner/golden/datasource_test.go
@@ -78,12 +78,14 @@ func (m *mockSpannerClient) GetProvenanceSummary(ctx context.Context, ids []stri
 func (m *mockSpannerClient) GetTermEmbeddingQuery(ctx context.Context, modelName, searchLabel, taskType string) ([]float64, error) {
 	return nil, nil
 }
-func (m *mockSpannerClient) FilterNodesByType(ctx context.Context, nodes []string, typeFilter string) ([]string, error) {
-	res := []string{}
-	allowedNodes := m.filterNodesByTypeRes[typeFilter]
-	for _, node := range nodes {
-		if slices.Contains(allowedNodes, node) {
-			res = append(res, node)
+func (m *mockSpannerClient) FilterNodesByTypes(ctx context.Context, nodes []string, typeFilters []string) (map[string][]string, error) {
+	res := map[string][]string{}
+	for _, typeFilter := range typeFilters {
+		allowedNodes := m.filterNodesByTypeRes[typeFilter]
+		for _, node := range nodes {
+			if slices.Contains(allowedNodes, node) {
+				res[node] = append(res[node], typeFilter)
+			}
 		}
 	}
 	return res, nil

--- a/internal/server/spanner/golden/datasource_test.go
+++ b/internal/server/spanner/golden/datasource_test.go
@@ -75,6 +75,9 @@ func (m *mockSpannerClient) GetProvenanceSummary(ctx context.Context, ids []stri
 func (m *mockSpannerClient) GetTermEmbeddingQuery(ctx context.Context, modelName, searchLabel, taskType string) ([]float64, error) {
 	return nil, nil
 }
+func (m *mockSpannerClient) FilterNodesByType(ctx context.Context, nodes []string, typeFilter string) ([]string, error) {
+	return nil, nil
+}
 func (m *mockSpannerClient) VectorSearchQuery(ctx context.Context, tableName string, limit int, embeddings []float64, numLeaves int, threshold float64, nodeTypes []string) ([]*spanner.VectorSearchResult, error) {
 	return nil, nil
 }

--- a/internal/server/spanner/golden/datasource_test.go
+++ b/internal/server/spanner/golden/datasource_test.go
@@ -560,4 +560,28 @@ func TestBulkVariableGroupInfo_Filtering(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "cannot mix Topic and StatVarGroup nodes") {
 		t.Errorf("Expected error for mixed nodes, got: %v", err)
 	}
+
+	// Test Case 4: Excluded node should return empty result
+	req4 := &pbv1.BulkVariableGroupInfoRequest{
+		Nodes: []string{"dc/g/Hidden"},
+	}
+	// Update mock to return it as a StatVarGroup
+	client.filterNodesByTypeRes["StatVarGroup"] = append(client.filterNodesByTypeRes["StatVarGroup"], "dc/g/Hidden")
+
+	resp4, err := ds.BulkVariableGroupInfo(ctx, req4)
+	if err != nil {
+		t.Errorf("Expected no error for ExcludedNode, got: %v", err)
+	}
+	found := false
+	for _, data := range resp4.GetData() {
+		if data.Node == "dc/g/Hidden" {
+			found = true
+			if data.Info != nil && (data.Info.AbsoluteName != "" || len(data.Info.ChildStatVars) > 0) {
+				t.Errorf("Expected empty result for ExcludedNode, got: %v", data.Info)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("Expected ExcludedNode in response, but it was missing")
+	}
 }

--- a/internal/server/spanner/golden/query_builder/filter_nodes_by_type_svg.sql
+++ b/internal/server/spanner/golden/query_builder/filter_nodes_by_type_svg.sql
@@ -1,4 +1,4 @@
-		SELECT subject_id
+		SELECT subject_id, ARRAY(SELECT t FROM UNNEST(types) t WHERE t IN ('StatVarGroup')) AS matched_types
 		FROM Node
-		WHERE 'StatVarGroup' IN UNNEST(types)
-			AND subject_id IN ('dc/g/Demographics','dc/topic/Demographics','WHO/Root')
+		WHERE subject_id IN ('dc/g/Demographics','dc/topic/Demographics','WHO/Root')
+			AND EXISTS (SELECT 1 FROM UNNEST(types) t WHERE t IN ('StatVarGroup'))

--- a/internal/server/spanner/golden/query_builder/filter_nodes_by_type_svg.sql
+++ b/internal/server/spanner/golden/query_builder/filter_nodes_by_type_svg.sql
@@ -1,5 +1,4 @@
-		SELECT DISTINCT subject_id
+		SELECT subject_id
 		FROM Node
-		WHERE ARRAY_LENGTH(types) > 0
-			AND 'StatVarGroup' IN UNNEST(types)
+		WHERE 'StatVarGroup' IN UNNEST(types)
 			AND subject_id IN ('dc/g/Demographics','dc/topic/Demographics','WHO/Root')

--- a/internal/server/spanner/golden/query_builder/filter_nodes_by_type_svg.sql
+++ b/internal/server/spanner/golden/query_builder/filter_nodes_by_type_svg.sql
@@ -1,0 +1,5 @@
+		SELECT DISTINCT subject_id
+		FROM Node
+		WHERE ARRAY_LENGTH(types) > 0
+			AND 'StatVarGroup' IN UNNEST(types)
+			AND subject_id IN ('dc/g/Demographics','dc/topic/Demographics','WHO/Root')

--- a/internal/server/spanner/golden/query_builder/filter_nodes_by_type_topic.sql
+++ b/internal/server/spanner/golden/query_builder/filter_nodes_by_type_topic.sql
@@ -1,5 +1,4 @@
-		SELECT DISTINCT subject_id
+		SELECT subject_id
 		FROM Node
-		WHERE ARRAY_LENGTH(types) > 0
-			AND 'Topic' IN UNNEST(types)
+		WHERE 'Topic' IN UNNEST(types)
 			AND subject_id IN ('dc/g/Demographics','dc/topic/Demographics','WHO/Root')

--- a/internal/server/spanner/golden/query_builder/filter_nodes_by_type_topic.sql
+++ b/internal/server/spanner/golden/query_builder/filter_nodes_by_type_topic.sql
@@ -1,4 +1,4 @@
-		SELECT subject_id
+		SELECT subject_id, ARRAY(SELECT t FROM UNNEST(types) t WHERE t IN ('Topic')) AS matched_types
 		FROM Node
-		WHERE 'Topic' IN UNNEST(types)
-			AND subject_id IN ('dc/g/Demographics','dc/topic/Demographics','WHO/Root')
+		WHERE subject_id IN ('dc/g/Demographics','dc/topic/Demographics','WHO/Root')
+			AND EXISTS (SELECT 1 FROM UNNEST(types) t WHERE t IN ('Topic'))

--- a/internal/server/spanner/golden/query_builder/filter_nodes_by_type_topic.sql
+++ b/internal/server/spanner/golden/query_builder/filter_nodes_by_type_topic.sql
@@ -1,0 +1,5 @@
+		SELECT DISTINCT subject_id
+		FROM Node
+		WHERE ARRAY_LENGTH(types) > 0
+			AND 'Topic' IN UNNEST(types)
+			AND subject_id IN ('dc/g/Demographics','dc/topic/Demographics','WHO/Root')

--- a/internal/server/spanner/golden/query_builder/filter_nodes_by_types_combined.sql
+++ b/internal/server/spanner/golden/query_builder/filter_nodes_by_types_combined.sql
@@ -1,0 +1,4 @@
+		SELECT subject_id, ARRAY(SELECT t FROM UNNEST(types) t WHERE t IN ('StatVarGroup','Topic')) AS matched_types
+		FROM Node
+		WHERE subject_id IN ('dc/g/Demographics','dc/topic/Demographics','WHO/Root')
+			AND EXISTS (SELECT 1 FROM UNNEST(types) t WHERE t IN ('StatVarGroup','Topic'))

--- a/internal/server/spanner/golden/query_builder_test.go
+++ b/internal/server/spanner/golden/query_builder_test.go
@@ -252,14 +252,14 @@ func TestVectorSearchQuery(t *testing.T) {
 	}
 }
 
-func TestFilterNodesByTypeQuery(t *testing.T) {
+func TestFilterNodesByTypesQuery(t *testing.T) {
 	t.Parallel()
 
 	for _, c := range filterNodesByTypeTestCases {
 		goldenFile := c.golden + ".sql"
 
 		runQueryBuilderGoldenTest(t, goldenFile, func(ctx context.Context) (interface{}, error) {
-			return spanner.FilterNodesByTypeQuery(c.nodes, c.typeFilter), nil
+			return spanner.FilterNodesByTypesQuery(c.nodes, c.typeFilters), nil
 		})
 	}
 }

--- a/internal/server/spanner/golden/query_builder_test.go
+++ b/internal/server/spanner/golden/query_builder_test.go
@@ -252,6 +252,18 @@ func TestVectorSearchQuery(t *testing.T) {
 	}
 }
 
+func TestFilterNodesByTypeQuery(t *testing.T) {
+	t.Parallel()
+
+	for _, c := range filterNodesByTypeTestCases {
+		goldenFile := c.golden + ".sql"
+
+		runQueryBuilderGoldenTest(t, goldenFile, func(ctx context.Context) (interface{}, error) {
+			return spanner.FilterNodesByTypeQuery(c.nodes, c.typeFilter), nil
+		})
+	}
+}
+
 // runQueryBuilderGoldenTest is a helper function that performs the golden file validation.
 func runQueryBuilderGoldenTest(t *testing.T, goldenFile string, fn goldenTestFunc) {
 	t.Helper()

--- a/internal/server/spanner/golden/query_cases_test.go
+++ b/internal/server/spanner/golden/query_cases_test.go
@@ -752,18 +752,23 @@ var vectorSearchQueryTestCases = []struct {
 }
 
 var filterNodesByTypeTestCases = []struct {
-	nodes      []string
-	typeFilter string
-	golden     string
+	nodes       []string
+	typeFilters []string
+	golden      string
 }{
 	{
-		nodes:      []string{"dc/g/Demographics", "dc/topic/Demographics", "WHO/Root"},
-		typeFilter: "StatVarGroup",
-		golden:     "filter_nodes_by_type_svg",
+		nodes:       []string{"dc/g/Demographics", "dc/topic/Demographics", "WHO/Root"},
+		typeFilters: []string{"StatVarGroup"},
+		golden:      "filter_nodes_by_type_svg",
 	},
 	{
-		nodes:      []string{"dc/g/Demographics", "dc/topic/Demographics", "WHO/Root"},
-		typeFilter: "Topic",
-		golden:     "filter_nodes_by_type_topic",
+		nodes:       []string{"dc/g/Demographics", "dc/topic/Demographics", "WHO/Root"},
+		typeFilters: []string{"Topic"},
+		golden:      "filter_nodes_by_type_topic",
+	},
+	{
+		nodes:       []string{"dc/g/Demographics", "dc/topic/Demographics", "WHO/Root"},
+		typeFilters: []string{"StatVarGroup", "Topic"},
+		golden:      "filter_nodes_by_types_combined",
 	},
 }

--- a/internal/server/spanner/golden/query_cases_test.go
+++ b/internal/server/spanner/golden/query_cases_test.go
@@ -750,3 +750,20 @@ var vectorSearchQueryTestCases = []struct {
 		golden:     "vector_search",
 	},
 }
+
+var filterNodesByTypeTestCases = []struct {
+	nodes      []string
+	typeFilter string
+	golden     string
+}{
+	{
+		nodes:      []string{"dc/g/Demographics", "dc/topic/Demographics", "WHO/Root"},
+		typeFilter: "StatVarGroup",
+		golden:     "filter_nodes_by_type_svg",
+	},
+	{
+		nodes:      []string{"dc/g/Demographics", "dc/topic/Demographics", "WHO/Root"},
+		typeFilter: "Topic",
+		golden:     "filter_nodes_by_type_topic",
+	},
+}

--- a/internal/server/spanner/golden/query_test.go
+++ b/internal/server/spanner/golden/query_test.go
@@ -461,6 +461,23 @@ func TestVectorSearch(t *testing.T) {
 	}
 }
 
+func TestFilterNodesByType(t *testing.T) {
+	client := test.NewSpannerClient()
+	if client == nil {
+		return
+	}
+
+	t.Parallel()
+
+	for _, c := range filterNodesByTypeTestCases {
+		goldenFile := c.golden + ".json"
+
+		runQueryGoldenTest(t, goldenFile, func(ctx context.Context) (interface{}, error) {
+			return client.FilterNodesByType(ctx, c.nodes, c.typeFilter)
+		})
+	}
+}
+
 // sortStatVarGroupNode sorts StatVarGroupNode results by SVG and subject_id to ensure deterministic order in tests.
 func sortStatVarGroupNode(results []*spanner.StatVarGroupNode) {
 	sort.Slice(results, func(i, j int) bool {

--- a/internal/server/spanner/golden/query_test.go
+++ b/internal/server/spanner/golden/query_test.go
@@ -461,7 +461,7 @@ func TestVectorSearch(t *testing.T) {
 	}
 }
 
-func TestFilterNodesByType(t *testing.T) {
+func TestFilterNodesByTypes(t *testing.T) {
 	client := test.NewSpannerClient()
 	if client == nil {
 		return
@@ -473,7 +473,7 @@ func TestFilterNodesByType(t *testing.T) {
 		goldenFile := c.golden + ".json"
 
 		runQueryGoldenTest(t, goldenFile, func(ctx context.Context) (interface{}, error) {
-			return client.FilterNodesByType(ctx, c.nodes, c.typeFilter)
+			return client.FilterNodesByTypes(ctx, c.nodes, c.typeFilters)
 		})
 	}
 }

--- a/internal/server/spanner/query.go
+++ b/internal/server/spanner/query.go
@@ -642,6 +642,27 @@ func (sc *spannerDatabaseClient) GetTermEmbeddingQuery(ctx context.Context, mode
 	return embeddings, err
 }
 
+// FilterNodesByType filters a list of nodes by type and returns the subset that matches.
+func (sc *spannerDatabaseClient) FilterNodesByType(ctx context.Context, nodes []string, typeFilter string) ([]string, error) {
+	if len(nodes) == 0 {
+		return []string{}, nil
+	}
+
+	stmt := FilterNodesByTypeQuery(nodes, typeFilter)
+	rows, err := queryDynamic(ctx, sc, *stmt)
+	if err != nil {
+		return nil, err
+	}
+
+	var res []string
+	for _, row := range rows {
+		if len(row) > 0 {
+			res = append(res, row[0])
+		}
+	}
+	return res, nil
+}
+
 // VectorSearchQuery performs vector similarity search in Spanner.
 func (sc *spannerDatabaseClient) VectorSearchQuery(ctx context.Context, tableName string, limit int, embeddings []float64, numLeaves int, threshold float64, nodeTypes []string) ([]*VectorSearchResult, error) {
 	var results []*VectorSearchResult

--- a/internal/server/spanner/query.go
+++ b/internal/server/spanner/query.go
@@ -642,24 +642,34 @@ func (sc *spannerDatabaseClient) GetTermEmbeddingQuery(ctx context.Context, mode
 	return embeddings, err
 }
 
-// FilterNodesByType filters a list of nodes by type and returns the subset that matches.
-func (sc *spannerDatabaseClient) FilterNodesByType(ctx context.Context, nodes []string, typeFilter string) ([]string, error) {
+// FilterNodesByTypes filters a list of nodes by types and returns a map of node to matched types.
+func (sc *spannerDatabaseClient) FilterNodesByTypes(ctx context.Context, nodes []string, typeFilters []string) (map[string][]string, error) {
 	if len(nodes) == 0 {
-		return []string{}, nil
+		return map[string][]string{}, nil
 	}
 
-	stmt := FilterNodesByTypeQuery(nodes, typeFilter)
-	rows, err := queryDynamic(ctx, sc, *stmt)
+	stmt := FilterNodesByTypesQuery(nodes, typeFilters)
+	res := map[string][]string{}
+
+	type rowResult struct {
+		SubjectID    string   `spanner:"subject_id"`
+		MatchedTypes []string `spanner:"matched_types"`
+	}
+
+	err := queryStructs(
+		ctx,
+		sc,
+		*stmt,
+		func() interface{} { return &rowResult{} },
+		func(rowStruct interface{}) {
+			r := rowStruct.(*rowResult)
+			res[r.SubjectID] = r.MatchedTypes
+		},
+	)
 	if err != nil {
 		return nil, err
 	}
 
-	var res []string
-	for _, row := range rows {
-		if len(row) > 0 {
-			res = append(res, row[0])
-		}
-	}
 	return res, nil
 }
 

--- a/internal/server/spanner/query_builder.go
+++ b/internal/server/spanner/query_builder.go
@@ -636,13 +636,13 @@ func VectorSearchQuery(tableName string, limit int, embeddings []float64, numLea
 	}
 }
 
-// FilterNodesByTypeQuery returns a Spanner statement to filter nodes by type.
-func FilterNodesByTypeQuery(nodes []string, typeFilter string) *spanner.Statement {
+// FilterNodesByTypesQuery returns a Spanner statement to filter nodes by type.
+func FilterNodesByTypesQuery(nodes []string, typeFilters []string) *spanner.Statement {
 	return &spanner.Statement{
-		SQL: statements.filterNodesByType,
+		SQL: statements.filterNodesByTypes,
 		Params: map[string]interface{}{
-			"nodes":       nodes,
-			"type_filter": typeFilter,
+			"nodes":        nodes,
+			"type_filters": typeFilters,
 		},
 	}
 }

--- a/internal/server/spanner/query_builder.go
+++ b/internal/server/spanner/query_builder.go
@@ -629,7 +629,7 @@ func GetTermEmbeddingQuery(modelName, searchLabel, taskType string) *spanner.Sta
 func VectorSearchQuery(tableName string, limit int, embeddings []float64, numLeaves int, threshold float64, nodeTypes []string) *spanner.Statement {
 	optionsJSON := fmt.Sprintf(`{"num_leaves_to_search": %d}`, numLeaves)
 	return &spanner.Statement{
-		SQL:    fmt.Sprintf(statements.vectorSearchNode, "`"+tableName+"`", optionsJSON, fmt.Sprintf("%.2f", threshold)),
+		SQL: fmt.Sprintf(statements.vectorSearchNode, "`"+tableName+"`", optionsJSON, fmt.Sprintf("%.2f", threshold)),
 		Params: map[string]interface{}{
 			"embeddings": embeddings,
 			"limit":      limit,

--- a/internal/server/spanner/query_builder.go
+++ b/internal/server/spanner/query_builder.go
@@ -68,8 +68,6 @@ const (
 	prefixDataset = "dc/d/"
 	// Source dcid prefix
 	prefixSource = "dc/s/"
-	// Topic dcid prefix
-	prefixTopic = "dc/topic/"
 	// StatVarGroup dcid prefix
 	prefixSVG = "dc/g/"
 )

--- a/internal/server/spanner/query_builder.go
+++ b/internal/server/spanner/query_builder.go
@@ -629,11 +629,22 @@ func GetTermEmbeddingQuery(modelName, searchLabel, taskType string) *spanner.Sta
 func VectorSearchQuery(tableName string, limit int, embeddings []float64, numLeaves int, threshold float64, nodeTypes []string) *spanner.Statement {
 	optionsJSON := fmt.Sprintf(`{"num_leaves_to_search": %d}`, numLeaves)
 	return &spanner.Statement{
-		SQL: fmt.Sprintf(statements.vectorSearchNode, "`"+tableName+"`", optionsJSON, fmt.Sprintf("%.2f", threshold)),
+		SQL:    fmt.Sprintf(statements.vectorSearchNode, "`"+tableName+"`", optionsJSON, fmt.Sprintf("%.2f", threshold)),
 		Params: map[string]interface{}{
 			"embeddings": embeddings,
 			"limit":      limit,
 			"node_types": nodeTypes,
+		},
+	}
+}
+
+// FilterNodesByTypeQuery returns a Spanner statement to filter nodes by type.
+func FilterNodesByTypeQuery(nodes []string, typeFilter string) *spanner.Statement {
+	return &spanner.Statement{
+		SQL: statements.filterNodesByType,
+		Params: map[string]interface{}{
+			"nodes":       nodes,
+			"type_filter": typeFilter,
 		},
 	}
 }

--- a/internal/server/spanner/statements.go
+++ b/internal/server/spanner/statements.go
@@ -646,10 +646,9 @@ var statements = struct {
 				HAVING COUNT(DISTINCT %s) >= @numEntitiesExistence`,
 	getEmbeddingFromQuery: `		SELECT embeddings.values
 		FROM ML.PREDICT(MODEL %s, (SELECT @search_label AS content, @task_type AS task_type))`,
-	filterNodesByType: `		SELECT DISTINCT subject_id
+	filterNodesByType: `		SELECT subject_id
 		FROM Node
-		WHERE ARRAY_LENGTH(types) > 0
-			AND @type_filter IN UNNEST(types)
+		WHERE @type_filter IN UNNEST(types)
 			AND subject_id IN UNNEST(@nodes)`,
 	vectorSearchNode: `		SELECT
 			subject_id,

--- a/internal/server/spanner/statements.go
+++ b/internal/server/spanner/statements.go
@@ -126,7 +126,7 @@ var statements = struct {
 	// Search nodes using vector search.
 	vectorSearchNode string
 	// Filter nodes by type.
-	filterNodesByType string
+	filterNodesByTypes string
 }{
 	getCompletionTimestamp: `		SELECT
 		CompletionTimestamp
@@ -646,10 +646,10 @@ var statements = struct {
 				HAVING COUNT(DISTINCT %s) >= @numEntitiesExistence`,
 	getEmbeddingFromQuery: `		SELECT embeddings.values
 		FROM ML.PREDICT(MODEL %s, (SELECT @search_label AS content, @task_type AS task_type))`,
-	filterNodesByType: `		SELECT subject_id
+	filterNodesByTypes: `		SELECT subject_id, ARRAY(SELECT t FROM UNNEST(types) t WHERE t IN UNNEST(@type_filters)) AS matched_types
 		FROM Node
-		WHERE @type_filter IN UNNEST(types)
-			AND subject_id IN UNNEST(@nodes)`,
+		WHERE subject_id IN UNNEST(@nodes)
+			AND EXISTS (SELECT 1 FROM UNNEST(types) t WHERE t IN UNNEST(@type_filters))`,
 	vectorSearchNode: `		SELECT
 			subject_id,
 			embedding_content AS name,

--- a/internal/server/spanner/statements.go
+++ b/internal/server/spanner/statements.go
@@ -125,6 +125,8 @@ var statements = struct {
 	getEmbeddingFromQuery string
 	// Search nodes using vector search.
 	vectorSearchNode string
+	// Filter nodes by type.
+	filterNodesByType string
 }{
 	getCompletionTimestamp: `		SELECT
 		CompletionTimestamp
@@ -644,6 +646,11 @@ var statements = struct {
 				HAVING COUNT(DISTINCT %s) >= @numEntitiesExistence`,
 	getEmbeddingFromQuery: `		SELECT embeddings.values
 		FROM ML.PREDICT(MODEL %s, (SELECT @search_label AS content, @task_type AS task_type))`,
+	filterNodesByType: `		SELECT DISTINCT subject_id
+		FROM Node
+		WHERE ARRAY_LENGTH(types) > 0
+			AND @type_filter IN UNNEST(types)
+			AND subject_id IN UNNEST(@nodes)`,
 	vectorSearchNode: `		SELECT
 			subject_id,
 			embedding_content AS name,


### PR DESCRIPTION
This PR add statement, query_builder, query that invokes the statement and datasource.go to use the function to filter SVG as well as topics from this logic