### PR TITLE
[v0/v1 migration] revert turndown of v1/bulk/info/place 

### DIFF
--- a/deploy/apigee/target_endpoints/api.template.xml
+++ b/deploy/apigee/target_endpoints/api.template.xml
@@ -60,7 +60,6 @@
             (proxy.pathsuffix MatchesPath "/stat/value") OR
             (proxy.pathsuffix MatchesPath "/translate") OR
             (proxy.pathsuffix MatchesPath "/update-cache") OR
-            ((proxy.pathsuffix MatchesPath "/v1/bulk/info/place") OR (proxy.pathsuffix MatchesPath "/v1/bulk/info/place/**")) OR
             ((proxy.pathsuffix MatchesPath "/v1/bulk/observation-dates/linked") OR (proxy.pathsuffix MatchesPath "/v1/bulk/observation-dates/linked/**")) OR
             (proxy.pathsuffix MatchesPath "/v1/bulk/observation-existence") OR
             ((proxy.pathsuffix MatchesPath "/v1/bulk/observations/point") OR (proxy.pathsuffix MatchesPath "/v1/bulk/observations/point/**")) OR


### PR DESCRIPTION
## Description

The turndown of `v1/bulk/info/place` had consequences for downstream repositories. This PR reverts this turndown temporarily.