### PR TITLE
Update mixer pod cpuRequest and memoryLimit values

### DIFF
--- a/deploy/helm_charts/envs/mixer_autopush.yaml
+++ b/deploy/helm_charts/envs/mixer_autopush.yaml
@@ -46,7 +46,7 @@ serviceGroups:
     resources:
       memoryRequest: "6G"
       memoryLimit: "6G"
-      cpuRequest: "1"
+      cpuRequest: "2"
   node:
     replicas: 20
   default:

--- a/deploy/helm_charts/envs/mixer_autopush.yaml
+++ b/deploy/helm_charts/envs/mixer_autopush.yaml
@@ -45,7 +45,7 @@ serviceGroups:
     replicas: 20
     resources:
       memoryRequest: "6G"
-      memoryLimit: "6G"
+      memoryLimit: "8G"
       cpuRequest: "2"
   node:
     replicas: 20

--- a/deploy/helm_charts/envs/mixer_autopush.yaml
+++ b/deploy/helm_charts/envs/mixer_autopush.yaml
@@ -46,6 +46,7 @@ serviceGroups:
     resources:
       memoryRequest: "6G"
       memoryLimit: "6G"
+      cpuRequest: "1"
   node:
     replicas: 20
   default:

--- a/deploy/helm_charts/envs/mixer_dev.yaml
+++ b/deploy/helm_charts/envs/mixer_dev.yaml
@@ -45,6 +45,7 @@ serviceGroups:
     resources:
       memoryRequest: "4G"
       memoryLimit: "4G"
+      cpuRequest: "100m"
   recon:
     replicas: 4
   observation:
@@ -54,6 +55,7 @@ serviceGroups:
     resources:
       memoryRequest: "4G"
       memoryLimit: "4G"
+      cpuRequest: "500m"
   default:
     replicas: 2
 

--- a/deploy/helm_charts/mixer/templates/deployment.yaml
+++ b/deploy/helm_charts/mixer/templates/deployment.yaml
@@ -139,6 +139,9 @@ spec:
               memory: {{ $group.resources.memoryLimit }}
             requests:
               memory:  {{ $group.resources.memoryRequest }}
+              {{- if $group.resources.cpuRequest }}
+              cpu: {{ $group.resources.cpuRequest }}
+              {{- end }}
           command:
             - /bin/sh
             - -c

--- a/deploy/helm_charts/mixer/values.yaml
+++ b/deploy/helm_charts/mixer/values.yaml
@@ -461,7 +461,7 @@ serviceGroups:
     resources:
       memoryRequest: "4G"
       memoryLimit: "4G"
-      cpuRequest: "1"
+      cpuRequest: "2"
   node:
     urlPaths:
       - "/node/*"

--- a/deploy/helm_charts/mixer/values.yaml
+++ b/deploy/helm_charts/mixer/values.yaml
@@ -436,6 +436,7 @@ serviceGroups:
     resources:
       memoryRequest: "8G"
       memoryLimit: "8G"
+      cpuRequest: "100m"
     cacheSVG: true
     # If the name of the recon service is changed here,
     # please also change the name in the deployment.yaml template.
@@ -448,6 +449,7 @@ serviceGroups:
     resources:
       memoryRequest: "2G"
       memoryLimit: "2G"
+      cpuRequest: "100m"
   observation:
     urlPaths:
       - "/bulk/stats"
@@ -459,6 +461,7 @@ serviceGroups:
     resources:
       memoryRequest: "4G"
       memoryLimit: "4G"
+      cpuRequest: "1"
   node:
     urlPaths:
       - "/node/*"
@@ -473,6 +476,7 @@ serviceGroups:
     resources:
       memoryRequest: "8G"
       memoryLimit: "8G"
+      cpuRequest: "500m"
     cacheSVG: true
   default:
     urlPaths:
@@ -481,3 +485,4 @@ serviceGroups:
     resources:
       memoryRequest: "2G"
       memoryLimit: "2G"
+      cpuRequest: "100m"

--- a/deploy/helm_charts/mixer/values.yaml
+++ b/deploy/helm_charts/mixer/values.yaml
@@ -460,7 +460,7 @@ serviceGroups:
     replicas: 1
     resources:
       memoryRequest: "4G"
-      memoryLimit: "4G"
+      memoryLimit: "8G"
       cpuRequest: "2"
   node:
     urlPaths:


### PR DESCRIPTION
# Context & Rationale

Original investigation was done by Gabe in b/502523171#comment2 (Google Corp access required)

We recently investigated and mitigated recurring pod restarts, particularly on the mixer-observation workloads. Two distinct but related issues were contributing to these failures: GKE scheduling imbalances (node-level CPU starvation) and container OOM terminations.

To resolve this, this PR addresses both issues through two key changes:

