### PR TITLE
 Enable SDMX query parameter handling in dev ESPv2

### DIFF
--- a/deploy/helm_charts/envs/mixer_dev.yaml
+++ b/deploy/helm_charts/envs/mixer_dev.yaml
@@ -32,6 +32,8 @@ ingress:
 # TODO(/v2/resolve cleanup): Remove this once /v2/resolve always requires an api key.
 esp:
   v2_resolve_allow_unregistered: false
+  transcodingIgnoreUnknownQueryParameters: true
+  transcodingQueryParametersDisableUnescapePlus: true
 
 # GCP level config
 ip: 35.244.157.41

--- a/deploy/helm_charts/mixer/templates/deployment.yaml
+++ b/deploy/helm_charts/mixer/templates/deployment.yaml
@@ -366,6 +366,12 @@ spec:
             - --healthz=healthz
             - --service_json_path=/etc/espv2_config/service_config.json
             - --envoy_connection_buffer_limit_bytes=209715200 # 200Mb
+            {{- if $.Values.esp.transcodingIgnoreUnknownQueryParameters }}
+            - --transcoding_ignore_unknown_query_parameters=true
+            {{- end }}
+            {{- if $.Values.esp.transcodingQueryParametersDisableUnescapePlus }}
+            - --transcoding_query_parameters_disable_unescape_plus=true
+            {{- end }}
           env:
             - name: SERVICE_NAME
               valueFrom:

--- a/deploy/helm_charts/mixer/values.yaml
+++ b/deploy/helm_charts/mixer/values.yaml
@@ -362,6 +362,8 @@ mixer:
       functionalDeps: dcid
 
 esp:
+  transcodingIgnoreUnknownQueryParameters: false
+  transcodingQueryParametersDisableUnescapePlus: false
   image:
     repository: gcr.io/endpoints-release/endpoints-runtime
     pullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary
  - Enable `--transcoding_ignore_unknown_query_parameters=true` for dev so ESPv2 allows SDMX query params like `c[variableMeasured]` to reach Mixer instead of rejecting them during transcoding.
  - Enable `--transcoding_query_parameters_disable_unescape_plus=true` for dev so `+` characters in SDMX query values are preserved instead of being decoded as spaces.

## Why
  SDMX parses component filters from the original request URI inside Mixer. These parameters are not protobuf fields on `SdmxRestRequest`, so dev ESPv2 needs to preserve them through HTTP-to-gRPC transcoding.

No local Envoy change is needed because `mixer/esp/envoy-config.yaml` already sets `ignore_unknown_query_parameters: true`, and local Envoy is not using ESPv2 startup flags.