### PR TITLE
[DCP - Embeddings] Keep the Indicator resolve through GCS embeddings for now

### DIFF
--- a/internal/server/handler_v2.go
+++ b/internal/server/handler_v2.go
@@ -46,7 +46,7 @@ func (s *Server) V2Resolve(
 ) (*pbv2.ResolveResponse, error) {
 	// TODO: Remove this once embeddings search (resolver == "indicator") are
 	// supported thorugh Spanner.
-	if s.shouldDivertV2(ctx) && in != nil && in.GetResolver() != "indicator" {
+	if s.shouldDivertV2(ctx) && (in == nil || in.GetResolver() != "indicator") {
 		return s.dispatcher.Resolve(ctx, in)
 	}
 

--- a/internal/server/handler_v2.go
+++ b/internal/server/handler_v2.go
@@ -468,35 +468,7 @@ func (s *Server) V2BulkVariableInfo(
 	ctx context.Context, in *pbv1.BulkVariableInfoRequest,
 ) (*pbv1.BulkVariableInfoResponse, error) {
 	if s.shouldDivertV2(ctx) {
-		// return s.dispatcher.BulkVariableInfo(ctx, in)
-
-		slog.Info("V2BulkVariableInfo diverted to Spanner")
-		
-		localResp, err := s.dispatcher.BulkVariableInfo(ctx, in)
-		if err != nil {
-			slog.Warn("Local BulkVariableInfo failed", "error", err)
-			localResp = &pbv1.BulkVariableInfoResponse{}
-		}
-
-		if s.metadata.RemoteMixerDomain != "" {
-			slog.Info("V2BulkVariableInfo calling remote Mixer", "domain", s.metadata.RemoteMixerDomain)
-			remoteResp := &pbv1.BulkVariableInfoResponse{}
-			
-			errRemote := util.FetchRemote(s.metadata, s.httpClient, "/v2/bulk/info/variable", in, remoteResp)
-			if errRemote != nil {
-				slog.Error("Failed to fetch remote variable info in V2", "error", errRemote)
-				if err != nil {
-					return nil, err // Return original local error if both failed
-				}
-				return nil, errRemote
-			}
-			return merger.MergeBulkVariableInfoResponse(localResp, remoteResp), nil
-		}
-
-		if err != nil {
-			return nil, err // Return original local error if no remote and local failed
-		}
-		return localResp, nil
+		return s.dispatcher.BulkVariableInfo(ctx, in)
 	}
 
 	v2StartTime := time.Now()

--- a/internal/server/handler_v2.go
+++ b/internal/server/handler_v2.go
@@ -45,7 +45,7 @@ func (s *Server) V2Resolve(
 	ctx context.Context, in *pbv2.ResolveRequest,
 ) (*pbv2.ResolveResponse, error) {
 	// TODO: Remove this once embeddings search (resolver == "indicator") are
-	// supported thorugh Spanner.
+	// supported through Spanner.
 	if s.shouldDivertV2(ctx) && (in == nil || in.GetResolver() != "indicator") {
 		return s.dispatcher.Resolve(ctx, in)
 	}

--- a/internal/server/handler_v2.go
+++ b/internal/server/handler_v2.go
@@ -44,7 +44,10 @@ import (
 func (s *Server) V2Resolve(
 	ctx context.Context, in *pbv2.ResolveRequest,
 ) (*pbv2.ResolveResponse, error) {
-	if s.shouldDivertV2(ctx) {
+	// If request is for embeddings search (resolver == "indicator"),
+	// do not divert to Spanner. Note, we will need to remove this once
+	// Spanner embeddings are supported.
+	if s.shouldDivertV2(ctx) && in.GetResolver() != "indicator" {
 		return s.dispatcher.Resolve(ctx, in)
 	}
 
@@ -465,7 +468,35 @@ func (s *Server) V2BulkVariableInfo(
 	ctx context.Context, in *pbv1.BulkVariableInfoRequest,
 ) (*pbv1.BulkVariableInfoResponse, error) {
 	if s.shouldDivertV2(ctx) {
-		return s.dispatcher.BulkVariableInfo(ctx, in)
+		// return s.dispatcher.BulkVariableInfo(ctx, in)
+
+		slog.Info("V2BulkVariableInfo diverted to Spanner")
+		
+		localResp, err := s.dispatcher.BulkVariableInfo(ctx, in)
+		if err != nil {
+			slog.Warn("Local BulkVariableInfo failed", "error", err)
+			localResp = &pbv1.BulkVariableInfoResponse{}
+		}
+
+		if s.metadata.RemoteMixerDomain != "" {
+			slog.Info("V2BulkVariableInfo calling remote Mixer", "domain", s.metadata.RemoteMixerDomain)
+			remoteResp := &pbv1.BulkVariableInfoResponse{}
+			
+			errRemote := util.FetchRemote(s.metadata, s.httpClient, "/v2/bulk/info/variable", in, remoteResp)
+			if errRemote != nil {
+				slog.Error("Failed to fetch remote variable info in V2", "error", errRemote)
+				if err != nil {
+					return nil, err // Return original local error if both failed
+				}
+				return nil, errRemote
+			}
+			return merger.MergeBulkVariableInfoResponse(localResp, remoteResp), nil
+		}
+
+		if err != nil {
+			return nil, err // Return original local error if no remote and local failed
+		}
+		return localResp, nil
 	}
 
 	v2StartTime := time.Now()

--- a/internal/server/handler_v2.go
+++ b/internal/server/handler_v2.go
@@ -44,10 +44,9 @@ import (
 func (s *Server) V2Resolve(
 	ctx context.Context, in *pbv2.ResolveRequest,
 ) (*pbv2.ResolveResponse, error) {
-	// If request is for embeddings search (resolver == "indicator"),
-	// do not divert to Spanner. Note, we will need to remove this once
-	// Spanner embeddings are supported.
-	if s.shouldDivertV2(ctx) && in.GetResolver() != "indicator" {
+	// TODO: Remove this once embeddings search (resolver == "indicator") are
+	// supported thorugh Spanner.
+	if s.shouldDivertV2(ctx) && in != nil && in.GetResolver() != "indicator" {
 		return s.dispatcher.Resolve(ctx, in)
 	}
 


### PR DESCRIPTION
Ensures the resolver keeps Indicators on V1 such that it goes through the GCS embeddings. This is only required until Spanner embeddings, expected in about a month.