### PR TITLE
Update variable metadata tool response per offline feedback

### DIFF
--- a/internal/agent/cache_test.go
+++ b/internal/agent/cache_test.go
@@ -35,7 +35,6 @@ type mockMixerClient struct {
 	observationFunc  func(ctx context.Context, in *pbv2.ObservationRequest) (*pbv2.ObservationResponse, error)
 }
 
-
 func (m *mockMixerClient) V2Observation(ctx context.Context, in *pbv2.ObservationRequest) (*pbv2.ObservationResponse, error) {
 	atomic.AddInt32(&m.observationCalls, 1)
 
@@ -95,8 +94,8 @@ func TestCacheCheckAvailability(t *testing.T) {
 			setupCache: func(c *Cache) {
 				// Cache empty
 			},
-			places:              []string{"geoId/06"},
-			variables:           []string{"Count_Person", "Count_Person_Male"},
+			places:    []string{"geoId/06"},
+			variables: []string{"Count_Person", "Count_Person_Male"},
 			mockResponse: &pbv2.ObservationResponse{
 				ByVariable: map[string]*pbv2.VariableObservation{
 					"Count_Person": {},
@@ -123,8 +122,8 @@ func TestCacheCheckAvailability(t *testing.T) {
 					"Count_Person": {},
 				}
 			},
-			places:              []string{"geoId/06", "geoId/17"}, // Illinois is missing
-			variables:           []string{"Count_Person"},
+			places:    []string{"geoId/06", "geoId/17"}, // Illinois is missing
+			variables: []string{"Count_Person"},
 			mockResponse: &pbv2.ObservationResponse{
 				ByVariable: map[string]*pbv2.VariableObservation{
 					"Count_Person": {},

--- a/internal/agent/get_variable_metadata.go
+++ b/internal/agent/get_variable_metadata.go
@@ -16,16 +16,18 @@ package agent
 
 import (
 	"context"
-	"log/slog"
-	"sync"
+	"log"
+	"sort"
 	"time"
 
+	pb "github.com/datacommonsorg/mixer/internal/proto"
 	pbv1 "github.com/datacommonsorg/mixer/internal/proto/v1"
 	pbv2 "github.com/datacommonsorg/mixer/internal/proto/v2"
 	"github.com/datacommonsorg/mixer/internal/util"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 const (
@@ -33,7 +35,67 @@ const (
 	maxConcurrentFetchers = 20
 )
 
-var obsMetadataSelect = []string{"variable", "entity", "facet"}
+var (
+	obsMetadataSelect = []string{"variable", "entity", "facet"}
+
+	// properties to exclude from Statistical Variable properties Struct
+	excludedSVProperties = map[string]struct{}{
+		"name":           {},
+		"description":    {},
+		"label":          {},
+		"typeOf":         {},
+		"provenance":     {},
+		"definition":     {},
+		"memberOf":       {},
+		"linkedMemberOf": {},
+		"linkedMember":   {},
+	}
+
+	// properties to explicitly include for Provenance and Source dataset properties Struct.
+	// These must be the exact raw property keys returned from the knowledge graph (V2Node).
+	includedDatasetProperties = map[string]struct{}{
+		"url":                     {},
+		"license":                 {},
+		"licenseType":             {},
+		"lastDataRefreshDate":     {},
+		"nextDataRefreshDate":     {},
+		"nextSourceReleaseDate":   {},
+		"sourceReleaseFrequency":  {},
+		"latestObservationDate":   {},
+		"earliestObservationDate": {},
+		"isPartOf":                {},
+		"source":                  {},
+		"domain":                  {},
+		"description":             {},
+		"descriptionUrl":          {},
+	}
+)
+
+// rawVariableData holds the raw, unmapped graph and summary data for a single Statistical Variable.
+type rawVariableData struct {
+	properties *pbv2.LinkedGraph
+	summary    *pb.StatVarSummary
+}
+
+// rawDatasetData holds the raw, unmapped graphs for a dataset's provenance and parent source.
+type rawDatasetData struct {
+	provenance *pbv2.LinkedGraph
+	source     *pbv2.LinkedGraph
+}
+
+// rawFetchResult aggregates all raw data retrieved during the concurrent fetch phase.
+type rawFetchResult struct {
+	variables    map[string]*rawVariableData
+	observations *pbv2.ObservationResponse
+	provenances  map[string]*rawDatasetData
+}
+
+// translatedProperties holds the resolved name, description, and filtered dynamic properties Struct.
+type translatedProperties struct {
+	name        string
+	description string
+	properties  *structpb.Struct
+}
 
 // GetVariableMetadata assesses Statistical Variables by retrieving their definitions,
 // temporal/entity coverage, and source provenance descriptions.
@@ -45,31 +107,25 @@ func (s *Service) GetVariableMetadata(
 		return nil, status.Error(codes.InvalidArgument, "request cannot be nil")
 	}
 	defer util.TimeTrack(time.Now(), "Agent: GetVariableMetadata")
+
+	if len(req.GetVariableDcids()) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "variable_dcids cannot be empty")
+	}
+	if len(req.GetEntityDcids()) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "entity_dcids cannot be empty")
+	}
+
 	varDcids := dedup(req.GetVariableDcids())
 	entityDcids := dedup(req.GetEntityDcids())
-	slog.Info("GetVariableMetadata started", "variablesCount", len(varDcids), "entitiesCount", len(entityDcids))
 
-	if len(varDcids) == 0 {
-		return &pbv2.GetVariableMetadataResponse{
-			Status:    StatusSuccess,
-			Variables: make(map[string]*pbv2.GetVariableMetadataResponse_VariableMetadata),
-		}, nil
+	// Phase 1: Fetch raw data concurrently
+	raw, err := s.fetchRawData(ctx, varDcids, entityDcids)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to fetch raw metadata: %v", err)
 	}
 
-	variables := initVariableMetadata(varDcids)
-
-	if err := s.fetchCoreMetadata(ctx, varDcids, entityDcids, variables); err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to fetch core variable metadata: %v", err)
-	}
-
-	if err := s.hydrateProvenanceMetadata(ctx, variables); err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to hydrate provenance metadata: %v", err)
-	}
-
-	return &pbv2.GetVariableMetadataResponse{
-		Status:    StatusSuccess,
-		Variables: variables,
-	}, nil
+	// Phase 2: Translate and compose response synchronously
+	return s.composeResponse(raw, varDcids, entityDcids), nil
 }
 
 // dedup removes duplicate strings from a slice.
@@ -87,244 +143,157 @@ func dedup(dcids []string) []string {
 	return res
 }
 
