### PR TITLE
Update the handler logic to read the EnableSpannerSearchEmbeddings flag

### DIFF
--- a/internal/server/handler_v2.go
+++ b/internal/server/handler_v2.go
@@ -46,7 +46,7 @@ func (s *Server) V2Resolve(
 ) (*pbv2.ResolveResponse, error) {
 	// TODO: Remove this once embeddings search (resolver == "indicator") and
 	// topic resolution (resolver == "topic") are fully supported through Spanner.
-	if s.shouldDivertV2(ctx) && (in == nil || (in.GetResolver() != "indicator" && in.GetResolver() != "topic")) {
+	if s.shouldDivertV2(ctx) && (in == nil || (in.GetResolver() != "indicator" && in.GetResolver() != "topic") || s.flags.EnableSpannerSearchEmbeddings) {
 		return s.dispatcher.Resolve(ctx, in)
 	}
 

--- a/internal/server/spanner/datasource.go
+++ b/internal/server/spanner/datasource.go
@@ -434,6 +434,7 @@ func (sds *SpannerDataSource) Resolve(ctx context.Context, req *pbv2.ResolveRequ
 			slog.Warn("Received unsupported ResolveResolverIndicator request to Spanner", "request", req)
 			return &pbv2.ResolveResponse{}, nil
 		}
+		slog.Info("SpannerDataSource: Starting resolution", "resolver", resolver, "nodes", req.GetNodes(), "inProp", normalizedResolveRequest.InProp)
 		return sds.vectorSearchResolution(ctx, normalizedResolveRequest)
 	}
 

--- a/internal/server/spanner/datasource.go
+++ b/internal/server/spanner/datasource.go
@@ -434,7 +434,7 @@ func (sds *SpannerDataSource) Resolve(ctx context.Context, req *pbv2.ResolveRequ
 			slog.Warn("Received unsupported ResolveResolverIndicator request to Spanner", "request", req)
 			return &pbv2.ResolveResponse{}, nil
 		}
-		slog.Info("SpannerDataSource: Starting resolution", "resolver", resolver, "nodes", req.GetNodes(), "inProp", normalizedResolveRequest.InProp)
+		slog.Info("SpannerDataSource: Starting resolution", "resolver", resolver, "num_nodes", len(req.GetNodes()), "inProp", normalizedResolveRequest.InProp)
 		return sds.vectorSearchResolution(ctx, normalizedResolveRequest)
 	}
 


### PR DESCRIPTION
Whenever EnableSpannerSearchEmbeddings is true for indicator/topic resolver type, we would still invoke the resolve through spanner