### PR TITLE
Allow overriding full spanner db uri via flags

### DIFF
--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -128,9 +128,13 @@ Enabling Spanner Graph requires the following feature flags to be set:
 
 These are currently set in `local.yaml`.
 
-Additionally, to use a database other than the default in `spanner_graph_info.yaml`, set the feature flag:
+Additionally, to use a Spanner project, instance, or database other than the default in `spanner_graph_info.yaml`, set the feature flag:
 
-- `SpannerGraphDatabase: <DATABASE NAME>` 
+- `SpannerGraphDatabase: <DATABASE NAME OR FULL URI>`
+
+Note: `SpannerGraphDatabase` accepts either:
+1. A simple database name (e.g., `dc_graph_2026_01_27`), which overrides only the database while inheriting project and instance from `spanner_graph_info.yaml`.
+2. A fully qualified Spanner database URI (`projects/<project>/instances/<instance>/databases/<database>`), which automatically overrides Project, Instance, and Database in a single flag specification.
 
 ```bash
 # In repo root directory

--- a/internal/featureflags/featureflags.go
+++ b/internal/featureflags/featureflags.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -78,8 +79,16 @@ func (f *Flags) validateFlagValues() error {
 	if f.V3MirrorFraction > 0 && !f.UseSpannerGraph {
 		return fmt.Errorf("V3MirrorFraction > 0 requires UseSpannerGraph to be true")
 	}
-	if f.SpannerGraphDatabase != "" && !f.UseSpannerGraph {
-		return fmt.Errorf("using SpannerGraphDatabase requires UseSpannerGraph to be true")
+	if f.SpannerGraphDatabase != "" {
+		if !f.UseSpannerGraph {
+			return fmt.Errorf("using SpannerGraphDatabase requires UseSpannerGraph to be true")
+		}
+		if strings.HasPrefix(f.SpannerGraphDatabase, "projects/") {
+			parts := strings.Split(f.SpannerGraphDatabase, "/")
+			if len(parts) != 6 || parts[0] != "projects" || parts[2] != "instances" || parts[4] != "databases" || parts[1] == "" || parts[3] == "" || parts[5] == "" {
+				return fmt.Errorf("invalid SpannerGraphDatabase URI format: %q (expected projects/<project>/instances/<instance>/databases/<database>)", f.SpannerGraphDatabase)
+			}
+		}
 	}
 	if f.UseStaleReads && !f.UseSpannerGraph {
 		return fmt.Errorf("UseStaleReads requires UseSpannerGraph to be true")

--- a/internal/featureflags/featureflags_test.go
+++ b/internal/featureflags/featureflags_test.go
@@ -148,6 +148,29 @@ flags:
 			want:    nil,
 			wantErr: true,
 		},
+		{
+			name: "valid database URI",
+			fileContent: `
+flags:
+  UseSpannerGraph: true
+  SpannerGraphDatabase: projects/test-proj/instances/test-inst/databases/test-db
+`,
+			want: expectedFlags(func(f *Flags) {
+				f.UseSpannerGraph = true
+				f.SpannerGraphDatabase = "projects/test-proj/instances/test-inst/databases/test-db"
+			}),
+			wantErr: false,
+		},
+		{
+			name: "validation error - invalid database URI",
+			fileContent: `
+flags:
+  UseSpannerGraph: true
+  SpannerGraphDatabase: projects/test-proj/instances/test-inst
+`,
+			want:    nil,
+			wantErr: true,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/server/spanner/client.go
+++ b/internal/server/spanner/client.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -178,6 +179,20 @@ func createSpannerClient(ctx context.Context, cfg *SpannerConfig) (*spanner.Clie
 	return client, nil
 }
 
+// parseDatabaseURI checks if databaseStr is a full Spanner database URI (projects/P/instances/I/databases/D).
+// If it is a full URI, it extracts project, instance, and database.
+// If it is not a full URI (e.g., just a database name like "dc_graph_2026_01_27"), it returns empty project/instance and the original string as database.
+func parseDatabaseURI(databaseStr string) (project, instance, database string, err error) {
+	if !strings.HasPrefix(databaseStr, "projects/") {
+		return "", "", databaseStr, nil
+	}
+	parts := strings.Split(databaseStr, "/")
+	if len(parts) != 6 || parts[0] != "projects" || parts[2] != "instances" || parts[4] != "databases" || parts[1] == "" || parts[3] == "" || parts[5] == "" {
+		return "", "", "", fmt.Errorf("invalid Spanner database URI format: %q (expected projects/<project>/instances/<instance>/databases/<database>)", databaseStr)
+	}
+	return parts[1], parts[3], parts[5], nil
+}
+
 // createSpannerConfig creates the config from the specific yaml string and an optional database override.
 func createSpannerConfig(spannerConfigYaml, databaseOverride string) (*SpannerConfig, error) {
 	var cfg SpannerConfig
@@ -185,12 +200,24 @@ func createSpannerConfig(spannerConfigYaml, databaseOverride string) (*SpannerCo
 		return nil, fmt.Errorf("failed to create spanner config: %w", err)
 	}
 
-	// Override database with flag value if set.
+	// Override database config with flag value if set.
 	// This is temporary during development to allow fast rollout of version changes.
 	// TODO: Once the Spanner instance is stable, revert to using the config.
 	if databaseOverride != "" {
-		slog.Debug("Setting Spanner database value from flag", "value", databaseOverride)
-		cfg.Database = databaseOverride
+		proj, inst, db, err := parseDatabaseURI(databaseOverride)
+		if err != nil {
+			return nil, err
+		}
+		if proj != "" {
+			slog.Debug("Setting Spanner project value from database URI flag", "value", proj)
+			cfg.Project = proj
+		}
+		if inst != "" {
+			slog.Debug("Setting Spanner instance value from database URI flag", "value", inst)
+			cfg.Instance = inst
+		}
+		slog.Debug("Setting Spanner database value from flag", "value", db)
+		cfg.Database = db
 	}
 
 	return &cfg, nil

--- a/internal/server/spanner/client_test.go
+++ b/internal/server/spanner/client_test.go
@@ -1,0 +1,97 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spanner
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestCreateSpannerConfig(t *testing.T) {
+	yamlConfig := `
+project: default-project
+instance: default-instance
+database: default-database
+`
+	testCases := []struct {
+		name     string
+		yaml     string
+		override string
+		want     *SpannerConfig
+		wantErr  bool
+	}{
+		{
+			name:     "no overrides",
+			yaml:     yamlConfig,
+			override: "",
+			want: &SpannerConfig{
+				Project:  "default-project",
+				Instance: "default-instance",
+				Database: "default-database",
+			},
+			wantErr: false,
+		},
+		{
+			name:     "override database only",
+			yaml:     yamlConfig,
+			override: "custom-db",
+			want: &SpannerConfig{
+				Project:  "default-project",
+				Instance: "default-instance",
+				Database: "custom-db",
+			},
+			wantErr: false,
+		},
+		{
+			name:     "override with full database URI",
+			yaml:     yamlConfig,
+			override: "projects/uri-project/instances/uri-instance/databases/uri-db",
+			want: &SpannerConfig{
+				Project:  "uri-project",
+				Instance: "uri-instance",
+				Database: "uri-db",
+			},
+			wantErr: false,
+		},
+		{
+			name:     "override with invalid database URI",
+			yaml:     yamlConfig,
+			override: "projects/invalid-uri",
+			want:     nil,
+			wantErr:  true,
+		},
+		{
+			name:     "invalid yaml",
+			yaml:     "project: [invalid-yaml",
+			override: "",
+			want:     nil,
+			wantErr:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := createSpannerConfig(tc.yaml, tc.override)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("createSpannerConfig() error = %v, wantErr %v", err, tc.wantErr)
+				return
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("createSpannerConfig() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR allows specifying the full spanner db uri (`projects/<project>/instances/<instance>/databases/<database>`) for the feature flag SpannerGraphDatabase to override the default values.

This is to enable testing the staging db on dev, which is part of a different spanner instance than the other envs. 

Since other envs are still using the db-only flag, for now this keeps support for overriding only the db for backwards compatibility until these changes roll out and the other envs can update.