### PR TITLE
Roll forward: Routing Refactoring & Header Overrides with Startup Validation Fix

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -497,7 +497,6 @@ func main() {
 	// Register component lifecycles
 	registerTopicCacheLifecycle(mixerServer)
 	registerAgentServiceLifecycle(mixerServer)
-	registerEmbeddingsLifecycle(mixerServer, embeddingsServiceClient)
 
 	// Run all startup initialization hooks
 	if err := mixerServer.RunInitHooks(ctx); err != nil {
@@ -596,14 +595,5 @@ func registerAgentServiceLifecycle(s *server.Server) {
 	}
 }
 
-func registerEmbeddingsLifecycle(s *server.Server, client *resolve.EmbeddingsServiceClient) {
-	if client != nil {
-		s.RegisterLifecycle("embeddings-index-validation",
-			func(ctx context.Context) error {
-				return client.LoadAvailableIndexes(ctx)
-			},
-			nil,
-		)
-	}
-}
+
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -44,6 +44,7 @@ import (
 	"github.com/datacommonsorg/mixer/internal/server/remote"
 	"github.com/datacommonsorg/mixer/internal/server/spanner"
 	"github.com/datacommonsorg/mixer/internal/server/topic"
+	"github.com/datacommonsorg/mixer/internal/server/v2/resolve"
 	"github.com/datacommonsorg/mixer/internal/server/v3/observation"
 	"github.com/datacommonsorg/mixer/internal/sqldb"
 	"github.com/datacommonsorg/mixer/internal/store"
@@ -62,6 +63,8 @@ import (
 const (
 	// Refresh interval for server hooks.
 	periodicRefreshInterval = 1 * time.Hour
+	// Timeout for HTTP requests to the embeddings service.
+	embeddingsServiceTimeout = 10 * time.Second
 )
 
 var (
@@ -394,7 +397,7 @@ func main() {
 	// Initialize SpannerDataSource now that dependencies are ready.
 	var spannerDS datasource.DataSource
 	if spannerClient != nil {
-		spannerDS = spanner.NewSpannerDataSource(spannerClient, store.RecogPlaceStore, mapsClient, flags.EnableSpannerSearchEmbeddings)
+		spannerDS = spanner.NewSpannerDataSource(spannerClient, store.RecogPlaceStore, mapsClient)
 		// TODO: Order sources by priority once other implementations are added.
 		sources = append(sources, spannerDS)
 	}
@@ -470,7 +473,12 @@ func main() {
 	slog.Info("Dispatcher initialized", "processorsCount", len(processors))
 
 	// Create server object
-	mixerServer := server.NewMixerServer(store, metadata, c, mapsClient, dispatcher, flags, *writeUsageLogs, *embeddingsServerURL, *resolveEmbeddingsIndexes, *useSpannerGraph, topicCacheManager)
+	embeddingsServiceClient := resolve.NewEmbeddingsServiceClient(
+		&http.Client{Timeout: embeddingsServiceTimeout},
+		*embeddingsServerURL,
+		*resolveEmbeddingsIndexes,
+	)
+	mixerServer := server.NewMixerServer(store, metadata, c, mapsClient, dispatcher, flags, *writeUsageLogs, embeddingsServiceClient, *useSpannerGraph, topicCacheManager)
 	pbs.RegisterMixerServer(srv, mixerServer)
 
 	// If Topic Cache is enabled, construct and initialize the NodeFetcher.
@@ -489,6 +497,7 @@ func main() {
 	// Register component lifecycles
 	registerTopicCacheLifecycle(mixerServer)
 	registerAgentServiceLifecycle(mixerServer)
+	registerEmbeddingsLifecycle(mixerServer, embeddingsServiceClient)
 
 	// Run all startup initialization hooks
 	if err := mixerServer.RunInitHooks(ctx); err != nil {
@@ -583,6 +592,17 @@ func registerAgentServiceLifecycle(s *server.Server) {
 				agentSvc.Reset()
 				return nil
 			},
+		)
+	}
+}
+
+func registerEmbeddingsLifecycle(s *server.Server, client *resolve.EmbeddingsServiceClient) {
+	if client != nil {
+		s.RegisterLifecycle("embeddings-index-validation",
+			func(ctx context.Context) error {
+				return client.LoadAvailableIndexes(ctx)
+			},
+			nil,
 		)
 	}
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -142,8 +142,32 @@ func (sds *SpannerDataSource) Observation(ctx context.Context, req *pbv2.Observa
 }
 ```
 
+### Feature Flags vs. Server/CLI Flags
+
+Mixer uses two mechanisms for configuration and feature gating: **Server/CLI Flags** and **Feature Flags**. It is important to use the correct mechanism depending on the scope of the change.
+
+#### 1. Server/CLI Flags (Startup Flags)
+*   **Definition**: Flags defined in `cmd/main.go` and parsed at startup (e.g., `port`, `config_path`). Passed to the server object during initialization.
+*   **When to use**:
+    *   **Infrastructure Configuration**: Setting up database connections, API ports, billing projects, or file paths.
+    *   **Backend Availability**: Indicating if a specific database backend is enabled and initialized (e.g., `s.useSpannerGraph` or `s.bigtableClient != nil`).
+*   **Characteristics**: Immutable after the server starts. Changing them requires a server restart.
+
+#### 2. Feature Flags (Deployment/Release Flags)
+*   **Definition**: Flags defined in `internal/featureflags/featureflags.go` and loaded from an environment-specific YAML configuration file (e.g., `V2DivertFraction`, `EnableExperimentalFeature`).
+*   **When to use**:
+    *   **Deployment-Specific Toggles**: Enabling/disabling features for specific environments (e.g., enabling experimental features in `autopush` or `local` environments via their respective YAML configs, but keeping them disabled in `prod`).
+    *   **Traffic Control & Routing**: Toggling default execution paths (e.g., routing traffic to Spanner vs. Bigtable).
+    *   **Gradual Rollouts / A/B Testing**: Supporting partial rollouts (e.g., `V2DivertFraction`) or enabling new features under a toggle.
+*   **Characteristics**: Loaded at startup from a YAML config file. **Changing them requires a server restart/redeployment.** They allow environment-specific behavior to be controlled via configuration files rather than altering command-line arguments.
+
+#### Best Practice: Combining Flags for Safe Rollouts
+When introducing a new feature that relies on a new backend:
+1.  Use a **Server/CLI Flag** (or server field check like `s.isBackendConfigured`) to verify the backend infrastructure is configured and initialized.
+2.  Use a **Feature Flag** (like `s.flags.EnableFeature`) to control the default routing.
+3.  Combine them in the routing logic: `useNewFeature := s.isBackendConfigured && s.flags.EnableFeature`. This ensures the server never routes traffic to a backend that was not initialized at startup, even if the feature flag is accidentally enabled.
+
 ### Testing and Documentation
 
 *   **Testing (`test/` vs `*_test.go`)**: Unit tests are located adjacent to the files they test. The repository also utilizes "Golden Testing" (comparing JSON outputs against text files). The `/test` folder holds larger integration testing wrappers.
 *   **Documentation (`docs/`)**: Technical and operational guides. For specific commands regarding boot sequences and profiling, see `docs/developer_guide.md`.
-```

--- a/internal/featureflags/featureflags.go
+++ b/internal/featureflags/featureflags.go
@@ -46,8 +46,8 @@ type Flags struct {
 	UseStatisticalCalculation bool `yaml:"UseStatisticalCalculation"`
 	// Whether to enable the SDMX API endpoint.
 	EnableSDMXDataApi bool `yaml:"EnableSDMXDataApi"`
-	// Whether to enable Spanner search embeddings.
-	// switch this to true in local.yaml for easier development
+	// Whether to default indicator resolution to Spanner.
+	// If false, default requests go to legacy remote service.
 	EnableSpannerSearchEmbeddings bool `yaml:"EnableSpannerSearchEmbeddings"`
 }
 

--- a/internal/server/handler_core.go
+++ b/internal/server/handler_core.go
@@ -49,11 +49,14 @@ func (s *Server) V2ResolveCore(
 		if !s.flags.EnableEmbeddingsResolver {
 			return nil, status.Errorf(codes.Unimplemented, "Resolving indicators is not enabled for this environment.")
 		}
-		idx, err := resolve.SelectEmbeddingsIndex(ctx, s.resolveEmbeddingsIndexes)
+		idx, err := s.embeddingsServiceClient.SelectIndex(ctx)
 		if err != nil {
 			return nil, err
 		}
-		return resolve.ResolveUsingEmbeddings(ctx, s.httpClient, s.embeddingsServerURL, idx, in.Request.GetNodes(), in.TypeOfValues, adapter, in.Request.GetExpandTopics())
+		if idx != "" && !s.embeddingsServiceClient.ValidateIndex(ctx, idx) {
+			return nil, status.Errorf(codes.InvalidArgument, "Embeddings index %q is not available in the embeddings server", idx)
+		}
+		return s.embeddingsServiceClient.Resolve(ctx, idx, in.Request.GetNodes(), in.TypeOfValues, adapter, in.Request.GetExpandTopics())
 	case resolve.ResolveResolverTopic:
 		return resolve.ResolveTopics(ctx, adapter, in.Request.GetNodes(), in.Request.GetExpandTopics())
 	}

--- a/internal/server/handler_core.go
+++ b/internal/server/handler_core.go
@@ -17,6 +17,7 @@ package server
 
 import (
 	"context"
+	"log/slog"
 
 	pbv2 "github.com/datacommonsorg/mixer/internal/proto/v2"
 	v1e "github.com/datacommonsorg/mixer/internal/server/v1/event"
@@ -49,11 +50,15 @@ func (s *Server) V2ResolveCore(
 		if !s.flags.EnableEmbeddingsResolver {
 			return nil, status.Errorf(codes.Unimplemented, "Resolving indicators is not enabled for this environment.")
 		}
+		if s.embeddingsServiceClient == nil {
+			return nil, status.Errorf(codes.FailedPrecondition, "Indicator resolution is not available because the embeddings service client is not initialized.")
+		}
 		idx, err := s.embeddingsServiceClient.SelectIndex(ctx)
 		if err != nil {
 			return nil, err
 		}
 		if idx != "" && !s.embeddingsServiceClient.ValidateIndex(ctx, idx) {
+			slog.Warn("Requested embeddings index is not available", "index", idx)
 			return nil, status.Errorf(codes.InvalidArgument, "Embeddings index %q is not available in the embeddings server", idx)
 		}
 		return s.embeddingsServiceClient.Resolve(ctx, idx, in.Request.GetNodes(), in.TypeOfValues, adapter, in.Request.GetExpandTopics())

--- a/internal/server/handler_v2.go
+++ b/internal/server/handler_v2.go
@@ -36,7 +36,9 @@ import (
 	"github.com/google/uuid"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -44,9 +46,15 @@ import (
 func (s *Server) V2Resolve(
 	ctx context.Context, in *pbv2.ResolveRequest,
 ) (*pbv2.ResolveResponse, error) {
-	// TODO: Remove this once embeddings search (resolver == "indicator") and
-	// topic resolution (resolver == "topic") are fully supported through Spanner.
-	if s.shouldDivertV2(ctx) && (in == nil || (in.GetResolver() != "indicator" && in.GetResolver() != "topic") || s.flags.EnableSpannerSearchEmbeddings) {
+	if in == nil {
+		return nil, status.Errorf(codes.InvalidArgument, "Request is nil")
+	}
+
+	useDispatcher, err := s.shouldRouteResolveToDispatcher(ctx, in.GetResolver())
+	if err != nil {
+		return nil, err
+	}
+	if useDispatcher {
 		return s.dispatcher.Resolve(ctx, in)
 	}
 
@@ -115,6 +123,56 @@ func (s *Server) V2Resolve(
 	)
 
 	return v2Resp, nil
+}
+
+// isSpannerEnabled returns true if the Spanner backend has been enabled.
+func (s *Server) isSpannerEnabled() bool {
+	return s.useSpannerGraph || (s.flags != nil && s.flags.UseSpannerGraph)
+}
+
+// shouldRouteResolveToDispatcher determines whether to route a V2Resolve request to the dispatcher.
+// It returns an error if the request explicitly asks for an unavailable backend.
+func (s *Server) shouldRouteResolveToDispatcher(ctx context.Context, resolver string) (bool, error) {
+	if resolver == "" {
+		resolver = resolve.ResolveResolverPlace // Default
+	}
+
+	// Place resolver uses standard diversion logic
+	if resolver == resolve.ResolveResolverPlace {
+		return s.shouldDivertV2(ctx), nil
+	}
+
+	// Topic resolver always goes to V2ResolveCore (local) because it uses in-memory TopicCache
+	// TODO: implement resolver==topic handling in spanner datasource for dispatch based fulfillment
+	if resolver == resolve.ResolveResolverTopic {
+		return false, nil
+	}
+
+	// Indicator resolver (embeddings-based) has custom request-time toggling
+	if resolver == resolve.ResolveResolverIndicator {
+		divertVal, err := util.GetOptionalBoolHeader(ctx, util.XV2ResolveIndicatorSpanner)
+		if err != nil {
+			return false, err
+		}
+		if divertVal != nil {
+			if *divertVal {
+				// Force Spanner: Fail fast if Spanner backend is not configured
+				if !s.isSpannerEnabled() {
+					slog.Error("Spanner backend requested via header, but Spanner is not enabled on this server")
+					return false, status.Errorf(codes.FailedPrecondition, "Spanner backend is not enabled in this mixer")
+				}
+				return true, nil
+			} else {
+				// Force Legacy
+				return false, nil
+			}
+		}
+		// Default: use Spanner if configured AND default routing flag is true
+		return s.flags != nil && s.flags.EnableSpannerSearchEmbeddings && s.isSpannerEnabled(), nil
+	}
+
+	// Fallback for safety (ValidateAndParseResolveInputs guarantees valid resolver type)
+	return false, nil
 }
 
 // V2Node implements API for mixer.V2Node.

--- a/internal/server/handler_v2_test.go
+++ b/internal/server/handler_v2_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/datacommonsorg/mixer/internal/server/cache"
 	"github.com/datacommonsorg/mixer/internal/server/resource"
 	v2observation "github.com/datacommonsorg/mixer/internal/server/v2/observation"
+	"github.com/datacommonsorg/mixer/internal/server/v2/resolve"
 	"github.com/datacommonsorg/mixer/internal/server/v2/shared"
 	"github.com/datacommonsorg/mixer/internal/store"
 	"github.com/datacommonsorg/mixer/internal/util"
@@ -242,5 +243,149 @@ func TestV2Observation_UsageLog(t *testing.T) {
 	}
 	if !matched {
 		t.Errorf("log output did not match expected pattern.\nGot: %s\nWant regex: %s", outStr, wantLogRegex)
+	}
+}
+
+func TestShouldRouteResolveToDispatcher(t *testing.T) {
+	tests := []struct {
+		desc                   string
+		useSpannerGraph        bool // CLI flag
+		useSpannerGraphFlag    bool // Feature flag
+		enableEmbeddings       bool // flags.EnableSpannerSearchEmbeddings
+		resolver               string
+		indicatorSpannerHeader string // X-V2Resolve-Indicator-Spanner header
+		wantRoute              bool
+		wantErr                bool
+	}{
+		// Place & Topic resolvers (should follow shouldDivertV2, which we mock by setting useSpannerGraph)
+		{
+			desc:            "Place resolver with Spanner enabled -> route",
+			useSpannerGraph: true,
+			resolver:        resolve.ResolveResolverPlace,
+			wantRoute:       true,
+		},
+		{
+			desc:            "Place resolver with Spanner disabled -> don't route",
+			useSpannerGraph: false,
+			resolver:        resolve.ResolveResolverPlace,
+			wantRoute:       false,
+		},
+		{
+			desc:            "Topic resolver with Spanner enabled -> don't route (bypassed to local in PR 1)",
+			useSpannerGraph: true,
+			resolver:        resolve.ResolveResolverTopic,
+			wantRoute:       false,
+		},
+		{
+			desc:            "Topic resolver with Spanner disabled -> don't route",
+			useSpannerGraph: false,
+			resolver:        resolve.ResolveResolverTopic,
+			wantRoute:       false,
+		},
+		{
+			desc:            "Empty resolver defaults to place (Spanner enabled) -> route",
+			useSpannerGraph: true,
+			resolver:        "",
+			wantRoute:       true,
+		},
+
+		// Indicator resolver - Default path (no header)
+		{
+			desc:             "Indicator resolver - Spanner enabled & flag true -> route",
+			useSpannerGraph:  true,
+			enableEmbeddings: true,
+			resolver:         resolve.ResolveResolverIndicator,
+			wantRoute:        true,
+		},
+		{
+			desc:             "Indicator resolver - Spanner enabled & flag false -> don't route",
+			useSpannerGraph:  true,
+			enableEmbeddings: false,
+			resolver:         resolve.ResolveResolverIndicator,
+			wantRoute:        false,
+		},
+		{
+			desc:             "Indicator resolver - Spanner disabled & flag true -> don't route",
+			useSpannerGraph:  false,
+			enableEmbeddings: true,
+			resolver:         resolve.ResolveResolverIndicator,
+			wantRoute:        false,
+		},
+
+		// Indicator resolver - Header override: true (force Spanner)
+		{
+			desc:                   "Indicator resolver - Force Spanner (true), Spanner enabled -> route",
+			useSpannerGraph:        true,
+			resolver:               resolve.ResolveResolverIndicator,
+			indicatorSpannerHeader: "true",
+			wantRoute:              true,
+		},
+		{
+			desc:                   "Indicator resolver - Force Spanner (true), Spanner disabled -> error (fail-fast)",
+			useSpannerGraph:        false,
+			resolver:               resolve.ResolveResolverIndicator,
+			indicatorSpannerHeader: "true",
+			wantErr:                true,
+		},
+		{
+			desc:                   "Indicator resolver - Force Spanner (true) via Feature Flag, Spanner enabled -> route",
+			useSpannerGraphFlag:    true,
+			resolver:               resolve.ResolveResolverIndicator,
+			indicatorSpannerHeader: "true",
+			wantRoute:              true,
+		},
+
+		// Indicator resolver - Header override: false (force Legacy)
+		{
+			desc:                   "Indicator resolver - Force Legacy (false), Spanner enabled & flag true -> don't route",
+			useSpannerGraph:        true,
+			enableEmbeddings:       true,
+			resolver:               resolve.ResolveResolverIndicator,
+			indicatorSpannerHeader: "false",
+			wantRoute:              false,
+		},
+		{
+			desc:                   "Indicator resolver - Force Legacy (false), Spanner disabled -> don't route",
+			useSpannerGraph:        false,
+			resolver:               resolve.ResolveResolverIndicator,
+			indicatorSpannerHeader: "false",
+			wantRoute:              false,
+		},
+
+		// Invalid header values
+		{
+			desc:                   "Indicator resolver - Invalid header value -> error",
+			resolver:               resolve.ResolveResolverIndicator,
+			indicatorSpannerHeader: "invalid_value",
+			wantErr:                true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			s := &Server{
+				useSpannerGraph: tc.useSpannerGraph,
+				flags: &featureflags.Flags{
+					UseSpannerGraph:               tc.useSpannerGraphFlag,
+					EnableSpannerSearchEmbeddings: tc.enableEmbeddings,
+				},
+			}
+
+			ctx := context.Background()
+			if tc.indicatorSpannerHeader != "" {
+				ctx = metadata.NewIncomingContext(ctx, metadata.Pairs(util.XV2ResolveIndicatorSpanner, tc.indicatorSpannerHeader))
+			}
+
+			gotRoute, err := s.shouldRouteResolveToDispatcher(ctx, tc.resolver)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("shouldRouteResolveToDispatcher() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if tc.wantErr {
+				return
+			}
+			if gotRoute != tc.wantRoute {
+				t.Errorf("shouldRouteResolveToDispatcher() = %v, want %v", gotRoute, tc.wantRoute)
+			}
+		})
 	}
 }

--- a/internal/server/resolve_flag_test.go
+++ b/internal/server/resolve_flag_test.go
@@ -3,7 +3,10 @@ package server
 import (
 	"context"
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/datacommonsorg/mixer/internal/featureflags"
 	pbv2 "github.com/datacommonsorg/mixer/internal/proto/v2"
@@ -91,3 +94,109 @@ func TestV2ResolveCore_EmbeddingsFlag(t *testing.T) {
 		t.Error("Expected HTTP client to be called when flag is enabled")
 	}
 }
+
+// Test: Server with nil embeddingsServiceClient.
+// Situation: resolver is "indicator" and EnableEmbeddingsResolver is enabled, but embeddingsServiceClient is nil.
+// Expectation: Returns FailedPrecondition error.
+func TestV2ResolveCore_NilEmbeddingsClient(t *testing.T) {
+	ctx := context.Background()
+
+	s := &Server{
+		flags: &featureflags.Flags{
+			EnableEmbeddingsResolver: true,
+		},
+		embeddingsServiceClient: nil,
+	}
+
+	req := &pbv2.ResolveRequest{
+		Resolver: "indicator",
+		Property: "<-description->dcid",
+		Nodes:    []string{"foo"},
+	}
+
+	_, err := s.V2ResolveCore(
+		ctx,
+		&resolve.NormalizedResolveRequest{
+			Request:      req,
+			InProp:       "description",
+			OutProp:      "dcid",
+			TypeOfValues: nil,
+		})
+
+	if err == nil {
+		t.Error("Expected error when embeddingsServiceClient is nil, got nil")
+	} else {
+		if status.Code(err) != codes.FailedPrecondition {
+			t.Errorf("Expected FailedPrecondition error, got %v", err)
+		}
+	}
+}
+
+// Test: Server with invalid embeddings index.
+// Situation: resolver is "indicator" and EnableEmbeddingsResolver is enabled.
+//            The default index is configured as "invalid_idx", but the embeddings server config
+//            only lists "base_uae_mem".
+// Expectation: Once loaded, requests fail with InvalidArgument.
+func TestV2ResolveCore_InvalidIndex(t *testing.T) {
+	ctx := context.Background()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"indexes": {"base_uae_mem": {}}}`))
+	}))
+	defer server.Close()
+
+	client := resolve.NewEmbeddingsServiceClient(server.Client(), server.URL, "invalid_idx")
+
+	s := &Server{
+		flags: &featureflags.Flags{
+			EnableEmbeddingsResolver: true,
+		},
+		embeddingsServiceClient: client,
+	}
+
+	req := &pbv2.ResolveRequest{
+		Resolver: "indicator",
+		Property: "<-description->dcid",
+		Nodes:    []string{"foo"},
+	}
+
+	// 1. First call triggers the async load, should fail open (or not fail with InvalidArgument)
+	_, err := s.V2ResolveCore(
+		ctx,
+		&resolve.NormalizedResolveRequest{
+			Request:      req,
+			InProp:       "description",
+			OutProp:      "dcid",
+			TypeOfValues: nil,
+		})
+	if err != nil && status.Code(err) == codes.InvalidArgument {
+		t.Errorf("First call expected to fail open, but got InvalidArgument: %v", err)
+	}
+
+	// Wait for async load to finish
+	time.Sleep(100 * time.Millisecond)
+
+	// 2. Second call should fail with InvalidArgument
+	_, err = s.V2ResolveCore(
+		ctx,
+		&resolve.NormalizedResolveRequest{
+			Request:      req,
+			InProp:       "description",
+			OutProp:      "dcid",
+			TypeOfValues: nil,
+		})
+
+	if err == nil {
+		t.Error("Expected error for invalid index, got nil")
+	} else {
+		if status.Code(err) != codes.InvalidArgument {
+			t.Errorf("Expected InvalidArgument error, got %v", err)
+		}
+		expectedMsg := `Embeddings index "invalid_idx" is not available in the embeddings server`
+		if !strings.Contains(err.Error(), expectedMsg) {
+			t.Errorf("Expected error to contain %q, got %q", expectedMsg, err.Error())
+		}
+	}
+}
+

--- a/internal/server/resolve_flag_test.go
+++ b/internal/server/resolve_flag_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/datacommonsorg/mixer/internal/featureflags"
 	pbv2 "github.com/datacommonsorg/mixer/internal/proto/v2"
@@ -161,24 +160,9 @@ func TestV2ResolveCore_InvalidIndex(t *testing.T) {
 		Nodes:    []string{"foo"},
 	}
 
-	// 1. First call triggers the async load, should fail open (or not fail with InvalidArgument)
+	// Call V2ResolveCore with "invalid_idx". This should block, fetch config synchronously,
+	// and fail immediately because "invalid_idx" is not in the config.
 	_, err := s.V2ResolveCore(
-		ctx,
-		&resolve.NormalizedResolveRequest{
-			Request:      req,
-			InProp:       "description",
-			OutProp:      "dcid",
-			TypeOfValues: nil,
-		})
-	if err != nil && status.Code(err) == codes.InvalidArgument {
-		t.Errorf("First call expected to fail open, but got InvalidArgument: %v", err)
-	}
-
-	// Wait for async load to finish
-	time.Sleep(100 * time.Millisecond)
-
-	// 2. Second call should fail with InvalidArgument
-	_, err = s.V2ResolveCore(
 		ctx,
 		&resolve.NormalizedResolveRequest{
 			Request:      req,

--- a/internal/server/resolve_flag_test.go
+++ b/internal/server/resolve_flag_test.go
@@ -75,8 +75,7 @@ func TestV2ResolveCore_EmbeddingsFlag(t *testing.T) {
 		flags: &featureflags.Flags{
 			EnableEmbeddingsResolver: true,
 		},
-		httpClient:          mockClient,
-		embeddingsServerURL: "http://example.com",
+		embeddingsServiceClient: resolve.NewEmbeddingsServiceClient(mockClient, "http://example.com", ""),
 	}
 
 	_, _ = sEnabled.V2ResolveCore(

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -43,6 +43,7 @@ import (
 	"github.com/datacommonsorg/mixer/internal/server/dispatcher"
 	"github.com/datacommonsorg/mixer/internal/server/resource"
 	"github.com/datacommonsorg/mixer/internal/server/topic"
+	"github.com/datacommonsorg/mixer/internal/server/v2/resolve"
 	"github.com/datacommonsorg/mixer/internal/store"
 	"github.com/datacommonsorg/mixer/internal/store/bigtable"
 	"github.com/datacommonsorg/mixer/internal/translator/solver"
@@ -52,16 +53,15 @@ import (
 
 // Server holds resources for a mixer server
 type Server struct {
-	store                    *store.Store
-	metadata                 *resource.Metadata
-	cachedata                atomic.Pointer[cache.Cache]
-	mapsClient               maps.MapsClient
-	httpClient               *http.Client
-	dispatcher               *dispatcher.Dispatcher
-	flags                    *featureflags.Flags
-	writeUsageLogs           bool
-	embeddingsServerURL      string
-	resolveEmbeddingsIndexes string
+	store             *store.Store
+	metadata          *resource.Metadata
+	cachedata         atomic.Pointer[cache.Cache]
+	mapsClient        maps.MapsClient
+	httpClient        *http.Client
+	dispatcher        *dispatcher.Dispatcher
+	flags             *featureflags.Flags
+	writeUsageLogs          bool
+	embeddingsServiceClient *resolve.EmbeddingsServiceClient
 	// Whether to use dispatcher flow with Spanner as a default datasource.
 	useSpannerGraph   bool
 	topicCacheManager *topic.TopicCacheManager
@@ -302,24 +302,22 @@ func NewMixerServer(
 	dispatcher *dispatcher.Dispatcher,
 	flags *featureflags.Flags,
 	writeUsageLogs bool,
-	embeddingsServerURL string,
-	resolveEmbeddingsIndexes string,
+	embeddingsServiceClient *resolve.EmbeddingsServiceClient,
 	useSpannerGraph bool,
 	topicCacheManager *topic.TopicCacheManager,
 ) *Server {
 	s := &Server{
-		store:                    store,
-		metadata:                 metadata,
-		cachedata:                atomic.Pointer[cache.Cache]{},
-		mapsClient:               mapsClient,
-		httpClient:               &http.Client{},
-		dispatcher:               dispatcher,
-		flags:                    flags,
-		writeUsageLogs:           writeUsageLogs,
-		embeddingsServerURL:      embeddingsServerURL,
-		resolveEmbeddingsIndexes: resolveEmbeddingsIndexes,
-		useSpannerGraph:          useSpannerGraph,
-		topicCacheManager:        topicCacheManager,
+		store:                   store,
+		metadata:                metadata,
+		cachedata:               atomic.Pointer[cache.Cache]{},
+		mapsClient:              mapsClient,
+		httpClient:              &http.Client{},
+		dispatcher:              dispatcher,
+		flags:                   flags,
+		writeUsageLogs:          writeUsageLogs,
+		embeddingsServiceClient: embeddingsServiceClient,
+		useSpannerGraph:         useSpannerGraph,
+		topicCacheManager:       topicCacheManager,
 	}
 	s.cachedata.Store(cachedata)
 	s.initAgentService()
@@ -369,3 +367,4 @@ func (s *Server) shouldDivertV2(ctx context.Context) bool {
 	}
 	return divert
 }
+

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -16,12 +16,116 @@ package server
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/datacommonsorg/mixer/internal/featureflags"
+	"github.com/datacommonsorg/mixer/internal/server/v2/resolve"
 	"github.com/datacommonsorg/mixer/internal/util"
 	"google.golang.org/grpc/metadata"
 )
+
+type testNLServerConfig struct {
+	Indexes map[string]interface{} `json:"indexes"`
+}
+
+func TestValidateEmbeddingsIndex(t *testing.T) {
+	tests := []struct {
+		name          string
+		serverURL     string
+		serverHandler http.HandlerFunc
+		idxToValidate string
+		wantValid     bool
+	}{
+		{
+			name:          "Empty Server URL (lenient)",
+			serverURL:     "",
+			idxToValidate: "any_index",
+			wantValid:     true,
+		},
+		{
+			name: "Valid Index",
+			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+				_ = json.NewEncoder(w).Encode(testNLServerConfig{
+					Indexes: map[string]interface{}{
+						"index1": map[string]interface{}{},
+						"index2": map[string]interface{}{},
+					},
+				})
+			},
+			idxToValidate: "index1",
+			wantValid:     true,
+		},
+		{
+			name: "Invalid Index",
+			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+				_ = json.NewEncoder(w).Encode(testNLServerConfig{
+					Indexes: map[string]interface{}{
+						"index1": map[string]interface{}{},
+					},
+				})
+			},
+			idxToValidate: "index2",
+			wantValid:     false,
+		},
+		{
+			name: "Multiple Valid Indexes",
+			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+				_ = json.NewEncoder(w).Encode(testNLServerConfig{
+					Indexes: map[string]interface{}{
+						"index1": map[string]interface{}{},
+						"index2": map[string]interface{}{},
+					},
+				})
+			},
+			idxToValidate: "index1, index2",
+			wantValid:     true,
+		},
+		{
+			name: "Multiple Indexes - One Invalid",
+			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+				_ = json.NewEncoder(w).Encode(testNLServerConfig{
+					Indexes: map[string]interface{}{
+						"index1": map[string]interface{}{},
+					},
+				})
+			},
+			idxToValidate: "index1, index2",
+			wantValid:     false,
+		},
+		{
+			name: "Server Error (lenient fallback)",
+			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			},
+			idxToValidate: "any_index",
+			wantValid:     true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var serverURL string
+			var testServer *httptest.Server
+			if tc.serverHandler != nil {
+				testServer = httptest.NewServer(tc.serverHandler)
+				defer testServer.Close()
+				serverURL = testServer.URL
+			} else {
+				serverURL = tc.serverURL
+			}
+
+			client := resolve.NewEmbeddingsServiceClient(&http.Client{}, serverURL, "")
+			_ = client.LoadAvailableIndexes(context.Background())
+			got := client.ValidateIndex(context.Background(), tc.idxToValidate)
+			if got != tc.wantValid {
+				t.Errorf("ValidateIndex() = %v, want %v", got, tc.wantValid)
+			}
+		})
+	}
+}
 
 func TestShouldDivertV2(t *testing.T) {
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/datacommonsorg/mixer/internal/featureflags"
 	"github.com/datacommonsorg/mixer/internal/server/v2/resolve"
@@ -118,7 +119,11 @@ func TestValidateEmbeddingsIndex(t *testing.T) {
 			}
 
 			client := resolve.NewEmbeddingsServiceClient(&http.Client{}, serverURL, "")
-			_ = client.LoadAvailableIndexes(context.Background())
+			// First call triggers the async load (if serverURL is set).
+			_ = client.ValidateIndex(context.Background(), tc.idxToValidate)
+			if serverURL != "" {
+				time.Sleep(100 * time.Millisecond)
+			}
 			got := client.ValidateIndex(context.Background(), tc.idxToValidate)
 			if got != tc.wantValid {
 				t.Errorf("ValidateIndex() = %v, want %v", got, tc.wantValid)

--- a/internal/server/spanner/coordinate_resolve_test.go
+++ b/internal/server/spanner/coordinate_resolve_test.go
@@ -167,7 +167,7 @@ func TestResolveCoordinate(t *testing.T) {
 				},
 			},
 		},
-	}, nil, nil, false)
+	}, nil, nil)
 
 	got, err := ds.Resolve(context.Background(), &pbv2.ResolveRequest{
 		Nodes:    []string{"37.42#-122.08"},
@@ -234,7 +234,7 @@ func TestResolveCoordinateFetchesAllCellsInBatch(t *testing.T) {
 				},
 			},
 		},
-	}, nil, nil, false)
+	}, nil, nil)
 
 	got, err := ds.Resolve(context.Background(), &pbv2.ResolveRequest{
 		Nodes:    []string{"37.42#-122.08", "36.77#-119.41"},
@@ -289,7 +289,7 @@ func TestResolveCoordinateTypeFilterUsesDominantType(t *testing.T) {
 				},
 			},
 		},
-	}, nil, nil, false)
+	}, nil, nil)
 
 	got, err := ds.Resolve(context.Background(), &pbv2.ResolveRequest{
 		Nodes:    []string{"37.42#-122.08"},
@@ -336,7 +336,7 @@ func TestResolveCoordinateSkipsS2CellCandidatesByType(t *testing.T) {
 				},
 			},
 		},
-	}, nil, nil, false)
+	}, nil, nil)
 
 	got, err := ds.Resolve(context.Background(), &pbv2.ResolveRequest{
 		Nodes:    []string{"37.42#-122.08"},

--- a/internal/server/spanner/datasource.go
+++ b/internal/server/spanner/datasource.go
@@ -56,11 +56,10 @@ var svgGroupInfoExclusionList = map[string]struct{}{
 
 // SpannerDataSource represents a data source that interacts with Spanner.
 type SpannerDataSource struct {
-	client                        SpannerClient
-	recogPlaceStore               *files.RecogPlaceStore
-	mapsClient                    internalmaps.MapsClient
-	searchConfig                  *SpannerSearchConfig
-	enableSpannerSearchEmbeddings bool
+	client          SpannerClient
+	recogPlaceStore *files.RecogPlaceStore
+	mapsClient      internalmaps.MapsClient
+	searchConfig    *SpannerSearchConfig
 }
 
 const (
@@ -73,15 +72,13 @@ func NewSpannerDataSource(
 	client SpannerClient,
 	recogPlaceStore *files.RecogPlaceStore,
 	mapsClient internalmaps.MapsClient,
-	enableSpannerSearchEmbeddings bool,
 ) *SpannerDataSource {
 	cfg, _ := loadSpannerSearchConfig()
 	return &SpannerDataSource{
-		client:                        client,
-		recogPlaceStore:               recogPlaceStore,
-		mapsClient:                    mapsClient,
-		searchConfig:                  cfg,
-		enableSpannerSearchEmbeddings: enableSpannerSearchEmbeddings,
+		client:          client,
+		recogPlaceStore: recogPlaceStore,
+		mapsClient:      mapsClient,
+		searchConfig:    cfg,
 	}
 }
 
@@ -430,10 +427,6 @@ func (sds *SpannerDataSource) Resolve(ctx context.Context, req *pbv2.ResolveRequ
 	}
 
 	if resolver := normalizedResolveRequest.Request.GetResolver(); resolver == resolvev2.ResolveResolverIndicator {
-		if !sds.enableSpannerSearchEmbeddings {
-			slog.Warn("Received unsupported ResolveResolverIndicator request to Spanner", "request", req)
-			return &pbv2.ResolveResponse{}, nil
-		}
 		slog.Info("SpannerDataSource: Starting resolution", "resolver", resolver, "num_nodes", len(req.GetNodes()), "inProp", normalizedResolveRequest.InProp)
 		return sds.vectorSearchResolution(ctx, normalizedResolveRequest)
 	}

--- a/internal/server/spanner/golden/datasource_test.go
+++ b/internal/server/spanner/golden/datasource_test.go
@@ -157,7 +157,7 @@ func TestSpannerResolve(t *testing.T) {
 			},
 		},
 	}
-	ds := spanner.NewSpannerDataSource(client, recogPlaceStore, &maps.FakeMapsClient{}, false)
+	ds := spanner.NewSpannerDataSource(client, recogPlaceStore, &maps.FakeMapsClient{})
 
 	t.Parallel()
 	ctx := context.Background()
@@ -212,7 +212,7 @@ func TestSpannerNode(t *testing.T) {
 	if client == nil {
 		return
 	}
-	ds := spanner.NewSpannerDataSource(client, nil, nil, false)
+	ds := spanner.NewSpannerDataSource(client, nil, nil)
 
 	t.Parallel()
 	ctx := context.Background()
@@ -267,7 +267,7 @@ func TestSpannerSparql(t *testing.T) {
 	if client == nil {
 		return
 	}
-	ds := spanner.NewSpannerDataSource(client, nil, nil, false)
+	ds := spanner.NewSpannerDataSource(client, nil, nil)
 
 	t.Parallel()
 	ctx := context.Background()
@@ -336,7 +336,7 @@ func TestSpannerEvent(t *testing.T) {
 	if client == nil {
 		return
 	}
-	ds := spanner.NewSpannerDataSource(client, nil, nil, false)
+	ds := spanner.NewSpannerDataSource(client, nil, nil)
 
 	t.Parallel()
 	ctx := context.Background()
@@ -562,7 +562,7 @@ func TestSpannerObservation(t *testing.T) {
 			filterNodesByTypeRes:            c.mockTypes,
 			checkGroupPlaceExistenceRes:     c.mockGroupPlaceRes,
 		}
-		ds := spanner.NewSpannerDataSource(client, nil, nil, false)
+		ds := spanner.NewSpannerDataSource(client, nil, nil)
 
 		got, err := ds.Observation(ctx, c.req)
 		if (err != nil) != c.wantErr {
@@ -601,7 +601,7 @@ func TestBulkVariableGroupInfo_Filtering(t *testing.T) {
 			"Topic":        {"dc/topic/Demographics"},
 		},
 	}
-	ds := spanner.NewSpannerDataSource(client, nil, nil, false)
+	ds := spanner.NewSpannerDataSource(client, nil, nil)
 
 	// Test Case 1: Valid SVGs including WHO/Root
 	req1 := &pbv1.BulkVariableGroupInfoRequest{
@@ -699,7 +699,7 @@ func TestSpannerObservation_ExpressionExpansion(t *testing.T) {
 		},
 	}
 
-	ds := spanner.NewSpannerDataSource(client, nil, nil, false)
+	ds := spanner.NewSpannerDataSource(client, nil, nil)
 
 	// Test Case 1: Expression with Remote Data in Context
 	req := &pbv2.ObservationRequest{
@@ -761,7 +761,7 @@ func TestSpannerObservation_ExpressionExpansion_Fallback(t *testing.T) {
 		},
 	}
 
-	ds := spanner.NewSpannerDataSource(client, nil, nil, false)
+	ds := spanner.NewSpannerDataSource(client, nil, nil)
 
 	req := &pbv2.ObservationRequest{
 		Variable: &pbv2.DcidOrExpression{Dcids: []string{"Count_Person"}},
@@ -805,7 +805,7 @@ func TestSpannerObservation_NoExpression(t *testing.T) {
 		},
 	}
 
-	ds := spanner.NewSpannerDataSource(client, nil, nil, false)
+	ds := spanner.NewSpannerDataSource(client, nil, nil)
 
 	req := &pbv2.ObservationRequest{
 		Variable: &pbv2.DcidOrExpression{Dcids: []string{"Count_Person"}},
@@ -911,7 +911,7 @@ func TestSpannerFilterStatVarsByEntity(t *testing.T) {
 			client := &mockSpannerClient{
 				checkVariableExistenceRes: c.mockExist,
 			}
-			ds := spanner.NewSpannerDataSource(client, nil, nil, false)
+			ds := spanner.NewSpannerDataSource(client, nil, nil)
 
 			got, err := ds.FilterStatVarsByEntity(ctx, c.req)
 			if err != nil {

--- a/internal/server/spanner/resolve_embeddings_test.go
+++ b/internal/server/spanner/resolve_embeddings_test.go
@@ -14,7 +14,7 @@ func TestResolveEmbeddingsEmpty(t *testing.T) {
 
 	ds := NewSpannerDataSource(&coordinateMockSpannerClient{
 		embeddingsRes: []float64{},
-	}, nil, nil, true)
+	}, nil, nil)
 
 	got, err := ds.Resolve(context.Background(), &pbv2.ResolveRequest{
 		Nodes:    []string{"California"},
@@ -51,7 +51,7 @@ func TestResolveEmbeddingsSuccess(t *testing.T) {
 				Types:            []string{"Topic"},
 			},
 		},
-	}, nil, nil, true)
+	}, nil, nil)
 
 	got, err := ds.Resolve(context.Background(), &pbv2.ResolveRequest{
 		Nodes:    []string{"Climate"},
@@ -97,7 +97,7 @@ func TestResolveEmbeddingsConcurrentSuccess(t *testing.T) {
 				Types:            []string{"Topic"},
 			},
 		},
-	}, nil, nil, true)
+	}, nil, nil)
 
 	got, err := ds.Resolve(context.Background(), &pbv2.ResolveRequest{
 		Nodes:    []string{"Climate", "Environment", "Weather"},

--- a/internal/server/topic/golden/topic_cache_golden_test.go
+++ b/internal/server/topic/golden/topic_cache_golden_test.go
@@ -45,7 +45,7 @@ func TestFetchTopicsFromKGGolden(t *testing.T) {
 	}
 
 	// Instantiate real SpannerDataSource wrapper with the real database client
-	ds := spanner.NewSpannerDataSource(client, nil, nil, false)
+	ds := spanner.NewSpannerDataSource(client, nil, nil)
 	fetcher := datasource.NewNodeFetcher(ds)
 	manager := topic.NewTopicCacheManager(nil)
 	manager.InitFetcher(fetcher)

--- a/internal/server/v2/resolve/embeddings.go
+++ b/internal/server/v2/resolve/embeddings.go
@@ -58,7 +58,7 @@ type EmbeddingsServiceClient struct {
 	defaultIndexes      string
 	lock                sync.RWMutex
 	availableIndexes    map[string]struct{}
-	isLoading           bool
+	loadLock            sync.Mutex
 }
 
 func NewEmbeddingsServiceClient(httpClient *http.Client, embeddingsServerURL string, defaultIndexes string) *EmbeddingsServiceClient {
@@ -371,7 +371,8 @@ func (c *EmbeddingsServiceClient) fetchAvailableIndexes(ctx context.Context) (ma
 }
 
 // ValidateIndex checks if the given index (or comma-separated indexes) are available using cached config.
-// If the indexes are not loaded yet, it starts an asynchronous load and returns true (skipping validation for this request).
+// If the indexes are not loaded yet, it performs a synchronous load on the first request,
+// blocking that request until the config is fetched.
 func (c *EmbeddingsServiceClient) ValidateIndex(ctx context.Context, idx string) bool {
 	if c.embeddingsServerURL == "" {
 		return true
@@ -382,41 +383,30 @@ func (c *EmbeddingsServiceClient) ValidateIndex(ctx context.Context, idx string)
 	c.lock.RUnlock()
 
 	if availableIndexes == nil {
-		c.lock.Lock()
-		if c.availableIndexes != nil {
-			loadedIndexes := c.availableIndexes
-			c.lock.Unlock()
-			return c.checkIndexes(idx, loadedIndexes)
-		}
-		if c.isLoading {
-			c.lock.Unlock()
-			slog.Warn("Available embeddings indexes not loaded yet, skipping validation (load already in progress)")
-			return true
-		}
-		c.isLoading = true
-		c.lock.Unlock()
+		c.loadLock.Lock()
 
-		slog.Warn("Available embeddings indexes not loaded yet, initiating asynchronous load and skipping validation")
-		go func() {
-			defer func() {
-				c.lock.Lock()
-				c.isLoading = false
-				c.lock.Unlock()
-			}()
+		// Double check under RLock inside loadLock
+		c.lock.RLock()
+		availableIndexes = c.availableIndexes
+		c.lock.RUnlock()
 
-			indexes, err := c.fetchAvailableIndexes(context.Background())
+		if availableIndexes == nil {
+			slog.Warn("Available embeddings indexes not loaded yet, executing synchronous fetch")
+			indexes, err := c.fetchAvailableIndexes(ctx)
 			if err != nil {
 				slog.Error("Failed to fetch available embeddings indexes on-demand", "error", err)
-				return
+				c.loadLock.Unlock()
+				// Fail open on error to prevent breaking Mixer when embeddings server is offline
+				return true
 			}
 
 			c.lock.Lock()
 			c.availableIndexes = indexes
-			slog.Info("Successfully loaded embeddings indexes on-demand")
 			c.lock.Unlock()
-		}()
-
-		return true
+			availableIndexes = indexes
+			slog.Info("Successfully loaded embeddings indexes synchronously on-demand")
+		}
+		c.loadLock.Unlock()
 	}
 
 	return c.checkIndexes(idx, availableIndexes)

--- a/internal/server/v2/resolve/embeddings.go
+++ b/internal/server/v2/resolve/embeddings.go
@@ -25,6 +25,7 @@ import (
 	"net/url"
 	"path"
 	"strings"
+	"sync"
 
 	pbv2 "github.com/datacommonsorg/mixer/internal/proto/v2"
 	"github.com/datacommonsorg/mixer/internal/util"
@@ -51,19 +52,36 @@ var labelToIndex = map[string]string{
 	LabelBaseNL:      IndexBaseUaeMem,
 }
 
-// SelectEmbeddingsIndex determines the correct index to use for embeddings resolution.
-func SelectEmbeddingsIndex(ctx context.Context, defaultIndex string) (string, error) {
+type EmbeddingsServiceClient struct {
+	httpClient          *http.Client
+	embeddingsServerURL string
+	defaultIndexes      string
+	lock                sync.RWMutex
+	availableIndexes    map[string]struct{}
+}
+
+func NewEmbeddingsServiceClient(httpClient *http.Client, embeddingsServerURL string, defaultIndexes string) *EmbeddingsServiceClient {
+	return &EmbeddingsServiceClient{
+		httpClient:          httpClient,
+		embeddingsServerURL: embeddingsServerURL,
+		defaultIndexes:      defaultIndexes,
+	}
+}
+
+// SelectIndex determines the correct index to use for embeddings resolution.
+func (c *EmbeddingsServiceClient) SelectIndex(ctx context.Context) (string, error) {
 	label := util.GetSingleHeaderValue(ctx, util.XV2ResolveIndex)
 	if label == "" {
-		return defaultIndex, nil
+		return c.defaultIndexes, nil
 	}
 
 	if indexName, ok := labelToIndex[label]; ok {
 		return indexName, nil
 	}
 
-	slog.Error("Invalid V2Resolve index label", "label", label, "header", util.XV2ResolveIndex)
-	return "", status.Errorf(codes.InvalidArgument, "Invalid V2Resolve index label: %s", label)
+	// If not in the map, just pass the label directly.
+	slog.Info("V2Resolve index label not in map, passing directly", "label", label, "header", util.XV2ResolveIndex)
+	return label, nil
 }
 
 // searchVarsRequest represents the request body for the embeddings server
@@ -85,23 +103,21 @@ type searchResult struct {
 	} `json:"SV_to_Sentences"`
 }
 
-// ResolveUsingEmbeddings calls the embeddings server to resolve natural language queries to SVs.
-func ResolveUsingEmbeddings(
+// Resolve calls the embeddings server to resolve natural language queries to SVs.
+func (c *EmbeddingsServiceClient) Resolve(
 	ctx context.Context,
-	httpClient *http.Client,
-	embeddingsServerURL string,
 	idx string,
 	nodes []string,
 	typeOfValues []string,
 	topicExpander TopicExpander,
 	expandTopics bool,
 ) (*pbv2.ResolveResponse, error) {
-	if embeddingsServerURL == "" {
+	if c.embeddingsServerURL == "" {
 		slog.Error("resolver=indicator requested, but the embeddings server is not configured for this deployment")
 		return nil, status.Errorf(codes.FailedPrecondition, "Indicator resolution is not available in this environment.")
 	}
 
-	searchResp, err := callEmbeddingsServer(ctx, httpClient, embeddingsServerURL, idx, nodes)
+	searchResp, err := c.callEmbeddingsServer(ctx, idx, nodes)
 	if err != nil {
 		return nil, err
 	}
@@ -110,10 +126,8 @@ func ResolveUsingEmbeddings(
 }
 
 // callEmbeddingsServer handles the HTTP communication with the embeddings server.
-func callEmbeddingsServer(
+func (c *EmbeddingsServiceClient) callEmbeddingsServer(
 	ctx context.Context,
-	httpClient *http.Client,
-	embeddingsServerURL string,
 	idx string,
 	nodes []string,
 ) (*searchVarsResponse, error) {
@@ -128,9 +142,9 @@ func callEmbeddingsServer(
 	}
 
 	// Create the HTTP request
-	searchVarsURL, err := url.Parse(embeddingsServerURL)
+	searchVarsURL, err := url.Parse(c.embeddingsServerURL)
 	if err != nil {
-		slog.Error("Failed to parse embeddings server URL", "error", err, "url", embeddingsServerURL)
+		slog.Error("Failed to parse embeddings server URL", "error", err, "url", c.embeddingsServerURL)
 		return nil, status.Errorf(codes.Internal, "An internal error occurred while connecting to the resolution service.")
 	}
 	searchVarsURL.Path = path.Join(searchVarsURL.Path, SearchVarsQueryEndpoint)
@@ -144,15 +158,15 @@ func callEmbeddingsServer(
 
 	req, err := http.NewRequestWithContext(ctx, "POST", searchVarsURL.String(), bytes.NewBuffer(requestBytes))
 	if err != nil {
-		slog.Error("Failed to create embeddings server request", "error", err, "url", embeddingsServerURL)
+		slog.Error("Failed to create embeddings server request", "error", err, "url", c.embeddingsServerURL)
 		return nil, status.Errorf(codes.Internal, "An internal error occurred while connecting to the resolution service.")
 	}
 	req.Header.Set("Content-Type", "application/json")
 
 	// Execute the request
-	httpResp, err := httpClient.Do(req)
+	httpResp, err := c.httpClient.Do(req)
 	if err != nil {
-		slog.Error("Failed to contact embeddings server", "error", err, "url", embeddingsServerURL, "queries", nodes)
+		slog.Error("Failed to contact embeddings server", "error", err, "url", c.embeddingsServerURL, "queries", nodes)
 		return nil, status.Errorf(codes.Unavailable, "The resolution service is currently unavailable. Please try again later.")
 	}
 	defer func() {
@@ -163,14 +177,21 @@ func callEmbeddingsServer(
 
 	if httpResp.StatusCode != http.StatusOK {
 		bodyBytes, _ := io.ReadAll(httpResp.Body)
-		slog.Error("Embeddings server returned non-200 status", "status_code", httpResp.StatusCode, "body", string(bodyBytes), "url", embeddingsServerURL, "queries", nodes)
-		return nil, status.Errorf(codes.Internal, "The resolution service encountered an error processing your request.")
+		slog.Error("Embeddings server returned non-200 status", "status_code", httpResp.StatusCode, "body", string(bodyBytes), "url", c.embeddingsServerURL, "queries", nodes)
+		
+		grpcCode := util.HTTPStatusToGRPCCode(httpResp.StatusCode)
+
+		errMsg := string(bodyBytes)
+		if errMsg == "" {
+			errMsg = "The resolution service encountered an error processing your request."
+		}
+		return nil, status.Errorf(grpcCode, "Embeddings server error: %s", errMsg)
 	}
 
 	// Parse the response
 	var searchResp searchVarsResponse
 	if err := json.NewDecoder(httpResp.Body).Decode(&searchResp); err != nil {
-		slog.Error("Failed to decode embeddings server response", "error", err, "url", embeddingsServerURL)
+		slog.Error("Failed to decode embeddings server response", "error", err, "url", c.embeddingsServerURL)
 		return nil, status.Errorf(codes.Internal, "An internal error occurred while parsing the resolution response.")
 	}
 	return &searchResp, nil
@@ -301,4 +322,98 @@ func fetchSVPropertyInfos(ctx context.Context, topicExpander TopicExpander, resu
 		return nil
 	}
 	return svInfos
+}
+
+type nlServerConfig struct {
+	Indexes map[string]interface{} `json:"indexes"`
+}
+
+func (c *EmbeddingsServiceClient) fetchAvailableIndexes(ctx context.Context) (map[string]struct{}, error) {
+	if c.embeddingsServerURL == "" {
+		return nil, fmt.Errorf("embeddings server URL is not configured")
+	}
+
+	u, err := url.Parse(c.embeddingsServerURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse embeddings server URL: %w", err)
+	}
+	u.Path = path.Join(u.Path, "/api/server_config/")
+
+	req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		// Drain and close the body to let the Transport reuse the connection
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("embeddings server returned status %d", resp.StatusCode)
+	}
+
+	var config nlServerConfig
+	if err := json.NewDecoder(resp.Body).Decode(&config); err != nil {
+		return nil, fmt.Errorf("failed to decode embeddings server config: %w", err)
+	}
+
+	indexes := make(map[string]struct{})
+	for idx := range config.Indexes {
+		indexes[idx] = struct{}{}
+	}
+
+	return indexes, nil
+}
+
+// LoadAvailableIndexes fetches the available indexes from the embeddings server and caches them.
+func (c *EmbeddingsServiceClient) LoadAvailableIndexes(ctx context.Context) error {
+	if c.embeddingsServerURL == "" {
+		return nil
+	}
+	indexes, err := c.fetchAvailableIndexes(ctx)
+	if err != nil {
+		return err
+	}
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.availableIndexes = indexes
+	return nil
+}
+
+// ValidateIndex checks if the given index (or comma-separated indexes) are available using cached config.
+func (c *EmbeddingsServiceClient) ValidateIndex(ctx context.Context, idx string) bool {
+	if c.embeddingsServerURL == "" {
+		return true
+	}
+
+	c.lock.RLock()
+	availableIndexes := c.availableIndexes
+	c.lock.RUnlock()
+
+	if availableIndexes == nil {
+		slog.Warn("Available embeddings indexes not loaded yet, skipping validation")
+		return true
+	}
+
+	return c.checkIndexes(idx, availableIndexes)
+}
+
+func (c *EmbeddingsServiceClient) checkIndexes(idx string, availableIndexes map[string]struct{}) bool {
+	parts := strings.Split(idx, ",")
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		if _, ok := availableIndexes[part]; !ok {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/server/v2/resolve/embeddings.go
+++ b/internal/server/v2/resolve/embeddings.go
@@ -58,9 +58,13 @@ type EmbeddingsServiceClient struct {
 	defaultIndexes      string
 	lock                sync.RWMutex
 	availableIndexes    map[string]struct{}
+	isLoading           bool
 }
 
 func NewEmbeddingsServiceClient(httpClient *http.Client, embeddingsServerURL string, defaultIndexes string) *EmbeddingsServiceClient {
+	if httpClient == nil {
+		httpClient = &http.Client{}
+	}
 	return &EmbeddingsServiceClient{
 		httpClient:          httpClient,
 		embeddingsServerURL: embeddingsServerURL,
@@ -159,7 +163,7 @@ func (c *EmbeddingsServiceClient) callEmbeddingsServer(
 	req, err := http.NewRequestWithContext(ctx, "POST", searchVarsURL.String(), bytes.NewBuffer(requestBytes))
 	if err != nil {
 		slog.Error("Failed to create embeddings server request", "error", err, "url", c.embeddingsServerURL)
-		return nil, status.Errorf(codes.Internal, "An internal error occurred while connecting to the resolution service.")
+		return nil, status.Errorf(codes.Internal, "An internal error occurred while connecting to the embeddings service backend.")
 	}
 	req.Header.Set("Content-Type", "application/json")
 
@@ -167,7 +171,7 @@ func (c *EmbeddingsServiceClient) callEmbeddingsServer(
 	httpResp, err := c.httpClient.Do(req)
 	if err != nil {
 		slog.Error("Failed to contact embeddings server", "error", err, "url", c.embeddingsServerURL, "queries", nodes)
-		return nil, status.Errorf(codes.Unavailable, "The resolution service is currently unavailable. Please try again later.")
+		return nil, status.Errorf(codes.Unavailable, "The embeddings service backend is currently unavailable. Please try again later.")
 	}
 	defer func() {
 		// Drain and close the body to let the Transport reuse the connection
@@ -178,21 +182,16 @@ func (c *EmbeddingsServiceClient) callEmbeddingsServer(
 	if httpResp.StatusCode != http.StatusOK {
 		bodyBytes, _ := io.ReadAll(httpResp.Body)
 		slog.Error("Embeddings server returned non-200 status", "status_code", httpResp.StatusCode, "body", string(bodyBytes), "url", c.embeddingsServerURL, "queries", nodes)
-		
-		grpcCode := util.HTTPStatusToGRPCCode(httpResp.StatusCode)
 
-		errMsg := string(bodyBytes)
-		if errMsg == "" {
-			errMsg = "The resolution service encountered an error processing your request."
-		}
-		return nil, status.Errorf(grpcCode, "Embeddings server error: %s", errMsg)
+		grpcCode := util.HTTPStatusToGRPCCode(httpResp.StatusCode)
+		return nil, status.Errorf(grpcCode, "The embeddings service backend encountered an error processing your request.")
 	}
 
 	// Parse the response
 	var searchResp searchVarsResponse
 	if err := json.NewDecoder(httpResp.Body).Decode(&searchResp); err != nil {
 		slog.Error("Failed to decode embeddings server response", "error", err, "url", c.embeddingsServerURL)
-		return nil, status.Errorf(codes.Internal, "An internal error occurred while parsing the resolution response.")
+		return nil, status.Errorf(codes.Internal, "An internal error occurred while parsing the response from the embeddings service backend.")
 	}
 	return &searchResp, nil
 }
@@ -371,22 +370,8 @@ func (c *EmbeddingsServiceClient) fetchAvailableIndexes(ctx context.Context) (ma
 	return indexes, nil
 }
 
-// LoadAvailableIndexes fetches the available indexes from the embeddings server and caches them.
-func (c *EmbeddingsServiceClient) LoadAvailableIndexes(ctx context.Context) error {
-	if c.embeddingsServerURL == "" {
-		return nil
-	}
-	indexes, err := c.fetchAvailableIndexes(ctx)
-	if err != nil {
-		return err
-	}
-	c.lock.Lock()
-	defer c.lock.Unlock()
-	c.availableIndexes = indexes
-	return nil
-}
-
 // ValidateIndex checks if the given index (or comma-separated indexes) are available using cached config.
+// If the indexes are not loaded yet, it starts an asynchronous load and returns true (skipping validation for this request).
 func (c *EmbeddingsServiceClient) ValidateIndex(ctx context.Context, idx string) bool {
 	if c.embeddingsServerURL == "" {
 		return true
@@ -397,7 +382,40 @@ func (c *EmbeddingsServiceClient) ValidateIndex(ctx context.Context, idx string)
 	c.lock.RUnlock()
 
 	if availableIndexes == nil {
-		slog.Warn("Available embeddings indexes not loaded yet, skipping validation")
+		c.lock.Lock()
+		if c.availableIndexes != nil {
+			loadedIndexes := c.availableIndexes
+			c.lock.Unlock()
+			return c.checkIndexes(idx, loadedIndexes)
+		}
+		if c.isLoading {
+			c.lock.Unlock()
+			slog.Warn("Available embeddings indexes not loaded yet, skipping validation (load already in progress)")
+			return true
+		}
+		c.isLoading = true
+		c.lock.Unlock()
+
+		slog.Warn("Available embeddings indexes not loaded yet, initiating asynchronous load and skipping validation")
+		go func() {
+			defer func() {
+				c.lock.Lock()
+				c.isLoading = false
+				c.lock.Unlock()
+			}()
+
+			indexes, err := c.fetchAvailableIndexes(context.Background())
+			if err != nil {
+				slog.Error("Failed to fetch available embeddings indexes on-demand", "error", err)
+				return
+			}
+
+			c.lock.Lock()
+			c.availableIndexes = indexes
+			slog.Info("Successfully loaded embeddings indexes on-demand")
+			c.lock.Unlock()
+		}()
+
 		return true
 	}
 

--- a/internal/server/v2/resolve/embeddings_test.go
+++ b/internal/server/v2/resolve/embeddings_test.go
@@ -6,7 +6,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/datacommonsorg/mixer/internal/util"
 	"google.golang.org/grpc/codes"
@@ -113,7 +115,7 @@ func TestResolveUsingEmbeddings_Errors(t *testing.T) {
 				w.WriteHeader(http.StatusInternalServerError)
 				_, _ = w.Write([]byte("internal error"))
 			},
-			expectedError: "internal error",
+			expectedError: "The embeddings service backend encountered an error processing your request.",
 			expectedCode:  codes.Internal,
 		},
 		{
@@ -122,7 +124,7 @@ func TestResolveUsingEmbeddings_Errors(t *testing.T) {
 				w.WriteHeader(http.StatusBadRequest)
 				_, _ = w.Write([]byte("bad index name"))
 			},
-			expectedError: "bad index name",
+			expectedError: "The embeddings service backend encountered an error processing your request.",
 			expectedCode:  codes.InvalidArgument,
 		},
 		{
@@ -131,7 +133,7 @@ func TestResolveUsingEmbeddings_Errors(t *testing.T) {
 				w.WriteHeader(http.StatusNotFound)
 				_, _ = w.Write([]byte("index not found"))
 			},
-			expectedError: "index not found",
+			expectedError: "The embeddings service backend encountered an error processing your request.",
 			expectedCode:  codes.NotFound,
 		},
 		{
@@ -139,7 +141,7 @@ func TestResolveUsingEmbeddings_Errors(t *testing.T) {
 			serverHandler: func(w http.ResponseWriter, r *http.Request) {
 				_, _ = w.Write([]byte("{invalid-json"))
 			},
-			expectedError: "An internal error occurred while parsing the resolution response.",
+			expectedError: "An internal error occurred while parsing the response from the embeddings service backend.",
 			expectedCode:  codes.Internal,
 		},
 		{
@@ -423,5 +425,156 @@ func TestSelectEmbeddingsIndex(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestValidateIndex_OnDemandLoad(t *testing.T) {
+	var requestCount int
+	var lock sync.Mutex
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/server_config" {
+			t.Errorf("Unexpected path: %s", r.URL.Path)
+		}
+
+		lock.Lock()
+		requestCount++
+		lock.Unlock()
+
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"indexes": map[string]interface{}{
+				"base_uae_mem": map[string]interface{}{},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := NewEmbeddingsServiceClient(server.Client(), server.URL, "")
+
+	ctx := context.Background()
+
+	// 1. Initial call when availableIndexes is nil.
+	// It should return true (lenient fallback) and trigger async load.
+	isValid := client.ValidateIndex(ctx, "base_uae_mem")
+	if !isValid {
+		t.Errorf("Expected ValidateIndex to return true (lenient) when not loaded")
+	}
+
+	// 2. Wait a bit for the async load to complete.
+	time.Sleep(100 * time.Millisecond)
+
+	lock.Lock()
+	count := requestCount
+	lock.Unlock()
+	if count != 1 {
+		t.Errorf("Expected 1 request to embeddings server, got %d", count)
+	}
+
+	// 3. Second call. Now availableIndexes should be loaded.
+	// Valid index should return true.
+	isValid = client.ValidateIndex(ctx, "base_uae_mem")
+	if !isValid {
+		t.Errorf("Expected ValidateIndex to return true for valid index after load")
+	}
+
+	// Invalid index should return false.
+	isValid = client.ValidateIndex(ctx, "invalid_index")
+	if isValid {
+		t.Errorf("Expected ValidateIndex to return false for invalid index after load")
+	}
+}
+
+// Test: Constructor with nil HTTP Client.
+// Situation: We initialize the client passing nil for the httpClient parameter.
+// Expectation: The client is initialized with a default HTTP client, and calling methods on it does not panic.
+func TestNewEmbeddingsServiceClient_NilClient(t *testing.T) {
+	var requestCount int
+	var lock sync.Mutex
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		lock.Lock()
+		requestCount++
+		lock.Unlock()
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer server.Close()
+
+	// Pass nil for httpClient
+	client := NewEmbeddingsServiceClient(nil, server.URL, "")
+	if client.httpClient == nil {
+		t.Fatal("Expected httpClient to be initialized to default, got nil")
+	}
+
+	ctx := context.Background()
+	// Trigger index validation which executes a GET request using the client
+	_ = client.ValidateIndex(ctx, "any_index")
+
+	// Wait for async load to complete
+	time.Sleep(100 * time.Millisecond)
+
+	lock.Lock()
+	count := requestCount
+	lock.Unlock()
+	if count != 1 {
+		t.Errorf("Expected 1 request to embeddings server, got %d (client probably failed to call server)", count)
+	}
+}
+
+// Test: Concurrent on-demand loading.
+// Situation: 50 concurrent requests try to validate indexes when they are not loaded yet.
+// Expectation: Only one HTTP call is made to the embeddings server (meaning only one goroutine is spawned),
+//              and all requests return true (leniently).
+func TestValidateIndex_ConcurrentOnDemandLoad(t *testing.T) {
+	var requestCount int
+	var lock sync.Mutex
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		lock.Lock()
+		requestCount++
+		lock.Unlock()
+
+		// Add artificial delay to simulate slow HTTP fetch and let other concurrent requests hit the check
+		time.Sleep(50 * time.Millisecond)
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"indexes": {"base_uae_mem": {}}}`))
+	}))
+	defer server.Close()
+
+	client := NewEmbeddingsServiceClient(&http.Client{}, server.URL, "")
+
+	ctx := context.Background()
+	var wg sync.WaitGroup
+	numConcurrentRequests := 50
+	results := make([]bool, numConcurrentRequests)
+
+	for i := 0; i < numConcurrentRequests; i++ {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			results[index] = client.ValidateIndex(ctx, "base_uae_mem")
+		}(i)
+	}
+
+	wg.Wait()
+
+	// 1. All concurrent requests should return true (lenient)
+	for i, res := range results {
+		if !res {
+			t.Errorf("Request %d: Expected true (lenient) validation before config is fully loaded", i)
+		}
+	}
+
+	// 2. Wait for the spawned load to complete
+	time.Sleep(100 * time.Millisecond)
+
+	// 3. Verify exactly 1 request was made to the backend
+	lock.Lock()
+	count := requestCount
+	lock.Unlock()
+
+	if count != 1 {
+		t.Errorf("Expected exactly 1 request to embeddings server, got %d (redundant goroutines were probably spawned)", count)
 	}
 }

--- a/internal/server/v2/resolve/embeddings_test.go
+++ b/internal/server/v2/resolve/embeddings_test.go
@@ -46,9 +46,10 @@ func TestResolveUsingEmbeddings(t *testing.T) {
 	defer server.Close()
 
 	ctx := context.Background()
-	resp, err := ResolveUsingEmbeddings(ctx, server.Client(), server.URL, "test_idx", []string{"population"}, nil, nil, false)
+	client := NewEmbeddingsServiceClient(server.Client(), server.URL, "")
+	resp, err := client.Resolve(ctx, "test_idx", []string{"population"}, nil, nil, false)
 	if err != nil {
-		t.Fatalf("ResolveEmbeddings() error: %v", err)
+		t.Fatalf("Resolve() error: %v", err)
 	}
 
 	if len(resp.Entities) != 1 {
@@ -103,15 +104,35 @@ func TestResolveUsingEmbeddings_Errors(t *testing.T) {
 		serverHandler http.HandlerFunc
 		serverURL     string
 		expectedError string
+		expectedCode  codes.Code
 		useEmptyURL   bool
 	}{
 		{
-			name: "Server Error",
+			name: "Server Error (500)",
 			serverHandler: func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusInternalServerError)
 				_, _ = w.Write([]byte("internal error"))
 			},
-			expectedError: "The resolution service encountered an error processing your request.",
+			expectedError: "internal error",
+			expectedCode:  codes.Internal,
+		},
+		{
+			name: "Bad Request (400)",
+			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte("bad index name"))
+			},
+			expectedError: "bad index name",
+			expectedCode:  codes.InvalidArgument,
+		},
+		{
+			name: "Not Found (404)",
+			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte("index not found"))
+			},
+			expectedError: "index not found",
+			expectedCode:  codes.NotFound,
 		},
 		{
 			name: "Malformed JSON",
@@ -119,25 +140,35 @@ func TestResolveUsingEmbeddings_Errors(t *testing.T) {
 				_, _ = w.Write([]byte("{invalid-json"))
 			},
 			expectedError: "An internal error occurred while parsing the resolution response.",
+			expectedCode:  codes.Internal,
 		},
 		{
 			name:          "Empty Server URL",
 			useEmptyURL:   true,
 			expectedError: "Indicator resolution is not available",
+			expectedCode:  codes.FailedPrecondition,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			server := httptest.NewServer(tc.serverHandler)
-			defer server.Close()
-
-			url := server.URL
-			if tc.useEmptyURL {
-				url = ""
+			var server *httptest.Server
+			var url string
+			if !tc.useEmptyURL {
+				server = httptest.NewServer(tc.serverHandler)
+				defer server.Close()
+				url = server.URL
 			}
 
-			_, err := ResolveUsingEmbeddings(context.Background(), server.Client(), url, "", []string{"query"}, nil, nil, false)
+			var client *http.Client
+			if server != nil {
+				client = server.Client()
+			} else {
+				client = http.DefaultClient
+			}
+
+			embeddingsServiceClient := NewEmbeddingsServiceClient(client, url, "")
+			_, err := embeddingsServiceClient.Resolve(context.Background(), "", []string{"query"}, nil, nil, false)
 			if err == nil {
 				t.Errorf("Expected error containing '%s', got nil", tc.expectedError)
 				return
@@ -145,6 +176,14 @@ func TestResolveUsingEmbeddings_Errors(t *testing.T) {
 
 			if !strings.Contains(err.Error(), tc.expectedError) {
 				t.Errorf("Expected error containing '%s', got '%v'", tc.expectedError, err)
+			}
+
+			status, ok := status.FromError(err)
+			if !ok {
+				t.Fatalf("Expected gRPC status error, got %v", err)
+			}
+			if status.Code() != tc.expectedCode {
+				t.Errorf("Expected error code %v, got %v", tc.expectedCode, status.Code())
 			}
 		})
 	}
@@ -178,7 +217,8 @@ func TestResolveUsingEmbeddings_InconsistentSearchVarsResponse(t *testing.T) {
 	}))
 	defer server.Close()
 
