### PR TITLE
Route v2/resolve topic requests to Spanner

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -382,6 +382,30 @@ func main() {
 	}
 	slog.Info("After cache creation")
 
+	// Setup Redis client for L2 caching if configured.
+	var redisCacheClient redis.CacheClient
+	if *useRedis && *redisInfo != "" {
+		slog.Info("Setting up Redis cache client")
+		client, err := redis.NewCacheClient(*redisInfo)
+		if err != nil {
+			slog.Error("Failed to create Redis client", "error", err)
+			os.Exit(1)
+		}
+		//nolint:errcheck // TODO: Fix pre-existing issue and remove comment.
+		defer client.Close()
+
+		redisCacheClient = client
+	}
+
+	// Topic Cache Manager: Manages the lifecycle of the topic hierarchy cache.
+	// It handles loading topic data from the database (Bigtable/Spanner)
+	// and maintaining the in-memory cache representation.
+	slog.Info("Initializing topic cache manager")
+	topicCacheManager := topic.NewTopicCacheManager(redisCacheClient)
+
+	// Topic Expander: Implements the resolve.TopicExpander interface wrapping the TopicCacheManager.
+	topicExpander := server.NewTopicExpander(topicCacheManager)
+
 	// Maps client
 	var mapsClient maps.MapsClient
 	if *useMapsApi {
@@ -393,11 +417,12 @@ func main() {
 	}
 
 	// Initialize SpannerDataSource now that dependencies are ready.
-	var spannerDS datasource.DataSource
+	var spannerDS *spanner.SpannerDataSource
 	if spannerClient != nil {
 		spannerDS = spanner.NewSpannerDataSource(spannerClient, &spanner.SpannerDataSourceOptions{
 			RecogPlaceStore: store.RecogPlaceStore,
 			MapsClient:      mapsClient,
+			TopicExpander:   topicExpander,
 		})
 		// TODO: Order sources by priority once other implementations are added.
 		sources = append(sources, spannerDS)
@@ -412,20 +437,6 @@ func main() {
 	dataSources := datasources.NewDataSources(sources, remoteDataSource)
 	slog.Info("DataSources initialized", "sources", dataSources.GetSources())
 
-	// Declare Redis client at higher scope for injection
-	var redisCacheClient redis.CacheClient
-	if *useRedis && *redisInfo != "" {
-		slog.Info("Setting up Redis cache client")
-		client, err := redis.NewCacheClient(*redisInfo)
-		if err != nil {
-			slog.Error("Failed to create Redis client", "error", err)
-			os.Exit(1)
-		}
-		//nolint:errcheck // TODO: Fix pre-existing issue and remove comment.
-		defer client.Close()
-
-		redisCacheClient = client
-	}
 
 	// Processors
 	processors := []*dispatcher.Processor{}
@@ -462,13 +473,6 @@ func main() {
 		}
 	}
 
-	// Topic Cache Manager
-	var topicCacheManager *topic.TopicCacheManager
-	if flags.EnableEmbeddingsResolver {
-		slog.Info("Initializing topic cache manager")
-		topicCacheManager = topic.NewTopicCacheManager(redisCacheClient)
-	}
-
 	// Dispatcher
 	dispatcher := dispatcher.NewDispatcher(processors, dataSources)
 	slog.Info("Dispatcher initialized", "processorsCount", len(processors))
@@ -492,7 +496,7 @@ func main() {
 			WriteUsageLogs:          *writeUsageLogs,
 			EmbeddingsServiceClient: embeddingsServiceClient,
 			UseSpannerGraph:         *useSpannerGraph,
-			TopicCacheManager:       topicCacheManager,
+			TopicExpander:           topicExpander,
 		},
 	)
 	pbs.RegisterMixerServer(srv, mixerServer)
@@ -511,7 +515,7 @@ func main() {
 	}
 
 	// Register component lifecycles
-	registerTopicCacheLifecycle(mixerServer)
+	registerTopicCacheLifecycle(mixerServer, topicCacheManager)
 	registerAgentServiceLifecycle(mixerServer)
 
 	// Run all startup initialization hooks
@@ -581,8 +585,8 @@ func main() {
 	}
 }
 
