### PR TITLE
point mixer-api-key to dc-api-key 

### DIFF
--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -63,7 +63,7 @@ const (
 	// Maps API key ID
 	MapsAPIKeyID = "maps-api-key"
 	// Mixer API key
-	MixerAPIKeyID = "mixer-api-key"
+	MixerAPIKeyID = "dc-api-key"
 )
 
 var childTypeDenyList = map[string]struct{}{


### PR DESCRIPTION
in CDC they're pointed to the same thing. next step would be remove references to this in `website/build/cdc_services/run.sh
` and `website/run_cdc_dev.sh`.