### PR TITLE
/v2/observation: Fetch all pages for ContainedInPlace relation expression expansion

### DIFF
--- a/internal/server/datasource/datasource.go
+++ b/internal/server/datasource/datasource.go
@@ -16,10 +16,13 @@ package datasource
 
 import (
 	"context"
+	"fmt"
+	"log/slog"
 
 	pb "github.com/datacommonsorg/mixer/internal/proto"
 	pbv1 "github.com/datacommonsorg/mixer/internal/proto/v1"
 	pbv2 "github.com/datacommonsorg/mixer/internal/proto/v2"
+	"google.golang.org/protobuf/proto"
 )
 
 // DataSourceType represents the type of data source.
@@ -45,4 +48,61 @@ type DataSource interface {
 	BulkVariableInfo(context.Context, *pbv1.BulkVariableInfoRequest) (*pbv1.BulkVariableInfoResponse, error)
 	BulkVariableGroupInfo(context.Context, *pbv1.BulkVariableGroupInfoRequest) (*pbv1.BulkVariableGroupInfoResponse, error)
 	SdmxData(context.Context, *pb.SdmxDataQuery) (*pb.SdmxDataResult, error)
+}
+
+// NodeFetchAll fetches all NodeResponse pages for a given request by repeatedly calling ds.Node
+// as long as a NextToken is returned and merges into single response.
+func NodeFetchAll(ctx context.Context, ds DataSource, req *pbv2.NodeRequest, pageSize int) (*pbv2.NodeResponse, error) {
+
+	// NOTE: Consider introducing datasource-specific default page sizes in the future.
+	if pageSize <= 0 {
+		return nil, fmt.Errorf("pageSize must be positive")
+	}
+
+	// Make initial call.
+	resp, err := ds.Node(ctx, req, pageSize)
+	if err != nil {
+		slog.Error("NodeFetchAll: initial fetch failed", "error", err)
+		return nil, err
+	}
+
+	if resp.NextToken == "" {
+		return resp, nil
+	}
+
+	// Clone the request to avoid modifying the caller's object when setting NextToken.
+	reqClone := proto.Clone(req).(*pbv2.NodeRequest)
+	
+	// Initialize accumulated response with data from the first page.
+	accumulatedResp := resp
+	
+	for accumulatedResp.NextToken != "" {
+		reqClone.NextToken = accumulatedResp.NextToken
+		
+		nextResp, err := ds.Node(ctx, reqClone, pageSize)
+		if err != nil {
+			slog.Error("NodeFetchAll: subsequent fetch failed", "nextToken", reqClone.NextToken, "error", err)
+			return nil, err
+		}
+		
+		// Merge nextResp into accumulatedResp.
+		accumulatedResp.NextToken = nextResp.NextToken
+		for subjectID, newGraph := range nextResp.Data {
+			accumulatedGraph, ok := accumulatedResp.Data[subjectID]
+			if !ok {
+				accumulatedResp.Data[subjectID] = newGraph
+				continue
+			}
+			for prop, newNodes := range newGraph.Arcs {
+				accumulatedNodes, ok := accumulatedGraph.Arcs[prop]
+				if !ok {
+					accumulatedGraph.Arcs[prop] = newNodes
+					continue
+				}
+				accumulatedNodes.Nodes = append(accumulatedNodes.Nodes, newNodes.Nodes...)
+			}
+		}
+	}
+
+	return accumulatedResp, nil
 }

