### PR TITLE
[DCP - Mixer] Use V2API when Spanner Graph is enabled.

### DIFF
--- a/deploy/featureflags/custom.yaml
+++ b/deploy/featureflags/custom.yaml
@@ -1,0 +1,3 @@
+flags:
+  UseSpannerGraph: true
+  V2DivertFraction: 1.0


### PR DESCRIPTION
This PR sets the base feature flags file. 

In website, when we create the cdc_services image, we will update the run.sh script to make updates to this file before starting mixer.