### PR TITLE
[v0/v1 migration] revert turndown of endpoints

### DIFF
--- a/deploy/apigee/target_endpoints/api.template.xml
+++ b/deploy/apigee/target_endpoints/api.template.xml
@@ -42,7 +42,6 @@
         </Step>
         <Step>
           <Condition>
-            ((proxy.pathsuffix MatchesPath "/bulk/stats") OR (proxy.pathsuffix MatchesPath "/bulk/stats/**")) OR
             (proxy.pathsuffix MatchesPath "/internal/bio") OR
             (proxy.pathsuffix MatchesPath "/internal/import-table") OR
             (proxy.pathsuffix MatchesPath "/node/places-in") OR
@@ -60,12 +59,9 @@
             (proxy.pathsuffix MatchesPath "/stat/value") OR
             (proxy.pathsuffix MatchesPath "/translate") OR
             (proxy.pathsuffix MatchesPath "/update-cache") OR
-            ((proxy.pathsuffix MatchesPath "/v1/bulk/observation-dates/linked") OR (proxy.pathsuffix MatchesPath "/v1/bulk/observation-dates/linked/**")) OR
             (proxy.pathsuffix MatchesPath "/v1/bulk/observation-existence") OR
-            ((proxy.pathsuffix MatchesPath "/v1/bulk/observations/point") OR (proxy.pathsuffix MatchesPath "/v1/bulk/observations/point/**")) OR
             (proxy.pathsuffix MatchesPath "/v1/bulk/observations/point/linked") OR
             ((proxy.pathsuffix MatchesPath "/v1/bulk/properties") OR (proxy.pathsuffix MatchesPath "/v1/bulk/properties/**")) OR
-            ((proxy.pathsuffix MatchesPath "/v1/bulk/property/values/linked") OR (proxy.pathsuffix MatchesPath "/v1/bulk/property/values/linked/**")) OR
             ((proxy.pathsuffix MatchesPath "/v1/bulk/triples") OR (proxy.pathsuffix MatchesPath "/v1/bulk/triples/**")) OR
             (proxy.pathsuffix MatchesPath "/v1/bulk/variables") OR
             (proxy.pathsuffix MatchesPath "/v1/events") OR
@@ -75,18 +71,14 @@
             ((proxy.pathsuffix MatchesPath "/v1/info/variable") OR (proxy.pathsuffix MatchesPath "/v1/info/variable/**")) OR
             ((proxy.pathsuffix MatchesPath "/v1/info/variable-group") OR (proxy.pathsuffix MatchesPath "/v1/info/variable-group/**")) OR
             ((proxy.pathsuffix MatchesPath "/v1/internal/page/bio") OR (proxy.pathsuffix MatchesPath "/v1/internal/page/bio/**")) OR
-            ((proxy.pathsuffix MatchesPath "/v1/internal/page/place") OR (proxy.pathsuffix MatchesPath "/v1/internal/page/place/**")) OR
             ((proxy.pathsuffix MatchesPath "/v1/observations/point") OR (proxy.pathsuffix MatchesPath "/v1/observations/point/**")) OR
             ((proxy.pathsuffix MatchesPath "/v1/observations/series") OR (proxy.pathsuffix MatchesPath "/v1/observations/series/**")) OR
             (proxy.pathsuffix MatchesPath "/v1/observations/series/derived") OR
-            ((proxy.pathsuffix MatchesPath "/v1/place/related") OR (proxy.pathsuffix MatchesPath "/v1/place/related/**")) OR
             (proxy.pathsuffix MatchesPath "/v1/place/stat-vars/union") OR
             (proxy.pathsuffix MatchesPath "/v1/properties") OR (proxy.pathsuffix MatchesPath "/v1/properties/**") OR
             (proxy.pathsuffix MatchesPath "/v1/property/values") OR (proxy.pathsuffix MatchesPath "/v1/property/values/**") OR
             (proxy.pathsuffix MatchesPath "/v1/query") OR
             (proxy.pathsuffix MatchesPath "/v1/recognize/entities") OR
-            ((proxy.pathsuffix MatchesPath "/v1/recon/entity/resolve") OR (proxy.pathsuffix MatchesPath "/v1/recon/entity/resolve/**")) OR
-            ((proxy.pathsuffix MatchesPath "/v1/recon/resolve/coordinate") OR (proxy.pathsuffix MatchesPath "/v1/recon/resolve/coordinate/**")) OR
             (proxy.pathsuffix MatchesPath "/v1/stat/date/within-place") OR
             ((proxy.pathsuffix MatchesPath "/v1/triples") OR (proxy.pathsuffix MatchesPath "/v1/triples/**")) OR
             ((proxy.pathsuffix MatchesPath "/v1/variables") OR (proxy.pathsuffix MatchesPath "/v1/variables/**")) OR
@@ -123,6 +115,12 @@
           <Condition>
             <!-- List of endpoints that do NOT require a key -->
             !(
+              (proxy.pathsuffix MatchesPath "/bulk/stats") OR
+              (proxy.pathsuffix MatchesPath "/search") OR
+              (proxy.pathsuffix MatchesPath "/v1/place/ranking") OR
+              (proxy.pathsuffix MatchesPath "/v1/place/related") OR
+              (proxy.pathsuffix MatchesPath "/v1/recon/entity/resolve") OR
+              (proxy.pathsuffix MatchesPath "/v1/recon/resolve/coordinate") OR
               (proxy.pathsuffix MatchesPath "/v1/recon/resolve/id") OR
               (proxy.pathsuffix MatchesPath "/v1/variable/search") OR
               <!-- /v2/resolve is public ONLY for legacy requests (no 'resolver' param). -->


### PR DESCRIPTION
## Description

The turndowns of the endpoints from [1881](https://github.com/datacommonsorg/mixer/pull/1881) had consequences for downstream repositories. This PR reverts these turndowns temporarily.