### PR TITLE
Redis cache null pointer issue

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -410,7 +410,7 @@ func main() {
 	slog.Info("DataSources initialized", "sources", dataSources.GetSources())
 
 	// Declare Redis client at higher scope for injection
-	var redisCacheClient *redis.RedisCacheClient
+	var redisCacheClient redis.CacheClient
 
 	// Processors
 	processors := []*dispatcher.Processor{}
@@ -427,14 +427,15 @@ func main() {
 		// Cache Processor
 		if *useRedis && *redisInfo != "" {
 			slog.Info("Setting up Redis cache processor")
-			var err error
-			redisCacheClient, err = redis.NewCacheClient(*redisInfo)
+			client, err := redis.NewCacheClient(*redisInfo)
 			if err != nil {
 				slog.Error("Failed to create Redis client", "error", err)
 				os.Exit(1)
 			}
 			//nolint:errcheck // TODO: Fix pre-existing issue and remove comment.
-			defer redisCacheClient.Close()
+			defer client.Close()
+
+			redisCacheClient = client
 
 			var redisProcessor dispatcher.Processor = redis.NewCacheProcessor(redisCacheClient)
 			processors = append(processors, &redisProcessor)

--- a/internal/server/topic/fetcher.go
+++ b/internal/server/topic/fetcher.go
@@ -98,7 +98,6 @@ func (m *TopicCacheManager) fetchTopicNodes(ctx context.Context) (map[string]*pb
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch topic nodes: %w", err)
 	}
-	slog.Debug("fetchTopicNodes response data", "data", resp.GetData())
 
 	topics := make(map[string]*pb.TopicNode)
 	graph, ok := resp.GetData()["Topic"]


### PR DESCRIPTION
## Description

This PR refactors the redisCacheClient initialization in main.go to declare the interface type directly. By instantiating the concrete client locally and deferring Close(), we prevent passing a typed-nil pointer to NewTopicCacheManager. This resolving the crash when running without Redis.