### PR TITLE
Federate /v2/observation entity expression expansions

### DIFF
--- a/internal/server/datasources/datasources.go
+++ b/internal/server/datasources/datasources.go
@@ -16,14 +16,17 @@ package datasources
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/datacommonsorg/mixer/internal/merger"
 	pb "github.com/datacommonsorg/mixer/internal/proto"
 	pbv1 "github.com/datacommonsorg/mixer/internal/proto/v1"
 	pbv2 "github.com/datacommonsorg/mixer/internal/proto/v2"
 	"github.com/datacommonsorg/mixer/internal/server/datasource"
+	v2 "github.com/datacommonsorg/mixer/internal/server/v2"
 	"github.com/datacommonsorg/mixer/internal/server/v2/resolve"
 	"github.com/datacommonsorg/mixer/internal/translator/sparql"
+	"google.golang.org/protobuf/proto"
 
 	"golang.org/x/sync/errgroup"
 )
@@ -94,9 +97,74 @@ func (ds *DataSources) Node(ctx context.Context, in *pbv2.NodeRequest, pageSize 
 }
 
 func (ds *DataSources) Observation(ctx context.Context, in *pbv2.ObservationRequest) (*pbv2.ObservationResponse, error) {
+	expandedReq := in
+	hasLocalSource := false
+	for _, s := range ds.sources {
+		if s.Type() != datasource.TypeRemote {
+			hasLocalSource = true
+			break
+		}
+	}
+	if in.Entity != nil && in.Entity.Expression != "" && ds.remoteDataSource != nil && hasLocalSource {
+		// When a remote mixer is present, we need to ensure that local sources fetch data
+		// for entities discovered by the remote mixer as well.
+		// We do this by resolving the expression against all sources (local + remote) first,
+		// and then passing the resolved DCIDs to the local sources.
+
+		// 1. Parse expression to extract ancestor and child type.
+		containedInPlace, err := v2.ParseContainedInPlace(in.Entity.Expression)
+		if err != nil {
+			return nil, err
+		}
+
+		// 2. Resolve expression via Node API.
+		// This calls all configured sources (local and remote) in parallel and merges results.
+		// This gives us a unified list of entities across both graphs before executing the local observation query.
+		property := fmt.Sprintf("<-containedInPlace+{typeOf:%s}", containedInPlace.ChildPlaceType)
+		nodeReq := &pbv2.NodeRequest{
+			Nodes:    []string{containedInPlace.Ancestor},
+			Property: property,
+		}
+		nodeResp, err := ds.Node(ctx, nodeReq, 0)
+		if err != nil {
+			return nil, err
+		}
+
+		// 3. Extract DCIDs from NodeResponse.
+		var dcids []string
+		for _, graph := range nodeResp.Data {
+			if nodes, ok := graph.Arcs[property]; ok {
+				for _, node := range nodes.Nodes {
+					if node.Dcid != "" {
+						dcids = append(dcids, node.Dcid)
+					}
+				}
+			}
+		}
+
+		// 4. Short-circuit if empty to avoid backend errors.
+		if len(dcids) == 0 {
+			return &pbv2.ObservationResponse{}, nil
+		}
+
+		// 5. Create cloned request for local sources with resolved DCIDs.
+		// The remote mixer must receive the original expression to do its own expansion.
+		// Local sources get the resolved list of DCIDs and have the expression cleared
+		// to prevent them from doing their own un-federated expansion or failing if both are set.
+		expandedReq = proto.Clone(in).(*pbv2.ObservationRequest)
+		expandedReq.Entity.Dcids = dcids
+		expandedReq.Entity.Expression = ""
+	}
+
 	return fetchAndMerge(ctx, ds.sources, in,
 		func(c context.Context, s datasource.DataSource, r *pbv2.ObservationRequest) (*pbv2.ObservationResponse, error) {
-			return s.Observation(c, r)
+			reqForSource := r
+			// Send the expanded DCIDs request to all local (non-remote) sources.
+			// Send the original request (with expression) to the remote mixer.
+			if s.Type() != datasource.TypeRemote {
+				reqForSource = expandedReq
+			}
+			return s.Observation(c, reqForSource)
 		},
 		func(all []*pbv2.ObservationResponse) (*pbv2.ObservationResponse, error) {
 			return merger.MergeMultiObservation(all), nil

--- a/internal/server/datasources/datasources.go
+++ b/internal/server/datasources/datasources.go
@@ -17,6 +17,7 @@ package datasources
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	"github.com/datacommonsorg/mixer/internal/merger"
 	pb "github.com/datacommonsorg/mixer/internal/proto"
@@ -88,12 +89,21 @@ func fetchAndMerge[req any, resp any](
 }
 
 func (ds *DataSources) Node(ctx context.Context, in *pbv2.NodeRequest, pageSize int) (*pbv2.NodeResponse, error) {
-	return fetchAndMerge(ctx, ds.sources, in,
+	resp, err := fetchAndMerge(ctx, ds.sources, in,
 		func(c context.Context, s datasource.DataSource, r *pbv2.NodeRequest) (*pbv2.NodeResponse, error) {
-			return s.Node(c, r, pageSize)
+			sourceResp, sourceErr := s.Node(c, r, pageSize)
+			if sourceErr != nil {
+				slog.Error("DataSources.Node: source failed", "id", s.Id(), "error", sourceErr)
+				return nil, sourceErr
+			}
+			return sourceResp, nil
 		},
 		merger.MergeMultiNode,
 	)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
 }
 
 func (ds *DataSources) Observation(ctx context.Context, in *pbv2.ObservationRequest) (*pbv2.ObservationResponse, error) {
@@ -114,32 +124,20 @@ func (ds *DataSources) Observation(ctx context.Context, in *pbv2.ObservationRequ
 		// 1. Parse expression to extract ancestor and child type.
 		containedInPlace, err := v2.ParseContainedInPlace(in.Entity.Expression)
 		if err != nil {
+			slog.Error("DataSources.Observation: failed to parse containedInPlace expression", "expression", in.Entity.Expression, "error", err)
 			return nil, err
 		}
 
-		// 2. Resolve expression via Node API.
-		// This calls all configured sources (local and remote) in parallel and merges results.
-		// This gives us a unified list of entities across both graphs before executing the local observation query.
+		// 2. Resolve expression via Node API, fetching all pages.
 		property := fmt.Sprintf("<-containedInPlace+{typeOf:%s}", containedInPlace.ChildPlaceType)
 		nodeReq := &pbv2.NodeRequest{
 			Nodes:    []string{containedInPlace.Ancestor},
 			Property: property,
 		}
-		nodeResp, err := ds.Node(ctx, nodeReq, 0)
+		dcids, err := ds.fetchAllDCIDs(ctx, nodeReq, "containedInPlace+")
 		if err != nil {
+			slog.Error("DataSources.Observation: failed to resolve expression", "expression", in.Entity.Expression, "error", err)
 			return nil, err
-		}
-
-		// 3. Extract DCIDs from NodeResponse.
-		var dcids []string
-		for _, graph := range nodeResp.Data {
-			if nodes, ok := graph.Arcs[property]; ok {
-				for _, node := range nodes.Nodes {
-					if node.Dcid != "" {
-						dcids = append(dcids, node.Dcid)
-					}
-				}
-			}
 		}
 
 		// 4. Short-circuit if empty to avoid backend errors.
@@ -156,7 +154,7 @@ func (ds *DataSources) Observation(ctx context.Context, in *pbv2.ObservationRequ
 		expandedReq.Entity.Expression = ""
 	}
 
-	return fetchAndMerge(ctx, ds.sources, in,
+	resp, err := fetchAndMerge(ctx, ds.sources, in,
 		func(c context.Context, s datasource.DataSource, r *pbv2.ObservationRequest) (*pbv2.ObservationResponse, error) {
 			reqForSource := r
 			// Send the expanded DCIDs request to all local (non-remote) sources.
@@ -164,12 +162,53 @@ func (ds *DataSources) Observation(ctx context.Context, in *pbv2.ObservationRequ
 			if s.Type() != datasource.TypeRemote {
 				reqForSource = expandedReq
 			}
-			return s.Observation(c, reqForSource)
+			sourceResp, sourceErr := s.Observation(c, reqForSource)
+			if sourceErr != nil {
+				slog.Error("DataSources.Observation: source failed", "id", s.Id(), "error", sourceErr)
+				return nil, sourceErr
+			}
+			return sourceResp, nil
 		},
 		func(all []*pbv2.ObservationResponse) (*pbv2.ObservationResponse, error) {
 			return merger.MergeMultiObservation(all), nil
 		},
 	)
+	if err != nil {
+		slog.Error("DataSources.Observation: fetchAndMerge failed", "error", err)
+		return nil, err
+	}
+	return resp, nil
+}
+
+// fetchAllDCIDs fetches all pages of NodeResponse and extracts DCIDs for a specific arc key.
+func (ds *DataSources) fetchAllDCIDs(ctx context.Context, nodeReq *pbv2.NodeRequest, arcKey string) ([]string, error) {
+	var dcids []string
+	nextToken := ""
+	for {
+		req := proto.Clone(nodeReq).(*pbv2.NodeRequest)
+		req.NextToken = nextToken
+
+		resp, err := ds.Node(ctx, req, 1000)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, graph := range resp.Data {
+			if nodes, ok := graph.Arcs[arcKey]; ok {
+				for _, node := range nodes.Nodes {
+					if node.Dcid != "" {
+						dcids = append(dcids, node.Dcid)
+					}
+				}
+			}
+		}
+
+		nextToken = resp.GetNextToken()
+		if nextToken == "" {
+			break
+		}
+	}
+	return dcids, nil
 }
 
 func (ds *DataSources) NodeSearch(ctx context.Context, in *pbv2.NodeSearchRequest) (*pbv2.NodeSearchResponse, error) {

--- a/internal/server/datasources/datasources_test.go
+++ b/internal/server/datasources/datasources_test.go
@@ -16,8 +16,11 @@ package datasources
 
 import (
 	"context"
+	"fmt"
 	"slices"
 	"testing"
+
+	"github.com/datacommonsorg/mixer/internal/util"
 
 	pb "github.com/datacommonsorg/mixer/internal/proto"
 	pbv2 "github.com/datacommonsorg/mixer/internal/proto/v2"
@@ -72,7 +75,7 @@ func TestObservation_ExpressionExpansion(t *testing.T) {
 				Data: map[string]*pbv2.LinkedGraph{
 					"geoId/06": {
 						Arcs: map[string]*pbv2.Nodes{
-							"<-containedInPlace+{typeOf:County}": {
+							"containedInPlace+": {
 								Nodes: []*pb.EntityInfo{
 									{Dcid: "geoId/06001"},
 								},
@@ -217,7 +220,7 @@ func TestObservation_ExpressionExpansion_NonSpanner(t *testing.T) {
 				Data: map[string]*pbv2.LinkedGraph{
 					"geoId/06": {
 						Arcs: map[string]*pbv2.Nodes{
-							"<-containedInPlace+{typeOf:County}": {
+							"containedInPlace+": {
 								Nodes: []*pb.EntityInfo{
 									{Dcid: "geoId/06001"},
 								},
@@ -273,5 +276,85 @@ func TestObservation_ExpressionExpansion_NonSpanner(t *testing.T) {
 	}
 	if remoteReceivedReq.Entity.Expression != "geoId/06<-containedInPlace+{typeOf:County}" {
 		t.Errorf("Remote received unexpected expression: %s", remoteReceivedReq.Entity.Expression)
+	}
+}
+
+func TestFetchAllDCIDs(t *testing.T) {
+	ctx := context.Background()
+
+	pi := &pbv2.Pagination{
+		Info: []*pbv2.Pagination_DataSourceInfo{
+			{
+				Id: "mock-source",
+				DataSourceInfo: &pbv2.Pagination_DataSourceInfo_SpannerInfo{
+					SpannerInfo: &pbv2.SpannerInfo{
+						Offset: 1000,
+					},
+				},
+			},
+		},
+	}
+	token1, err := util.EncodeProto(pi)
+	if err != nil {
+		t.Fatalf("failed to encode proto: %v", err)
+	}
+
+	// Mock source that returns paginated results.
+	mockSource := &mockSource{
+		id:         "mock-source",
+		sourceType: datasource.TypeSpanner,
+		nodeFunc: func(ctx context.Context, req *pbv2.NodeRequest, pageSize int) (*pbv2.NodeResponse, error) {
+			if req.NextToken == "" {
+				return &pbv2.NodeResponse{
+					Data: map[string]*pbv2.LinkedGraph{
+						"geoId/06": {
+							Arcs: map[string]*pbv2.Nodes{
+								"containedInPlace+": {
+									Nodes: []*pb.EntityInfo{
+										{Dcid: "geoId/06001"},
+									},
+								},
+							},
+						},
+					},
+					NextToken: token1,
+				}, nil
+			} else if req.NextToken == token1 {
+				return &pbv2.NodeResponse{
+					Data: map[string]*pbv2.LinkedGraph{
+						"geoId/06": {
+							Arcs: map[string]*pbv2.Nodes{
+								"containedInPlace+": {
+									Nodes: []*pb.EntityInfo{
+										{Dcid: "geoId/06002"},
+									},
+								},
+							},
+						},
+					},
+					NextToken: "",
+				}, nil
+			}
+			return nil, fmt.Errorf("unexpected next token: %s", req.NextToken)
+		},
+	}
+
+	ds := &DataSources{
+		sources: []datasource.DataSource{mockSource},
+	}
+
+	req := &pbv2.NodeRequest{
+		Nodes:    []string{"geoId/06"},
+		Property: "<-containedInPlace+{typeOf:County}",
+	}
+
+	dcids, err := ds.fetchAllDCIDs(ctx, req, "containedInPlace+")
+	if err != nil {
+		t.Fatalf("fetchAllDCIDs failed: %v", err)
+	}
+
+	expected := []string{"geoId/06001", "geoId/06002"}
+	if !slices.Equal(dcids, expected) {
+		t.Errorf("fetchAllDCIDs = %v, want %v", dcids, expected)
 	}
 }

--- a/internal/server/datasources/datasources_test.go
+++ b/internal/server/datasources/datasources_test.go
@@ -1,0 +1,277 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datasources
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	pb "github.com/datacommonsorg/mixer/internal/proto"
+	pbv2 "github.com/datacommonsorg/mixer/internal/proto/v2"
+	"github.com/datacommonsorg/mixer/internal/server/datasource"
+)
+
+// mockSource implements datasource.DataSource for testing.
+type mockSource struct {
+	datasource.DataSource
+	id              string
+	sourceType      datasource.DataSourceType
+	nodeFunc        func(context.Context, *pbv2.NodeRequest, int) (*pbv2.NodeResponse, error)
+	observationFunc func(context.Context, *pbv2.ObservationRequest) (*pbv2.ObservationResponse, error)
+}
+
+func (m *mockSource) Id() string { return m.id }
+func (m *mockSource) Type() datasource.DataSourceType { return m.sourceType }
+func (m *mockSource) Node(ctx context.Context, req *pbv2.NodeRequest, pageSize int) (*pbv2.NodeResponse, error) {
+	if m.nodeFunc != nil {
+		return m.nodeFunc(ctx, req, pageSize)
+	}
+	return &pbv2.NodeResponse{}, nil
+}
+func (m *mockSource) Observation(ctx context.Context, req *pbv2.ObservationRequest) (*pbv2.ObservationResponse, error) {
+	if m.observationFunc != nil {
+		return m.observationFunc(ctx, req)
+	}
+	return &pbv2.ObservationResponse{}, nil
+}
+
+// Test main path: Expression + Remote Mixer
+// Verify that Spanner receives resolved DCIDs and Remote receives the original expression.
+func TestObservation_ExpressionExpansion(t *testing.T) {
+	ctx := context.Background()
+
+	var spannerReceivedReq *pbv2.ObservationRequest
+	mockSpanner := &mockSource{
+		id:         "mock-spanner",
+		sourceType: datasource.TypeSpanner,
+		observationFunc: func(ctx context.Context, req *pbv2.ObservationRequest) (*pbv2.ObservationResponse, error) {
+			spannerReceivedReq = req
+			return &pbv2.ObservationResponse{}, nil
+		},
+	}
+
+	var remoteReceivedReq *pbv2.ObservationRequest
+	mockRemote := &mockSource{
+		id:         "mock-remote",
+		sourceType: datasource.TypeRemote,
+		nodeFunc: func(ctx context.Context, req *pbv2.NodeRequest, pageSize int) (*pbv2.NodeResponse, error) {
+			return &pbv2.NodeResponse{
+				Data: map[string]*pbv2.LinkedGraph{
+					"geoId/06": {
+						Arcs: map[string]*pbv2.Nodes{
+							"<-containedInPlace+{typeOf:County}": {
+								Nodes: []*pb.EntityInfo{
+									{Dcid: "geoId/06001"},
+								},
+							},
+						},
+					},
+				},
+			}, nil
+		},
+		observationFunc: func(ctx context.Context, req *pbv2.ObservationRequest) (*pbv2.ObservationResponse, error) {
+			remoteReceivedReq = req
+			return &pbv2.ObservationResponse{}, nil
+		},
+	}
+
+	ds := NewDataSources([]datasource.DataSource{mockSpanner, mockRemote}, mockRemote)
+
+	req := &pbv2.ObservationRequest{
+		Variable: &pbv2.DcidOrExpression{Dcids: []string{"Count_Person"}},
+		Entity:   &pbv2.DcidOrExpression{Expression: "geoId/06<-containedInPlace+{typeOf:County}"},
+		Select:   []string{"variable", "entity"},
+	}
+
+	_, err := ds.Observation(ctx, req)
+	if err != nil {
+		t.Fatalf("Observation failed: %v", err)
+	}
+
+	// Verify Spanner received resolved DCIDs
+	if spannerReceivedReq == nil {
+		t.Fatal("Spanner did not receive request")
+	}
+	if spannerReceivedReq.Entity.Expression != "" {
+		t.Errorf("Spanner received expression, expected empty: %s", spannerReceivedReq.Entity.Expression)
+	}
+	if !slices.Contains(spannerReceivedReq.Entity.Dcids, "geoId/06001") {
+		t.Errorf("Spanner did not receive resolved DCID: %v", spannerReceivedReq.Entity.Dcids)
+	}
+
+	// Verify Remote received original expression
+	if remoteReceivedReq == nil {
+		t.Fatal("Remote did not receive request")
+	}
+	if remoteReceivedReq.Entity.Expression != "geoId/06<-containedInPlace+{typeOf:County}" {
+		t.Errorf("Remote received unexpected expression: %s", remoteReceivedReq.Entity.Expression)
+	}
+	if len(remoteReceivedReq.Entity.Dcids) != 0 {
+		t.Errorf("Remote received DCIDs, expected none: %v", remoteReceivedReq.Entity.Dcids)
+	}
+}
+
+// Test path: Expression + No Remote Mixer
+// Verify that Spanner receives the expression (one-shot) and no resolution step is taken.
+func TestObservation_ExpressionNoRemote(t *testing.T) {
+	ctx := context.Background()
+
+	var spannerReceivedReq *pbv2.ObservationRequest
+	mockSpanner := &mockSource{
+		id:         "mock-spanner",
+		sourceType: datasource.TypeSpanner,
+		observationFunc: func(ctx context.Context, req *pbv2.ObservationRequest) (*pbv2.ObservationResponse, error) {
+			spannerReceivedReq = req
+			return &pbv2.ObservationResponse{}, nil
+		},
+	}
+
+	ds := NewDataSources([]datasource.DataSource{mockSpanner}, nil)
+
+	req := &pbv2.ObservationRequest{
+		Variable: &pbv2.DcidOrExpression{Dcids: []string{"Count_Person"}},
+		Entity:   &pbv2.DcidOrExpression{Expression: "geoId/06<-containedInPlace+{typeOf:County}"},
+		Select:   []string{"variable", "entity"},
+	}
+
+	_, err := ds.Observation(ctx, req)
+	if err != nil {
+		t.Fatalf("Observation failed: %v", err)
+	}
+
+	if spannerReceivedReq == nil {
+		t.Fatal("Spanner did not receive request")
+	}
+	if spannerReceivedReq.Entity.Expression != "geoId/06<-containedInPlace+{typeOf:County}" {
+		t.Errorf("Spanner received unexpected expression: %s", spannerReceivedReq.Entity.Expression)
+	}
+}
+
+// Test edge case: Expression Resolution Returns Empty
+// Verify that if ds.Node returns no entities, we return an empty ObservationResponse immediately without calling Spanner.
+func TestObservation_ExpressionEmptyResolution(t *testing.T) {
+	ctx := context.Background()
+
+	mockSpanner := &mockSource{
+		id:         "mock-spanner",
+		sourceType: datasource.TypeSpanner,
+		observationFunc: func(ctx context.Context, req *pbv2.ObservationRequest) (*pbv2.ObservationResponse, error) {
+			t.Fatal("Spanner should not be called when resolution returns empty")
+			return &pbv2.ObservationResponse{}, nil
+		},
+	}
+
+	mockRemote := &mockSource{
+		id:         "mock-remote",
+		sourceType: datasource.TypeRemote,
+		nodeFunc: func(ctx context.Context, req *pbv2.NodeRequest, pageSize int) (*pbv2.NodeResponse, error) {
+			return &pbv2.NodeResponse{}, nil // Empty response
+		},
+	}
+
+	ds := NewDataSources([]datasource.DataSource{mockSpanner, mockRemote}, mockRemote)
+
+	req := &pbv2.ObservationRequest{
+		Variable: &pbv2.DcidOrExpression{Dcids: []string{"Count_Person"}},
+		Entity:   &pbv2.DcidOrExpression{Expression: "geoId/06<-containedInPlace+{typeOf:County}"},
+		Select:   []string{"variable", "entity"},
+	}
+
+	resp, err := ds.Observation(ctx, req)
+	if err != nil {
+		t.Fatalf("Observation failed: %v", err)
+	}
+
+	if resp == nil {
+		t.Fatal("Expected non-nil response")
+	}
+	if len(resp.ByVariable) != 0 {
+		t.Errorf("Expected empty response, got: %v", resp.ByVariable)
+	}
+}
+
+// Test path: Expression + Remote Mixer + Non-Spanner Local Source
+// Verify that non-remote sources receive resolved DCIDs.
+func TestObservation_ExpressionExpansion_NonSpanner(t *testing.T) {
+	ctx := context.Background()
+
+	var remoteReceivedReq *pbv2.ObservationRequest
+	mockRemote := &mockSource{
+		id:         "mock-remote",
+		sourceType: datasource.TypeRemote,
+		nodeFunc: func(ctx context.Context, req *pbv2.NodeRequest, pageSize int) (*pbv2.NodeResponse, error) {
+			return &pbv2.NodeResponse{
+				Data: map[string]*pbv2.LinkedGraph{
+					"geoId/06": {
+						Arcs: map[string]*pbv2.Nodes{
+							"<-containedInPlace+{typeOf:County}": {
+								Nodes: []*pb.EntityInfo{
+									{Dcid: "geoId/06001"},
+								},
+							},
+						},
+					},
+				},
+			}, nil
+		},
+		observationFunc: func(ctx context.Context, req *pbv2.ObservationRequest) (*pbv2.ObservationResponse, error) {
+			remoteReceivedReq = req
+			return &pbv2.ObservationResponse{}, nil
+		},
+	}
+
+	var sqlReceivedReq *pbv2.ObservationRequest
+	mockSQL := &mockSource{
+		id:         "mock-sql",
+		sourceType: datasource.TypeSQL,
+		observationFunc: func(ctx context.Context, req *pbv2.ObservationRequest) (*pbv2.ObservationResponse, error) {
+			sqlReceivedReq = req
+			return &pbv2.ObservationResponse{}, nil
+		},
+	}
+
+	ds := NewDataSources([]datasource.DataSource{mockSQL, mockRemote}, mockRemote)
+
+	req := &pbv2.ObservationRequest{
+		Variable: &pbv2.DcidOrExpression{Dcids: []string{"Count_Person"}},
+		Entity:   &pbv2.DcidOrExpression{Expression: "geoId/06<-containedInPlace+{typeOf:County}"},
+		Select:   []string{"variable", "entity"},
+	}
+
+	_, err := ds.Observation(ctx, req)
+	if err != nil {
+		t.Fatalf("Observation failed: %v", err)
+	}
+
+	// Verify SQL received resolved DCIDs
+	if sqlReceivedReq == nil {
+		t.Fatal("SQL did not receive request")
+	}
+	if sqlReceivedReq.Entity.Expression != "" {
+		t.Errorf("SQL received expression, expected empty: %s", sqlReceivedReq.Entity.Expression)
+	}
+	if !slices.Contains(sqlReceivedReq.Entity.Dcids, "geoId/06001") {
+		t.Errorf("SQL did not receive resolved DCID: %v", sqlReceivedReq.Entity.Dcids)
+	}
+
+	// Verify Remote received original expression
+	if remoteReceivedReq == nil {
+		t.Fatal("Remote did not receive request")
+	}
+	if remoteReceivedReq.Entity.Expression != "geoId/06<-containedInPlace+{typeOf:County}" {
+		t.Errorf("Remote received unexpected expression: %s", remoteReceivedReq.Entity.Expression)
+	}
+}


### PR DESCRIPTION
## Goal
Implement expression expansion for the `Observation` API in the `DataSources` layer to support federated queries across local Spanner and Remote Mixer.

## Requirements based on Legacy Flow
*   **Original Expression to Remote**: The Remote Mixer must receive the original request with the expression intact so it can perform its own expansion against its complete graph.
*   **Unified Resolution**: We must resolve the expression against all available sources (local + remote) to get a complete list of child entities.
*   **Targeted Local Queries**: Local sources (like Spanner) must be queried with the resolved list of DCIDs, and the expression must be cleared to prevent them from attempting expansion they cannot support or failing due to constraints (Spanner driver forbids both `Dcids` and `Expression` being set).

## Implementation Details
We implemented this logic in `internal/server/datasources/datasources.go` inside the `Observation` method.

### Why this location?
The `DataSources` struct is the federation hub of Mixer. It knows about all configured sources and handles dispatching and merging. By intercepting the request here, we can:
1.  Perform the expansion once using the existing `Node` API (which already federates).
2.  Shape the requests appropriately for each source before they are dispatched in parallel.
    * Remote Mixer gets the original entity expression
    * Other datasources get the expanded dcid list.

### Architectural Flow
1.  **Intercept**: If the request contains an entity expression and we are in a federated environment (both local and remote sources present), we trigger the expansion flow.
2.  **Resolve**: We call `ds.Node` (our own method) with the expression to get all child places. We added a helper `fetchAllDCIDs` to handle pagination and ensure we get all results.
4.  **Extract**: We look for the arc key `"containedInPlace+"` in the response (handled normalization differences between Remote and Spanner).
5.  **Clone & Dispatch**: We clone the request for local sources, populating `Dcids` with the resolved list and clearing `Expression`. The remote source receives the unmodified original request.
6.  **Merge**: Results are merged using `merger.MergeMultiObservation`.

## Testing

### Unit Tests
We added tests in `datasources_test.go`:
*   `TestObservation_ExpressionExpansion`: Verifies that Spanner receives resolved DCIDs and Remote receives the original expression.
*   `TestFetchAllDCIDs`: Verifies that the pagination loop correctly follows `NextToken` to fetch all pages of results.

### Manual Verification
To verify this change manually or in the future, I:

#### 1. Set up Spanner Database
I set up a Spanner database with the Data Commons schema and some dummy data. Detailed instructions are in [Verification.md](file:///Users/calinc/.gemini/jetski/brain/4456a06e-03b6-4343-89c0-dd97ea498f9d/Verification.md) to:
*   Upload proto descriptors.
*   Create `Node`, `Edge`, and `Observation` tables.
*   Insert a dummy county linked to California via `linkedContainedInPlace` and `typeOf` edges.

#### 2. Started Envoy
I ran Envoy to handle HTTP to gRPC transcoding:
```bash
envoy -l warning --config-path esp/envoy-config.yaml
```

#### 3. Ran Local Mixer
I started the local Mixer pointing to my Spanner instance and enabling remote federation:
```bash
export SPANNER_CONF="project: <project>\ninstance: <instance>\ndatabase: <database>"
export MIXER_API_KEY="<your_api_key>"

./run_server.sh \
  --use_bigquery=false \
  --use_base_bigtable=false \
  --use_branch_bigtable=false \
  --use_spanner_graph=true \
  --spanner_graph_info="$SPANNER_CONF" \
  --remote_mixer_domain=https://api.datacommons.org
```

#### 4. Verified with Curl
I ran a query with an expression and verified that results contained both remote data (California counties) and my local dummy data:
```bash
curl -X POST -H "Content-Type: application/json" -d '{
  "select": ["variable", "entity", "date", "value"],
  "variable": {"dcids": ["Count_Person"]},
  "entity": {"expression": "geoId/06<-containedInPlace+{typeOf:County}"},
  "date": "2020"
}' http://localhost:8081/v2/observation
```