--- a/internal/server/datasource/datasource.go
+++ b/internal/server/datasource/datasource.go
@@ -53,8 +53,6 @@ type DataSource interface {
 // NodeFetchAll fetches all NodeResponse pages for a given request by repeatedly calling ds.Node
 // as long as a NextToken is returned and merges into single response.
 func NodeFetchAll(ctx context.Context, ds DataSource, req *pbv2.NodeRequest, pageSize int) (*pbv2.NodeResponse, error) {
-
-	// NOTE: Consider introducing datasource-specific default page sizes in the future.
 	if pageSize <= 0 {
 		return nil, fmt.Errorf("pageSize must be positive")
 	}
@@ -65,12 +63,15 @@ func NodeFetchAll(ctx context.Context, ds DataSource, req *pbv2.NodeRequest, pag
 		slog.Error("NodeFetchAll: initial fetch failed", "error", err)
 		return nil, err
 	}
+	if resp == nil {
+		return nil, fmt.Errorf("NodeFetchAll: initial fetch returned nil response")
+	}
 
 	if resp.NextToken == "" {
 		return resp, nil
 	}
 
-	// Clone the request to avoid modifying the caller's object when setting NextToken.
+	// Clone the request to avoid modifying the caller's object and prevent data races.
 	reqClone := proto.Clone(req).(*pbv2.NodeRequest)
 	
 	// Initialize accumulated response with data from the first page.
@@ -84,15 +85,29 @@ func NodeFetchAll(ctx context.Context, ds DataSource, req *pbv2.NodeRequest, pag
 			slog.Error("NodeFetchAll: subsequent fetch failed", "nextToken", reqClone.NextToken, "error", err)
 			return nil, err
 		}
+		if nextResp == nil {
+			return nil, fmt.Errorf("NodeFetchAll: subsequent fetch returned nil response")
+		}
 		
-		// Merge nextResp into accumulatedResp.
-		accumulatedResp.NextToken = nextResp.NextToken
+		// Capture next token before merging.
+		nextToken := nextResp.NextToken
+		
+		// Manual deep merge to avoid proto.Merge issues (which failed in tests by overwriting).
+		if accumulatedResp.Data == nil {
+			accumulatedResp.Data = make(map[string]*pbv2.LinkedGraph)
+		}
+		
 		for subjectID, newGraph := range nextResp.Data {
 			accumulatedGraph, ok := accumulatedResp.Data[subjectID]
 			if !ok {
 				accumulatedResp.Data[subjectID] = newGraph
 				continue
 			}
+			
+			if accumulatedGraph.Arcs == nil {
+				accumulatedGraph.Arcs = make(map[string]*pbv2.Nodes)
+			}
+			
 			for prop, newNodes := range newGraph.Arcs {
 				accumulatedNodes, ok := accumulatedGraph.Arcs[prop]
 				if !ok {
@@ -102,6 +117,8 @@ func NodeFetchAll(ctx context.Context, ds DataSource, req *pbv2.NodeRequest, pag
 				accumulatedNodes.Nodes = append(accumulatedNodes.Nodes, newNodes.Nodes...)
 			}
 		}
+		
+		accumulatedResp.NextToken = nextToken
 	}
 
 	return accumulatedResp, nil

--- a/internal/server/datasource/datasource_test.go
+++ b/internal/server/datasource/datasource_test.go
@@ -13,201 +13,125 @@ import (
 
 type mockDataSource struct {
 	DataSource
-	nodeFunc func(ctx context.Context, req *pbv2.NodeRequest, pageSize int) (*pbv2.NodeResponse, error)
+	responses []*pbv2.NodeResponse
+	errs      []error
+	calls     int
 }
 
 func (m *mockDataSource) Node(ctx context.Context, req *pbv2.NodeRequest, pageSize int) (*pbv2.NodeResponse, error) {
-	return m.nodeFunc(ctx, req, pageSize)
+	if m.calls >= len(m.responses) {
+		return nil, errors.New("too many calls")
+	}
+	resp := m.responses[m.calls]
+	err := m.errs[m.calls]
+	m.calls++
+	return resp, err
+}
+
+// makeNodeResponse helper generates the standard test response graph.
+func makeNodeResponse(nextToken string, childDcids ...string) *pbv2.NodeResponse {
+	var nodes []*pb.EntityInfo
+	for _, dcid := range childDcids {
+		nodes = append(nodes, &pb.EntityInfo{Dcid: dcid})
+	}
+	return &pbv2.NodeResponse{
+		NextToken: nextToken,
+		Data: map[string]*pbv2.LinkedGraph{
+			"geoId/06": {
+				Arcs: map[string]*pbv2.Nodes{
+					"containedInPlace": {Nodes: nodes},
+				},
+			},
+		},
+	}
 }
 
 func TestNodeFetchAll(t *testing.T) {
 	ctx := context.Background()
+	req := &pbv2.NodeRequest{Nodes: []string{"geoId/06"}}
 
-	// Test: Single page response.
-	// Situation: The data source returns a response with no NextToken.
-	// Expectation: The helper returns the response directly without further calls.
-	t.Run("SinglePage", func(t *testing.T) {
-		mockDS := &mockDataSource{
-			nodeFunc: func(ctx context.Context, req *pbv2.NodeRequest, pageSize int) (*pbv2.NodeResponse, error) {
-				return &pbv2.NodeResponse{
-					Data: map[string]*pbv2.LinkedGraph{
-						"geoId/06": {
-							Arcs: map[string]*pbv2.Nodes{
-								"containedInPlace": {
-									Nodes: []*pb.EntityInfo{{Dcid: "geoId/06001"}},
-								},
-							},
-						},
-					},
-				}, nil
+	cases := []struct {
+		name      string
+		responses []*pbv2.NodeResponse
+		errs      []error
+		want      *pbv2.NodeResponse
+		wantErr   bool
+		errStr    string
+	}{
+		// Test: Single page response.
+		// Situation: The data source returns a response with no NextToken.
+		// Expectation: The helper returns the response directly without further calls.
+		{
+			name: "SinglePage",
+			responses: []*pbv2.NodeResponse{
+				makeNodeResponse("", "geoId/06001"),
 			},
-		}
-
-		req := &pbv2.NodeRequest{Nodes: []string{"geoId/06"}}
-		resp, err := NodeFetchAll(ctx, mockDS, req, 10)
-		if err != nil {
-			t.Fatalf("NodeFetchAll failed: %v", err)
-		}
-
-		expected := &pbv2.NodeResponse{
-			Data: map[string]*pbv2.LinkedGraph{
-				"geoId/06": {
-					Arcs: map[string]*pbv2.Nodes{
-						"containedInPlace": {
-							Nodes: []*pb.EntityInfo{{Dcid: "geoId/06001"}},
-						},
-					},
-				},
+			errs: []error{nil},
+			want: makeNodeResponse("", "geoId/06001"),
+		},
+		// Test: Multi-page response.
+		// Situation: The data source returns 3 pages of data, linked by NextToken.
+		// Expectation: The helper loops 3 times, fetches all pages, and merges the nodes correctly.
+		{
+			name: "MultiPage",
+			responses: []*pbv2.NodeResponse{
+				makeNodeResponse("token1", "geoId/06001"),
+				makeNodeResponse("token2", "geoId/06002"),
+				makeNodeResponse("", "geoId/06003"),
 			},
-		}
+			errs: []error{nil, nil, nil},
+			want: makeNodeResponse("", "geoId/06001", "geoId/06002", "geoId/06003"),
+		},
+		// Test: Error on initial call.
+		// Situation: The data source fails on the very first call.
+		// Expectation: The helper immediately returns the error.
+		{
+			name:      "InitialError",
+			responses: []*pbv2.NodeResponse{nil},
+			errs:      []error{errors.New("initial error")},
+			wantErr:   true,
+			errStr:    "initial error",
+		},
+		// Test: Error on subsequent call.
+		// Situation: The data source succeeds on the first call but fails on the second.
+		// Expectation: The helper returns the error encountered on the second call.
+		{
+			name: "SubsequentError",
+			responses: []*pbv2.NodeResponse{
+				makeNodeResponse("token1", "geoId/06001"),
+				nil,
+			},
+			errs:    []error{nil, errors.New("subsequent error")},
+			wantErr: true,
+			errStr:  "subsequent error",
+		},
+	}
 
-		if diff := cmp.Diff(expected, resp, protocmp.Transform()); diff != "" {
-			t.Errorf("NodeFetchAll mismatch (-want +got):\n%s", diff)
-		}
-	})
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockDS := &mockDataSource{
+				responses: tc.responses,
+				errs:      tc.errs,
+			}
 
-	// Test: Multi-page response.
-	// Situation: The data source returns 3 pages of data, linked by NextToken.
-	// Expectation: The helper loops 3 times, fetches all pages, and merges the nodes correctly.
-	t.Run("MultiPage", func(t *testing.T) {
-		calls := 0
-		mockDS := &mockDataSource{
-			nodeFunc: func(ctx context.Context, req *pbv2.NodeRequest, pageSize int) (*pbv2.NodeResponse, error) {
-				calls++
-				switch calls {
-				case 1:
-					return &pbv2.NodeResponse{
-						Data: map[string]*pbv2.LinkedGraph{
-							"geoId/06": {
-								Arcs: map[string]*pbv2.Nodes{
-									"containedInPlace": {
-										Nodes: []*pb.EntityInfo{{Dcid: "geoId/06001"}},
-									},
-								},
-							},
-						},
-						NextToken: "token1",
-					}, nil
-				case 2:
-					if req.NextToken != "token1" {
-						return nil, errors.New("unexpected nextToken")
-					}
-					return &pbv2.NodeResponse{
-						Data: map[string]*pbv2.LinkedGraph{
-							"geoId/06": {
-								Arcs: map[string]*pbv2.Nodes{
-									"containedInPlace": {
-										Nodes: []*pb.EntityInfo{{Dcid: "geoId/06002"}},
-									},
-								},
-							},
-						},
-						NextToken: "token2",
-					}, nil
-				case 3:
-					if req.NextToken != "token2" {
-						return nil, errors.New("unexpected nextToken")
-					}
-					return &pbv2.NodeResponse{
-						Data: map[string]*pbv2.LinkedGraph{
-							"geoId/06": {
-								Arcs: map[string]*pbv2.Nodes{
-									"containedInPlace": {
-										Nodes: []*pb.EntityInfo{{Dcid: "geoId/06003"}},
-									},
-								},
-							},
-						},
-					}, nil
-				default:
-					return nil, errors.New("too many calls")
+			got, err := NodeFetchAll(ctx, mockDS, req, 10)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("NodeFetchAll() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if tc.wantErr {
+				if err.Error() != tc.errStr {
+					t.Errorf("Expected error '%s', got '%v'", tc.errStr, err)
 				}
-			},
-		}
+				return
+			}
 
-		req := &pbv2.NodeRequest{Nodes: []string{"geoId/06"}}
-		resp, err := NodeFetchAll(ctx, mockDS, req, 10)
-		if err != nil {
-			t.Fatalf("NodeFetchAll failed: %v", err)
-		}
+			if diff := cmp.Diff(tc.want, got, protocmp.Transform()); diff != "" {
+				t.Errorf("NodeFetchAll() mismatch (-want +got):\n%s", diff)
+			}
 
-		expected := &pbv2.NodeResponse{
-			Data: map[string]*pbv2.LinkedGraph{
-				"geoId/06": {
-					Arcs: map[string]*pbv2.Nodes{
-						"containedInPlace": {
-							Nodes: []*pb.EntityInfo{
-								{Dcid: "geoId/06001"},
-								{Dcid: "geoId/06002"},
-								{Dcid: "geoId/06003"},
-							},
-						},
-					},
-				},
-			},
-		}
-
-		if diff := cmp.Diff(expected, resp, protocmp.Transform()); diff != "" {
-			t.Errorf("NodeFetchAll mismatch (-want +got):\n%s", diff)
-		}
-		if calls != 3 {
-			t.Errorf("Expected 3 calls, got %d", calls)
-		}
-	})
-
-	// Test: Error on initial call.
-	// Situation: The data source fails on the very first call.
-	// Expectation: The helper immediately returns the error.
-	t.Run("InitialError", func(t *testing.T) {
-		mockDS := &mockDataSource{
-			nodeFunc: func(ctx context.Context, req *pbv2.NodeRequest, pageSize int) (*pbv2.NodeResponse, error) {
-				return nil, errors.New("initial error")
-			},
-		}
-
-		req := &pbv2.NodeRequest{Nodes: []string{"geoId/06"}}
-		_, err := NodeFetchAll(ctx, mockDS, req, 10)
-		if err == nil {
-			t.Fatal("Expected error, got nil")
-		}
-		if err.Error() != "initial error" {
-			t.Errorf("Expected 'initial error', got '%v'", err)
-		}
-	})
-
-	// Test: Error on subsequent call.
-	// Situation: The data source succeeds on the first call but fails on the second.
-	// Expectation: The helper returns the error encountered on the second call.
-	t.Run("SubsequentError", func(t *testing.T) {
-		calls := 0
-		mockDS := &mockDataSource{
-			nodeFunc: func(ctx context.Context, req *pbv2.NodeRequest, pageSize int) (*pbv2.NodeResponse, error) {
-				calls++
-				if calls == 1 {
-					return &pbv2.NodeResponse{
-						Data: map[string]*pbv2.LinkedGraph{
-							"geoId/06": {
-								Arcs: map[string]*pbv2.Nodes{
-									"containedInPlace": {
-										Nodes: []*pb.EntityInfo{{Dcid: "geoId/06001"}},
-									},
-								},
-							},
-						},
-						NextToken: "token1",
-					}, nil
-				}
-				return nil, errors.New("subsequent error")
-			},
-		}
-
-		req := &pbv2.NodeRequest{Nodes: []string{"geoId/06"}}
-		_, err := NodeFetchAll(ctx, mockDS, req, 10)
-		if err == nil {
-			t.Fatal("Expected error, got nil")
-		}
-		if err.Error() != "subsequent error" {
-			t.Errorf("Expected 'subsequent error', got '%v'", err)
-		}
-	})
+			if mockDS.calls != len(tc.responses) {
+				t.Errorf("Expected %d calls, got %d", len(tc.responses), mockDS.calls)
+			}
+		})
+	}
 }

--- a/internal/server/datasource/datasource_test.go
+++ b/internal/server/datasource/datasource_test.go
@@ -1,0 +1,213 @@
+package datasource
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	pb "github.com/datacommonsorg/mixer/internal/proto"
+	pbv2 "github.com/datacommonsorg/mixer/internal/proto/v2"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+type mockDataSource struct {
+	DataSource
+	nodeFunc func(ctx context.Context, req *pbv2.NodeRequest, pageSize int) (*pbv2.NodeResponse, error)
+}
+
+func (m *mockDataSource) Node(ctx context.Context, req *pbv2.NodeRequest, pageSize int) (*pbv2.NodeResponse, error) {
+	return m.nodeFunc(ctx, req, pageSize)
+}
+
+func TestNodeFetchAll(t *testing.T) {
+	ctx := context.Background()
+
+	// Test: Single page response.
+	// Situation: The data source returns a response with no NextToken.
+	// Expectation: The helper returns the response directly without further calls.
+	t.Run("SinglePage", func(t *testing.T) {
+		mockDS := &mockDataSource{
+			nodeFunc: func(ctx context.Context, req *pbv2.NodeRequest, pageSize int) (*pbv2.NodeResponse, error) {
+				return &pbv2.NodeResponse{
+					Data: map[string]*pbv2.LinkedGraph{
+						"geoId/06": {
+							Arcs: map[string]*pbv2.Nodes{
+								"containedInPlace": {
+									Nodes: []*pb.EntityInfo{{Dcid: "geoId/06001"}},
+								},
+							},
+						},
+					},
+				}, nil
+			},
+		}
+
+		req := &pbv2.NodeRequest{Nodes: []string{"geoId/06"}}
+		resp, err := NodeFetchAll(ctx, mockDS, req, 10)
+		if err != nil {
+			t.Fatalf("NodeFetchAll failed: %v", err)
+		}
+
+		expected := &pbv2.NodeResponse{
+			Data: map[string]*pbv2.LinkedGraph{
+				"geoId/06": {
+					Arcs: map[string]*pbv2.Nodes{
+						"containedInPlace": {
+							Nodes: []*pb.EntityInfo{{Dcid: "geoId/06001"}},
+						},
+					},
+				},
+			},
+		}
+
+		if diff := cmp.Diff(expected, resp, protocmp.Transform()); diff != "" {
+			t.Errorf("NodeFetchAll mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	// Test: Multi-page response.
+	// Situation: The data source returns 3 pages of data, linked by NextToken.
+	// Expectation: The helper loops 3 times, fetches all pages, and merges the nodes correctly.
+	t.Run("MultiPage", func(t *testing.T) {
+		calls := 0
+		mockDS := &mockDataSource{
+			nodeFunc: func(ctx context.Context, req *pbv2.NodeRequest, pageSize int) (*pbv2.NodeResponse, error) {
+				calls++
+				switch calls {
+				case 1:
+					return &pbv2.NodeResponse{
+						Data: map[string]*pbv2.LinkedGraph{
+							"geoId/06": {
+								Arcs: map[string]*pbv2.Nodes{
+									"containedInPlace": {
+										Nodes: []*pb.EntityInfo{{Dcid: "geoId/06001"}},
+									},
+								},
+							},
+						},
+						NextToken: "token1",
+					}, nil
+				case 2:
+					if req.NextToken != "token1" {
+						return nil, errors.New("unexpected nextToken")
+					}
+					return &pbv2.NodeResponse{
+						Data: map[string]*pbv2.LinkedGraph{
+							"geoId/06": {
+								Arcs: map[string]*pbv2.Nodes{
+									"containedInPlace": {
+										Nodes: []*pb.EntityInfo{{Dcid: "geoId/06002"}},
+									},
+								},
+							},
+						},
+						NextToken: "token2",
+					}, nil
+				case 3:
+					if req.NextToken != "token2" {
+						return nil, errors.New("unexpected nextToken")
+					}
+					return &pbv2.NodeResponse{
+						Data: map[string]*pbv2.LinkedGraph{
+							"geoId/06": {
+								Arcs: map[string]*pbv2.Nodes{
+									"containedInPlace": {
+										Nodes: []*pb.EntityInfo{{Dcid: "geoId/06003"}},
+									},
+								},
+							},
+						},
+					}, nil
+				default:
+					return nil, errors.New("too many calls")
+				}
+			},
+		}
+
+		req := &pbv2.NodeRequest{Nodes: []string{"geoId/06"}}
+		resp, err := NodeFetchAll(ctx, mockDS, req, 10)
+		if err != nil {
+			t.Fatalf("NodeFetchAll failed: %v", err)
+		}
+
+		expected := &pbv2.NodeResponse{
+			Data: map[string]*pbv2.LinkedGraph{
+				"geoId/06": {
+					Arcs: map[string]*pbv2.Nodes{
+						"containedInPlace": {
+							Nodes: []*pb.EntityInfo{
+								{Dcid: "geoId/06001"},
+								{Dcid: "geoId/06002"},
+								{Dcid: "geoId/06003"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		if diff := cmp.Diff(expected, resp, protocmp.Transform()); diff != "" {
+			t.Errorf("NodeFetchAll mismatch (-want +got):\n%s", diff)
+		}
+		if calls != 3 {
+			t.Errorf("Expected 3 calls, got %d", calls)
+		}
+	})
+
+	// Test: Error on initial call.
+	// Situation: The data source fails on the very first call.
+	// Expectation: The helper immediately returns the error.
+	t.Run("InitialError", func(t *testing.T) {
+		mockDS := &mockDataSource{
+			nodeFunc: func(ctx context.Context, req *pbv2.NodeRequest, pageSize int) (*pbv2.NodeResponse, error) {
+				return nil, errors.New("initial error")
+			},
+		}
+
+		req := &pbv2.NodeRequest{Nodes: []string{"geoId/06"}}
+		_, err := NodeFetchAll(ctx, mockDS, req, 10)
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if err.Error() != "initial error" {
+			t.Errorf("Expected 'initial error', got '%v'", err)
+		}
+	})
+
+	// Test: Error on subsequent call.
+	// Situation: The data source succeeds on the first call but fails on the second.
+	// Expectation: The helper returns the error encountered on the second call.
+	t.Run("SubsequentError", func(t *testing.T) {
+		calls := 0
+		mockDS := &mockDataSource{
+			nodeFunc: func(ctx context.Context, req *pbv2.NodeRequest, pageSize int) (*pbv2.NodeResponse, error) {
+				calls++
+				if calls == 1 {
+					return &pbv2.NodeResponse{
+						Data: map[string]*pbv2.LinkedGraph{
+							"geoId/06": {
+								Arcs: map[string]*pbv2.Nodes{
+									"containedInPlace": {
+										Nodes: []*pb.EntityInfo{{Dcid: "geoId/06001"}},
+									},
+								},
+							},
+						},
+						NextToken: "token1",
+					}, nil
+				}
+				return nil, errors.New("subsequent error")
+			},
+		}
+
+		req := &pbv2.NodeRequest{Nodes: []string{"geoId/06"}}
+		_, err := NodeFetchAll(ctx, mockDS, req, 10)
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if err.Error() != "subsequent error" {
+			t.Errorf("Expected 'subsequent error', got '%v'", err)
+		}
+	})
+}

--- a/internal/server/dispatcher/relation_expression_processor.go
+++ b/internal/server/dispatcher/relation_expression_processor.go
@@ -21,6 +21,7 @@ import (
 
 	pbv2 "github.com/datacommonsorg/mixer/internal/proto/v2"
 	"github.com/datacommonsorg/mixer/internal/server/datasource"
+	"github.com/datacommonsorg/mixer/internal/server/datasources"
 
 	v2 "github.com/datacommonsorg/mixer/internal/server/v2"
 )
@@ -96,13 +97,10 @@ func (p *RelationExpressionProcessor) fetchEntities(
 		Property: property,
 	}
 
-	// Call Node API on the source directly.
-	// PageSize (0) is ignored for now.
-	// TODO: iterate paged responses to compile full entity set
-	resp, err := source.Node(ctx, nodeReq, 0)
+	// Call Node API on the source, fetching all pages.
+	resp, err := datasource.NodeFetchAll(ctx, source, nodeReq, datasources.DefaultPageSize)
 	if err != nil {
-		slog.Error("RelationExpressionProcessor: Node call failed", "error", err)
-		return nil, fmt.Errorf("failed to resolve expression via Node API: %w", err)
+		return nil, err
 	}
 
 	var dcids []string

--- a/internal/server/spanner/datasource.go
+++ b/internal/server/spanner/datasource.go
@@ -247,7 +247,7 @@ func (sds *SpannerDataSource) fetchObservations(ctx context.Context, req *pbv2.O
 // expandAndMergeEntities fetches local child places and merges them with pre-expanded DCIDs.
 func (sds *SpannerDataSource) expandAndMergeEntities(ctx context.Context, containedInPlace *v2.ContainedInPlace, preExpandedDcids []string) ([]string, error) {
 	slog.Info("Spanner.Observation: using pre-expanded entities from context", "count", len(preExpandedDcids))
-	
+
 	// 1. Fetch local child places from Spanner.
 	localDcids, err := sds.fetchLocalChildPlaces(ctx, containedInPlace.Ancestor, containedInPlace.ChildPlaceType)
 	if err != nil {
@@ -265,8 +265,9 @@ func (sds *SpannerDataSource) expandAndMergeEntities(ctx context.Context, contai
 
 // fetchLocalChildPlaces fetches child places from Spanner.
 // Example:
-//   Inputs: ancestor="geoId/06", childType="County"
-//   Outputs: []string{"geoId/06001", "geoId/06002"}, nil
+//
+//	Inputs: ancestor="geoId/06", childType="County"
+//	Outputs: []string{"geoId/06001", "geoId/06002"}, nil
 func (sds *SpannerDataSource) fetchLocalChildPlaces(ctx context.Context, ancestor, childType string) ([]string, error) {
 	property := fmt.Sprintf("<-%s+{typeOf:%s}", v2.ContainedInPlaceProperty, childType)
 	nodeReq := &pbv2.NodeRequest{
@@ -275,11 +276,10 @@ func (sds *SpannerDataSource) fetchLocalChildPlaces(ctx context.Context, ancesto
 	}
 
 	// Call Node API to let it handle optimizations (e.g., mapping to linkedContainedInPlace).
-	// TODO: Handle iterating paged response if NextToken is present.
-	resp, err := sds.Node(ctx, nodeReq, 1000)
+
+	resp, err := datasource.NodeFetchAll(ctx, sds, nodeReq, 1000)
 	if err != nil {
-		slog.Error("Spanner.Observation: failed to get local child places", "error", err)
-		return nil, fmt.Errorf("error getting local child places: %w", err)
+		return nil, err
 	}
 
 	var localDcids []string

--- a/internal/server/spanner/datasource.go
+++ b/internal/server/spanner/datasource.go
@@ -44,6 +44,10 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+// fetchAllPageSize is used when we want to fetch all pages of nodes.
+// 1000 is chosen as an initial balance between minimizing round-trips and OOM risks.
+const fetchAllPageSize = 1000
+
 // svgGroupInfoExclusionList contains StatVarGroup IDs that should be excluded
 // from BulkVariableGroupInfo responses (e.g., hidden nodes).
 var svgGroupInfoExclusionList = map[string]struct{}{
@@ -265,9 +269,8 @@ func (sds *SpannerDataSource) expandAndMergeEntities(ctx context.Context, contai
 
 // fetchLocalChildPlaces fetches child places from Spanner.
 // Example:
-//
-//	Inputs: ancestor="geoId/06", childType="County"
-//	Outputs: []string{"geoId/06001", "geoId/06002"}, nil
+//   Inputs: ancestor="geoId/06", childType="County"
+//   Outputs: []string{"geoId/06001", "geoId/06002"}, nil
 func (sds *SpannerDataSource) fetchLocalChildPlaces(ctx context.Context, ancestor, childType string) ([]string, error) {
 	property := fmt.Sprintf("<-%s+{typeOf:%s}", v2.ContainedInPlaceProperty, childType)
 	nodeReq := &pbv2.NodeRequest{
@@ -277,7 +280,7 @@ func (sds *SpannerDataSource) fetchLocalChildPlaces(ctx context.Context, ancesto
 
 	// Call Node API to let it handle optimizations (e.g., mapping to linkedContainedInPlace).
 
-	resp, err := datasource.NodeFetchAll(ctx, sds, nodeReq, 1000)
+	resp, err := datasource.NodeFetchAll(ctx, sds, nodeReq, fetchAllPageSize)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/spanner/datasource.go
+++ b/internal/server/spanner/datasource.go
@@ -279,7 +279,6 @@ func (sds *SpannerDataSource) fetchLocalChildPlaces(ctx context.Context, ancesto
 	}
 
 	// Call Node API to let it handle optimizations (e.g., mapping to linkedContainedInPlace).
-
 	resp, err := datasource.NodeFetchAll(ctx, sds, nodeReq, fetchAllPageSize)
 	if err != nil {
 		return nil, err

--- a/internal/server/spanner/datasource.go
+++ b/internal/server/spanner/datasource.go
@@ -281,7 +281,8 @@ func (sds *SpannerDataSource) fetchLocalChildPlaces(ctx context.Context, ancesto
 	// Call Node API to let it handle optimizations (e.g., mapping to linkedContainedInPlace).
 	resp, err := datasource.NodeFetchAll(ctx, sds, nodeReq, fetchAllPageSize)
 	if err != nil {
-		return nil, err
+		slog.Error("Spanner.Observation: failed to get local child places", "error", err)
+		return nil, fmt.Errorf("error getting local child places: %w", err)
 	}
 
 	var localDcids []string


### PR DESCRIPTION
## High Level Summary
Follow up to https://github.com/datacommonsorg/mixer/pull/1894

Implemented exhaustive page fetching (traversing all pages) for `/v2/node` calls during relation expression expansion. This ensures that we get the complete set of entities across both remote and local sources, fixing the issue where only the first page of results was processed.

We chose to implement this via a shared helper function `NodeFetchAll` in the `datasource` package. We selected this approach after evaluating several design alternatives (including making DataSources "page-aware" or updating the `DataSource` interface).

**Pros of the Helper Approach:**
*   **Zero Interface Changes**: It avoids the need to modify the `DataSource` interface, which would have required updating all implementations (Spanner, Bigtable, SQL, Mocks) and would have had a high blast radius.
*   **No Code Duplication**: It centralizes the complex logic for handling pagination tokens and deep-merging `NodeResponse` objects, preventing duplication in `RelationExpressionProcessor` and `SpannerDataSource`.
*   **Safety**: It keeps the behavior strictly internal without leaking implementation details (like auto-pagination flags) to the public API via `NodeRequest` protos.

## Detailed Changes

#### `internal/server/datasource/datasource.go`
*   Added `NodeFetchAll` helper function. It repeatedly calls `ds.Node` as long as a `NextToken` is returned, and merges the responses into a single response.
*   Requires `pageSize` to be positive, forcing callers to be explicit.

#### `internal/server/dispatcher/relation_expression_processor.go`
*   Updated `fetchEntities` to use `NodeFetchAll` when calling the remote source, passing `datasources.DefaultPageSize` (500).

#### `internal/server/spanner/datasource.go`
*   Updated `fetchLocalChildPlaces` to use `NodeFetchAll` when fetching local child places, passing `1000`.

## Testing
*   Added unit tests for `NodeFetchAll` in `internal/server/datasource/datasource_test.go` testing:
    *   **Single Page**: Verified that the helper returns response directly without unnecessary looping when `NextToken` is empty.
    *   **Multi-Page**: Verified that the helper correctly loops and deep-merges nested maps in `NodeResponse.Data` across multiple pages.
    *   **Errors**: Verified that errors on both initial and subsequent calls are properly propagated.
*   Ran the full test suite, and all tests passed successfully.
*   **Manual E2E Verification**:
    *   Simulated responses exceeding page size limits to verify pagination traversal.
    *   **Remote Pagination**: Queried for cities in California (returning ~1900 results from remote mixer) to trigger its 500 limit.
    *   **Local Pagination**: Added 1005 dummy cities to local Spanner to trigger the 1000 limit in `fetchLocalChildPlaces`.
    *   Verified that results from both sources are fully fetched and merged correctly by checking the count of returned entities in the response. Tested with both `BaseDCMixer` (local-only) and `LocalMixer` (federated).

## Discussion on Default Page Size
Consider introducing datasource-specific default page sizes in the future.
Currently, we require the caller to specify the page size. However, different backends might perform better with different page sizes. For example, a local Spanner call might handle 1000 nodes efficiently, reducing round-trips, while a remote HTTP call might want to stay at 500 or less to keep payloads manageable.

We could implement this by defining an unexported map and a helper function in the `datasource` package:

```go
var defaultPageSizes = map[DataSourceType]int{
	TypeSpanner: 1000,
	TypeRemote:  0,
	TypeSQL:     500,
	TypeMock:    100,
}

func GetDefaultPageSize(ds DataSource) int {
	if size, ok := defaultPageSizes[ds.Type()]; ok {
		return size
	}
	return datasources.DefaultPageSize // Global fallback
}
```
Hiding the map behind a helper would avoid leaking implementation details to callers.