-	resp, err := ResolveUsingEmbeddings(context.Background(), server.Client(), server.URL, "", []string{"query"}, nil, nil, false)
+	client := NewEmbeddingsServiceClient(server.Client(), server.URL, "")
+	resp, err := client.Resolve(context.Background(), "", []string{"query"}, nil, nil, false)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -252,7 +292,8 @@ func TestResolveUsingEmbeddings_IdxParameter(t *testing.T) {
 			}))
 			defer server.Close()
 
-			_, err := ResolveUsingEmbeddings(context.Background(), server.Client(), server.URL, tc.expectedIdx, []string{"query"}, nil, nil, false)
+			client := NewEmbeddingsServiceClient(server.Client(), server.URL, "")
+			_, err := client.Resolve(context.Background(), tc.expectedIdx, []string{"query"}, nil, nil, false)
 			if err != nil {
 				t.Fatalf("Unexpected error: %v", err)
 			}
@@ -278,10 +319,12 @@ func TestResolveUsingEmbeddings_Filter(t *testing.T) {
 
 	ctx := context.Background()
 
-	// Test 1: Filter for StatisticalVariable
-	resp, err := ResolveUsingEmbeddings(ctx, server.Client(), server.URL, "test_idx", []string{"filter_test"}, []string{"StatisticalVariable"}, nil, false)
+	client := NewEmbeddingsServiceClient(server.Client(), server.URL, "")
+
+	// Filter for StatisticalVariable
+	resp, err := client.Resolve(ctx, "test_idx", []string{"filter_test"}, []string{"StatisticalVariable"}, nil, false)
 	if err != nil {
-		t.Fatalf("ResolveEmbeddings() error: %v", err)
+		t.Fatalf("Resolve() error: %v", err)
 	}
 	if len(resp.Entities[0].Candidates) != 1 {
 		t.Fatalf("Expected 1 candidate, got %d", len(resp.Entities[0].Candidates))
@@ -290,10 +333,10 @@ func TestResolveUsingEmbeddings_Filter(t *testing.T) {
 		t.Errorf("Expected 'Count_Person', got '%s'", resp.Entities[0].Candidates[0].Dcid)
 	}
 
-	// Test 2: Filter for Topic
-	resp, err = ResolveUsingEmbeddings(ctx, server.Client(), server.URL, "test_idx", []string{"filter_test"}, []string{"Topic"}, nil, false)
+	// Filter for Topic
+	resp, err = client.Resolve(ctx, "test_idx", []string{"filter_test"}, []string{"Topic"}, nil, false)
 	if err != nil {
-		t.Fatalf("ResolveEmbeddings() error: %v", err)
+		t.Fatalf("Resolve() error: %v", err)
 	}
 	if len(resp.Entities[0].Candidates) != 1 {
 		t.Fatalf("Expected 1 candidate, got %d", len(resp.Entities[0].Candidates))
@@ -339,13 +382,13 @@ func TestSelectEmbeddingsIndex(t *testing.T) {
 			expectError:        false,
 		},
 		{
-			// Test: Error on invalid label.
+			// Test: Pass through unknown label.
 			// Situation: Header is set to an unknown value "invalid".
-			// Expectation: Returns InvalidArgument error.
-			name:               "Invalid header, enabled",
+			// Expectation: Returns "invalid".
+			name:               "Invalid header, pass through",
 			headerValue:        "invalid",
-			expectError:        true,
-			expectedErrorCode:  codes.InvalidArgument,
+			expectedIdx:        "invalid",
+			expectError:        false,
 		},
 	}
 
@@ -357,7 +400,8 @@ func TestSelectEmbeddingsIndex(t *testing.T) {
 				ctx = metadata.NewIncomingContext(ctx, md)
 			}
 
-			idx, err := SelectEmbeddingsIndex(ctx, "default_idx")
+			client := NewEmbeddingsServiceClient(nil, "", "default_idx")
+			idx, err := client.SelectIndex(ctx)
 
 			if tc.expectError {
 				if err == nil {

--- a/internal/server/v2/resolve/embeddings_test.go
+++ b/internal/server/v2/resolve/embeddings_test.go
@@ -453,16 +453,13 @@ func TestValidateIndex_OnDemandLoad(t *testing.T) {
 
 	ctx := context.Background()
 
-	// 1. Initial call when availableIndexes is nil.
-	// It should return true (lenient fallback) and trigger async load.
+	// 1. First call with valid index. This should block and fetch config, returning true.
 	isValid := client.ValidateIndex(ctx, "base_uae_mem")
 	if !isValid {
-		t.Errorf("Expected ValidateIndex to return true (lenient) when not loaded")
+		t.Errorf("Expected ValidateIndex to return true for valid index")
 	}
 
-	// 2. Wait a bit for the async load to complete.
-	time.Sleep(100 * time.Millisecond)
-
+	// 2. Verify exactly 1 request was made to the server.
 	lock.Lock()
 	count := requestCount
 	lock.Unlock()
@@ -470,17 +467,18 @@ func TestValidateIndex_OnDemandLoad(t *testing.T) {
 		t.Errorf("Expected 1 request to embeddings server, got %d", count)
 	}
 
-	// 3. Second call. Now availableIndexes should be loaded.
-	// Valid index should return true.
-	isValid = client.ValidateIndex(ctx, "base_uae_mem")
-	if !isValid {
-		t.Errorf("Expected ValidateIndex to return true for valid index after load")
-	}
-
-	// Invalid index should return false.
+	// 3. Second call with invalid index. It should use cached config and return false immediately.
 	isValid = client.ValidateIndex(ctx, "invalid_index")
 	if isValid {
-		t.Errorf("Expected ValidateIndex to return false for invalid index after load")
+		t.Errorf("Expected ValidateIndex to return false for invalid index")
+	}
+
+	// 4. Verify no new requests were made.
+	lock.Lock()
+	count = requestCount
+	lock.Unlock()
+	if count != 1 {
+		t.Errorf("Expected still only 1 request to embeddings server, got %d", count)
 	}
 }
 
@@ -508,16 +506,14 @@ func TestNewEmbeddingsServiceClient_NilClient(t *testing.T) {
 
 	ctx := context.Background()
 	// Trigger index validation which executes a GET request using the client
+	// It should block and make 1 request.
 	_ = client.ValidateIndex(ctx, "any_index")
-
-	// Wait for async load to complete
-	time.Sleep(100 * time.Millisecond)
 
 	lock.Lock()
 	count := requestCount
 	lock.Unlock()
 	if count != 1 {
-		t.Errorf("Expected 1 request to embeddings server, got %d (client probably failed to call server)", count)
+		t.Errorf("Expected 1 request to embeddings server, got %d", count)
 	}
 }
 
@@ -534,7 +530,7 @@ func TestValidateIndex_ConcurrentOnDemandLoad(t *testing.T) {
 		requestCount++
 		lock.Unlock()
 
-		// Add artificial delay to simulate slow HTTP fetch and let other concurrent requests hit the check
+		// Add artificial delay to simulate slow HTTP fetch and let other concurrent requests block
 		time.Sleep(50 * time.Millisecond)
 
 		w.WriteHeader(http.StatusOK)
@@ -559,22 +555,19 @@ func TestValidateIndex_ConcurrentOnDemandLoad(t *testing.T) {
 
 	wg.Wait()
 
-	// 1. All concurrent requests should return true (lenient)
+	// 1. All concurrent requests should return true because the index is valid
 	for i, res := range results {
 		if !res {
-			t.Errorf("Request %d: Expected true (lenient) validation before config is fully loaded", i)
+			t.Errorf("Request %d: Expected true (valid index) after sync config load", i)
 		}
 	}
 
-	// 2. Wait for the spawned load to complete
-	time.Sleep(100 * time.Millisecond)
-
-	// 3. Verify exactly 1 request was made to the backend
+	// 2. Verify exactly 1 request was made to the backend
 	lock.Lock()
 	count := requestCount
 	lock.Unlock()
 
 	if count != 1 {
-		t.Errorf("Expected exactly 1 request to embeddings server, got %d (redundant goroutines were probably spawned)", count)
+		t.Errorf("Expected exactly 1 request to embeddings server, got %d (redundant fetches were probably made)", count)
 	}
 }

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -154,6 +154,9 @@ const (
 	// Header to specify which embeddings index to use for V2 Resolve.
 	// To use, set header "X-V2Resolve-Index: multi-entity"
 	XV2ResolveIndex = "X-V2Resolve-Index"
+	// Header to force V2 Resolve (indicators only) to use Spanner.
+	// To use, set header "X-V2Resolve-Indicator-Spanner: true" (force Spanner) or "false" (force legacy).
+	XV2ResolveIndicatorSpanner = "X-V2Resolve-Indicator-Spanner"
 	// Whether to divert request to Spanner.
 	// To use, set header "X-Divert-Spanner: true"
 	XDivertSpanner = "X-Divert-Spanner"
@@ -809,6 +812,59 @@ func GetSingleHeaderValue(ctx context.Context, headerName string) string {
 func IsHeaderTrue(ctx context.Context, headerName string) bool {
 	return GetSingleHeaderValue(ctx, headerName) == "true"
 }
+
+// GetOptionalBoolHeader reads the specified header from the context metadata.
+// It returns (nil, nil) if the header is missing.
+// It returns (true, nil) if the header is "true".
+// It returns (false, nil) if the header is "false".
+// It returns (nil, error) if the header has any other value.
+func GetOptionalBoolHeader(ctx context.Context, headerName string) (*bool, error) {
+	val := GetSingleHeaderValue(ctx, headerName)
+	if val == "" {
+		return nil, nil
+	}
+	if val == "true" {
+		t := true
+		return &t, nil
+	}
+	if val == "false" {
+		f := false
+		return &f, nil
+	}
+	return nil, status.Errorf(codes.InvalidArgument, "Invalid %s header value: %q. Valid values are 'true' or 'false'", headerName, val)
+}
+
+// HTTPStatusToGRPCCode maps HTTP status codes to gRPC codes.
+func HTTPStatusToGRPCCode(statusCode int) codes.Code {
+	switch statusCode {
+	case http.StatusOK:
+		return codes.OK
+	case http.StatusBadRequest:
+		return codes.InvalidArgument
+	case http.StatusUnauthorized:
+		return codes.Unauthenticated
+	case http.StatusForbidden:
+		return codes.PermissionDenied
+	case http.StatusNotFound:
+		return codes.NotFound
+	case http.StatusConflict:
+		return codes.AlreadyExists
+	case http.StatusTooManyRequests:
+		return codes.ResourceExhausted
+	case http.StatusInternalServerError:
+		return codes.Internal
+	case http.StatusNotImplemented:
+		return codes.Unimplemented
+	case http.StatusServiceUnavailable:
+		return codes.Unavailable
+	case http.StatusGatewayTimeout:
+		return codes.DeadlineExceeded
+	default:
+		return codes.Unknown
+	}
+}
+
+
 
 // IsTopicDcid checks if the DCID belongs to a Topic.
 // It checks for the pattern "[prefix]/topic/", requiring /topic/ to be the segment of the id.

--- a/test/setup.go
+++ b/test/setup.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"log"
 	"net"
+	"net/http"
 	"os"
 	"path"
 	"path/filepath"
@@ -41,6 +42,7 @@ import (
 	"github.com/datacommonsorg/mixer/internal/server/remote"
 	"github.com/datacommonsorg/mixer/internal/server/resource"
 	"github.com/datacommonsorg/mixer/internal/server/spanner"
+	"github.com/datacommonsorg/mixer/internal/server/v2/resolve"
 	"github.com/datacommonsorg/mixer/internal/server/v3/observation"
 	"github.com/datacommonsorg/mixer/internal/sqldb"
 	"github.com/datacommonsorg/mixer/internal/store"
@@ -193,7 +195,7 @@ func setupInternal(
 	}
 	mapsClient := &maps.FakeMapsClient{}
 	if spannerClient != nil {
-		spannerDataSource = spanner.NewSpannerDataSource(spannerClient, st.RecogPlaceStore, mapsClient, false)
+		spannerDataSource = spanner.NewSpannerDataSource(spannerClient, st.RecogPlaceStore, mapsClient)
 		sources = append(sources, spannerDataSource)
 	}
 	c, err := cache.NewCache(ctx, st, cacheOptions, metadata)
@@ -284,7 +286,8 @@ func newClient(
 	}
 	// Create mixer server. writeUsageLogs is false by default for tests but is directly tested in handler_v2_test.go
 	// useSpannerGraph is also false by default while the legacy implementation remains, but is tested directly by V3 APIs.
-	mixerServer := server.NewMixerServer(mixerStore, metadata, cachedata, mapsClient, dispatcher, flags, false, "", "", false, nil)
+	embeddingsServiceClient := resolve.NewEmbeddingsServiceClient(&http.Client{}, "", "")
+	mixerServer := server.NewMixerServer(mixerStore, metadata, cachedata, mapsClient, dispatcher, flags, false, embeddingsServiceClient, false, nil)
 	srv := grpc.NewServer()
 	pbs.RegisterMixerServer(srv, mixerServer)
 	reflection.Register(srv)


### PR DESCRIPTION
Rolls forward https://github.com/datacommonsorg/mixer/pull/1925 (which was reverted in https://github.com/datacommonsorg/mixer/pull/1934) with a patch. 

* Replaced the startup index validation hook (which crashed Mixer on boot when the embeddings server was offline) with an asynchronous load triggered by the first incoming request.
* The first request loads the indexes in the background and bypasses validation to avoid blocking; subsequent requests are validated against the cache.