### PR TITLE
[DCP - Stale Timestamp] Just use the oldest CreationTimestamp from Running/pending ingestion history recods.

### DIFF
--- a/internal/server/spanner/query.go
+++ b/internal/server/spanner/query.go
@@ -967,14 +967,18 @@ func (sc *spannerDatabaseClient) fetchAndUpdateTimestamp(ctx context.Context) er
 		return fmt.Errorf("failed to fetch row: %w", err)
 	}
 
-	var timestamp time.Time
-	if err := row.Column(0, &timestamp); err != nil {
+	var nullTs spanner.NullTime
+	if err := row.Column(0, &nullTs); err != nil {
 		return fmt.Errorf("failed to read Timestamp column: %w", err)
+	}
+
+	var newNano int64
+	if nullTs.Valid {
+		newNano = nullTs.Time.UnixNano()
 	}
 
 	now := time.Now()
 	prevNano := sc.timestamp.Load()
-	newNano := timestamp.UnixNano()
 
 	if prevNano == 0 || prevNano != newNano {
 		sc.timestamp.Store(newNano)

--- a/internal/server/spanner/query.go
+++ b/internal/server/spanner/query.go
@@ -998,8 +998,7 @@ func (sc *spannerDatabaseClient) getStalenessTimestamp() (time.Time, error) {
 	if val != 0 {
 		return time.Unix(0, val).UTC(), nil
 	}
-	slog.Error("Spanner staleness timestamp not available")
-	return time.Time{}, fmt.Errorf("error getting staleness timestamp")
+	return time.Time{}, fmt.Errorf("staleness timestamp not available")
 }
 
 func (sc *spannerDatabaseClient) executeQuery(

--- a/internal/server/spanner/staleness_tracker.go
+++ b/internal/server/spanner/staleness_tracker.go
@@ -43,6 +43,13 @@ func newStalenessTracker(noChangeThreshold, failureThreshold time.Duration) *sta
 	}
 }
 
+func formatTimestamp(val int64) string {
+	if val == 0 {
+		return "none (strong read fallback)"
+	}
+	return time.Unix(0, val).UTC().String()
+}
+
 func (t *stalenessTracker) RecordSuccess(now time.Time, prevVal, newVal int64) *logEvent {
 	t.lastSuccessTime = now
 	t.lastLoggedFailureTime = time.Time{} // Reset failure log time
@@ -53,19 +60,17 @@ func (t *stalenessTracker) RecordSuccess(now time.Time, prevVal, newVal int64) *
 		return &logEvent{
 			level:   slog.LevelInfo,
 			message: "Spanner staleness timestamp initialized",
-			args:    []interface{}{"timestamp", time.Unix(0, newVal).UTC().String()},
+			args:    []interface{}{"timestamp", formatTimestamp(newVal)},
 		}
 	}
 
 	if prevVal != newVal {
-		oldTime := time.Unix(0, prevVal).UTC()
-		newTime := time.Unix(0, newVal).UTC()
 		t.lastChangeTime = now
 		t.lastLoggedNoChangeTime = now
 		return &logEvent{
 			level:   slog.LevelInfo,
 			message: "Spanner staleness timestamp updated",
-			args:    []interface{}{"old", oldTime.String(), "new", newTime.String()},
+			args:    []interface{}{"old", formatTimestamp(prevVal), "new", formatTimestamp(newVal)},
 		}
 	}
 
@@ -81,7 +86,7 @@ func (t *stalenessTracker) RecordSuccess(now time.Time, prevVal, newVal int64) *
 			level:   slog.LevelInfo,
 			message: fmt.Sprintf("Spanner staleness timestamp has not changed in the last %s", t.noChangeThreshold),
 			args: []interface{}{
-				"timestamp", time.Unix(0, newVal).UTC().String(),
+				"timestamp", formatTimestamp(newVal),
 				"durationSinceLastChange", now.Sub(t.lastChangeTime).Round(time.Second).String(),
 			},
 		}

--- a/internal/server/spanner/staleness_tracker.go
+++ b/internal/server/spanner/staleness_tracker.go
@@ -45,7 +45,7 @@ func newStalenessTracker(noChangeThreshold, failureThreshold time.Duration) *sta
 
 func formatTimestamp(val int64) string {
 	if val == 0 {
-		return "none (strong read fallback)"
+		return "none (exact staleness fallback)"
 	}
 	return time.Unix(0, val).UTC().String()
 }

--- a/internal/server/spanner/statements.go
+++ b/internal/server/spanner/statements.go
@@ -146,19 +146,11 @@ var statements = struct {
 			CompletionTimestamp DESC
 		LIMIT 1`,
 	getIngestionHistoryTimestamp: `		SELECT
-			CompletionTimestamp
+			MIN(CreationTimestamp)
 		FROM
 			IngestionHistory
 		WHERE
-			Status = 'SUCCESS'
-			AND CompletionTimestamp < (
-				SELECT COALESCE(MIN(CreationTimestamp), TIMESTAMP '9999-12-31T23:59:59Z')
-				FROM IngestionHistory
-				WHERE Status IN ('RUNNING', 'PENDING')
-			)
-		ORDER BY 
-			CompletionTimestamp DESC
-		LIMIT 1`,
+			Status IN ('RUNNING', 'PENDING')`,
 	getParam:  `= @%s`,
 	getParams: `IN UNNEST(@%s)`,
 	getPropsBySubjectID: `		GRAPH DCGraph MATCH -[e:Edge


### PR DESCRIPTION
Last PR had mistakenly kept the requirement for the SUCCESS row as well. This is no longer needed for the new path. We just rely on the min creationTimestamp for IngestionHistory rows with status PENDING/Running. Or, we fallback to 15 seconds ago.