## 1. Added `cpuRequest` to Observation & other mixer Pods
**The Issue**: Previously, observation pods had no cpuRequest defined. GKE’s scheduler relies on requests for bin-packing; without a CPU request, GKE was scheduling multiple observation pods on the same nodes solely based on memory. When peak query traffic hit, these co-located pods routinely spiked to 1-2 cores (or more) simultaneously, starving the node-level CPU and reaching physical machine capacity.

**The Fix:** We have added a cpuRequest of 2 cores to observation pods. This ensures that GKE guarantees CPU capacity and distributes observation pods evenly across different nodes, keeping node-level CPU consumption in check.

We've also added similar cpuRequests to the other mixer ServiceGroups following Kubernetes best practice.

## 2. Bumped Observation Pod `memoryLimit` to 8G
**The Issue**: Observation pods were experiencing recurrent crashes due to memory constraints (OOMKilled). Peak query traffic regularly pushed memory usage up to or beyond the strict 4G limit, resulting in immediate terminations.

**The Fix**: We bumped the `memoryLimit` for the observation service group from 4G to 8G. Physical GKE nodes running on our machine pools (`e2-highmem-4` with 32GB and `e2-highmem-8` with 64GB) have ample RAM headroom to absorb these query spikes safely. We have kept the `memoryRequest` at 4G to maintain scheduling density while giving individual pods a safer memory ceiling.

# Justification of values

## 1. Finding `cpuRequest` values
To look up how much CPU to assign, I looked at the CPU usage of a few example pods of the service in question, assigned a number slightly higher than baseline.

E.g. For dc-mixer-recon, [https://pantheon.corp.google.com/kubernetes/pod/us-west1/website-us-west1/web...](https://screenshot.googleplex.com/6rDgdfgM5C5JnVL) (Google corp access required to see screenshot)

## 2. `memoryLimit` for observation
Per b/502523171#comment2, 8G matches a previous configuration that was shown to solve the OOM restarts.

# Testing Strategy

This configuration was deployed to `datcom-website-dev` and load tested using Locust. Based on [this GCP console metrics explorer chart](https://pantheon.corp.google.com/monitoring/metrics-explorer;duration=PT12H?pageState=%7B%22xyChart%22:%7B%22constantLines%22:%5B%5D,%22dataSets%22:%5B%7B%22legendTemplate%22:%22Limit%22,%22plotType%22:%22LINE%22,%22pointConnectionMethod%22:%22GAP_DETECTION%22,%22targetAxis%22:%22Y1%22,%22timeSeriesFilter%22:%7B%22aggregations%22:%5B%7B%22alignmentPeriod%22:%2260s%22,%22crossSeriesReducer%22:%22REDUCE_SUM%22,%22groupByFields%22:%5B%5D,%22perSeriesAligner%22:%22ALIGN_RATE%22%7D%5D,%22apiSource%22:%22DEFAULT_CLOUD%22,%22crossSeriesReducer%22:%22REDUCE_SUM%22,%22filter%22:%22metric.type%3D%5C%22serviceruntime.googleapis.com%2Fapi%2Frequest_count%5C%22%20resource.type%3D%5C%22api%5C%22%20resource.label.%5C%22method%5C%22%3D%5C%22datacommons.Mixer.V2Observation%5C%22%22,%22groupByFields%22:%5B%5D,%22minAlignmentPeriod%22:%2260s%22,%22perSeriesAligner%22:%22ALIGN_RATE%22%7D%7D%5D,%22options%22:%7B%22mode%22:%22COLOR%22%7D,%22y1Axis%22:%7B%22label%22:%22%22,%22scale%22:%22LINEAR%22%7D%7D%7D&project=datcom-website-prod&e=13803378&mods=-monitoring_api_staging) suggests the maximum API requests per second for V2/Observation over the last 14 days is around 330 requests/sec. I used this as a proxy for the expected number of requests per second across all pods.

In Locust, I performed 2 sets of tests:

First, I simulated about 350 requests/sec to v2/observation on dev, resulting in a total of 8 CPUs requested, up to 10 CPUs used [see chart](https://pantheon.corp.google.com/kubernetes/deployment/us-central1/website-us-central1/website/dc-mixer-observation/overview?e=13803378&mods=-monitoring_api_staging&project=datcom-website-dev). Note that this is across just 4 pods, in production the traffic would be distributed across 60 pods.

Second, I simulated about 50 requests/sec to v2/observation on dev, resulting in a total of 8 CPUS requested, up to 1 CPU used [see chart](https://pantheon.corp.google.com/kubernetes/deployment/us-central1/website-us-central1/website/dc-mixer-observation/overview?e=13803378&mods=-monitoring_api_staging&project=datcom-website-dev). This is to mimic a per-pod request/sec estimate of ~5 rps times a 10X fudge factor.

In both cases, all pods stayed green, no errors or warnings seen.


