### PR TITLE
Remove cpuRequests from helm charts

### DIFF
--- a/deploy/helm_charts/envs/mixer_autopush.yaml
+++ b/deploy/helm_charts/envs/mixer_autopush.yaml
@@ -46,7 +46,6 @@ serviceGroups:
     resources:
       memoryRequest: "6G"
       memoryLimit: "8G"
-      cpuRequest: "2"
   node:
     replicas: 20
   default:

--- a/deploy/helm_charts/envs/mixer_dev.yaml
+++ b/deploy/helm_charts/envs/mixer_dev.yaml
@@ -45,7 +45,6 @@ serviceGroups:
     resources:
       memoryRequest: "4G"
       memoryLimit: "4G"
-      cpuRequest: "100m"
   recon:
     replicas: 4
   observation:
@@ -55,7 +54,6 @@ serviceGroups:
     resources:
       memoryRequest: "4G"
       memoryLimit: "4G"
-      cpuRequest: "500m"
   default:
     replicas: 2
 

--- a/deploy/helm_charts/mixer/values.yaml
+++ b/deploy/helm_charts/mixer/values.yaml
@@ -436,7 +436,6 @@ serviceGroups:
     resources:
       memoryRequest: "8G"
       memoryLimit: "8G"
-      cpuRequest: "100m"
     cacheSVG: true
     # If the name of the recon service is changed here,
     # please also change the name in the deployment.yaml template.
@@ -449,7 +448,6 @@ serviceGroups:
     resources:
       memoryRequest: "2G"
       memoryLimit: "2G"
-      cpuRequest: "100m"
   observation:
     urlPaths:
       - "/bulk/stats"
@@ -461,7 +459,6 @@ serviceGroups:
     resources:
       memoryRequest: "4G"
       memoryLimit: "8G"
-      cpuRequest: "2"
   node:
     urlPaths:
       - "/node/*"
@@ -476,7 +473,6 @@ serviceGroups:
     resources:
       memoryRequest: "8G"
       memoryLimit: "8G"
-      cpuRequest: "500m"
     cacheSVG: true
   default:
     urlPaths:
@@ -485,4 +481,3 @@ serviceGroups:
     resources:
       memoryRequest: "2G"
       memoryLimit: "2G"
-      cpuRequest: "100m"


### PR DESCRIPTION
This PR removes the cpuRequests added in #1883 because they were causing issues with prod deployment. These changes match the helm charts I used to successfully deploy to prod on Tuesday, May 19, 2026.