-// initVariableMetadata initializes the map of VariableMetadata entries.
-func initVariableMetadata(dcids []string) map[string]*pbv2.GetVariableMetadataResponse_VariableMetadata {
-	res := make(map[string]*pbv2.GetVariableMetadataResponse_VariableMetadata)
-	for _, vDcid := range dcids {
-		res[vDcid] = &pbv2.GetVariableMetadataResponse_VariableMetadata{
-			Dcid:              vDcid,
-			Properties:        make(map[string]*pbv2.PropertyValues),
-			Provenances:       make(map[string]*pbv2.GetVariableMetadataResponse_ProvenanceMetadata),
-			PerEntityMetadata: make(map[string]*pbv2.GetVariableMetadataResponse_EntityMetadata),
-		}
+// fetchRawData retrieves all raw variables, summaries, and observations concurrently.
+func (s *Service) fetchRawData(ctx context.Context, varDcids, entityDcids []string) (*rawFetchResult, error) {
+	raw := &rawFetchResult{
+		variables:   make(map[string]*rawVariableData),
+		provenances: make(map[string]*rawDatasetData),
 	}
-	return res
-}
 
-// fetchCoreMetadata concurrently retrieves general properties, summaries, and observation facets.
-// Note on Caching: We execute V2Node and V2BulkVariableInfo calls individually per variable via
-// parallel goroutines rather than a single batch call. Because the underlying Redis caching layer
-// builds cache keys from the exact requested node slice, single-node lookups maximize cache-hit rates across requests.
-func (s *Service) fetchCoreMetadata(
-	ctx context.Context,
-	varDcids, entityDcids []string,
-	variables map[string]*pbv2.GetVariableMetadataResponse_VariableMetadata,
-) error {
 	g, gCtx := errgroup.WithContext(ctx)
 	g.SetLimit(maxConcurrentFetchers)
-	var mu sync.Mutex
 
+	// Initialize slots sequentially, then fetch concurrently using direct pointers
 	for _, vDcid := range varDcids {
 		dcid := vDcid
+		rawVar := &rawVariableData{}
+		raw.variables[dcid] = rawVar // Safe: sequential map write in main thread
+
+		// Worker 1: Fetch Node Graph (Non-critical: log and skip on error)
 		g.Go(func() error {
-			return s.fetchVariableProperties(gCtx, dcid, variables, &mu)
+			graph, err := s.fetchNodeGraph(gCtx, dcid)
+			if err != nil {
+				log.Printf("Warning: failed to fetch node graph for variable %s: %v", dcid, err)
+				return nil // Graceful degradation: do not fail the errgroup
+			}
+			rawVar.properties = graph // Safe: direct pointer access (no map lookup)
+			return nil
 		})
+
+		// Worker 2: Fetch Bulk Variable Info (Non-critical: log and skip on error)
 		g.Go(func() error {
-			return s.fetchVariableSummary(gCtx, dcid, variables, &mu)
+			req := &pbv1.BulkVariableInfoRequest{Nodes: []string{dcid}}
+			resp, err := s.mixer.V2BulkVariableInfo(gCtx, req)
+			if err != nil {
+				log.Printf("Warning: failed to fetch bulk variable info for %s: %v", dcid, err)
+				return nil // Graceful degradation
+			}
+			if resp != nil && resp.GetData() != nil {
+				for _, info := range resp.GetData() {
+					if info.GetNode() == dcid {
+						rawVar.summary = info.GetInfo() // Safe: direct pointer access
+					}
+				}
+			}
+			return nil
 		})
 	}
 
-	if len(entityDcids) > 0 {
+	// Worker 3: Fetch Observations (Critical bulk query: fail if this fails)
+	g.Go(func() error {
+		obsReq := &pbv2.ObservationRequest{
+			Variable: &pbv2.DcidOrExpression{Dcids: varDcids},
+			Entity:   &pbv2.DcidOrExpression{Dcids: entityDcids},
+			Select:   obsMetadataSelect,
+		}
+		resp, err := s.mixer.V2Observation(gCtx, obsReq)
+		if err != nil {
+			return err // Fail the request if the bulk observations query fails
+		}
+		raw.observations = resp
+		return nil
+	})
+
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	// Now hydrate provenances using the fetched data (lock-free!)
+	if err := s.fetchRawProvenances(ctx, raw); err != nil {
+		return nil, err
+	}
+
+	return raw, nil
+}
+
+// fetchRawProvenances identifies all unique provenance IDs and fetches their graphs concurrently in a lock-free manner.
+func (s *Service) fetchRawProvenances(ctx context.Context, raw *rawFetchResult) error {
+	provIDs := extractProvenanceIDs(raw.observations)
+	if len(provIDs) == 0 {
+		return nil
+	}
+
+	g, gCtx := errgroup.WithContext(ctx)
+	g.SetLimit(maxConcurrentFetchers)
+
+	// Pre-allocate slots sequentially to enable lock-free parallel execution
+	for _, pDcid := range provIDs {
+		provDcid := pDcid
+		rawDataset := &rawDatasetData{}
+		raw.provenances[provDcid] = rawDataset // Safe: sequential map write in main thread
+
 		g.Go(func() error {
-			return s.fetchPerEntityFacets(gCtx, varDcids, entityDcids, variables, &mu)
+			dataset, err := s.fetchDatasetGraphs(gCtx, provDcid)
+			if err != nil {
+				log.Printf("Warning: failed to fetch dataset graphs for provenance %s: %v", provDcid, err)
+				return nil // Graceful degradation: do not fail the entire request
+			}
+			// Safe: lock-free direct pointer writes!
+			rawDataset.provenance = dataset.provenance
+			rawDataset.source = dataset.source
+			return nil
 		})
 	}
 
 	return g.Wait()
 }
 
-// fetchVariableProperties fetches outbound properties for a single Statistical Variable.
-func (s *Service) fetchVariableProperties(
-	ctx context.Context, dcid string,
-	variables map[string]*pbv2.GetVariableMetadataResponse_VariableMetadata,
-	mu *sync.Mutex,
-) error {
+// fetchNodeGraph fetches wildcard outbound properties (->*) for a single node.
+func (s *Service) fetchNodeGraph(ctx context.Context, dcid string) (*pbv2.LinkedGraph, error) {
 	req := &pbv2.NodeRequest{Nodes: []string{dcid}, Property: wildcardPropertyQuery}
 	resp, err := s.mixer.V2Node(ctx, req)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if resp != nil && resp.GetData() != nil {
-		if graph, ok := resp.GetData()[dcid]; ok && graph != nil {
-			props := toPropertyValuesMap(graph)
-			mu.Lock()
-			variables[dcid].Properties = props
-			mu.Unlock()
-		}
+		return resp.GetData()[dcid], nil
 	}
-	return nil
+	return nil, nil
 }
 
-// fetchVariableSummary retrieves summary information for a single Statistical Variable.
-func (s *Service) fetchVariableSummary(
-	ctx context.Context, dcid string,
-	variables map[string]*pbv2.GetVariableMetadataResponse_VariableMetadata,
-	mu *sync.Mutex,
-) error {
-	req := &pbv1.BulkVariableInfoRequest{Nodes: []string{dcid}}
-	resp, err := s.mixer.V2BulkVariableInfo(ctx, req)
+// fetchDatasetGraphs fetches the provenance graph and parent source graph for a dataset.
+func (s *Service) fetchDatasetGraphs(ctx context.Context, provDcid string) (*rawDatasetData, error) {
+	provGraph, err := s.fetchNodeGraph(ctx, provDcid)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	if resp != nil {
-		for _, info := range resp.GetData() {
-			if info.GetNode() == dcid && info.GetInfo() != nil {
-				mu.Lock()
-				variables[dcid].StatVarSummary = info.GetInfo()
-				mu.Unlock()
-			}
+
+	var sourceGraph *pbv2.LinkedGraph
+	if sourceDcid := extractSourceDcid(provGraph); sourceDcid != "" {
+		sGraph, err := s.fetchNodeGraph(ctx, sourceDcid)
+		if err != nil {
+			return nil, err
 		}
+		sourceGraph = sGraph
 	}
-	return nil
+
+	return &rawDatasetData{
+		provenance: provGraph,
+		source:     sourceGraph,
+	}, nil
 }
 
-// fetchPerEntityFacets retrieves observation facets across target variables and entities.
-func (s *Service) fetchPerEntityFacets(
-	ctx context.Context,
-	varDcids, entityDcids []string,
-	variables map[string]*pbv2.GetVariableMetadataResponse_VariableMetadata,
-	mu *sync.Mutex,
-) error {
-	obsReq := &pbv2.ObservationRequest{
-		Variable: &pbv2.DcidOrExpression{Dcids: varDcids},
-		Entity:   &pbv2.DcidOrExpression{Dcids: entityDcids},
-		Select:   obsMetadataSelect,
-	}
-	obsResp, err := s.mixer.V2Observation(ctx, obsReq)
-	if err != nil {
-		return err
-	}
-	assignVariableFacets(obsResp, variables, mu)
-	return nil
-}
-
-// assignVariableFacets extracts observation facets scoped to their matching statistical variable and entity.
-func assignVariableFacets(
-	obsResp *pbv2.ObservationResponse,
-	variables map[string]*pbv2.GetVariableMetadataResponse_VariableMetadata,
-	mu *sync.Mutex,
-) {
-	if obsResp == nil || obsResp.GetByVariable() == nil {
-		return
-	}
-	for vDcid, vObs := range obsResp.GetByVariable() {
-		mu.Lock()
-		vMeta, ok := variables[vDcid]
-		mu.Unlock()
-		if !ok || vObs == nil {
-			continue
-		}
-		for eDcid, eObs := range vObs.GetByEntity() {
-			if eObs == nil {
-				continue
-			}
-			mu.Lock()
-			eMeta, eExists := vMeta.PerEntityMetadata[eDcid]
-			if !eExists {
-				eMeta = &pbv2.GetVariableMetadataResponse_EntityMetadata{
-					FacetSeriesSummaries: make(map[string]*pbv2.GetVariableMetadataResponse_FacetSeriesSummary),
-				}
-				vMeta.PerEntityMetadata[eDcid] = eMeta
-			}
-			for _, fObs := range eObs.GetOrderedFacets() {
-				if fObs == nil {
-					continue
-				}
-				fID := fObs.GetFacetId()
-				if fObj, exists := obsResp.GetFacets()[fID]; exists && fObj != nil {
-					eMeta.FacetSeriesSummaries[fID] = &pbv2.GetVariableMetadataResponse_FacetSeriesSummary{
-						Facet:        fObj,
-						ObsCount:     fObs.GetObsCount(),
-						EarliestDate: fObs.GetEarliestDate(),
-						LatestDate:   fObs.GetLatestDate(),
-					}
-				}
-			}
-			mu.Unlock()
-		}
-	}
-}
-
-// hydrateProvenanceMetadata collects unique provenance IDs and hydrates their descriptive properties.
-func (s *Service) hydrateProvenanceMetadata(
-	ctx context.Context,
-	variables map[string]*pbv2.GetVariableMetadataResponse_VariableMetadata,
-) error {
-	provIDs := collectProvenanceIDs(variables)
-	if len(provIDs) == 0 {
+// extractProvenanceIDs gathers unique provenance identifiers from the observation response.
+func extractProvenanceIDs(obs *pbv2.ObservationResponse) []string {
+	if obs == nil || len(obs.GetFacets()) == 0 {
 		return nil
 	}
-	slog.Info("Hydrating provenance descriptions", "provenancesCount", len(provIDs))
-
-	g, gCtx := errgroup.WithContext(ctx)
-	g.SetLimit(maxConcurrentFetchers)
-	var mu sync.Mutex
-	provenancesMap := make(map[string]*pbv2.GetVariableMetadataResponse_ProvenanceMetadata)
-
-	for _, pID := range provIDs {
-		provID := pID
-		g.Go(func() error {
-			return s.fetchProvenanceMetadata(gCtx, provID, provenancesMap, &mu)
-		})
-	}
-
-	if err := g.Wait(); err != nil {
-		return err
-	}
-
-	for _, vMeta := range variables {
-		vMeta.Provenances = make(map[string]*pbv2.GetVariableMetadataResponse_ProvenanceMetadata)
-
-		if vMeta.StatVarSummary != nil {
-			for provID := range vMeta.StatVarSummary.GetProvenanceSummary() {
-				if pMeta, ok := provenancesMap[provID]; ok {
-					vMeta.Provenances[provID] = pMeta
-				}
-			}
-		}
-
-		for _, eMeta := range vMeta.PerEntityMetadata {
-			if eMeta != nil {
-				for _, fSum := range eMeta.GetFacetSeriesSummaries() {
-					if fSum != nil && fSum.GetFacet() != nil && fSum.GetFacet().GetProvenanceId() != "" {
-						provID := fSum.GetFacet().GetProvenanceId()
-						if pMeta, ok := provenancesMap[provID]; ok {
-							vMeta.Provenances[provID] = pMeta
-						}
-					}
-				}
-			}
-		}
-	}
-	return nil
-}
-
-// collectProvenanceIDs gathers all unique provenance identifiers across summaries and facets.
-func collectProvenanceIDs(variables map[string]*pbv2.GetVariableMetadataResponse_VariableMetadata) []string {
 	seen := make(map[string]struct{})
-	for _, vMeta := range variables {
-		if vMeta.StatVarSummary != nil {
-			for provID := range vMeta.StatVarSummary.GetProvenanceSummary() {
-				if provID != "" {
-					seen[provID] = struct{}{}
-				}
-			}
-		}
-		for _, eMeta := range vMeta.PerEntityMetadata {
-			if eMeta != nil {
-				for _, fSum := range eMeta.GetFacetSeriesSummaries() {
-					if fSum != nil && fSum.GetFacet() != nil && fSum.GetFacet().GetProvenanceId() != "" {
-						seen[fSum.GetFacet().GetProvenanceId()] = struct{}{}
-					}
-				}
-			}
+	for _, fObj := range obs.GetFacets() {
+		if fObj != nil && fObj.GetProvenanceId() != "" {
+			seen[fObj.GetProvenanceId()] = struct{}{}
 		}
 	}
-
-
-
-
-
 	var ids []string
 	for id := range seen {
 		ids = append(ids, id)
@@ -332,81 +301,370 @@ func collectProvenanceIDs(variables map[string]*pbv2.GetVariableMetadataResponse
 	return ids
 }
 
-// fetchProvenanceMetadata fetches descriptive properties for a single provenance entity.
-func (s *Service) fetchProvenanceMetadata(
-	ctx context.Context, pDcid string,
-	provenancesMap map[string]*pbv2.GetVariableMetadataResponse_ProvenanceMetadata,
-	mu *sync.Mutex,
-) error {
-	req := &pbv2.NodeRequest{Nodes: []string{pDcid}, Property: wildcardPropertyQuery}
-	resp, err := s.mixer.V2Node(ctx, req)
-	if err != nil {
-		return err
+// extractSourceDcid extracts the parent source DCID from a provenance graph.
+func extractSourceDcid(graph *pbv2.LinkedGraph) string {
+	if graph == nil || graph.GetArcs() == nil {
+		return ""
 	}
-	if resp != nil && resp.GetData() != nil {
-		if graph, ok := resp.GetData()[pDcid]; ok && graph != nil {
-			props := toPropertyValuesMap(graph)
-			mu.Lock()
-			provenancesMap[pDcid] = &pbv2.GetVariableMetadataResponse_ProvenanceMetadata{
-				Dcid:       pDcid,
-				Properties: props,
+	if srcArc, ok := graph.GetArcs()["source"]; ok {
+		for _, n := range srcArc.GetNodes() {
+			if n != nil && n.GetDcid() != "" {
+				return n.GetDcid()
 			}
-			mu.Unlock()
 		}
 	}
-	return nil
+	return ""
 }
 
-// toPropertyValuesMap converts a LinkedGraph into a map of PropertyValues lists.
-func toPropertyValuesMap(graph *pbv2.LinkedGraph) map[string]*pbv2.PropertyValues {
+// composeResponse synchronously transforms raw fetched data into the final response payload.
+func (s *Service) composeResponse(raw *rawFetchResult, varDcids, entityDcids []string) *pbv2.GetVariableMetadataResponse {
+	resp := &pbv2.GetVariableMetadataResponse{
+		Status:      StatusSuccess,
+		Variables:   make(map[string]*pbv2.GetVariableMetadataResponse_VariableMetadata),
+		Provenances: make(map[string]*pbv2.GetVariableMetadataResponse_ProvenanceMetadata),
+	}
+
+	// Translate variables
+	for _, dcid := range varDcids {
+		if rawVar, ok := raw.variables[dcid]; ok && rawVar != nil {
+			// Skip variables that failed all metadata fetches entirely (graceful degradation)
+			if rawVar.properties == nil && rawVar.summary == nil {
+				continue
+			}
+			resp.Variables[dcid] = translateVariable(dcid, rawVar, raw.observations, entityDcids)
+		}
+	}
+
+	// Translate provenances
+	for provDcid, rawDataset := range raw.provenances {
+		resp.Provenances[provDcid] = translateProvenance(provDcid, rawDataset)
+	}
+
+	return resp
+}
+
+// translateVariable resolves a single variable's headers, properties, and active facets list.
+func translateVariable(
+	dcid string,
+	rawVar *rawVariableData,
+	obs *pbv2.ObservationResponse,
+	entityDcids []string,
+) *pbv2.GetVariableMetadataResponse_VariableMetadata {
+	tp := translateProperties(rawVar.properties)
+
+	varMeta := &pbv2.GetVariableMetadataResponse_VariableMetadata{
+		Id:          dcid,
+		Name:        tp.name,
+		Description: tp.description,
+		Properties:  tp.properties,
+		Facets:      translateFacets(dcid, obs, rawVar.summary, entityDcids),
+	}
+
+	return varMeta
+}
+
+// translateProperties extracts headers and builds the dynamic properties Struct, filtering out primary name/description.
+func translateProperties(graph *pbv2.LinkedGraph) *translatedProperties {
+	tp := &translatedProperties{
+		properties: &structpb.Struct{Fields: make(map[string]*structpb.Value)},
+	}
+
 	if graph == nil || graph.GetArcs() == nil {
-		return make(map[string]*pbv2.PropertyValues)
+		return tp
 	}
 
-	type propValKey struct {
-		val, dcid, name string
+	// 1. Resolve root Name (primary name or label)
+	if nameArc, ok := graph.GetArcs()["name"]; ok {
+		tp.name = resolveFirstValue(nameArc.GetNodes())
+	}
+	if tp.name == "" {
+		if labelArc, ok := graph.GetArcs()["label"]; ok {
+			tp.name = resolveFirstValue(labelArc.GetNodes())
+		}
 	}
 
-	res := make(map[string]*pbv2.PropertyValues)
+	// 2. Resolve root Description
+	if descArc, ok := graph.GetArcs()["description"]; ok {
+		tp.description = resolveFirstValue(descArc.GetNodes())
+	}
+
+	// 3. Build filtered dynamic properties Struct
 	for prop, nodesArc := range graph.GetArcs() {
 		if nodesArc == nil || len(nodesArc.GetNodes()) == 0 {
 			continue
 		}
 
-		var pvList []*pbv2.PropertyValue
-		seen := make(map[propValKey]struct{})
-		for _, n := range nodesArc.GetNodes() {
-			if n == nil {
-				continue
-			}
-			val := n.GetValue()
-			dcid := n.GetDcid()
-			name := n.GetName()
-			if val == "" && dcid == "" && name == "" {
-				continue
-			}
-
-			key := propValKey{val, dcid, name}
-			if _, ok := seen[key]; ok {
-				continue
-			}
-			seen[key] = struct{}{}
-
-			pv := &pbv2.PropertyValue{}
-			if val != "" {
-				pv.Value = val
-			}
-			if dcid != "" {
-				pv.Dcid = dcid
-			}
-			if name != "" {
-				pv.Name = name
-			}
-			pvList = append(pvList, pv)
+		// Filter out properties that are mapped to root or represent internal detail
+		if _, shouldExclude := excludedSVProperties[prop]; shouldExclude {
+			continue
 		}
-		if len(pvList) > 0 {
-			res[prop] = &pbv2.PropertyValues{Values: pvList}
+
+		// Convert values completely as-is (no root-value duplication filtering)
+		if structVal, ok := toStructValue(nodesArc.GetNodes()); ok {
+			tp.properties.Fields[prop] = structVal
 		}
 	}
-	return res
+
+	return tp
+}
+
+// translateFacets maps observation responses to the list of structured FacetMetadata.
+func translateFacets(
+	varDcid string,
+	obs *pbv2.ObservationResponse,
+	summary *pb.StatVarSummary,
+	entityDcids []string,
+) []*pbv2.GetVariableMetadataResponse_FacetMetadata {
+	var facets []*pbv2.GetVariableMetadataResponse_FacetMetadata
+	if obs == nil || obs.GetByVariable() == nil {
+		return facets
+	}
+
+	vObs, exists := obs.GetByVariable()[varDcid]
+	if !exists || vObs == nil {
+		return facets
+	}
+
+	// We aggregate by Facet ID first, then map to list of Structs
+	type facetStats struct {
+		facetObj *pb.Facet
+		obsCount int32
+		earliest string
+		latest   string
+		covered  map[string]struct{}
+	}
+
+	facetGroups := make(map[string]*facetStats)
+
+	for eDcid, eObs := range vObs.GetByEntity() {
+		if eObs == nil {
+			continue
+		}
+		for _, fObs := range eObs.GetOrderedFacets() {
+			if fObs == nil {
+				continue
+			}
+			fID := fObs.GetFacetId()
+			fObj, ok := obs.GetFacets()[fID]
+			if !ok || fObj == nil {
+				continue
+			}
+
+			stats, exists := facetGroups[fID]
+			if !exists {
+				stats = &facetStats{
+					facetObj: fObj,
+					obsCount: 0,
+					covered:  make(map[string]struct{}),
+				}
+				facetGroups[fID] = stats
+			}
+
+			// Accumulate obs counts
+			stats.obsCount += fObs.GetObsCount()
+			stats.covered[eDcid] = struct{}{}
+
+			// Date ranges
+			if fObs.GetEarliestDate() != "" {
+				if stats.earliest == "" || fObs.GetEarliestDate() < stats.earliest {
+					stats.earliest = fObs.GetEarliestDate()
+				}
+			}
+			if fObs.GetLatestDate() != "" {
+				if stats.latest == "" || fObs.GetLatestDate() > stats.latest {
+					stats.latest = fObs.GetLatestDate()
+				}
+			}
+		}
+	}
+
+	// Sort facet IDs to ensure deterministic response order across requests
+	var facetIDs []string
+	for fID := range facetGroups {
+		facetIDs = append(facetIDs, fID)
+	}
+	sort.Strings(facetIDs)
+
+	for _, fID := range facetIDs {
+		stats := facetGroups[fID]
+
+		// Compile geographic granularities for this specific provenance from summary
+		geoGranularities := extractGeographicGranularities(summary, stats.facetObj.GetProvenanceId())
+
+		// Build scope location coverage (active subset of queried places)
+		var activeCoverage []string
+		for _, reqPlace := range entityDcids {
+			if _, ok := stats.covered[reqPlace]; ok {
+				activeCoverage = append(activeCoverage, reqPlace)
+			}
+		}
+
+		// Build flat dynamic properties map for facet details
+		fPropsMap := map[string]any{
+			"measurementMethod": stats.facetObj.GetMeasurementMethod(),
+			"observationPeriod": stats.facetObj.GetObservationPeriod(),
+			"unit":              stats.facetObj.GetUnit(),
+			"scalingFactor":     stats.facetObj.GetScalingFactor(),
+		}
+
+		// Strip empty keys to keep JSON pristine
+		for k, v := range fPropsMap {
+			if s, ok := v.(string); ok && s == "" {
+				delete(fPropsMap, k)
+			}
+		}
+
+		fProps, err := structpb.NewStruct(fPropsMap)
+		if err != nil {
+			fProps = &structpb.Struct{Fields: make(map[string]*structpb.Value)}
+		}
+
+		facetMeta := &pbv2.GetVariableMetadataResponse_FacetMetadata{
+			Id:           fID,
+			ProvenanceId: stats.facetObj.GetProvenanceId(),
+			ObsCount:     stats.obsCount,
+			DateRange: &pbv2.GetVariableMetadataResponse_FacetMetadata_DateRange{
+				Start: stats.earliest,
+				End:   stats.latest,
+			},
+			Scope: &pbv2.GetVariableMetadataResponse_FacetMetadata_Scope{
+				EntityGranularity: geoGranularities,
+				EntityCoverage:    activeCoverage,
+			},
+			Properties: fProps,
+		}
+		facets = append(facets, facetMeta)
+	}
+
+	return facets
+}
+
+// translateProvenance merges provenance and parent source properties into a single dynamic Struct.
+func translateProvenance(id string, rawDataset *rawDatasetData) *pbv2.GetVariableMetadataResponse_ProvenanceMetadata {
+	provMeta := &pbv2.GetVariableMetadataResponse_ProvenanceMetadata{
+		Id:         id,
+		Properties: &structpb.Struct{Fields: make(map[string]*structpb.Value)},
+	}
+
+	mergeProperties := func(graph *pbv2.LinkedGraph) {
+		if graph == nil || graph.GetArcs() == nil {
+			return
+		}
+		for prop, nodesArc := range graph.GetArcs() {
+			if nodesArc == nil || len(nodesArc.GetNodes()) == 0 {
+				continue
+			}
+			if _, shouldInclude := includedDatasetProperties[prop]; !shouldInclude {
+				continue
+			}
+			if structVal, ok := toStructValue(nodesArc.GetNodes()); ok {
+				provMeta.Properties.Fields[prop] = structVal
+			}
+		}
+	}
+
+	// Merge parent source first, then overlay provenance specific properties
+	mergeProperties(rawDataset.source)
+	mergeProperties(rawDataset.provenance)
+
+	return provMeta
+}
+
+// resolveFirstValue retrieves the raw string value of the first available candidate.
+func resolveFirstValue(nodes []*pb.EntityInfo) string {
+	if len(nodes) == 0 {
+		return ""
+	}
+	for _, n := range nodes {
+		if n == nil {
+			continue
+		}
+		val := n.GetValue()
+		if val == "" {
+			val = n.GetName()
+		}
+		if val == "" {
+			val = n.GetDcid()
+		}
+		if val != "" {
+			return val
+		}
+	}
+	return ""
+}
+
+// toStructValue converts a slice of properties into a flat Struct Value.
+func toStructValue(nodes []*pb.EntityInfo) (*structpb.Value, bool) {
+	var values []string
+	seen := make(map[string]struct{})
+
+	for _, n := range nodes {
+		if n == nil {
+			continue
+		}
+		val := n.GetValue()
+		if val == "" {
+			val = n.GetName()
+		}
+		if val == "" {
+			val = n.GetDcid()
+		}
+		if val == "" {
+			continue
+		}
+
+		if _, ok := seen[val]; !ok {
+			seen[val] = struct{}{}
+			values = append(values, val)
+		}
+	}
+
+	if len(values) == 0 {
+		return nil, false
+	}
+
+	// If exactly 1 value, return as a flat string
+	if len(values) == 1 {
+		return structpb.NewStringValue(values[0]), true
+	}
+
+	// If multiple values, return as a list of strings
+	var listVals []*structpb.Value
+	for _, v := range values {
+		listVals = append(listVals, structpb.NewStringValue(v))
+	}
+	return structpb.NewListValue(&structpb.ListValue{Values: listVals}), true
+}
+
+// extractGeographicGranularities retrieves sorted unique place types for a specific provenance from a StatVarSummary.
+func extractGeographicGranularities(summary *pb.StatVarSummary, provID string) []string {
+	var granularities []string
+	if summary == nil || summary.GetProvenanceSummary() == nil {
+		return []string{}
+	}
+	provSummary, ok := summary.GetProvenanceSummary()[provID]
+	if !ok || provSummary == nil {
+		return []string{}
+	}
+
+	seenPlaceTypes := make(map[string]struct{})
+	for _, seriesSummary := range provSummary.GetSeriesSummary() {
+		if seriesSummary != nil {
+			for placeType := range seriesSummary.GetPlaceTypeSummary() {
+				seenPlaceTypes[placeType] = struct{}{}
+			}
+		}
+	}
+
+	for placeType := range seenPlaceTypes {
+		granularities = append(granularities, placeType)
+	}
+
+	// Sort to ensure deterministic order
+	sort.Strings(granularities)
+
+	if len(granularities) == 0 {
+		return []string{}
+	}
+	return granularities
 }

--- a/internal/agent/get_variable_metadata.go
+++ b/internal/agent/get_variable_metadata.go
@@ -42,7 +42,6 @@ var (
 	excludedSVProperties = map[string]struct{}{
 		"name":           {},
 		"description":    {},
-		"label":          {},
 		"typeOf":         {},
 		"provenance":     {},
 		"definition":     {},
@@ -111,8 +110,14 @@ func (s *Service) GetVariableMetadata(
 	if len(req.GetVariableDcids()) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "variable_dcids cannot be empty")
 	}
+	if len(req.GetVariableDcids()) > 10 {
+		return nil, status.Error(codes.InvalidArgument, "variable_dcids cannot exceed 10")
+	}
 	if len(req.GetEntityDcids()) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "entity_dcids cannot be empty")
+	}
+	if len(req.GetEntityDcids()) > 10 {
+		return nil, status.Error(codes.InvalidArgument, "entity_dcids cannot exceed 10")
 	}
 
 	varDcids := dedup(req.GetVariableDcids())

--- a/internal/agent/get_variable_metadata.go
+++ b/internal/agent/get_variable_metadata.go
@@ -16,7 +16,7 @@ package agent
 
 import (
 	"context"
-	"log"
+	"log/slog"
 	"sort"
 	"time"
 
@@ -35,6 +35,29 @@ const (
 	maxConcurrentFetchers = 20
 	maxVariablesLimit     = 10
 	maxEntitiesLimit      = 10
+
+	// Schema property names
+	propName                    = "name"
+	propDescription             = "description"
+	propTypeOf                  = "typeOf"
+	propProvenance              = "provenance"
+	propDefinition              = "definition"
+	propMemberOf                = "memberOf"
+	propLinkedMemberOf          = "linkedMemberOf"
+	propLinkedMember            = "linkedMember"
+	propUrl                     = "url"
+	propLicense                 = "license"
+	propLicenseType             = "licenseType"
+	propLastDataRefreshDate     = "lastDataRefreshDate"
+	propNextDataRefreshDate     = "nextDataRefreshDate"
+	propNextSourceReleaseDate   = "nextSourceReleaseDate"
+	propSourceReleaseFrequency  = "sourceReleaseFrequency"
+	propLatestObservationDate   = "latestObservationDate"
+	propEarliestObservationDate = "earliestObservationDate"
+	propIsPartOf                = "isPartOf"
+	propSource                  = "source"
+	propDomain                  = "domain"
+	propDescriptionUrl          = "descriptionUrl"
 )
 
 var (
@@ -42,33 +65,33 @@ var (
 
 	// properties to exclude from Statistical Variable properties Struct
 	excludedSVProperties = map[string]struct{}{
-		"name":           {},
-		"description":    {},
-		"typeOf":         {},
-		"provenance":     {},
-		"definition":     {},
-		"memberOf":       {},
-		"linkedMemberOf": {},
-		"linkedMember":   {},
+		propName:           {},
+		propDescription:    {},
+		propTypeOf:         {},
+		propProvenance:     {},
+		propDefinition:     {},
+		propMemberOf:       {},
+		propLinkedMemberOf: {},
+		propLinkedMember:   {},
 	}
 
 	// properties to explicitly include for Provenance and Source dataset properties Struct.
 	// These must be the exact raw property keys returned from the knowledge graph (V2Node).
 	includedDatasetProperties = map[string]struct{}{
-		"url":                     {},
-		"license":                 {},
-		"licenseType":             {},
-		"lastDataRefreshDate":     {},
-		"nextDataRefreshDate":     {},
-		"nextSourceReleaseDate":   {},
-		"sourceReleaseFrequency":  {},
-		"latestObservationDate":   {},
-		"earliestObservationDate": {},
-		"isPartOf":                {},
-		"source":                  {},
-		"domain":                  {},
-		"description":             {},
-		"descriptionUrl":          {},
+		propUrl:                     {},
+		propLicense:                 {},
+		propLicenseType:             {},
+		propLastDataRefreshDate:     {},
+		propNextDataRefreshDate:     {},
+		propNextSourceReleaseDate:   {},
+		propSourceReleaseFrequency:  {},
+		propLatestObservationDate:   {},
+		propEarliestObservationDate: {},
+		propIsPartOf:                {},
+		propSource:                  {},
+		propDomain:                  {},
+		propDescription:             {},
+		propDescriptionUrl:          {},
 	}
 )
 
@@ -172,7 +195,7 @@ func (s *Service) fetchRawData(ctx context.Context, varDcids, entityDcids []stri
 		g.Go(func() error {
 			graph, err := s.fetchNodeGraph(gCtx, dcid)
 			if err != nil {
-				log.Printf("Warning: failed to fetch node graph for variable %s: %v", dcid, err)
+				slog.Warn("Failed to fetch node graph", "variable", dcid, "err", err)
 				return nil // Graceful degradation: do not fail the errgroup
 			}
 			properties[idx] = graph // Safe: write to unique index
@@ -184,7 +207,7 @@ func (s *Service) fetchRawData(ctx context.Context, varDcids, entityDcids []stri
 			req := &pbv1.BulkVariableInfoRequest{Nodes: []string{dcid}}
 			resp, err := s.mixer.V2BulkVariableInfo(gCtx, req)
 			if err != nil {
-				log.Printf("Warning: failed to fetch bulk variable info for %s: %v", dcid, err)
+				slog.Warn("Failed to fetch bulk variable info", "variable", dcid, "err", err)
 				return nil // Graceful degradation
 			}
 			if resp != nil && resp.GetData() != nil {
@@ -254,7 +277,7 @@ func (s *Service) fetchRawProvenances(ctx context.Context, raw *rawFetchResult) 
 		g.Go(func() error {
 			dataset, err := s.fetchDatasetGraphs(gCtx, provDcid)
 			if err != nil {
-				log.Printf("Warning: failed to fetch dataset graphs for provenance %s: %v", provDcid, err)
+				slog.Warn("Failed to fetch dataset graphs", "provenance", provDcid, "err", err)
 				return nil // Graceful degradation: do not fail the entire request
 			}
 			// Safe: lock-free direct pointer writes!
@@ -325,7 +348,7 @@ func extractSourceDcid(graph *pbv2.LinkedGraph) string {
 	if graph == nil || graph.GetArcs() == nil {
 		return ""
 	}
-	if srcArc, ok := graph.GetArcs()["source"]; ok && srcArc != nil {
+	if srcArc, ok := graph.GetArcs()[propSource]; ok && srcArc != nil {
 		for _, n := range srcArc.GetNodes() {
 			if n != nil && n.GetDcid() != "" {
 				return n.GetDcid()
@@ -392,18 +415,13 @@ func translateProperties(graph *pbv2.LinkedGraph) *translatedProperties {
 		return tp
 	}
 
-	// 1. Resolve root Name (primary name or label)
-	if nameArc, ok := graph.GetArcs()["name"]; ok && nameArc != nil {
+	// 1. Resolve root Name (primary name)
+	if nameArc, ok := graph.GetArcs()[propName]; ok && nameArc != nil {
 		tp.name = resolveFirstValue(nameArc.GetNodes())
-	}
-	if tp.name == "" {
-		if labelArc, ok := graph.GetArcs()["label"]; ok && labelArc != nil {
-			tp.name = resolveFirstValue(labelArc.GetNodes())
-		}
 	}
 
 	// 2. Resolve root Description
-	if descArc, ok := graph.GetArcs()["description"]; ok && descArc != nil {
+	if descArc, ok := graph.GetArcs()[propDescription]; ok && descArc != nil {
 		tp.description = resolveFirstValue(descArc.GetNodes())
 	}
 

--- a/internal/agent/get_variable_metadata.go
+++ b/internal/agent/get_variable_metadata.go
@@ -33,6 +33,8 @@ import (
 const (
 	wildcardPropertyQuery = "->*"
 	maxConcurrentFetchers = 20
+	maxVariablesLimit     = 10
+	maxEntitiesLimit      = 10
 )
 
 var (
@@ -110,14 +112,14 @@ func (s *Service) GetVariableMetadata(
 	if len(req.GetVariableDcids()) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "variable_dcids cannot be empty")
 	}
-	if len(req.GetVariableDcids()) > 10 {
-		return nil, status.Error(codes.InvalidArgument, "variable_dcids cannot exceed 10")
+	if len(req.GetVariableDcids()) > maxVariablesLimit {
+		return nil, status.Errorf(codes.InvalidArgument, "variable_dcids cannot exceed %d", maxVariablesLimit)
 	}
 	if len(req.GetEntityDcids()) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "entity_dcids cannot be empty")
 	}
-	if len(req.GetEntityDcids()) > 10 {
-		return nil, status.Error(codes.InvalidArgument, "entity_dcids cannot exceed 10")
+	if len(req.GetEntityDcids()) > maxEntitiesLimit {
+		return nil, status.Errorf(codes.InvalidArgument, "entity_dcids cannot exceed %d", maxEntitiesLimit)
 	}
 
 	varDcids := dedup(req.GetVariableDcids())

--- a/internal/agent/get_variable_metadata.go
+++ b/internal/agent/get_variable_metadata.go
@@ -153,11 +153,13 @@ func (s *Service) fetchRawData(ctx context.Context, varDcids, entityDcids []stri
 	g, gCtx := errgroup.WithContext(ctx)
 	g.SetLimit(maxConcurrentFetchers)
 
-	// Initialize slots sequentially, then fetch concurrently using direct pointers
-	for _, vDcid := range varDcids {
+	// Pre-allocate local slices to prevent CPU false sharing/cache bouncing across goroutines
+	properties := make([]*pbv2.LinkedGraph, len(varDcids))
+	summaries := make([]*pb.StatVarSummary, len(varDcids))
+
+	for i, vDcid := range varDcids {
+		idx := i
 		dcid := vDcid
-		rawVar := &rawVariableData{}
-		raw.variables[dcid] = rawVar // Safe: sequential map write in main thread
 
 		// Worker 1: Fetch Node Graph (Non-critical: log and skip on error)
 		g.Go(func() error {
@@ -166,7 +168,7 @@ func (s *Service) fetchRawData(ctx context.Context, varDcids, entityDcids []stri
 				log.Printf("Warning: failed to fetch node graph for variable %s: %v", dcid, err)
 				return nil // Graceful degradation: do not fail the errgroup
 			}
-			rawVar.properties = graph // Safe: direct pointer access (no map lookup)
+			properties[idx] = graph // Safe: write to unique index
 			return nil
 		})
 
@@ -181,7 +183,7 @@ func (s *Service) fetchRawData(ctx context.Context, varDcids, entityDcids []stri
 			if resp != nil && resp.GetData() != nil {
 				for _, info := range resp.GetData() {
 					if info.GetNode() == dcid {
-						rawVar.summary = info.GetInfo() // Safe: direct pointer access
+						summaries[idx] = info.GetInfo() // Safe: write to unique index
 					}
 				}
 			}
@@ -206,6 +208,16 @@ func (s *Service) fetchRawData(ctx context.Context, varDcids, entityDcids []stri
 
 	if err := g.Wait(); err != nil {
 		return nil, err
+	}
+
+	// Populate variables map sequentially from local slices after concurrent execution completes
+	for i, dcid := range varDcids {
+		if properties[i] != nil || summaries[i] != nil {
+			raw.variables[dcid] = &rawVariableData{
+				properties: properties[i],
+				summary:    summaries[i],
+			}
+		}
 	}
 
 	// Now hydrate provenances using the fetched data (lock-free!)
@@ -306,7 +318,7 @@ func extractSourceDcid(graph *pbv2.LinkedGraph) string {
 	if graph == nil || graph.GetArcs() == nil {
 		return ""
 	}
-	if srcArc, ok := graph.GetArcs()["source"]; ok {
+	if srcArc, ok := graph.GetArcs()["source"]; ok && srcArc != nil {
 		for _, n := range srcArc.GetNodes() {
 			if n != nil && n.GetDcid() != "" {
 				return n.GetDcid()
@@ -374,17 +386,17 @@ func translateProperties(graph *pbv2.LinkedGraph) *translatedProperties {
 	}
 
 	// 1. Resolve root Name (primary name or label)
-	if nameArc, ok := graph.GetArcs()["name"]; ok {
+	if nameArc, ok := graph.GetArcs()["name"]; ok && nameArc != nil {
 		tp.name = resolveFirstValue(nameArc.GetNodes())
 	}
 	if tp.name == "" {
-		if labelArc, ok := graph.GetArcs()["label"]; ok {
+		if labelArc, ok := graph.GetArcs()["label"]; ok && labelArc != nil {
 			tp.name = resolveFirstValue(labelArc.GetNodes())
 		}
 	}
 
 	// 2. Resolve root Description
-	if descArc, ok := graph.GetArcs()["description"]; ok {
+	if descArc, ok := graph.GetArcs()["description"]; ok && descArc != nil {
 		tp.description = resolveFirstValue(descArc.GetNodes())
 	}
 
@@ -544,6 +556,9 @@ func translateProvenance(id string, rawDataset *rawDatasetData) *pbv2.GetVariabl
 	provMeta := &pbv2.GetVariableMetadataResponse_ProvenanceMetadata{
 		Id:         id,
 		Properties: &structpb.Struct{Fields: make(map[string]*structpb.Value)},
+	}
+	if rawDataset == nil {
+		return provMeta
 	}
 
 	mergeProperties := func(graph *pbv2.LinkedGraph) {

--- a/internal/agent/get_variable_metadata_test.go
+++ b/internal/agent/get_variable_metadata_test.go
@@ -165,6 +165,24 @@ func TestGetVariableMetadata(t *testing.T) {
 			wantCode: codes.InvalidArgument,
 		},
 		{
+			desc: "Validation Failure: variable dcids exceed limit of 10",
+			req: &pbv2.GetVariableMetadataRequest{
+				VariableDcids: []string{"v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9", "v10", "v11"},
+				EntityDcids:   []string{"geoId/06"},
+			},
+			wantErr:  true,
+			wantCode: codes.InvalidArgument,
+		},
+		{
+			desc: "Validation Failure: entity dcids exceed limit of 10",
+			req: &pbv2.GetVariableMetadataRequest{
+				VariableDcids: []string{"Count_Person"},
+				EntityDcids:   []string{"e1", "e2", "e3", "e4", "e5", "e6", "e7", "e8", "e9", "e10", "e11"},
+			},
+			wantErr:  true,
+			wantCode: codes.InvalidArgument,
+		},
+		{
 			desc: "Graceful Degradation: Fail to fetch one variable, but successfully return other",
 			req: &pbv2.GetVariableMetadataRequest{
 				VariableDcids: []string{"Count_Person", "Median_Age_Person"}, // Median_Age_Person will fail graph fetch

--- a/internal/agent/get_variable_metadata_test.go
+++ b/internal/agent/get_variable_metadata_test.go
@@ -21,6 +21,8 @@ import (
 	pb "github.com/datacommonsorg/mixer/internal/proto"
 	pbv1 "github.com/datacommonsorg/mixer/internal/proto/v1"
 	pbv2 "github.com/datacommonsorg/mixer/internal/proto/v2"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type mockVMMixerServer struct {
@@ -28,6 +30,7 @@ type mockVMMixerServer struct {
 	nodeData map[string]*pbv2.LinkedGraph
 	bulkData map[string]*pb.StatVarSummary
 	obsData  map[string]*pb.Facet
+	obsErr   error // optional error to simulate critical path failure
 }
 
 func (m *mockVMMixerServer) V2Node(ctx context.Context, in *pbv2.NodeRequest) (*pbv2.NodeResponse, error) {
@@ -54,6 +57,9 @@ func (m *mockVMMixerServer) V2BulkVariableInfo(ctx context.Context, in *pbv1.Bul
 }
 
 func (m *mockVMMixerServer) V2Observation(ctx context.Context, in *pbv2.ObservationRequest) (*pbv2.ObservationResponse, error) {
+	if m.obsErr != nil {
+		return nil, m.obsErr
+	}
 	resp := &pbv2.ObservationResponse{
 		Facets:     make(map[string]*pb.Facet),
 		ByVariable: make(map[string]*pbv2.VariableObservation),
@@ -82,21 +88,86 @@ func (m *mockVMMixerServer) V2Observation(ctx context.Context, in *pbv2.Observat
 
 func TestGetVariableMetadata(t *testing.T) {
 	for _, tc := range []struct {
-		desc          string
-		req           *pbv2.GetVariableMetadataRequest
-		nodeData      map[string]*pbv2.LinkedGraph
-		bulkData      map[string]*pb.StatVarSummary
-		obsData       map[string]*pb.Facet
-		wantVar       string
-		wantPropName  string
-		wantProvDcid  string
-		wantProvUrl   string
-		wantFacetName string
+		desc              string
+		req               *pbv2.GetVariableMetadataRequest
+		nodeData          map[string]*pbv2.LinkedGraph
+		bulkData          map[string]*pb.StatVarSummary
+		obsData           map[string]*pb.Facet
+		obsErr            error // optional error to simulate critical path failure
+		wantErr           bool
+		wantCode          codes.Code
+		wantVar           string
+		wantPropName      string
+		wantProvDcid      string
+		wantProvUrl       string
+		wantGranularities []string
+		omitVar           string // variable that should be omitted from the final response due to mock fetch error
 	}{
 		{
 			desc: "Successfully retrieve metadata across variable, provenance, and observation facets",
 			req: &pbv2.GetVariableMetadataRequest{
 				VariableDcids: []string{"Count_Person"},
+				EntityDcids:   []string{"geoId/06"},
+			},
+			nodeData: map[string]*pbv2.LinkedGraph{
+				"Count_Person": {
+					Arcs: map[string]*pbv2.Nodes{
+						"name": {Nodes: []*pb.EntityInfo{{Value: "Population"}}},
+					},
+				},
+				"dc/base/USCensus_PEP": {
+					Arcs: map[string]*pbv2.Nodes{
+						"url": {Nodes: []*pb.EntityInfo{{Value: "https://census.gov"}}},
+					},
+				},
+			},
+			bulkData: map[string]*pb.StatVarSummary{
+				"Count_Person": {
+					ProvenanceSummary: map[string]*pb.StatVarSummary_ProvenanceSummary{
+						"dc/base/USCensus_PEP": {
+							ImportName: "USCensus_PEP",
+							SeriesSummary: []*pb.StatVarSummary_SeriesSummary{
+								{
+									PlaceTypeSummary: map[string]*pb.StatVarSummary_PlaceTypeSummary{
+										"Country": {},
+										"State":   {},
+										"County":  {},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			obsData: map[string]*pb.Facet{
+				"facet1": {ImportName: "USCensus_PEP", ProvenanceId: "dc/base/USCensus_PEP"},
+			},
+			wantVar:           "Count_Person",
+			wantPropName:      "Population",
+			wantProvDcid:      "dc/base/USCensus_PEP",
+			wantProvUrl:       "https://census.gov",
+			wantGranularities: []string{"Country", "County", "State"}, // sorted alphabetically
+		},
+		{
+			desc: "Validation Failure: Missing variable dcids",
+			req: &pbv2.GetVariableMetadataRequest{
+				EntityDcids: []string{"geoId/06"},
+			},
+			wantErr:  true,
+			wantCode: codes.InvalidArgument,
+		},
+		{
+			desc: "Validation Failure: Missing entity dcids",
+			req: &pbv2.GetVariableMetadataRequest{
+				VariableDcids: []string{"Count_Person"},
+			},
+			wantErr:  true,
+			wantCode: codes.InvalidArgument,
+		},
+		{
+			desc: "Graceful Degradation: Fail to fetch one variable, but successfully return other",
+			req: &pbv2.GetVariableMetadataRequest{
+				VariableDcids: []string{"Count_Person", "Median_Age_Person"}, // Median_Age_Person will fail graph fetch
 				EntityDcids:   []string{"geoId/06"},
 			},
 			nodeData: map[string]*pbv2.LinkedGraph{
@@ -121,12 +192,21 @@ func TestGetVariableMetadata(t *testing.T) {
 			obsData: map[string]*pb.Facet{
 				"facet1": {ImportName: "USCensus_PEP", ProvenanceId: "dc/base/USCensus_PEP"},
 			},
-
-			wantVar:       "Count_Person",
-			wantPropName:  "Population",
-			wantProvDcid:  "dc/base/USCensus_PEP",
-			wantProvUrl:   "https://census.gov",
-			wantFacetName: "USCensus_PEP",
+			wantVar:      "Count_Person",
+			wantPropName: "Population",
+			wantProvDcid: "dc/base/USCensus_PEP",
+			wantProvUrl:  "https://census.gov",
+			omitVar:      "Median_Age_Person",
+		},
+		{
+			desc: "Critical Path Failure: observations query fails",
+			req: &pbv2.GetVariableMetadataRequest{
+				VariableDcids: []string{"Count_Person"},
+				EntityDcids:   []string{"geoId/06"},
+			},
+			obsErr:   status.Error(codes.Internal, "Spanner connection lost"),
+			wantErr:  true,
+			wantCode: codes.Internal,
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
@@ -134,10 +214,22 @@ func TestGetVariableMetadata(t *testing.T) {
 				nodeData: tc.nodeData,
 				bulkData: tc.bulkData,
 				obsData:  tc.obsData,
+				obsErr:   tc.obsErr,
 			}
 			svc := NewService(mock, NewCache(mock))
 
 			got, err := svc.GetVariableMetadata(context.Background(), tc.req)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("Expected error, got nil")
+				}
+				stat, ok := status.FromError(err)
+				if !ok || stat.Code() != tc.wantCode {
+					t.Fatalf("Expected error code %v, got %v: %v", tc.wantCode, stat.Code(), err)
+				}
+				return
+			}
+
 			if err != nil {
 				t.Fatalf("GetVariableMetadata failed: %v", err)
 			}
@@ -146,42 +238,76 @@ func TestGetVariableMetadata(t *testing.T) {
 				t.Fatalf("GetVariableMetadata returned non-success response: %v", got)
 			}
 
+			// 1. Assert skipped variables (graceful degradation)
+			if tc.omitVar != "" {
+				if _, exists := got.GetVariables()[tc.omitVar]; exists {
+					t.Errorf("Expected variable %s to be omitted due to fetch failure, but it was present", tc.omitVar)
+				}
+			}
+
 			vMeta, ok := got.GetVariables()[tc.wantVar]
 			if !ok {
 				t.Fatalf("Missing expected variable metadata for %s", tc.wantVar)
 			}
 
-			if vMeta.GetProperties()["name"].GetValues()[0].GetValue() != tc.wantPropName {
-				t.Errorf("Expected property name %q, got: %v", tc.wantPropName, vMeta.GetProperties())
+			// 2. Assert root headers are correctly mapped
+			if vMeta.GetName() != tc.wantPropName {
+				t.Errorf("Expected root name %q, got: %q", tc.wantPropName, vMeta.GetName())
 			}
 
-			prov, ok := vMeta.GetProvenances()[tc.wantProvDcid]
-			if !ok {
-				t.Fatalf("Missing expected provenance metadata for %s", tc.wantProvDcid)
-			}
-			if prov.GetProperties()["url"].GetValues()[0].GetValue() != tc.wantProvUrl {
-				t.Errorf("Expected provenance url %q, got: %v", tc.wantProvUrl, prov.GetProperties())
+			// 3. Assert properties does not contain redundant name
+			if _, nameExists := vMeta.GetProperties().GetFields()["name"]; nameExists {
+				t.Error("Expected properties Struct to exclude redundant 'name' key")
 			}
 
-			eMeta, ok := vMeta.GetPerEntityMetadata()["geoId/06"]
+			// 4. Assert provenance is resolved at root map level
+			prov, ok := got.GetProvenances()[tc.wantProvDcid]
 			if !ok {
-				t.Fatalf("Missing expected entity metadata for geoId/06")
+				t.Fatalf("Missing expected root provenance metadata for %s", tc.wantProvDcid)
 			}
-			fSum, ok := eMeta.GetFacetSeriesSummaries()["facet1"]
-			if !ok || fSum == nil {
-				t.Fatalf("Missing expected facet series summary for facet1")
+			if prov.GetProperties().GetFields()["url"].GetStringValue() != tc.wantProvUrl {
+				t.Errorf("Expected provenance url %q, got: %v", tc.wantProvUrl, prov.GetProperties().GetFields()["url"].GetStringValue())
 			}
-			if fSum.GetFacet().GetImportName() != tc.wantFacetName {
-				t.Errorf("Expected per-entity facet importName %q, got: %v", tc.wantFacetName, fSum.GetFacet())
+
+			// 5. Assert structured facets and scopes
+			if len(vMeta.GetFacets()) != 1 {
+				t.Fatalf("Expected exactly 1 facet, got: %d", len(vMeta.GetFacets()))
 			}
-			if fSum.GetObsCount() != 54 {
-				t.Errorf("Expected obsCount 54, got: %v", fSum.GetObsCount())
+
+			facet := vMeta.GetFacets()[0]
+			if facet.GetProvenanceId() != tc.wantProvDcid {
+				t.Errorf("Expected facet provenanceId %q, got: %q", tc.wantProvDcid, facet.GetProvenanceId())
 			}
-			if fSum.GetEarliestDate() != "2010" {
-				t.Errorf("Expected earliestDate '2010', got: %v", fSum.GetEarliestDate())
+			if facet.GetObsCount() != 54 {
+				t.Errorf("Expected obsCount 54, got: %d", facet.GetObsCount())
 			}
-			if fSum.GetLatestDate() != "2020" {
-				t.Errorf("Expected latestDate '2020', got: %v", fSum.GetLatestDate())
+
+			dateRange := facet.GetDateRange()
+			if dateRange.GetStart() != "2010" {
+				t.Errorf("Expected start date '2010', got: %q", dateRange.GetStart())
+			}
+			if dateRange.GetEnd() != "2020" {
+				t.Errorf("Expected end date '2020', got: %q", dateRange.GetEnd())
+			}
+
+			scope := facet.GetScope()
+			coverage := scope.GetEntityCoverage()
+			if len(coverage) != 1 || coverage[0] != "geoId/06" {
+				t.Errorf("Expected entityCoverage ['geoId/06'], got: %v", coverage)
+			}
+
+			// 6. Assert mock PlaceTypeSummary geographic granularities
+			if len(tc.wantGranularities) > 0 {
+				granularities := scope.GetEntityGranularity()
+				if len(granularities) != len(tc.wantGranularities) {
+					t.Errorf("Expected granularities count %d, got: %d (%v)", len(tc.wantGranularities), len(granularities), granularities)
+				} else {
+					for i, g := range granularities {
+						if g != tc.wantGranularities[i] {
+							t.Errorf("Expected granularity at index %d to be %q, got: %q", i, tc.wantGranularities[i], g)
+						}
+					}
+				}
 			}
 		})
 	}

--- a/internal/agent/search_indicators.go
+++ b/internal/agent/search_indicators.go
@@ -642,11 +642,11 @@ func translateTopicCandidate(
 	}
 
 	resp.Topics = append(resp.Topics, &pbv2.SearchIndicatorsResponse_Topic{
-		Dcid:                 c.GetDcid(),
-		MemberTopics:         memberTopics,
-		MemberVariables:      memberVariables,
-		PlacesWithData:       placesWithData,
-		Description:          c.GetName(),
+		Dcid:                  c.GetDcid(),
+		MemberTopics:          memberTopics,
+		MemberVariables:       memberVariables,
+		PlacesWithData:        placesWithData,
+		Description:           c.GetName(),
 		AlternateDescriptions: []string{c.GetName()}, // Fallback alt description
 	})
 }

--- a/internal/agent/search_indicators_test.go
+++ b/internal/agent/search_indicators_test.go
@@ -39,9 +39,8 @@ type mockMixerServer struct {
 
 	// obsMockData maps a place DCID string to the slice of variable DCIDs
 	// that have active observation series data available for that place.
-	obsMockData     map[string][]string
+	obsMockData map[string][]string
 }
-
 
 // V2Resolve dynamically maps input query nodes to candidates from its resolveMockData map.
 func (m *mockMixerServer) V2Resolve(ctx context.Context, in *pbv2.ResolveRequest) (*pbv2.ResolveResponse, error) {
@@ -144,8 +143,8 @@ func TestSearchIndicators_Basic(t *testing.T) {
 	}
 
 	for _, tc := range []struct {
-		desc            string
-		request         *pbv2.SearchIndicatorsRequest
+		desc    string
+		request *pbv2.SearchIndicatorsRequest
 
 		// resolveMockData maps a search query node string (or place description like "World")
 		// to its pre-populated list of resolved KG entity candidates.
@@ -153,10 +152,10 @@ func TestSearchIndicators_Basic(t *testing.T) {
 
 		// obsMockData maps a place DCID string to the slice of variable DCIDs
 		// that have active observation series data available for that place.
-		obsMockData     map[string][]string
+		obsMockData map[string][]string
 
-		wantResponse    *pbv2.SearchIndicatorsResponse
-		expectedError   string
+		wantResponse  *pbv2.SearchIndicatorsResponse
+		expectedError string
 	}{
 		{
 			desc: "Basic indicator search without place constraints",
@@ -194,9 +193,9 @@ func TestSearchIndicators_Basic(t *testing.T) {
 				},
 				Topics: []*pbv2.SearchIndicatorsResponse_Topic{
 					{
-						Dcid:                 "topic/Health",
-						Description:          "Health",
-						MemberVariables:      []string{"Count_Person_WithAsthma"},
+						Dcid:                  "topic/Health",
+						Description:           "Health",
+						MemberVariables:       []string{"Count_Person_WithAsthma"},
 						AlternateDescriptions: []string{"Health"},
 					},
 				},
@@ -253,11 +252,11 @@ func TestSearchIndicators_Basic(t *testing.T) {
 				},
 				Topics: []*pbv2.SearchIndicatorsResponse_Topic{
 					{
-						Dcid:                 "topic/RootHealth",
-						Description:          "Global Health Topic",
-						MemberVariables:      []string{"Count_Person"},
+						Dcid:                  "topic/RootHealth",
+						Description:           "Global Health Topic",
+						MemberVariables:       []string{"Count_Person"},
 						AlternateDescriptions: []string{"Global Health Topic"},
-						PlacesWithData:       []string{"Earth"},
+						PlacesWithData:        []string{"Earth"},
 					},
 				},
 			},
@@ -350,10 +349,10 @@ func TestSearchIndicators_Basic(t *testing.T) {
 				},
 				Topics: []*pbv2.SearchIndicatorsResponse_Topic{
 					{
-						Dcid:                 "topic/Health",
-						Description:          "Health",
-						MemberTopics:         []string{"topic/HealthSubTopic"},
-						MemberVariables:      []string{"Count_Person_WithDiabetes"},
+						Dcid:                  "topic/Health",
+						Description:           "Health",
+						MemberTopics:          []string{"topic/HealthSubTopic"},
+						MemberVariables:       []string{"Count_Person_WithDiabetes"},
 						AlternateDescriptions: []string{"Health"},
 					},
 				},

--- a/internal/proto/v2/agent.pb.go
+++ b/internal/proto/v2/agent.pb.go
@@ -21,7 +21,6 @@
 package v2
 
 import (
-	proto "github.com/datacommonsorg/mixer/internal/proto"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	structpb "google.golang.org/protobuf/types/known/structpb"
@@ -385,111 +384,8 @@ func (x *GetObservationsResponse) GetAlternativeSources() []*GetObservationsResp
 	return nil
 }
 
-type PropertyValue struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Value         string                 `protobuf:"bytes,1,opt,name=value,proto3" json:"value,omitempty"`
-	Dcid          string                 `protobuf:"bytes,2,opt,name=dcid,proto3" json:"dcid,omitempty"`
-	Name          string                 `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *PropertyValue) Reset() {
-	*x = PropertyValue{}
-	mi := &file_v2_agent_proto_msgTypes[4]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *PropertyValue) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*PropertyValue) ProtoMessage() {}
-
-func (x *PropertyValue) ProtoReflect() protoreflect.Message {
-	mi := &file_v2_agent_proto_msgTypes[4]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use PropertyValue.ProtoReflect.Descriptor instead.
-func (*PropertyValue) Descriptor() ([]byte, []int) {
-	return file_v2_agent_proto_rawDescGZIP(), []int{4}
-}
-
-func (x *PropertyValue) GetValue() string {
-	if x != nil {
-		return x.Value
-	}
-	return ""
-}
-
-func (x *PropertyValue) GetDcid() string {
-	if x != nil {
-		return x.Dcid
-	}
-	return ""
-}
-
-func (x *PropertyValue) GetName() string {
-	if x != nil {
-		return x.Name
-	}
-	return ""
-}
-
-type PropertyValues struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Values        []*PropertyValue       `protobuf:"bytes,1,rep,name=values,proto3" json:"values,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *PropertyValues) Reset() {
-	*x = PropertyValues{}
-	mi := &file_v2_agent_proto_msgTypes[5]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *PropertyValues) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*PropertyValues) ProtoMessage() {}
-
-func (x *PropertyValues) ProtoReflect() protoreflect.Message {
-	mi := &file_v2_agent_proto_msgTypes[5]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use PropertyValues.ProtoReflect.Descriptor instead.
-func (*PropertyValues) Descriptor() ([]byte, []int) {
-	return file_v2_agent_proto_rawDescGZIP(), []int{5}
-}
-
-func (x *PropertyValues) GetValues() []*PropertyValue {
-	if x != nil {
-		return x.Values
-	}
-	return nil
-}
-
 // Request payload for the get_variable_metadata tool endpoint.
+// Both variable_dcids and entity_dcids are strictly required.
 type GetVariableMetadataRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	VariableDcids []string               `protobuf:"bytes,1,rep,name=variable_dcids,json=variableDcids,proto3" json:"variable_dcids,omitempty"`
@@ -500,7 +396,7 @@ type GetVariableMetadataRequest struct {
 
 func (x *GetVariableMetadataRequest) Reset() {
 	*x = GetVariableMetadataRequest{}
-	mi := &file_v2_agent_proto_msgTypes[6]
+	mi := &file_v2_agent_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -512,7 +408,7 @@ func (x *GetVariableMetadataRequest) String() string {
 func (*GetVariableMetadataRequest) ProtoMessage() {}
 
 func (x *GetVariableMetadataRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_v2_agent_proto_msgTypes[6]
+	mi := &file_v2_agent_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -525,7 +421,7 @@ func (x *GetVariableMetadataRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetVariableMetadataRequest.ProtoReflect.Descriptor instead.
 func (*GetVariableMetadataRequest) Descriptor() ([]byte, []int) {
-	return file_v2_agent_proto_rawDescGZIP(), []int{6}
+	return file_v2_agent_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *GetVariableMetadataRequest) GetVariableDcids() []string {
@@ -544,16 +440,17 @@ func (x *GetVariableMetadataRequest) GetEntityDcids() []string {
 
 // Response payload for the get_variable_metadata tool endpoint.
 type GetVariableMetadataResponse struct {
-	state         protoimpl.MessageState                                   `protogen:"open.v1"`
-	Status        string                                                   `protobuf:"bytes,1,opt,name=status,proto3" json:"status,omitempty"`
-	Variables     map[string]*GetVariableMetadataResponse_VariableMetadata `protobuf:"bytes,2,rep,name=variables,proto3" json:"variables,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	state         protoimpl.MessageState                                     `protogen:"open.v1"`
+	Status        string                                                     `protobuf:"bytes,1,opt,name=status,proto3" json:"status,omitempty"`
+	Variables     map[string]*GetVariableMetadataResponse_VariableMetadata   `protobuf:"bytes,2,rep,name=variables,proto3" json:"variables,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Provenances   map[string]*GetVariableMetadataResponse_ProvenanceMetadata `protobuf:"bytes,3,rep,name=provenances,proto3" json:"provenances,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *GetVariableMetadataResponse) Reset() {
 	*x = GetVariableMetadataResponse{}
-	mi := &file_v2_agent_proto_msgTypes[7]
+	mi := &file_v2_agent_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -565,7 +462,7 @@ func (x *GetVariableMetadataResponse) String() string {
 func (*GetVariableMetadataResponse) ProtoMessage() {}
 
 func (x *GetVariableMetadataResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_v2_agent_proto_msgTypes[7]
+	mi := &file_v2_agent_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -578,7 +475,7 @@ func (x *GetVariableMetadataResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetVariableMetadataResponse.ProtoReflect.Descriptor instead.
 func (*GetVariableMetadataResponse) Descriptor() ([]byte, []int) {
-	return file_v2_agent_proto_rawDescGZIP(), []int{7}
+	return file_v2_agent_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *GetVariableMetadataResponse) GetStatus() string {
@@ -591,6 +488,13 @@ func (x *GetVariableMetadataResponse) GetStatus() string {
 func (x *GetVariableMetadataResponse) GetVariables() map[string]*GetVariableMetadataResponse_VariableMetadata {
 	if x != nil {
 		return x.Variables
+	}
+	return nil
+}
+
+func (x *GetVariableMetadataResponse) GetProvenances() map[string]*GetVariableMetadataResponse_ProvenanceMetadata {
+	if x != nil {
+		return x.Provenances
 	}
 	return nil
 }
@@ -609,7 +513,7 @@ type SearchIndicatorsResponse_Topic struct {
 
 func (x *SearchIndicatorsResponse_Topic) Reset() {
 	*x = SearchIndicatorsResponse_Topic{}
-	mi := &file_v2_agent_proto_msgTypes[8]
+	mi := &file_v2_agent_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -621,7 +525,7 @@ func (x *SearchIndicatorsResponse_Topic) String() string {
 func (*SearchIndicatorsResponse_Topic) ProtoMessage() {}
 
 func (x *SearchIndicatorsResponse_Topic) ProtoReflect() protoreflect.Message {
-	mi := &file_v2_agent_proto_msgTypes[8]
+	mi := &file_v2_agent_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -691,7 +595,7 @@ type SearchIndicatorsResponse_Variable struct {
 
 func (x *SearchIndicatorsResponse_Variable) Reset() {
 	*x = SearchIndicatorsResponse_Variable{}
-	mi := &file_v2_agent_proto_msgTypes[9]
+	mi := &file_v2_agent_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -703,7 +607,7 @@ func (x *SearchIndicatorsResponse_Variable) String() string {
 func (*SearchIndicatorsResponse_Variable) ProtoMessage() {}
 
 func (x *SearchIndicatorsResponse_Variable) ProtoReflect() protoreflect.Message {
-	mi := &file_v2_agent_proto_msgTypes[9]
+	mi := &file_v2_agent_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -758,7 +662,7 @@ type SearchIndicatorsResponse_ResolvedPlace struct {
 
 func (x *SearchIndicatorsResponse_ResolvedPlace) Reset() {
 	*x = SearchIndicatorsResponse_ResolvedPlace{}
-	mi := &file_v2_agent_proto_msgTypes[10]
+	mi := &file_v2_agent_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -770,7 +674,7 @@ func (x *SearchIndicatorsResponse_ResolvedPlace) String() string {
 func (*SearchIndicatorsResponse_ResolvedPlace) ProtoMessage() {}
 
 func (x *SearchIndicatorsResponse_ResolvedPlace) ProtoReflect() protoreflect.Message {
-	mi := &file_v2_agent_proto_msgTypes[10]
+	mi := &file_v2_agent_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -818,7 +722,7 @@ type GetObservationsResponse_Node struct {
 
 func (x *GetObservationsResponse_Node) Reset() {
 	*x = GetObservationsResponse_Node{}
-	mi := &file_v2_agent_proto_msgTypes[13]
+	mi := &file_v2_agent_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -830,7 +734,7 @@ func (x *GetObservationsResponse_Node) String() string {
 func (*GetObservationsResponse_Node) ProtoMessage() {}
 
 func (x *GetObservationsResponse_Node) ProtoReflect() protoreflect.Message {
-	mi := &file_v2_agent_proto_msgTypes[13]
+	mi := &file_v2_agent_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -881,7 +785,7 @@ type GetObservationsResponse_FacetMetadata struct {
 
 func (x *GetObservationsResponse_FacetMetadata) Reset() {
 	*x = GetObservationsResponse_FacetMetadata{}
-	mi := &file_v2_agent_proto_msgTypes[14]
+	mi := &file_v2_agent_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -893,7 +797,7 @@ func (x *GetObservationsResponse_FacetMetadata) String() string {
 func (*GetObservationsResponse_FacetMetadata) ProtoMessage() {}
 
 func (x *GetObservationsResponse_FacetMetadata) ProtoReflect() protoreflect.Message {
-	mi := &file_v2_agent_proto_msgTypes[14]
+	mi := &file_v2_agent_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -961,7 +865,7 @@ type GetObservationsResponse_AlternativeSource struct {
 
 func (x *GetObservationsResponse_AlternativeSource) Reset() {
 	*x = GetObservationsResponse_AlternativeSource{}
-	mi := &file_v2_agent_proto_msgTypes[15]
+	mi := &file_v2_agent_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -973,7 +877,7 @@ func (x *GetObservationsResponse_AlternativeSource) String() string {
 func (*GetObservationsResponse_AlternativeSource) ProtoMessage() {}
 
 func (x *GetObservationsResponse_AlternativeSource) ProtoReflect() protoreflect.Message {
-	mi := &file_v2_agent_proto_msgTypes[15]
+	mi := &file_v2_agent_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1013,7 +917,7 @@ type GetObservationsResponse_TimeSeriesPoint struct {
 
 func (x *GetObservationsResponse_TimeSeriesPoint) Reset() {
 	*x = GetObservationsResponse_TimeSeriesPoint{}
-	mi := &file_v2_agent_proto_msgTypes[16]
+	mi := &file_v2_agent_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1025,7 +929,7 @@ func (x *GetObservationsResponse_TimeSeriesPoint) String() string {
 func (*GetObservationsResponse_TimeSeriesPoint) ProtoMessage() {}
 
 func (x *GetObservationsResponse_TimeSeriesPoint) ProtoReflect() protoreflect.Message {
-	mi := &file_v2_agent_proto_msgTypes[16]
+	mi := &file_v2_agent_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1065,7 +969,7 @@ type GetObservationsResponse_PlaceObservation struct {
 
 func (x *GetObservationsResponse_PlaceObservation) Reset() {
 	*x = GetObservationsResponse_PlaceObservation{}
-	mi := &file_v2_agent_proto_msgTypes[17]
+	mi := &file_v2_agent_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1077,7 +981,7 @@ func (x *GetObservationsResponse_PlaceObservation) String() string {
 func (*GetObservationsResponse_PlaceObservation) ProtoMessage() {}
 
 func (x *GetObservationsResponse_PlaceObservation) ProtoReflect() protoreflect.Message {
-	mi := &file_v2_agent_proto_msgTypes[17]
+	mi := &file_v2_agent_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1107,10 +1011,170 @@ func (x *GetObservationsResponse_PlaceObservation) GetTimeSeries() []*GetObserva
 	return nil
 }
 
+type GetVariableMetadataResponse_FacetMetadata struct {
+	state         protoimpl.MessageState                               `protogen:"open.v1"`
+	Id            string                                               `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	ProvenanceId  string                                               `protobuf:"bytes,2,opt,name=provenance_id,json=provenanceId,proto3" json:"provenance_id,omitempty"`
+	ObsCount      int32                                                `protobuf:"varint,3,opt,name=obs_count,json=obsCount,proto3" json:"obs_count,omitempty"`
+	DateRange     *GetVariableMetadataResponse_FacetMetadata_DateRange `protobuf:"bytes,4,opt,name=date_range,json=dateRange,proto3" json:"date_range,omitempty"`
+	Scope         *GetVariableMetadataResponse_FacetMetadata_Scope     `protobuf:"bytes,5,opt,name=scope,proto3" json:"scope,omitempty"`
+	Properties    *structpb.Struct                                     `protobuf:"bytes,6,opt,name=properties,proto3" json:"properties,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetVariableMetadataResponse_FacetMetadata) Reset() {
+	*x = GetVariableMetadataResponse_FacetMetadata{}
+	mi := &file_v2_agent_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetVariableMetadataResponse_FacetMetadata) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetVariableMetadataResponse_FacetMetadata) ProtoMessage() {}
+
+func (x *GetVariableMetadataResponse_FacetMetadata) ProtoReflect() protoreflect.Message {
+	mi := &file_v2_agent_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetVariableMetadataResponse_FacetMetadata.ProtoReflect.Descriptor instead.
+func (*GetVariableMetadataResponse_FacetMetadata) Descriptor() ([]byte, []int) {
+	return file_v2_agent_proto_rawDescGZIP(), []int{5, 0}
+}
+
+func (x *GetVariableMetadataResponse_FacetMetadata) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *GetVariableMetadataResponse_FacetMetadata) GetProvenanceId() string {
+	if x != nil {
+		return x.ProvenanceId
+	}
+	return ""
+}
+
+func (x *GetVariableMetadataResponse_FacetMetadata) GetObsCount() int32 {
+	if x != nil {
+		return x.ObsCount
+	}
+	return 0
+}
+
+func (x *GetVariableMetadataResponse_FacetMetadata) GetDateRange() *GetVariableMetadataResponse_FacetMetadata_DateRange {
+	if x != nil {
+		return x.DateRange
+	}
+	return nil
+}
+
+func (x *GetVariableMetadataResponse_FacetMetadata) GetScope() *GetVariableMetadataResponse_FacetMetadata_Scope {
+	if x != nil {
+		return x.Scope
+	}
+	return nil
+}
+
+func (x *GetVariableMetadataResponse_FacetMetadata) GetProperties() *structpb.Struct {
+	if x != nil {
+		return x.Properties
+	}
+	return nil
+}
+
+type GetVariableMetadataResponse_VariableMetadata struct {
+	state         protoimpl.MessageState                       `protogen:"open.v1"`
+	Id            string                                       `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Name          string                                       `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	Description   string                                       `protobuf:"bytes,3,opt,name=description,proto3" json:"description,omitempty"`
+	Properties    *structpb.Struct                             `protobuf:"bytes,4,opt,name=properties,proto3" json:"properties,omitempty"`
+	Facets        []*GetVariableMetadataResponse_FacetMetadata `protobuf:"bytes,5,rep,name=facets,proto3" json:"facets,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetVariableMetadataResponse_VariableMetadata) Reset() {
+	*x = GetVariableMetadataResponse_VariableMetadata{}
+	mi := &file_v2_agent_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetVariableMetadataResponse_VariableMetadata) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetVariableMetadataResponse_VariableMetadata) ProtoMessage() {}
+
+func (x *GetVariableMetadataResponse_VariableMetadata) ProtoReflect() protoreflect.Message {
+	mi := &file_v2_agent_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetVariableMetadataResponse_VariableMetadata.ProtoReflect.Descriptor instead.
+func (*GetVariableMetadataResponse_VariableMetadata) Descriptor() ([]byte, []int) {
+	return file_v2_agent_proto_rawDescGZIP(), []int{5, 1}
+}
+
+func (x *GetVariableMetadataResponse_VariableMetadata) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *GetVariableMetadataResponse_VariableMetadata) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *GetVariableMetadataResponse_VariableMetadata) GetDescription() string {
+	if x != nil {
+		return x.Description
+	}
+	return ""
+}
+
+func (x *GetVariableMetadataResponse_VariableMetadata) GetProperties() *structpb.Struct {
+	if x != nil {
+		return x.Properties
+	}
+	return nil
+}
+
+func (x *GetVariableMetadataResponse_VariableMetadata) GetFacets() []*GetVariableMetadataResponse_FacetMetadata {
+	if x != nil {
+		return x.Facets
+	}
+	return nil
+}
+
 type GetVariableMetadataResponse_ProvenanceMetadata struct {
-	state         protoimpl.MessageState     `protogen:"open.v1"`
-	Dcid          string                     `protobuf:"bytes,1,opt,name=dcid,proto3" json:"dcid,omitempty"`
-	Properties    map[string]*PropertyValues `protobuf:"bytes,2,rep,name=properties,proto3" json:"properties,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Properties    *structpb.Struct       `protobuf:"bytes,2,opt,name=properties,proto3" json:"properties,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1142,48 +1206,46 @@ func (x *GetVariableMetadataResponse_ProvenanceMetadata) ProtoReflect() protoref
 
 // Deprecated: Use GetVariableMetadataResponse_ProvenanceMetadata.ProtoReflect.Descriptor instead.
 func (*GetVariableMetadataResponse_ProvenanceMetadata) Descriptor() ([]byte, []int) {
-	return file_v2_agent_proto_rawDescGZIP(), []int{7, 0}
+	return file_v2_agent_proto_rawDescGZIP(), []int{5, 2}
 }
 
-func (x *GetVariableMetadataResponse_ProvenanceMetadata) GetDcid() string {
+func (x *GetVariableMetadataResponse_ProvenanceMetadata) GetId() string {
 	if x != nil {
-		return x.Dcid
+		return x.Id
 	}
 	return ""
 }
 
-func (x *GetVariableMetadataResponse_ProvenanceMetadata) GetProperties() map[string]*PropertyValues {
+func (x *GetVariableMetadataResponse_ProvenanceMetadata) GetProperties() *structpb.Struct {
 	if x != nil {
 		return x.Properties
 	}
 	return nil
 }
 
-type GetVariableMetadataResponse_FacetSeriesSummary struct {
+type GetVariableMetadataResponse_FacetMetadata_DateRange struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Facet         *proto.Facet           `protobuf:"bytes,1,opt,name=facet,proto3" json:"facet,omitempty"`
-	ObsCount      int32                  `protobuf:"varint,2,opt,name=obs_count,json=obsCount,proto3" json:"obs_count,omitempty"`
-	EarliestDate  string                 `protobuf:"bytes,3,opt,name=earliest_date,json=earliestDate,proto3" json:"earliest_date,omitempty"`
-	LatestDate    string                 `protobuf:"bytes,4,opt,name=latest_date,json=latestDate,proto3" json:"latest_date,omitempty"`
+	Start         string                 `protobuf:"bytes,1,opt,name=start,proto3" json:"start,omitempty"`
+	End           string                 `protobuf:"bytes,2,opt,name=end,proto3" json:"end,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *GetVariableMetadataResponse_FacetSeriesSummary) Reset() {
-	*x = GetVariableMetadataResponse_FacetSeriesSummary{}
-	mi := &file_v2_agent_proto_msgTypes[19]
+func (x *GetVariableMetadataResponse_FacetMetadata_DateRange) Reset() {
+	*x = GetVariableMetadataResponse_FacetMetadata_DateRange{}
+	mi := &file_v2_agent_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *GetVariableMetadataResponse_FacetSeriesSummary) String() string {
+func (x *GetVariableMetadataResponse_FacetMetadata_DateRange) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*GetVariableMetadataResponse_FacetSeriesSummary) ProtoMessage() {}
+func (*GetVariableMetadataResponse_FacetMetadata_DateRange) ProtoMessage() {}
 
-func (x *GetVariableMetadataResponse_FacetSeriesSummary) ProtoReflect() protoreflect.Message {
-	mi := &file_v2_agent_proto_msgTypes[19]
+func (x *GetVariableMetadataResponse_FacetMetadata_DateRange) ProtoReflect() protoreflect.Message {
+	mi := &file_v2_agent_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1194,109 +1256,48 @@ func (x *GetVariableMetadataResponse_FacetSeriesSummary) ProtoReflect() protoref
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use GetVariableMetadataResponse_FacetSeriesSummary.ProtoReflect.Descriptor instead.
-func (*GetVariableMetadataResponse_FacetSeriesSummary) Descriptor() ([]byte, []int) {
-	return file_v2_agent_proto_rawDescGZIP(), []int{7, 1}
+// Deprecated: Use GetVariableMetadataResponse_FacetMetadata_DateRange.ProtoReflect.Descriptor instead.
+func (*GetVariableMetadataResponse_FacetMetadata_DateRange) Descriptor() ([]byte, []int) {
+	return file_v2_agent_proto_rawDescGZIP(), []int{5, 0, 0}
 }
 
-func (x *GetVariableMetadataResponse_FacetSeriesSummary) GetFacet() *proto.Facet {
+func (x *GetVariableMetadataResponse_FacetMetadata_DateRange) GetStart() string {
 	if x != nil {
-		return x.Facet
-	}
-	return nil
-}
-
-func (x *GetVariableMetadataResponse_FacetSeriesSummary) GetObsCount() int32 {
-	if x != nil {
-		return x.ObsCount
-	}
-	return 0
-}
-
-func (x *GetVariableMetadataResponse_FacetSeriesSummary) GetEarliestDate() string {
-	if x != nil {
-		return x.EarliestDate
+		return x.Start
 	}
 	return ""
 }
 
-func (x *GetVariableMetadataResponse_FacetSeriesSummary) GetLatestDate() string {
+func (x *GetVariableMetadataResponse_FacetMetadata_DateRange) GetEnd() string {
 	if x != nil {
-		return x.LatestDate
+		return x.End
 	}
 	return ""
 }
 
-type GetVariableMetadataResponse_EntityMetadata struct {
-	state                protoimpl.MessageState                                     `protogen:"open.v1"`
-	FacetSeriesSummaries map[string]*GetVariableMetadataResponse_FacetSeriesSummary `protobuf:"bytes,1,rep,name=facet_series_summaries,json=facetSeriesSummaries,proto3" json:"facet_series_summaries,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	unknownFields        protoimpl.UnknownFields
-	sizeCache            protoimpl.SizeCache
-}
-
-func (x *GetVariableMetadataResponse_EntityMetadata) Reset() {
-	*x = GetVariableMetadataResponse_EntityMetadata{}
-	mi := &file_v2_agent_proto_msgTypes[20]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *GetVariableMetadataResponse_EntityMetadata) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*GetVariableMetadataResponse_EntityMetadata) ProtoMessage() {}
-
-func (x *GetVariableMetadataResponse_EntityMetadata) ProtoReflect() protoreflect.Message {
-	mi := &file_v2_agent_proto_msgTypes[20]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use GetVariableMetadataResponse_EntityMetadata.ProtoReflect.Descriptor instead.
-func (*GetVariableMetadataResponse_EntityMetadata) Descriptor() ([]byte, []int) {
-	return file_v2_agent_proto_rawDescGZIP(), []int{7, 2}
-}
-
-func (x *GetVariableMetadataResponse_EntityMetadata) GetFacetSeriesSummaries() map[string]*GetVariableMetadataResponse_FacetSeriesSummary {
-	if x != nil {
-		return x.FacetSeriesSummaries
-	}
-	return nil
-}
-
-type GetVariableMetadataResponse_VariableMetadata struct {
-	state             protoimpl.MessageState                                     `protogen:"open.v1"`
-	Dcid              string                                                     `protobuf:"bytes,1,opt,name=dcid,proto3" json:"dcid,omitempty"`
-	Properties        map[string]*PropertyValues                                 `protobuf:"bytes,2,rep,name=properties,proto3" json:"properties,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	StatVarSummary    *proto.StatVarSummary                                      `protobuf:"bytes,3,opt,name=stat_var_summary,json=statVarSummary,proto3" json:"stat_var_summary,omitempty"`
-	Provenances       map[string]*GetVariableMetadataResponse_ProvenanceMetadata `protobuf:"bytes,4,rep,name=provenances,proto3" json:"provenances,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	PerEntityMetadata map[string]*GetVariableMetadataResponse_EntityMetadata     `protobuf:"bytes,5,rep,name=per_entity_metadata,json=perEntityMetadata,proto3" json:"per_entity_metadata,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+type GetVariableMetadataResponse_FacetMetadata_Scope struct {
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	EntityCoverage    []string               `protobuf:"bytes,1,rep,name=entity_coverage,json=entityCoverage,proto3" json:"entity_coverage,omitempty"`
+	EntityGranularity []string               `protobuf:"bytes,2,rep,name=entity_granularity,json=entityGranularity,proto3" json:"entity_granularity,omitempty"`
 	unknownFields     protoimpl.UnknownFields
 	sizeCache         protoimpl.SizeCache
 }
 
-func (x *GetVariableMetadataResponse_VariableMetadata) Reset() {
-	*x = GetVariableMetadataResponse_VariableMetadata{}
-	mi := &file_v2_agent_proto_msgTypes[21]
+func (x *GetVariableMetadataResponse_FacetMetadata_Scope) Reset() {
+	*x = GetVariableMetadataResponse_FacetMetadata_Scope{}
+	mi := &file_v2_agent_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *GetVariableMetadataResponse_VariableMetadata) String() string {
+func (x *GetVariableMetadataResponse_FacetMetadata_Scope) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*GetVariableMetadataResponse_VariableMetadata) ProtoMessage() {}
+func (*GetVariableMetadataResponse_FacetMetadata_Scope) ProtoMessage() {}
 
-func (x *GetVariableMetadataResponse_VariableMetadata) ProtoReflect() protoreflect.Message {
-	mi := &file_v2_agent_proto_msgTypes[21]
+func (x *GetVariableMetadataResponse_FacetMetadata_Scope) ProtoReflect() protoreflect.Message {
+	mi := &file_v2_agent_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1307,42 +1308,21 @@ func (x *GetVariableMetadataResponse_VariableMetadata) ProtoReflect() protorefle
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use GetVariableMetadataResponse_VariableMetadata.ProtoReflect.Descriptor instead.
-func (*GetVariableMetadataResponse_VariableMetadata) Descriptor() ([]byte, []int) {
-	return file_v2_agent_proto_rawDescGZIP(), []int{7, 3}
+// Deprecated: Use GetVariableMetadataResponse_FacetMetadata_Scope.ProtoReflect.Descriptor instead.
+func (*GetVariableMetadataResponse_FacetMetadata_Scope) Descriptor() ([]byte, []int) {
+	return file_v2_agent_proto_rawDescGZIP(), []int{5, 0, 1}
 }
 
-func (x *GetVariableMetadataResponse_VariableMetadata) GetDcid() string {
+func (x *GetVariableMetadataResponse_FacetMetadata_Scope) GetEntityCoverage() []string {
 	if x != nil {
-		return x.Dcid
-	}
-	return ""
-}
-
-func (x *GetVariableMetadataResponse_VariableMetadata) GetProperties() map[string]*PropertyValues {
-	if x != nil {
-		return x.Properties
+		return x.EntityCoverage
 	}
 	return nil
 }
 
-func (x *GetVariableMetadataResponse_VariableMetadata) GetStatVarSummary() *proto.StatVarSummary {
+func (x *GetVariableMetadataResponse_FacetMetadata_Scope) GetEntityGranularity() []string {
 	if x != nil {
-		return x.StatVarSummary
-	}
-	return nil
-}
-
-func (x *GetVariableMetadataResponse_VariableMetadata) GetProvenances() map[string]*GetVariableMetadataResponse_ProvenanceMetadata {
-	if x != nil {
-		return x.Provenances
-	}
-	return nil
-}
-
-func (x *GetVariableMetadataResponse_VariableMetadata) GetPerEntityMetadata() map[string]*GetVariableMetadataResponse_EntityMetadata {
-	if x != nil {
-		return x.PerEntityMetadata
+		return x.EntityGranularity
 	}
 	return nil
 }
@@ -1351,8 +1331,7 @@ var File_v2_agent_proto protoreflect.FileDescriptor
 
 const file_v2_agent_proto_rawDesc = "" +
 	"\n" +
-	"\x0ev2/agent.proto\x12\x0edatacommons.v2\x1a\x1cgoogle/protobuf/struct.proto\x1a\n" +
-	"stat.proto\x1a\x0estat_var.proto\"\x8f\x02\n" +
+	"\x0ev2/agent.proto\x12\x0edatacommons.v2\x1a\x1cgoogle/protobuf/struct.proto\"\x8f\x02\n" +
 	"\x17SearchIndicatorsRequest\x12\x14\n" +
 	"\x05query\x18\x01 \x01(\tR\x05query\x12\x16\n" +
 	"\x06places\x18\x02 \x03(\tR\x06places\x12!\n" +
@@ -1435,58 +1414,50 @@ const file_v2_agent_proto_rawDesc = "" +
 	"\x10PlaceObservation\x12B\n" +
 	"\x05place\x18\x01 \x01(\v2,.datacommons.v2.GetObservationsResponse.NodeR\x05place\x12X\n" +
 	"\vtime_series\x18\x02 \x03(\v27.datacommons.v2.GetObservationsResponse.TimeSeriesPointR\n" +
-	"timeSeries\"M\n" +
-	"\rPropertyValue\x12\x14\n" +
-	"\x05value\x18\x01 \x01(\tR\x05value\x12\x12\n" +
-	"\x04dcid\x18\x02 \x01(\tR\x04dcid\x12\x12\n" +
-	"\x04name\x18\x03 \x01(\tR\x04name\"G\n" +
-	"\x0ePropertyValues\x125\n" +
-	"\x06values\x18\x01 \x03(\v2\x1d.datacommons.v2.PropertyValueR\x06values\"f\n" +
+	"timeSeries\"f\n" +
 	"\x1aGetVariableMetadataRequest\x12%\n" +
 	"\x0evariable_dcids\x18\x01 \x03(\tR\rvariableDcids\x12!\n" +
-	"\fentity_dcids\x18\x02 \x03(\tR\ventityDcids\"\x8a\x0e\n" +
+	"\fentity_dcids\x18\x02 \x03(\tR\ventityDcids\"\x9f\n" +
+	"\n" +
 	"\x1bGetVariableMetadataResponse\x12\x16\n" +
 	"\x06status\x18\x01 \x01(\tR\x06status\x12X\n" +
-	"\tvariables\x18\x02 \x03(\v2:.datacommons.v2.GetVariableMetadataResponse.VariablesEntryR\tvariables\x1a\xf7\x01\n" +
-	"\x12ProvenanceMetadata\x12\x12\n" +
-	"\x04dcid\x18\x01 \x01(\tR\x04dcid\x12n\n" +
+	"\tvariables\x18\x02 \x03(\v2:.datacommons.v2.GetVariableMetadataResponse.VariablesEntryR\tvariables\x12^\n" +
+	"\vprovenances\x18\x03 \x03(\v2<.datacommons.v2.GetVariableMetadataResponse.ProvenancesEntryR\vprovenances\x1a\xeb\x03\n" +
+	"\rFacetMetadata\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12#\n" +
+	"\rprovenance_id\x18\x02 \x01(\tR\fprovenanceId\x12\x1b\n" +
+	"\tobs_count\x18\x03 \x01(\x05R\bobsCount\x12b\n" +
 	"\n" +
-	"properties\x18\x02 \x03(\v2N.datacommons.v2.GetVariableMetadataResponse.ProvenanceMetadata.PropertiesEntryR\n" +
-	"properties\x1a]\n" +
-	"\x0fPropertiesEntry\x12\x10\n" +
-	"\x03key\x18\x01 \x01(\tR\x03key\x124\n" +
-	"\x05value\x18\x02 \x01(\v2\x1e.datacommons.v2.PropertyValuesR\x05value:\x028\x01\x1a\xa1\x01\n" +
-	"\x12FacetSeriesSummary\x12(\n" +
-	"\x05facet\x18\x01 \x01(\v2\x12.datacommons.FacetR\x05facet\x12\x1b\n" +
-	"\tobs_count\x18\x02 \x01(\x05R\bobsCount\x12#\n" +
-	"\rearliest_date\x18\x03 \x01(\tR\fearliestDate\x12\x1f\n" +
-	"\vlatest_date\x18\x04 \x01(\tR\n" +
-	"latestDate\x1a\xa7\x02\n" +
-	"\x0eEntityMetadata\x12\x8a\x01\n" +
-	"\x16facet_series_summaries\x18\x01 \x03(\v2T.datacommons.v2.GetVariableMetadataResponse.EntityMetadata.FacetSeriesSummariesEntryR\x14facetSeriesSummaries\x1a\x87\x01\n" +
-	"\x19FacetSeriesSummariesEntry\x12\x10\n" +
-	"\x03key\x18\x01 \x01(\tR\x03key\x12T\n" +
-	"\x05value\x18\x02 \x01(\v2>.datacommons.v2.GetVariableMetadataResponse.FacetSeriesSummaryR\x05value:\x028\x01\x1a\xb4\x06\n" +
-	"\x10VariableMetadata\x12\x12\n" +
-	"\x04dcid\x18\x01 \x01(\tR\x04dcid\x12l\n" +
+	"date_range\x18\x04 \x01(\v2C.datacommons.v2.GetVariableMetadataResponse.FacetMetadata.DateRangeR\tdateRange\x12U\n" +
+	"\x05scope\x18\x05 \x01(\v2?.datacommons.v2.GetVariableMetadataResponse.FacetMetadata.ScopeR\x05scope\x127\n" +
 	"\n" +
-	"properties\x18\x02 \x03(\v2L.datacommons.v2.GetVariableMetadataResponse.VariableMetadata.PropertiesEntryR\n" +
-	"properties\x12E\n" +
-	"\x10stat_var_summary\x18\x03 \x01(\v2\x1b.datacommons.StatVarSummaryR\x0estatVarSummary\x12o\n" +
-	"\vprovenances\x18\x04 \x03(\v2M.datacommons.v2.GetVariableMetadataResponse.VariableMetadata.ProvenancesEntryR\vprovenances\x12\x83\x01\n" +
-	"\x13per_entity_metadata\x18\x05 \x03(\v2S.datacommons.v2.GetVariableMetadataResponse.VariableMetadata.PerEntityMetadataEntryR\x11perEntityMetadata\x1a]\n" +
-	"\x0fPropertiesEntry\x12\x10\n" +
-	"\x03key\x18\x01 \x01(\tR\x03key\x124\n" +
-	"\x05value\x18\x02 \x01(\v2\x1e.datacommons.v2.PropertyValuesR\x05value:\x028\x01\x1a~\n" +
-	"\x10ProvenancesEntry\x12\x10\n" +
-	"\x03key\x18\x01 \x01(\tR\x03key\x12T\n" +
-	"\x05value\x18\x02 \x01(\v2>.datacommons.v2.GetVariableMetadataResponse.ProvenanceMetadataR\x05value:\x028\x01\x1a\x80\x01\n" +
-	"\x16PerEntityMetadataEntry\x12\x10\n" +
-	"\x03key\x18\x01 \x01(\tR\x03key\x12P\n" +
-	"\x05value\x18\x02 \x01(\v2:.datacommons.v2.GetVariableMetadataResponse.EntityMetadataR\x05value:\x028\x01\x1az\n" +
+	"properties\x18\x06 \x01(\v2\x17.google.protobuf.StructR\n" +
+	"properties\x1a3\n" +
+	"\tDateRange\x12\x14\n" +
+	"\x05start\x18\x01 \x01(\tR\x05start\x12\x10\n" +
+	"\x03end\x18\x02 \x01(\tR\x03end\x1a_\n" +
+	"\x05Scope\x12'\n" +
+	"\x0fentity_coverage\x18\x01 \x03(\tR\x0eentityCoverage\x12-\n" +
+	"\x12entity_granularity\x18\x02 \x03(\tR\x11entityGranularity\x1a\xe4\x01\n" +
+	"\x10VariableMetadata\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\x12 \n" +
+	"\vdescription\x18\x03 \x01(\tR\vdescription\x127\n" +
+	"\n" +
+	"properties\x18\x04 \x01(\v2\x17.google.protobuf.StructR\n" +
+	"properties\x12Q\n" +
+	"\x06facets\x18\x05 \x03(\v29.datacommons.v2.GetVariableMetadataResponse.FacetMetadataR\x06facets\x1a]\n" +
+	"\x12ProvenanceMetadata\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x127\n" +
+	"\n" +
+	"properties\x18\x02 \x01(\v2\x17.google.protobuf.StructR\n" +
+	"properties\x1az\n" +
 	"\x0eVariablesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12R\n" +
-	"\x05value\x18\x02 \x01(\v2<.datacommons.v2.GetVariableMetadataResponse.VariableMetadataR\x05value:\x028\x01B3Z1github.com/datacommonsorg/mixer/internal/proto/v2b\x06proto3"
+	"\x05value\x18\x02 \x01(\v2<.datacommons.v2.GetVariableMetadataResponse.VariableMetadataR\x05value:\x028\x01\x1a~\n" +
+	"\x10ProvenancesEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12T\n" +
+	"\x05value\x18\x02 \x01(\v2>.datacommons.v2.GetVariableMetadataResponse.ProvenanceMetadataR\x05value:\x028\x01B3Z1github.com/datacommonsorg/mixer/internal/proto/v2b\x06proto3"
 
 var (
 	file_v2_agent_proto_rawDescOnce sync.Once
@@ -1500,75 +1471,64 @@ func file_v2_agent_proto_rawDescGZIP() []byte {
 	return file_v2_agent_proto_rawDescData
 }
 
-var file_v2_agent_proto_msgTypes = make([]protoimpl.MessageInfo, 28)
+var file_v2_agent_proto_msgTypes = make([]protoimpl.MessageInfo, 23)
 var file_v2_agent_proto_goTypes = []any{
 	(*SearchIndicatorsRequest)(nil),                // 0: datacommons.v2.SearchIndicatorsRequest
 	(*SearchIndicatorsResponse)(nil),               // 1: datacommons.v2.SearchIndicatorsResponse
 	(*GetObservationsRequest)(nil),                 // 2: datacommons.v2.GetObservationsRequest
 	(*GetObservationsResponse)(nil),                // 3: datacommons.v2.GetObservationsResponse
-	(*PropertyValue)(nil),                          // 4: datacommons.v2.PropertyValue
-	(*PropertyValues)(nil),                         // 5: datacommons.v2.PropertyValues
-	(*GetVariableMetadataRequest)(nil),             // 6: datacommons.v2.GetVariableMetadataRequest
-	(*GetVariableMetadataResponse)(nil),            // 7: datacommons.v2.GetVariableMetadataResponse
-	(*SearchIndicatorsResponse_Topic)(nil),         // 8: datacommons.v2.SearchIndicatorsResponse.Topic
-	(*SearchIndicatorsResponse_Variable)(nil),      // 9: datacommons.v2.SearchIndicatorsResponse.Variable
-	(*SearchIndicatorsResponse_ResolvedPlace)(nil), // 10: datacommons.v2.SearchIndicatorsResponse.ResolvedPlace
-	nil,                                  // 11: datacommons.v2.SearchIndicatorsResponse.DcidNameMappingsEntry
-	nil,                                  // 12: datacommons.v2.SearchIndicatorsResponse.DcidPlaceTypeMappingsEntry
-	(*GetObservationsResponse_Node)(nil), // 13: datacommons.v2.GetObservationsResponse.Node
-	(*GetObservationsResponse_FacetMetadata)(nil),          // 14: datacommons.v2.GetObservationsResponse.FacetMetadata
-	(*GetObservationsResponse_AlternativeSource)(nil),      // 15: datacommons.v2.GetObservationsResponse.AlternativeSource
-	(*GetObservationsResponse_TimeSeriesPoint)(nil),        // 16: datacommons.v2.GetObservationsResponse.TimeSeriesPoint
-	(*GetObservationsResponse_PlaceObservation)(nil),       // 17: datacommons.v2.GetObservationsResponse.PlaceObservation
+	(*GetVariableMetadataRequest)(nil),             // 4: datacommons.v2.GetVariableMetadataRequest
+	(*GetVariableMetadataResponse)(nil),            // 5: datacommons.v2.GetVariableMetadataResponse
+	(*SearchIndicatorsResponse_Topic)(nil),         // 6: datacommons.v2.SearchIndicatorsResponse.Topic
+	(*SearchIndicatorsResponse_Variable)(nil),      // 7: datacommons.v2.SearchIndicatorsResponse.Variable
+	(*SearchIndicatorsResponse_ResolvedPlace)(nil), // 8: datacommons.v2.SearchIndicatorsResponse.ResolvedPlace
+	nil,                                  // 9: datacommons.v2.SearchIndicatorsResponse.DcidNameMappingsEntry
+	nil,                                  // 10: datacommons.v2.SearchIndicatorsResponse.DcidPlaceTypeMappingsEntry
+	(*GetObservationsResponse_Node)(nil), // 11: datacommons.v2.GetObservationsResponse.Node
+	(*GetObservationsResponse_FacetMetadata)(nil),          // 12: datacommons.v2.GetObservationsResponse.FacetMetadata
+	(*GetObservationsResponse_AlternativeSource)(nil),      // 13: datacommons.v2.GetObservationsResponse.AlternativeSource
+	(*GetObservationsResponse_TimeSeriesPoint)(nil),        // 14: datacommons.v2.GetObservationsResponse.TimeSeriesPoint
+	(*GetObservationsResponse_PlaceObservation)(nil),       // 15: datacommons.v2.GetObservationsResponse.PlaceObservation
+	(*GetVariableMetadataResponse_FacetMetadata)(nil),      // 16: datacommons.v2.GetVariableMetadataResponse.FacetMetadata
+	(*GetVariableMetadataResponse_VariableMetadata)(nil),   // 17: datacommons.v2.GetVariableMetadataResponse.VariableMetadata
 	(*GetVariableMetadataResponse_ProvenanceMetadata)(nil), // 18: datacommons.v2.GetVariableMetadataResponse.ProvenanceMetadata
-	(*GetVariableMetadataResponse_FacetSeriesSummary)(nil), // 19: datacommons.v2.GetVariableMetadataResponse.FacetSeriesSummary
-	(*GetVariableMetadataResponse_EntityMetadata)(nil),     // 20: datacommons.v2.GetVariableMetadataResponse.EntityMetadata
-	(*GetVariableMetadataResponse_VariableMetadata)(nil),   // 21: datacommons.v2.GetVariableMetadataResponse.VariableMetadata
-	nil,                          // 22: datacommons.v2.GetVariableMetadataResponse.VariablesEntry
-	nil,                          // 23: datacommons.v2.GetVariableMetadataResponse.ProvenanceMetadata.PropertiesEntry
-	nil,                          // 24: datacommons.v2.GetVariableMetadataResponse.EntityMetadata.FacetSeriesSummariesEntry
-	nil,                          // 25: datacommons.v2.GetVariableMetadataResponse.VariableMetadata.PropertiesEntry
-	nil,                          // 26: datacommons.v2.GetVariableMetadataResponse.VariableMetadata.ProvenancesEntry
-	nil,                          // 27: datacommons.v2.GetVariableMetadataResponse.VariableMetadata.PerEntityMetadataEntry
-	(*structpb.ListValue)(nil),   // 28: google.protobuf.ListValue
-	(*proto.Facet)(nil),          // 29: datacommons.Facet
-	(*proto.StatVarSummary)(nil), // 30: datacommons.StatVarSummary
+	nil, // 19: datacommons.v2.GetVariableMetadataResponse.VariablesEntry
+	nil, // 20: datacommons.v2.GetVariableMetadataResponse.ProvenancesEntry
+	(*GetVariableMetadataResponse_FacetMetadata_DateRange)(nil), // 21: datacommons.v2.GetVariableMetadataResponse.FacetMetadata.DateRange
+	(*GetVariableMetadataResponse_FacetMetadata_Scope)(nil),     // 22: datacommons.v2.GetVariableMetadataResponse.FacetMetadata.Scope
+	(*structpb.ListValue)(nil),                                  // 23: google.protobuf.ListValue
+	(*structpb.Struct)(nil),                                     // 24: google.protobuf.Struct
 }
 var file_v2_agent_proto_depIdxs = []int32{
-	11, // 0: datacommons.v2.SearchIndicatorsResponse.dcid_name_mappings:type_name -> datacommons.v2.SearchIndicatorsResponse.DcidNameMappingsEntry
-	12, // 1: datacommons.v2.SearchIndicatorsResponse.dcid_place_type_mappings:type_name -> datacommons.v2.SearchIndicatorsResponse.DcidPlaceTypeMappingsEntry
-	8,  // 2: datacommons.v2.SearchIndicatorsResponse.topics:type_name -> datacommons.v2.SearchIndicatorsResponse.Topic
-	9,  // 3: datacommons.v2.SearchIndicatorsResponse.variables:type_name -> datacommons.v2.SearchIndicatorsResponse.Variable
-	10, // 4: datacommons.v2.SearchIndicatorsResponse.resolved_parent_place:type_name -> datacommons.v2.SearchIndicatorsResponse.ResolvedPlace
-	13, // 5: datacommons.v2.GetObservationsResponse.variable:type_name -> datacommons.v2.GetObservationsResponse.Node
-	13, // 6: datacommons.v2.GetObservationsResponse.resolved_parent_place:type_name -> datacommons.v2.GetObservationsResponse.Node
-	17, // 7: datacommons.v2.GetObservationsResponse.place_observations:type_name -> datacommons.v2.GetObservationsResponse.PlaceObservation
-	14, // 8: datacommons.v2.GetObservationsResponse.source_metadata:type_name -> datacommons.v2.GetObservationsResponse.FacetMetadata
-	15, // 9: datacommons.v2.GetObservationsResponse.alternative_sources:type_name -> datacommons.v2.GetObservationsResponse.AlternativeSource
-	4,  // 10: datacommons.v2.PropertyValues.values:type_name -> datacommons.v2.PropertyValue
-	22, // 11: datacommons.v2.GetVariableMetadataResponse.variables:type_name -> datacommons.v2.GetVariableMetadataResponse.VariablesEntry
-	28, // 12: datacommons.v2.SearchIndicatorsResponse.DcidPlaceTypeMappingsEntry.value:type_name -> google.protobuf.ListValue
-	14, // 13: datacommons.v2.GetObservationsResponse.AlternativeSource.source_metadata:type_name -> datacommons.v2.GetObservationsResponse.FacetMetadata
-	13, // 14: datacommons.v2.GetObservationsResponse.PlaceObservation.place:type_name -> datacommons.v2.GetObservationsResponse.Node
-	16, // 15: datacommons.v2.GetObservationsResponse.PlaceObservation.time_series:type_name -> datacommons.v2.GetObservationsResponse.TimeSeriesPoint
-	23, // 16: datacommons.v2.GetVariableMetadataResponse.ProvenanceMetadata.properties:type_name -> datacommons.v2.GetVariableMetadataResponse.ProvenanceMetadata.PropertiesEntry
-	29, // 17: datacommons.v2.GetVariableMetadataResponse.FacetSeriesSummary.facet:type_name -> datacommons.Facet
-	24, // 18: datacommons.v2.GetVariableMetadataResponse.EntityMetadata.facet_series_summaries:type_name -> datacommons.v2.GetVariableMetadataResponse.EntityMetadata.FacetSeriesSummariesEntry
-	25, // 19: datacommons.v2.GetVariableMetadataResponse.VariableMetadata.properties:type_name -> datacommons.v2.GetVariableMetadataResponse.VariableMetadata.PropertiesEntry
-	30, // 20: datacommons.v2.GetVariableMetadataResponse.VariableMetadata.stat_var_summary:type_name -> datacommons.StatVarSummary
-	26, // 21: datacommons.v2.GetVariableMetadataResponse.VariableMetadata.provenances:type_name -> datacommons.v2.GetVariableMetadataResponse.VariableMetadata.ProvenancesEntry
-	27, // 22: datacommons.v2.GetVariableMetadataResponse.VariableMetadata.per_entity_metadata:type_name -> datacommons.v2.GetVariableMetadataResponse.VariableMetadata.PerEntityMetadataEntry
-	21, // 23: datacommons.v2.GetVariableMetadataResponse.VariablesEntry.value:type_name -> datacommons.v2.GetVariableMetadataResponse.VariableMetadata
-	5,  // 24: datacommons.v2.GetVariableMetadataResponse.ProvenanceMetadata.PropertiesEntry.value:type_name -> datacommons.v2.PropertyValues
-	19, // 25: datacommons.v2.GetVariableMetadataResponse.EntityMetadata.FacetSeriesSummariesEntry.value:type_name -> datacommons.v2.GetVariableMetadataResponse.FacetSeriesSummary
-	5,  // 26: datacommons.v2.GetVariableMetadataResponse.VariableMetadata.PropertiesEntry.value:type_name -> datacommons.v2.PropertyValues
-	18, // 27: datacommons.v2.GetVariableMetadataResponse.VariableMetadata.ProvenancesEntry.value:type_name -> datacommons.v2.GetVariableMetadataResponse.ProvenanceMetadata
-	20, // 28: datacommons.v2.GetVariableMetadataResponse.VariableMetadata.PerEntityMetadataEntry.value:type_name -> datacommons.v2.GetVariableMetadataResponse.EntityMetadata
-	29, // [29:29] is the sub-list for method output_type
-	29, // [29:29] is the sub-list for method input_type
-	29, // [29:29] is the sub-list for extension type_name
-	29, // [29:29] is the sub-list for extension extendee
-	0,  // [0:29] is the sub-list for field type_name
+	9,  // 0: datacommons.v2.SearchIndicatorsResponse.dcid_name_mappings:type_name -> datacommons.v2.SearchIndicatorsResponse.DcidNameMappingsEntry
+	10, // 1: datacommons.v2.SearchIndicatorsResponse.dcid_place_type_mappings:type_name -> datacommons.v2.SearchIndicatorsResponse.DcidPlaceTypeMappingsEntry
+	6,  // 2: datacommons.v2.SearchIndicatorsResponse.topics:type_name -> datacommons.v2.SearchIndicatorsResponse.Topic
+	7,  // 3: datacommons.v2.SearchIndicatorsResponse.variables:type_name -> datacommons.v2.SearchIndicatorsResponse.Variable
+	8,  // 4: datacommons.v2.SearchIndicatorsResponse.resolved_parent_place:type_name -> datacommons.v2.SearchIndicatorsResponse.ResolvedPlace
+	11, // 5: datacommons.v2.GetObservationsResponse.variable:type_name -> datacommons.v2.GetObservationsResponse.Node
+	11, // 6: datacommons.v2.GetObservationsResponse.resolved_parent_place:type_name -> datacommons.v2.GetObservationsResponse.Node
+	15, // 7: datacommons.v2.GetObservationsResponse.place_observations:type_name -> datacommons.v2.GetObservationsResponse.PlaceObservation
+	12, // 8: datacommons.v2.GetObservationsResponse.source_metadata:type_name -> datacommons.v2.GetObservationsResponse.FacetMetadata
+	13, // 9: datacommons.v2.GetObservationsResponse.alternative_sources:type_name -> datacommons.v2.GetObservationsResponse.AlternativeSource
+	19, // 10: datacommons.v2.GetVariableMetadataResponse.variables:type_name -> datacommons.v2.GetVariableMetadataResponse.VariablesEntry
+	20, // 11: datacommons.v2.GetVariableMetadataResponse.provenances:type_name -> datacommons.v2.GetVariableMetadataResponse.ProvenancesEntry
+	23, // 12: datacommons.v2.SearchIndicatorsResponse.DcidPlaceTypeMappingsEntry.value:type_name -> google.protobuf.ListValue
+	12, // 13: datacommons.v2.GetObservationsResponse.AlternativeSource.source_metadata:type_name -> datacommons.v2.GetObservationsResponse.FacetMetadata
+	11, // 14: datacommons.v2.GetObservationsResponse.PlaceObservation.place:type_name -> datacommons.v2.GetObservationsResponse.Node
+	14, // 15: datacommons.v2.GetObservationsResponse.PlaceObservation.time_series:type_name -> datacommons.v2.GetObservationsResponse.TimeSeriesPoint
+	21, // 16: datacommons.v2.GetVariableMetadataResponse.FacetMetadata.date_range:type_name -> datacommons.v2.GetVariableMetadataResponse.FacetMetadata.DateRange
+	22, // 17: datacommons.v2.GetVariableMetadataResponse.FacetMetadata.scope:type_name -> datacommons.v2.GetVariableMetadataResponse.FacetMetadata.Scope
+	24, // 18: datacommons.v2.GetVariableMetadataResponse.FacetMetadata.properties:type_name -> google.protobuf.Struct
+	24, // 19: datacommons.v2.GetVariableMetadataResponse.VariableMetadata.properties:type_name -> google.protobuf.Struct
+	16, // 20: datacommons.v2.GetVariableMetadataResponse.VariableMetadata.facets:type_name -> datacommons.v2.GetVariableMetadataResponse.FacetMetadata
+	24, // 21: datacommons.v2.GetVariableMetadataResponse.ProvenanceMetadata.properties:type_name -> google.protobuf.Struct
+	17, // 22: datacommons.v2.GetVariableMetadataResponse.VariablesEntry.value:type_name -> datacommons.v2.GetVariableMetadataResponse.VariableMetadata
+	18, // 23: datacommons.v2.GetVariableMetadataResponse.ProvenancesEntry.value:type_name -> datacommons.v2.GetVariableMetadataResponse.ProvenanceMetadata
+	24, // [24:24] is the sub-list for method output_type
+	24, // [24:24] is the sub-list for method input_type
+	24, // [24:24] is the sub-list for extension type_name
+	24, // [24:24] is the sub-list for extension extendee
+	0,  // [0:24] is the sub-list for field type_name
 }
 
 func init() { file_v2_agent_proto_init() }
@@ -1578,14 +1538,14 @@ func file_v2_agent_proto_init() {
 	}
 	file_v2_agent_proto_msgTypes[0].OneofWrappers = []any{}
 	file_v2_agent_proto_msgTypes[2].OneofWrappers = []any{}
-	file_v2_agent_proto_msgTypes[15].OneofWrappers = []any{}
+	file_v2_agent_proto_msgTypes[13].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_v2_agent_proto_rawDesc), len(file_v2_agent_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   28,
+			NumMessages:   23,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/proto/v2/agent.proto
+++ b/proto/v2/agent.proto
@@ -16,8 +16,6 @@ syntax = "proto3";
 package datacommons.v2;
 
 import "google/protobuf/struct.proto";
-import "stat.proto";
-import "stat_var.proto";
 
 option go_package = "github.com/datacommonsorg/mixer/internal/proto/v2";
 
@@ -114,17 +112,8 @@ message GetObservationsResponse {
   repeated AlternativeSource alternative_sources = 6;
 }
 
-message PropertyValue {
-  string value = 1;
-  string dcid = 2;
-  string name = 3;
-}
-
-message PropertyValues {
-  repeated PropertyValue values = 1;
-}
-
 // Request payload for the get_variable_metadata tool endpoint.
+// Both variable_dcids and entity_dcids are strictly required.
 message GetVariableMetadataRequest {
   repeated string variable_dcids = 1;
   repeated string entity_dcids = 2;
@@ -132,30 +121,40 @@ message GetVariableMetadataRequest {
 
 // Response payload for the get_variable_metadata tool endpoint.
 message GetVariableMetadataResponse {
-  message ProvenanceMetadata {
-    string dcid = 1;
-    map<string, PropertyValues> properties = 2;
-  }
+  message FacetMetadata {
+    string id = 1;
+    string provenance_id = 2;
+    int32 obs_count = 3;
 
-  message FacetSeriesSummary {
-    datacommons.Facet facet = 1;
-    int32 obs_count = 2;
-    string earliest_date = 3;
-    string latest_date = 4;
-  }
+    message DateRange {
+      string start = 1;
+      string end = 2;
+    }
+    DateRange date_range = 4;
 
-  message EntityMetadata {
-    map<string, FacetSeriesSummary> facet_series_summaries = 1;
+    message Scope {
+      repeated string entity_coverage = 1;
+      repeated string entity_granularity = 2;
+    }
+    Scope scope = 5;
+
+    google.protobuf.Struct properties = 6;
   }
 
   message VariableMetadata {
-    string dcid = 1;
-    map<string, PropertyValues> properties = 2;
-    datacommons.StatVarSummary stat_var_summary = 3;
-    map<string, ProvenanceMetadata> provenances = 4;
-    map<string, EntityMetadata> per_entity_metadata = 5;
+    string id = 1;
+    string name = 2;
+    string description = 3;
+    google.protobuf.Struct properties = 4;
+    repeated FacetMetadata facets = 5;
+  }
+
+  message ProvenanceMetadata {
+    string id = 1;
+    google.protobuf.Struct properties = 2;
   }
 
   string status = 1;
   map<string, VariableMetadata> variables = 2;
+  map<string, ProvenanceMetadata> provenances = 3;
 }


### PR DESCRIPTION
- Redesigned GetVariableMetadata response to use structured proto and lock-free concurrency
- Updated the response schema to return strongly-typed facet metadata.
- Refactored the backend handler to implement a lock-free concurrent fetch pipeline.
- Added an include list for dataset properties to prevent internal metadata leaks.
- Implemented graceful degradation for downstream metadata fetch failures.

### Local Verification

**Single variable + place with constrained properties (short response)**
```
http://localhost:8081/v2/agent/get_variable_metadata?variable_dcids=Mean_WagesDaily_Amount_Male_Rural_ConstructionWorker&entity_dcids=country/IND
```

**Multiple variables + places with no constrained props (large response)**
```
http://localhost:8081/v2/agent/get_variable_metadata?variable_dcids=Count_Person&variable_dcids=Median_Age_Person&entity_dcids=country/IND&entity_dcids=geoId/01
```