-func registerTopicCacheLifecycle(s *server.Server) {
-	if tcm := s.TopicCacheManager(); tcm != nil {
+func registerTopicCacheLifecycle(s *server.Server, tcm *topic.TopicCacheManager) {
+	if tcm != nil {
 		s.RegisterLifecycle("topic-cache",
 			func(ctx context.Context) error {
 				_, err := tcm.LoadHierarchy(ctx)

--- a/internal/server/adapter.go
+++ b/internal/server/adapter.go
@@ -35,13 +35,13 @@ type topicExpanderAdapter struct {
 	m *topic.TopicCacheManager
 }
 
-// newTopicExpander is a Server factory method to instantiate and return a resolve.TopicExpander.
-// It hides concrete adapter details entirely from core handlers.
-func (s *Server) newTopicExpander() resolve.TopicExpander {
-	if s.topicCacheManager == nil {
+// NewTopicExpander is a factory to instantiate a resolve.TopicExpander adapter.
+// It is used in main.go to construct the expander for datasource injection.
+func NewTopicExpander(m *topic.TopicCacheManager) resolve.TopicExpander {
+	if m == nil {
 		return nil
 	}
-	return &topicExpanderAdapter{m: s.topicCacheManager}
+	return &topicExpanderAdapter{m: m}
 }
 
 // ExpandRoots resolves root topics using the underlying TopicCacheManager.

--- a/internal/server/handler_core.go
+++ b/internal/server/handler_core.go
@@ -41,7 +41,7 @@ func (s *Server) V2ResolveCore(
 	in *resolve.NormalizedResolveRequest,
 ) (*pbv2.ResolveResponse, error) {
 	// Check for explicit "indicator" or "topic" resolvers, otherwise default to legacy place resolver logic.
-	adapter := s.newTopicExpander()
+	adapter := s.topicExpander
 
 	resolver := in.Request.GetResolver()
 	switch resolver {

--- a/internal/server/handler_v2.go
+++ b/internal/server/handler_v2.go
@@ -137,15 +137,9 @@ func (s *Server) shouldRouteResolveToDispatcher(ctx context.Context, resolver st
 		resolver = resolve.ResolveResolverPlace // Default
 	}
 
-	// Place resolver uses standard diversion logic
-	if resolver == resolve.ResolveResolverPlace {
+	// Place and Topic resolvers use standard diversion logic
+	if resolver == resolve.ResolveResolverPlace || resolver == resolve.ResolveResolverTopic {
 		return s.shouldDivertV2(ctx), nil
-	}
-
-	// Topic resolver always goes to V2ResolveCore (local) because it uses in-memory TopicCache
-	// TODO: implement resolver==topic handling in spanner datasource for dispatch based fulfillment
-	if resolver == resolve.ResolveResolverTopic {
-		return false, nil
 	}
 
 	// Indicator resolver (embeddings-based) has custom request-time toggling

--- a/internal/server/handler_v2_test.go
+++ b/internal/server/handler_v2_test.go
@@ -271,10 +271,10 @@ func TestShouldRouteResolveToDispatcher(t *testing.T) {
 			wantRoute:       false,
 		},
 		{
-			desc:            "Topic resolver with Spanner enabled -> don't route (bypassed to local in PR 1)",
+			desc:            "Topic resolver with Spanner enabled -> route",
 			useSpannerGraph: true,
 			resolver:        resolve.ResolveResolverTopic,
-			wantRoute:       false,
+			wantRoute:       true,
 		},
 		{
 			desc:            "Topic resolver with Spanner disabled -> don't route",

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -42,7 +42,6 @@ import (
 	"github.com/datacommonsorg/mixer/internal/server/cache"
 	"github.com/datacommonsorg/mixer/internal/server/dispatcher"
 	"github.com/datacommonsorg/mixer/internal/server/resource"
-	"github.com/datacommonsorg/mixer/internal/server/topic"
 	"github.com/datacommonsorg/mixer/internal/server/v2/resolve"
 	"github.com/datacommonsorg/mixer/internal/store"
 	"github.com/datacommonsorg/mixer/internal/store/bigtable"
@@ -63,9 +62,9 @@ type Server struct {
 	writeUsageLogs          bool
 	embeddingsServiceClient *resolve.EmbeddingsServiceClient
 	// Whether to use dispatcher flow with Spanner as a default datasource.
-	useSpannerGraph   bool
-	topicCacheManager *topic.TopicCacheManager
-	agentService      *agent.Service
+	useSpannerGraph bool
+	topicExpander   resolve.TopicExpander
+	agentService    *agent.Service
 
 	// Centralized lifecycle scheduler registries
 	initHooks     map[string]func(ctx context.Context) error
@@ -299,7 +298,7 @@ type MixerServerOptions struct {
 	WriteUsageLogs          bool
 	EmbeddingsServiceClient *resolve.EmbeddingsServiceClient
 	UseSpannerGraph         bool
-	TopicCacheManager       *topic.TopicCacheManager
+	TopicExpander           resolve.TopicExpander
 }
 
 // NewMixerServer creates a new mixer server instance.
@@ -323,7 +322,7 @@ func NewMixerServer(
 		s.writeUsageLogs = opts.WriteUsageLogs
 		s.embeddingsServiceClient = opts.EmbeddingsServiceClient
 		s.useSpannerGraph = opts.UseSpannerGraph
-		s.topicCacheManager = opts.TopicCacheManager
+		s.topicExpander = opts.TopicExpander
 		s.cachedata.Store(opts.CacheData)
 	}
 	s.initAgentService()
@@ -334,11 +333,6 @@ func NewMixerServer(
 // AgentService returns the internal agent.Service instance.
 func (s *Server) AgentService() *agent.Service {
 	return s.agentService
-}
-
-// TopicCacheManager returns the internal topic.TopicCacheManager instance.
-func (s *Server) TopicCacheManager() *topic.TopicCacheManager {
-	return s.topicCacheManager
 }
 
 // shouldDivertV2 returns true if the request should be diverted to the dispatcher.

--- a/internal/server/spanner/datasource.go
+++ b/internal/server/spanner/datasource.go
@@ -61,6 +61,7 @@ type SpannerDataSource struct {
 	recogPlaceStore *files.RecogPlaceStore
 	mapsClient      internalmaps.MapsClient
 	searchConfig    *SpannerSearchConfig
+	topicExpander   resolvev2.TopicExpander
 }
 
 const (
@@ -72,6 +73,7 @@ const (
 type SpannerDataSourceOptions struct {
 	RecogPlaceStore *files.RecogPlaceStore
 	MapsClient      internalmaps.MapsClient
+	TopicExpander   resolvev2.TopicExpander
 }
 
 func NewSpannerDataSource(
@@ -86,6 +88,7 @@ func NewSpannerDataSource(
 	if opts != nil {
 		sds.recogPlaceStore = opts.RecogPlaceStore
 		sds.mapsClient = opts.MapsClient
+		sds.topicExpander = opts.TopicExpander
 	}
 	return sds
 }
@@ -485,6 +488,15 @@ func (sds *SpannerDataSource) Resolve(ctx context.Context, req *pbv2.ResolveRequ
 	if resolver := normalizedResolveRequest.Request.GetResolver(); resolver == resolvev2.ResolveResolverIndicator {
 		slog.Info("SpannerDataSource: Starting resolution", "resolver", resolver, "num_nodes", len(req.GetNodes()), "inProp", normalizedResolveRequest.InProp)
 		return sds.vectorSearchResolution(ctx, normalizedResolveRequest)
+	}
+
+	if resolver := normalizedResolveRequest.Request.GetResolver(); resolver == resolvev2.ResolveResolverTopic {
+		if sds.topicExpander == nil {
+			slog.Error("SpannerDataSource: topic expander is not initialized")
+			return nil, status.Errorf(codes.FailedPrecondition, "Topic expander is not initialized in SpannerDataSource")
+		}
+		slog.Info("SpannerDataSource: Starting resolution", "resolver", resolver, "num_nodes", len(req.GetNodes()))
+		return resolvev2.ResolveTopics(ctx, sds.topicExpander, req.GetNodes(), req.GetExpandTopics())
 	}
 
 	switch normalizedResolveRequest.InProp {

--- a/internal/server/spanner/resolve_embeddings_test.go
+++ b/internal/server/spanner/resolve_embeddings_test.go
@@ -5,7 +5,10 @@ import (
 	"testing"
 
 	pbv2 "github.com/datacommonsorg/mixer/internal/proto/v2"
+	"github.com/datacommonsorg/mixer/internal/server/v2/resolve"
 	"github.com/google/go-cmp/cmp"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/testing/protocmp"
 )
 
@@ -144,6 +147,89 @@ func TestResolveEmbeddingsConcurrentSuccess(t *testing.T) {
 						Metadata: map[string]string{
 							"score":    "0.8500",
 							"sentence": "Climate Change",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+		t.Fatalf("Resolve() diff (-want +got):\n%s", diff)
+	}
+}
+
+func TestResolveTopic_NoExpander(t *testing.T) {
+	t.Parallel()
+
+	ds := NewSpannerDataSource(nil, nil)
+
+	_, err := ds.Resolve(context.Background(), &pbv2.ResolveRequest{
+		Nodes:    []string{"dc/topic/Climate"},
+		Resolver: "topic",
+	})
+	if err == nil {
+		t.Fatalf("Resolve() expected error, got nil")
+	}
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Errorf("Resolve() expected FailedPrecondition error, got: %v", err)
+	}
+}
+
+type mockTopicExpander struct {
+	resolve.TopicExpander
+	expandTopicRes []*pbv2.ResolveResponse_Entity_Candidate
+	expandTopicErr error
+	displayNameRes string
+}
+
+func (m *mockTopicExpander) ExpandTopic(ctx context.Context, topicDcid string, expandTopics bool) ([]*pbv2.ResolveResponse_Entity_Candidate, error) {
+	return m.expandTopicRes, m.expandTopicErr
+}
+
+func (m *mockTopicExpander) GetTopicDisplayName(ctx context.Context, topicDcid string) string {
+	return m.displayNameRes
+}
+
+func TestResolveTopic_Success(t *testing.T) {
+	t.Parallel()
+
+	mockExpander := &mockTopicExpander{
+		displayNameRes: "Climate",
+		expandTopicRes: []*pbv2.ResolveResponse_Entity_Candidate{
+			{
+				Dcid:   "dc/topic/ClimateChange",
+				TypeOf: []string{"Topic"},
+			},
+		},
+	}
+
+	ds := NewSpannerDataSource(nil, &SpannerDataSourceOptions{
+		TopicExpander: mockExpander,
+	})
+
+	got, err := ds.Resolve(context.Background(), &pbv2.ResolveRequest{
+		Nodes:    []string{"dc/topic/Climate"},
+		Resolver: "topic",
+	})
+	if err != nil {
+		t.Fatalf("Resolve() error: %v", err)
+	}
+
+	want := &pbv2.ResolveResponse{
+		Entities: []*pbv2.ResolveResponse_Entity{
+			{
+				Node: "dc/topic/Climate",
+				Candidates: []*pbv2.ResolveResponse_Entity_Candidate{
+					{
+						Dcid:   "dc/topic/Climate",
+						TypeOf: []string{"Topic"},
+						Name:   "Climate",
+						Children: []*pbv2.ResolveResponse_Entity_Candidate{
+							{
+								Dcid:   "dc/topic/ClimateChange",
+								TypeOf: []string{"Topic"},
+							},
 						},
 					},
 				},

--- a/internal/server/v2/resolve/topic.go
+++ b/internal/server/v2/resolve/topic.go
@@ -31,6 +31,7 @@ func ResolveTopics(
 	expandTopics bool,
 ) (*pbv2.ResolveResponse, error) {
 	if topicExpander == nil {
+		slog.Error("ResolveTopics: topicExpander is nil")
 		return nil, status.Errorf(codes.FailedPrecondition, "Topic resolution is not available in this environment.")
 	}
 

--- a/test/setup.go
+++ b/test/setup.go
@@ -298,6 +298,7 @@ func newClient(
 			CacheData:               cachedata,
 			MapsClient:              mapsClient,
 			EmbeddingsServiceClient: embeddingsServiceClient,
+			TopicExpander:           nil, // Not testing topics in standard integration tests
 		},
 	)
 	srv := grpc.NewServer()


### PR DESCRIPTION
# Route v2/resolve topic requests to Spanner

## Goal
Route `v2/resolve` requests with `resolver=topic` to the Spanner dispatcher when Spanner is enabled, allowing topic resolution to be handled by the dispatcher-based fulfillment flow.

## Key Aspects of the Approach
We want to route `v2/resolve` requests with `resolver=topic` to the Spanner dispatcher when Spanner is enabled. To implement this, we resolved a startup sequencing issue: `SpannerDataSource` needs the topic expander, but the topic expander needs `Server` (for its node fetcher), which in turn needs `SpannerDataSource` (via the dispatcher).

We resolved this by decoupling the components and delaying the fetcher wiring:
*   **Decoupled Server via Interface**: Changed `Server` and `MixerServerOptions` in `server.go` to accept the `resolve.TopicExpander` interface instead of the concrete `*topic.TopicCacheManager`. This decouples the server core from the caching implementation and allows mocking the expander in unit tests.
*   **Constructor Options Injection**: Added `TopicExpander` to `SpannerDataSourceOptions` in `datasource.go` and assign it in `NewSpannerDataSource` constructor. This allows injecting the dependency at construction time.
*   **Refactored Adapter for Injection**: Changed the `topicExpanderAdapter` in `adapter.go` to be constructed via a package-level factory `NewTopicExpander` so it can be initialized early in `main.go` and passed to the `SpannerDataSource` constructor.

### Startup Flow
1.  **Create Cache Manager**: `TopicCacheManager` is constructed (needs only `redisCacheClient`, no fetcher yet).
2.  **Create Adapter**: Wrap it in the `topicExpanderAdapter` in `main.go` (`topicExpander := server.NewTopicExpander(topicCacheManager)`).
3.  **Create Spanner DS**: `SpannerDataSource` is constructed, receiving the `topicExpander` in `SpannerDataSourceOptions`.
4.  **Create Server**: `Server` is constructed, receiving the same adapter.
5.  **Wire Fetcher**: A `NodeFetcher` is created (using `SpannerDataSource` if Spanner is enabled, or `Server.V2NodeCore` as legacy fallback) and injected into `TopicCacheManager` via `InitFetcher`.
6.  **Load Topic Cache**: `mixerServer.RunInitHooks(ctx)` is called during startup, which triggers the `topic-cache` initialization hook. This hook loads the initial topic hierarchy cache from the configured database (Spanner or Bigtable) using the wired `NodeFetcher`.

### Request Flow (resolver=topic)
*   **Legacy Path (Spanner Disabled)**: Request goes to `V2ResolveCore` -> uses `Server.topicExpander` (adapter) -> resolves via `TopicCacheManager` (in-memory cache loaded from Bigtable via `Server.V2NodeCore`).
*   **Dispatcher Path (Spanner Enabled)**: Request is routed to `SpannerDataSource.Resolve` -> uses its injected `topicExpander` (adapter) -> resolves via `TopicCacheManager` (in-memory cache loaded from Spanner via `SpannerDataSource.Node`).

## Edge Cases, Errors & Logging
*   **Nil Expander**: If `topicExpander` is not initialized in `SpannerDataSource` when a topic resolution request is received, it logs an error (`SpannerDataSource: topic expander is not initialized`) and returns a `FailedPrecondition` gRPC error.
*   **Nil Expander in ResolveTopics**: If `ResolveTopics` is called with a nil expander, it logs an error (`ResolveTopics: topicExpander is nil`) and returns `FailedPrecondition`.
*   **Resolution Failures**: Failures during root topic expansion or specific topic expansion are logged as errors (e.g., `Failed to resolve root topics during resolve`, `Failed to expand topic during resolve`) and returned as `Internal` gRPC errors.

## Testing & E2E Verification
### Automated Tests
*   Updated `TestShouldRouteResolveToDispatcher` in `handler_v2_test.go` to expect routing to Spanner for topic resolver.
*   Added unit tests in `resolve_embeddings_test.go` using a mock `TopicExpander` to verify topic resolution in `SpannerDataSource` (passing the mock via constructor options).
*   All unit and integration tests passed.

### E2E Verification
Both Legacy (Bigtable) and Spanner flows were verified locally.

<details>
<summary><b>Scenario 1: Legacy Flow (Bigtable only)</b></summary>

**Startup Command:**
```bash
./run_server.sh --port=12345
```

**Queries & Outcomes:**
*   **Query Root Topics:**
    ```bash
    grpcurl -plaintext -import-path proto -proto proto/service/mixer.proto -d '{"resolver": "topic"}' localhost:12345 datacommons.Mixer/V2Resolve
    ```
    *Outcome:* Successfully returned root topic hierarchy (loaded from Bigtable).
*   **Query specific topic (Demographics) without expansion:**
    ```bash
    grpcurl -plaintext -import-path proto -proto proto/service/mixer.proto -d '{"nodes": ["dc/topic/Demographics"], "resolver": "topic"}' localhost:12345 datacommons.Mixer/V2Resolve
    ```
    *Outcome:* Returned immediate children of Demographics topic.
*   **Query specific topic (Demographics) with expansion:**
    ```bash
    grpcurl -plaintext -import-path proto -proto proto/service/mixer.proto -d '{"nodes": ["dc/topic/Demographics"], "resolver": "topic", "expand_topics": true}' localhost:12345 datacommons.Mixer/V2Resolve
    ```
    *Outcome:* Recursively unpacked all demographics descendant SVs.
</details>

<details>
<summary><b>Scenario 2: Spanner Flow (Spanner enabled, Bigtable disabled)</b></summary>

**Startup Command:**
```bash
./run_server.sh \
  --port=12345 \
  --use_base_bigtable=false \
  --use_spanner_graph=true \
  --spanner_graph_info="$(cat deploy/storage/spanner_graph_info.yaml)"
```

**Queries & Outcomes:**
*   **Query Root Topics:**
    ```bash
    grpcurl -plaintext -import-path proto -proto proto/service/mixer.proto -d '{"resolver": "topic"}' localhost:12345 datacommons.Mixer/V2Resolve
    ```
    *Outcome:* Successfully returned root topic hierarchy (loaded from Spanner).
*   **Query specific topic (Demographics) without expansion:**
    ```bash
    grpcurl -plaintext -import-path proto -proto proto/service/mixer.proto -d '{"nodes": ["dc/topic/Demographics"], "resolver": "topic"}' localhost:12345 datacommons.Mixer/V2Resolve
    ```
    *Outcome:* Returned immediate children (loaded from Spanner).
*   **Query specific topic (Demographics) with expansion:**
    ```bash
    grpcurl -plaintext -import-path proto -proto proto/service/mixer.proto -d '{"nodes": ["dc/topic/Demographics"], "resolver": "topic", "expand_topics": true}' localhost:12345 datacommons.Mixer/V2Resolve
    ```
    *Outcome:* Recursively unpacked demographics descendant SVs (loaded from Spanner).
*   **Verification Logs:** Server log confirmed routing to Spanner:
    `SpannerDataSource: Starting resolution`
</details>

TAG=agy
CONV=0645fff7-c056-467d-a74f-ed3c7ceee78d
