### PR TITLE
Enable embeddings sidecar for default Mixer service group

### DIFF
--- a/deploy/helm_charts/mixer/values.yaml
+++ b/deploy/helm_charts/mixer/values.yaml
@@ -476,6 +476,7 @@ serviceGroups:
       memoryLimit: "8G"
     cacheSVG: true
   default:
+    enableEmbeddingsSidecar: true
     urlPaths:
       - "/*"
     replicas: 1


### PR DESCRIPTION
Enables the embeddings sidecar on the default service group. This ensures that endpoints like `/v2/agent/search_indicators`, which require embeddings search but are routed to the default service group, do not fail with FailedPrecondition errors in deployed environments.