### PR TITLE
[v0/v1 migration] Existence check queries: deterministic return order.

### DIFF
--- a/internal/server/spanner/statements.go
+++ b/internal/server/spanner/statements.go
@@ -677,7 +677,8 @@ var statements = struct {
 		JOIN Edge e2 ON c.provenance = e2.subject_id
 		WHERE c.type = 'ProvenanceSummary'
 		  AND e2.predicate IN ('source', 'isPartOf')
-		  AND c.key IN UNNEST(@variables)`,
+		  AND c.key IN UNNEST(@variables)
+		ORDER BY variable, source`,
 	checkGroupSourceExistence: `		SELECT DISTINCT e3.object_id AS variable, e2.object_id AS source
 		FROM Cache c
 		JOIN Edge e2 ON c.provenance = e2.subject_id
@@ -685,7 +686,8 @@ var statements = struct {
 		WHERE c.type = 'ProvenanceSummary'
 		  AND e2.predicate IN ('source', 'isPartOf')
 		  AND e3.predicate = @predicate
-		  AND e3.object_id IN UNNEST(@variables)`,
+		  AND e3.object_id IN UNNEST(@variables)
+		ORDER BY variable, source`,
 	checkGroupPlaceExistence: `		SELECT DISTINCT e.object_id AS variable, o.observation_about AS entity
 		FROM Edge@{FORCE_INDEX=InEdge} e
 		JOIN@{JOIN_TYPE=APPLY_JOIN} Observation@{FORCE_INDEX=VariableMeasuredObservationAbout} o ON e.subject_id = o.variable_measured


### PR DESCRIPTION
## Issue

[b/516807725](b/516807725)

## Description

Add ORDER BY clause to source and group existence SQL queries to force deterministic return order (to ensure consistent results for tests, as well as for payload return order in the future).