### PR TITLE
[Stale Timestamp] Make mixer use the right stale timestamp. 

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -208,7 +208,7 @@ func main() {
 	var spannerClient spanner.SpannerClient
 	if shouldUseSpannerGraph {
 		var err error
-		spannerClient, err = spanner.NewSpannerClient(ctx, *spannerGraphInfo, flags.SpannerGraphDatabase, flags.UseMultiEntitySchema)
+		spannerClient, err = spanner.NewSpannerClient(ctx, *spannerGraphInfo, flags.SpannerGraphDatabase, flags.UseMultiEntitySchema, flags.UseNewIngestionHistorySchema)
 		if err != nil {
 			slog.Error("Failed to create Spanner client", "error", err)
 			os.Exit(1)

--- a/internal/featureflags/featureflags.go
+++ b/internal/featureflags/featureflags.go
@@ -51,6 +51,8 @@ type Flags struct {
 	// Whether to default indicator resolution to Spanner.
 	// If false, default requests go to legacy remote service.
 	EnableSpannerSearchEmbeddings bool `yaml:"EnableSpannerSearchEmbeddings"`
+	// Whether to use the new IngestionHistory schema with Timestamp.
+	UseNewIngestionHistorySchema bool `yaml:"UseNewIngestionHistorySchema"`
 }
 
 // setDefaultValues creates a new Flags struct with default values.
@@ -67,6 +69,7 @@ func setDefaultValues() *Flags {
 		UseStatisticalCalculation:     false,
 		EnableSDMXDataApi:             false,
 		EnableSpannerSearchEmbeddings: false,
+		UseNewIngestionHistorySchema:  false,
 	}
 }
 

--- a/internal/server/spanner/client.go
+++ b/internal/server/spanner/client.go
@@ -21,6 +21,7 @@ import (
 	"log/slog"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"cloud.google.com/go/spanner"
 	pb "github.com/datacommonsorg/mixer/internal/proto"
@@ -62,6 +63,11 @@ type SpannerClient interface {
 	Close()
 }
 
+const (
+	noChangeLogThreshold = 10 * time.Minute
+	failureLogThreshold  = 10 * time.Minute
+)
+
 // spannerDatabaseClient encapsulates the Spanner client that directly interacts with the Spanner database.
 type spannerDatabaseClient struct {
 	client    *spanner.Client
@@ -77,6 +83,9 @@ type spannerDatabaseClient struct {
 
 	// Flag to control query logic for IngestionHistory table.
 	useNewIngestionHistorySchema bool
+
+	// Logging/State tracking for the timestamp poller.
+	tracker *stalenessTracker
 }
 
 // newSpannerDatabaseClient creates a new spannerDatabaseClient.
@@ -84,6 +93,7 @@ func newSpannerDatabaseClient(client *spanner.Client, useNewSchema bool) (*spann
 	sc := &spannerDatabaseClient{
 		client:                       client,
 		useNewIngestionHistorySchema: useNewSchema,
+		tracker:                      newStalenessTracker(noChangeLogThreshold, failureLogThreshold),
 	}
 
 	// Set an initial timestamp synchronously before starting the background loop.
@@ -224,9 +234,15 @@ func (sc *spannerDatabaseClient) Start() {
 				case <-sc.ticker.C():
 					// Ignore the error here to allow the process to continue running
 					// even if one fetch fails. The previous timestamp remains in cache.
+					now := time.Now()
 					err := sc.updateTimestamp(ctx)
 					if err != nil {
 						slog.Error("Error updating Spanner staleness timestamp", "error", err)
+						if sc.tracker != nil {
+							if ev := sc.tracker.RecordFailure(now, err); ev != nil {
+								slog.Log(ctx, ev.level, ev.message, ev.args...)
+							}
+						}
 					}
 				}
 			}

--- a/internal/server/spanner/client.go
+++ b/internal/server/spanner/client.go
@@ -74,12 +74,16 @@ type spannerDatabaseClient struct {
 
 	// For mocking in tests.
 	updateTimestamp func(context.Context) error
+
+	// Flag to control query logic for IngestionHistory table.
+	useNewIngestionHistorySchema bool
 }
 
 // newSpannerDatabaseClient creates a new spannerDatabaseClient.
-func newSpannerDatabaseClient(client *spanner.Client) (*spannerDatabaseClient, error) {
+func newSpannerDatabaseClient(client *spanner.Client, useNewSchema bool) (*spannerDatabaseClient, error) {
 	sc := &spannerDatabaseClient{
-		client: client,
+		client:                       client,
+		useNewIngestionHistorySchema: useNewSchema,
 	}
 
 	// Set an initial timestamp synchronously before starting the background loop.
@@ -95,7 +99,7 @@ func newSpannerDatabaseClient(client *spanner.Client) (*spannerDatabaseClient, e
 
 // NewRawSpannerClient creates a new SpannerClient without the schema selector.
 // This is intended for testing and internal use where a direct client is needed.
-func NewRawSpannerClient(ctx context.Context, spannerConfigYaml, databaseOverride string) (SpannerClient, error) {
+func NewRawSpannerClient(ctx context.Context, spannerConfigYaml, databaseOverride string, useNewSchema bool) (SpannerClient, error) {
 	cfg, err := createSpannerConfig(spannerConfigYaml, databaseOverride)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create spannerDatabaseClient: %w", err)
@@ -104,7 +108,7 @@ func NewRawSpannerClient(ctx context.Context, spannerConfigYaml, databaseOverrid
 	if err != nil {
 		return nil, fmt.Errorf("failed to create spannerDatabaseClient: %w", err)
 	}
-	return newSpannerDatabaseClient(client)
+	return newSpannerDatabaseClient(client, useNewSchema)
 }
 
 // TableConfig holds the names of multi-entity Spanner tables and indexes.
@@ -129,10 +133,8 @@ func DefaultTableConfig() TableConfig {
 	}
 }
 
-// NewSpannerClient creates a new SpannerClient from the config yaml string and an optional database override.
-// It returns a wrapper client that handles request-time schema dispatching.
-func NewSpannerClient(ctx context.Context, spannerConfigYaml, databaseOverride string, useMultiEntitySchema bool) (SpannerClient, error) {
-	rawClient, err := NewRawSpannerClient(ctx, spannerConfigYaml, databaseOverride)
+func NewSpannerClient(ctx context.Context, spannerConfigYaml, databaseOverride string, useMultiEntitySchema bool, useNewIngestionHistorySchema bool) (SpannerClient, error) {
+	rawClient, err := NewRawSpannerClient(ctx, spannerConfigYaml, databaseOverride, useNewIngestionHistorySchema)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/spanner/query.go
+++ b/internal/server/spanner/query.go
@@ -969,7 +969,20 @@ func (sc *spannerDatabaseClient) fetchAndUpdateTimestamp(ctx context.Context) er
 		return fmt.Errorf("failed to read Timestamp column: %w", err)
 	}
 
-	sc.timestamp.Store(timestamp.UnixNano())
+	now := time.Now()
+	prevNano := sc.timestamp.Load()
+	newNano := timestamp.UnixNano()
+
+	if prevNano == 0 || prevNano != newNano {
+		sc.timestamp.Store(newNano)
+	}
+
+	if sc.tracker != nil {
+		if ev := sc.tracker.RecordSuccess(now, prevNano, newNano); ev != nil {
+			slog.Log(ctx, ev.level, ev.message, ev.args...)
+		}
+	}
+
 	return nil
 }
 

--- a/internal/server/spanner/query.go
+++ b/internal/server/spanner/query.go
@@ -935,7 +935,7 @@ func (sc *spannerDatabaseClient) fetchAndUpdateTimestamp(ctx context.Context) er
 	queryCtx, cancel := context.WithTimeout(ctx, timestampPollingTimeout)
 	defer cancel()
 
-	iter := sc.client.Single().Query(queryCtx, *GetCompletionTimestampQuery())
+	iter := sc.client.Single().Query(queryCtx, *GetCompletionTimestampQuery(sc.useNewIngestionHistorySchema))
 	defer iter.Stop()
 
 	row, err := iter.Next()
@@ -966,7 +966,7 @@ func (sc *spannerDatabaseClient) fetchAndUpdateTimestamp(ctx context.Context) er
 
 	var timestamp time.Time
 	if err := row.Column(0, &timestamp); err != nil {
-		return fmt.Errorf("failed to read CompletionTimestamp column: %w", err)
+		return fmt.Errorf("failed to read Timestamp column: %w", err)
 	}
 
 	sc.timestamp.Store(timestamp.UnixNano())

--- a/internal/server/spanner/query_builder.go
+++ b/internal/server/spanner/query_builder.go
@@ -99,9 +99,13 @@ func handleLangOperator(prefix string, langs []string, params map[string]interfa
 	return strings.Join(parts, " OR ")
 }
 
-func GetCompletionTimestampQuery() *spanner.Statement {
+func GetCompletionTimestampQuery(useNewSchema bool) *spanner.Statement {
+	sql := statements.getCompletionTimestamp
+	if useNewSchema {
+		sql = statements.getIngestionHistoryTimestamp
+	}
 	return &spanner.Statement{
-		SQL: statements.getCompletionTimestamp,
+		SQL: sql,
 	}
 }
 

--- a/internal/server/spanner/staleness_tracker.go
+++ b/internal/server/spanner/staleness_tracker.go
@@ -1,0 +1,115 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spanner
+
+import (
+	"fmt"
+	"log/slog"
+	"time"
+)
+
+type logEvent struct {
+	level   slog.Level
+	message string
+	args    []interface{}
+}
+
+type stalenessTracker struct {
+	noChangeThreshold time.Duration
+	failureThreshold  time.Duration
+
+	lastSuccessTime        time.Time
+	lastChangeTime         time.Time
+	lastLoggedNoChangeTime time.Time
+	lastLoggedFailureTime  time.Time
+}
+
+func newStalenessTracker(noChangeThreshold, failureThreshold time.Duration) *stalenessTracker {
+	return &stalenessTracker{
+		noChangeThreshold: noChangeThreshold,
+		failureThreshold:  failureThreshold,
+	}
+}
+
+func (t *stalenessTracker) RecordSuccess(now time.Time, prevVal, newVal int64) *logEvent {
+	t.lastSuccessTime = now
+	t.lastLoggedFailureTime = time.Time{} // Reset failure log time
+
+	if prevVal == 0 {
+		t.lastChangeTime = now
+		t.lastLoggedNoChangeTime = now
+		return &logEvent{
+			level:   slog.LevelInfo,
+			message: "Spanner staleness timestamp initialized",
+			args:    []interface{}{"timestamp", time.Unix(0, newVal).UTC().String()},
+		}
+	}
+
+	if prevVal != newVal {
+		oldTime := time.Unix(0, prevVal).UTC()
+		newTime := time.Unix(0, newVal).UTC()
+		t.lastChangeTime = now
+		t.lastLoggedNoChangeTime = now
+		return &logEvent{
+			level:   slog.LevelInfo,
+			message: "Spanner staleness timestamp updated",
+			args:    []interface{}{"old", oldTime.String(), "new", newTime.String()},
+		}
+	}
+
+	// Value hasn't changed.
+	if t.lastChangeTime.IsZero() {
+		t.lastChangeTime = now
+		t.lastLoggedNoChangeTime = now
+	}
+
+	if now.Sub(t.lastChangeTime) >= t.noChangeThreshold && now.Sub(t.lastLoggedNoChangeTime) >= t.noChangeThreshold {
+		t.lastLoggedNoChangeTime = now
+		return &logEvent{
+			level:   slog.LevelInfo,
+			message: fmt.Sprintf("Spanner staleness timestamp has not changed in the last %s", t.noChangeThreshold),
+			args: []interface{}{
+				"timestamp", time.Unix(0, newVal).UTC().String(),
+				"durationSinceLastChange", now.Sub(t.lastChangeTime).Round(time.Second).String(),
+			},
+		}
+	}
+
+	return nil
+}
+
+func (t *stalenessTracker) RecordFailure(now time.Time, err error) *logEvent {
+	if t.lastSuccessTime.IsZero() {
+		// If we never succeeded, we don't log the persistent failure warning
+		// since we already log the direct error on every tick.
+		return nil
+	}
+
+	if now.Sub(t.lastSuccessTime) >= t.failureThreshold {
+		if t.lastLoggedFailureTime.IsZero() || now.Sub(t.lastLoggedFailureTime) >= t.failureThreshold {
+			t.lastLoggedFailureTime = now
+			return &logEvent{
+				level:   slog.LevelWarn,
+				message: fmt.Sprintf("Spanner staleness timestamp poller has failed to run successfully for %s", t.failureThreshold),
+				args: []interface{}{
+					"lastSuccessTime", t.lastSuccessTime.UTC().String(),
+					"error", err.Error(),
+				},
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/server/spanner/staleness_tracker.go
+++ b/internal/server/spanner/staleness_tracker.go
@@ -105,7 +105,7 @@ func (t *stalenessTracker) RecordFailure(now time.Time, err error) *logEvent {
 				message: fmt.Sprintf("Spanner staleness timestamp poller has failed to run successfully for %s", t.failureThreshold),
 				args: []interface{}{
 					"lastSuccessTime", t.lastSuccessTime.UTC().String(),
-					"error", err.Error(),
+					"error", err,
 				},
 			}
 		}

--- a/internal/server/spanner/staleness_tracker_test.go
+++ b/internal/server/spanner/staleness_tracker_test.go
@@ -98,7 +98,7 @@ func TestStalenessTracker(t *testing.T) {
 	}
 
 	// 10. Success at baseTime + 38m resets the failure state
-	event = tracker.RecordSuccess(baseTime.Add(38*time.Minute), newVal, newVal)
+	tracker.RecordSuccess(baseTime.Add(38*time.Minute), newVal, newVal)
 	// We might get nil if no-change is not reached, but failure should be reset
 	// Let's verify failure log is reset by triggering a failure at 39m (nil since it's only 1m since last success)
 	event = tracker.RecordFailure(baseTime.Add(39*time.Minute), testErr)

--- a/internal/server/spanner/staleness_tracker_test.go
+++ b/internal/server/spanner/staleness_tracker_test.go
@@ -1,0 +1,108 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spanner
+
+import (
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+)
+
+func TestStalenessTracker(t *testing.T) {
+	noChangeThresh := 10 * time.Minute
+	failureThresh := 10 * time.Minute
+	tracker := newStalenessTracker(noChangeThresh, failureThresh)
+
+	baseTime := time.Date(2026, time.July, 6, 12, 0, 0, 0, time.UTC)
+	initVal := int64(123456789)
+
+	// 1. First success should initialize
+	event := tracker.RecordSuccess(baseTime, 0, initVal)
+	if event == nil {
+		t.Fatal("expected initialization event, got nil")
+	}
+	if event.level != slog.LevelInfo || event.message != "Spanner staleness timestamp initialized" {
+		t.Errorf("unexpected init event: %+v", event)
+	}
+
+	// 2. Poll succeeding with same value at baseTime + 1m should return nil (no change, below threshold)
+	event = tracker.RecordSuccess(baseTime.Add(time.Minute), initVal, initVal)
+	if event != nil {
+		t.Errorf("expected nil event for same value within threshold, got %+v", event)
+	}
+
+	// 3. Poll succeeding with same value at baseTime + 11m should trigger "no change" event
+	event = tracker.RecordSuccess(baseTime.Add(11*time.Minute), initVal, initVal)
+	if event == nil {
+		t.Fatal("expected no-change event after 11m, got nil")
+	}
+	if event.level != slog.LevelInfo || event.message != "Spanner staleness timestamp has not changed in the last 10m0s" {
+		t.Errorf("unexpected no-change event: %+v", event)
+	}
+
+	// 4. Poll succeeding with same value at baseTime + 12m should return nil (no-change threshold already logged)
+	event = tracker.RecordSuccess(baseTime.Add(12*time.Minute), initVal, initVal)
+	if event != nil {
+		t.Errorf("expected nil event at 12m, got %+v", event)
+	}
+
+	// 5. Poll succeeding with same value at baseTime + 22m should trigger "no change" event again (since 11 minutes have passed since last log)
+	event = tracker.RecordSuccess(baseTime.Add(22*time.Minute), initVal, initVal)
+	if event == nil {
+		t.Fatal("expected second no-change event at 22m, got nil")
+	}
+
+	// 6. Value changes at baseTime + 25m
+	newVal := int64(987654321)
+	event = tracker.RecordSuccess(baseTime.Add(25*time.Minute), initVal, newVal)
+	if event == nil {
+		t.Fatal("expected update event, got nil")
+	}
+	if event.level != slog.LevelInfo || event.message != "Spanner staleness timestamp updated" {
+		t.Errorf("unexpected update event: %+v", event)
+	}
+
+	// 7. Poller fails at baseTime + 26m (1 minute after last success)
+	testErr := errors.New("connection reset")
+	event = tracker.RecordFailure(baseTime.Add(26*time.Minute), testErr)
+	if event != nil {
+		t.Errorf("expected nil event for single failure, got %+v", event)
+	}
+
+	// 8. Poller fails continuously, at baseTime + 36m (11 minutes after last success)
+	event = tracker.RecordFailure(baseTime.Add(36*time.Minute), testErr)
+	if event == nil {
+		t.Fatal("expected failure event after 11m of failures, got nil")
+	}
+	if event.level != slog.LevelWarn || event.message != "Spanner staleness timestamp poller has failed to run successfully for 10m0s" {
+		t.Errorf("unexpected failure warning event: %+v", event)
+	}
+
+	// 9. Failure at baseTime + 37m should be nil (logged within threshold)
+	event = tracker.RecordFailure(baseTime.Add(37*time.Minute), testErr)
+	if event != nil {
+		t.Errorf("expected nil event at 37m, got %+v", event)
+	}
+
+	// 10. Success at baseTime + 38m resets the failure state
+	event = tracker.RecordSuccess(baseTime.Add(38*time.Minute), newVal, newVal)
+	// We might get nil if no-change is not reached, but failure should be reset
+	// Let's verify failure log is reset by triggering a failure at 39m (nil since it's only 1m since last success)
+	event = tracker.RecordFailure(baseTime.Add(39*time.Minute), testErr)
+	if event != nil {
+		t.Errorf("expected nil event at 39m, got %+v", event)
+	}
+}

--- a/internal/server/spanner/statements.go
+++ b/internal/server/spanner/statements.go
@@ -140,6 +140,8 @@ var statements = struct {
 			CompletionTimestamp
 		FROM
 			IngestionHistory
+		WHERE
+			IngestionFailure = FALSE
 		ORDER BY 
 			CompletionTimestamp DESC
 		LIMIT 1`,

--- a/internal/server/spanner/statements.go
+++ b/internal/server/spanner/statements.go
@@ -148,7 +148,7 @@ var statements = struct {
 		FROM
 			IngestionHistory
 		WHERE
-			IngestionFailure = FALSE
+			Status = 'SUCCESS'
 			AND CompletionTimestamp < (
 				SELECT COALESCE(MIN(CreationTimestamp), TIMESTAMP '9999-12-31T23:59:59Z')
 				FROM IngestionHistory

--- a/internal/server/spanner/statements.go
+++ b/internal/server/spanner/statements.go
@@ -19,6 +19,8 @@ package spanner
 var statements = struct {
 	// Fetch latest CompletionTimestamp from IngestionHistory table.
 	getCompletionTimestamp string
+	// Fetch latest Timestamp from IngestionHistory table with run protection.
+	getIngestionHistoryTimestamp string
 	// Filter by single parameter value.
 	getParam string
 	// Filter by multiple parameter values.
@@ -142,6 +144,20 @@ var statements = struct {
 			IngestionFailure = FALSE
 		ORDER BY 
 			CompletionTimestamp DESC
+		LIMIT 1`,
+	getIngestionHistoryTimestamp: `		SELECT
+			Timestamp
+		FROM
+			IngestionHistory
+		WHERE
+			Status = 'SUCCESS'
+			AND Timestamp < (
+				SELECT COALESCE(MIN(Timestamp), TIMESTAMP '9999-12-31T23:59:59Z')
+				FROM IngestionHistory
+				WHERE Status IN ('RUNNING', 'PENDING')
+			)
+		ORDER BY 
+			Timestamp DESC
 		LIMIT 1`,
 	getParam:  `= @%s`,
 	getParams: `IN UNNEST(@%s)`,

--- a/internal/server/spanner/statements.go
+++ b/internal/server/spanner/statements.go
@@ -17,9 +17,9 @@ package spanner
 
 // SQL / GQL statements executed by the SpannerClient
 var statements = struct {
-	// Fetch latest CompletionTimestamp from IngestionHistory table.
+	// Fetch latest CompletionTimestamp from IngestionHistory table (legacy schema).
 	getCompletionTimestamp string
-	// Fetch latest Timestamp from IngestionHistory table with run protection.
+	// Fetch latest CompletionTimestamp from IngestionHistory table with run protection (new schema).
 	getIngestionHistoryTimestamp string
 	// Filter by single parameter value.
 	getParam string
@@ -137,27 +137,25 @@ var statements = struct {
 	checkGroupPlaceExistence string
 }{
 	getCompletionTimestamp: `		SELECT
-		CompletionTimestamp
+			CompletionTimestamp
 		FROM
 			IngestionHistory
-		WHERE
-			IngestionFailure = FALSE
 		ORDER BY 
 			CompletionTimestamp DESC
 		LIMIT 1`,
 	getIngestionHistoryTimestamp: `		SELECT
-			Timestamp
+			CompletionTimestamp
 		FROM
 			IngestionHistory
 		WHERE
-			Status = 'SUCCESS'
-			AND Timestamp < (
-				SELECT COALESCE(MIN(Timestamp), TIMESTAMP '9999-12-31T23:59:59Z')
+			IngestionFailure = FALSE
+			AND CompletionTimestamp < (
+				SELECT COALESCE(MIN(CreationTimestamp), TIMESTAMP '9999-12-31T23:59:59Z')
 				FROM IngestionHistory
 				WHERE Status IN ('RUNNING', 'PENDING')
 			)
 		ORDER BY 
-			Timestamp DESC
+			CompletionTimestamp DESC
 		LIMIT 1`,
 	getParam:  `= @%s`,
 	getParams: `IN UNNEST(@%s)`,

--- a/test/setup.go
+++ b/test/setup.go
@@ -447,7 +447,7 @@ func newSpannerClient(ctx context.Context, spannerGraphInfoYamlPath string) span
 		log.Fatalf("Failed to read spanner yaml: %v", err)
 	}
 	// Don't override spannerGraphInfoYaml.database for testing.
-	spannerClient, err := spanner.NewRawSpannerClient(ctx, string(spannerGraphInfoYaml), "")
+	spannerClient, err := spanner.NewRawSpannerClient(ctx, string(spannerGraphInfoYaml), "", false)
 	if err != nil {
 		log.Fatalf("Failed to create SpannerClient: %v", err)
 	}

--- a/tools/perf_test/main.go
+++ b/tools/perf_test/main.go
@@ -212,7 +212,7 @@ func initSpannerClient(ctx context.Context, configPath string) (spanner.SpannerC
 
 	// We reuse the logic from client.go by passing the YAML string directly.
 	// The client.go NewSpannerClient expects the YAML content.
-	return spanner.NewSpannerClient(ctx, string(yamlFile), "", false)
+	return spanner.NewSpannerClient(ctx, string(yamlFile), "", false, false)
 }
 
 // runParallelTest runs two operations in parallel and injects metadata headers.


### PR DESCRIPTION
Change the logic for computing the staleness timestamp. Before we just sought out the most recent Successful run which opened up the possibility of this timestamp being out of retention period, which then defaults to strong reads. And that would mean the next time we start a run, we would be reading from a database as it's getting updated, defeating the purpse of the stale timestamp.

The update ingestion history logic will log a new entry when the ingestion starts (status pending), and updates it to running as it works through the stages. now the query will look at the creationTimestamp of the ingestionhistory row to determine the timestamp BEFORE the current ingestion started. 

The only way that we end up in a bad state would be if the duration of the ingestion is greater than the spanner retention window. 

Note that this introduces a mixer flag to use this new logic, and we remain backwards compatible on the old schema. We will be migrating Base DC before killing this logic.