### PR TITLE
Only set bq_dataset if bq is enabled 

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -42,9 +42,9 @@ import (
 	"github.com/datacommonsorg/mixer/internal/server/healthcheck"
 	"github.com/datacommonsorg/mixer/internal/server/redis"
 	"github.com/datacommonsorg/mixer/internal/server/remote"
-	"github.com/datacommonsorg/mixer/internal/server/v2/resolve"
 	"github.com/datacommonsorg/mixer/internal/server/spanner"
 	"github.com/datacommonsorg/mixer/internal/server/topic"
+	"github.com/datacommonsorg/mixer/internal/server/v2/resolve"
 	"github.com/datacommonsorg/mixer/internal/server/v3/observation"
 	"github.com/datacommonsorg/mixer/internal/sqldb"
 	"github.com/datacommonsorg/mixer/internal/store"
@@ -282,10 +282,15 @@ func main() {
 	slog.Info("After branch setup")
 
 	// Metadata.
+	// Don't set the BigQuery dataset if BigQuery is not enabled.
+	bqDataset := *bigQueryDataset
+	if !*useBigquery {
+		bqDataset = ""
+	}
 	metadata, err := server.NewMetadata(
 		ctx,
 		*hostProject,
-		*bigQueryDataset,
+		bqDataset,
 		*schemaPath,
 		*remoteMixerDomain,
 		*foldRemoteRootSvg,
@@ -436,7 +441,6 @@ func main() {
 	// DataSources
 	dataSources := datasources.NewDataSources(sources, remoteDataSource)
 	slog.Info("DataSources initialized", "sources", dataSources.GetSources())
-
 
 	// Processors
 	processors := []*dispatcher.Processor{}

--- a/deploy/helm_charts/mixer/templates/deployment.yaml
+++ b/deploy/helm_charts/mixer/templates/deployment.yaml
@@ -177,7 +177,9 @@ spec:
               /go/bin/mixer --base_bigtable_info="$FINAL_BT_CONFIG_CONTENT" \
               --custom_bigtable_info="${CUSTOM_BIGTABLE_INFO}" \
               --host_project="${HOST_PROJECT}" \
+              {{- if $.Values.mixer.useBigquery }}
               --bq_dataset="$FINAL_BQ_VERSION" \
+              {{- end }}
               --schema_path=/datacommons/mapping \
               --remote_mixer_domain={{ $.Values.mixer.remoteMixerDomain }} \
               --use_base_bigtable={{ $.Values.mixer.useBaseBigtable }} \

--- a/run_server.sh
+++ b/run_server.sh
@@ -57,9 +57,23 @@ for arg in "$@"; do
   fi
 done
 
+# Check if BigQuery is disabled. It is enabled by default.
+use_bigquery=true
+for arg in "$@"; do
+  if [[ "$arg" == "--use_bigquery=false" ]]; then
+    use_bigquery=false
+    break
+  fi
+done
+
 CMD=("go" "run" "cmd/main.go"
-    "--host_project=datcom-mixer-dev-316822"
-    "--bq_dataset=$(head -1 deploy/storage/bigquery.version)"
+    "--host_project=datcom-mixer-dev-316822")
+# Only set bq_dataset if BigQuery is enabled
+if [[ "$use_bigquery" == "true" ]]; then
+    CMD+=("--bq_dataset=$(head -1 deploy/storage/bigquery.version)")
+fi
+
+CMD+=(
     "--base_bigtable_info=$(cat deploy/storage/base_bigtable_info.yaml)"
     "--schema_path=$PWD/deploy/mapping/"
     "--use_base_bigtable=true"

--- a/run_server.sh
+++ b/run_server.sh
@@ -66,15 +66,9 @@ for arg in "$@"; do
   fi
 done
 
-CMD=("go" "run" "cmd/main.go"
-    "--host_project=datcom-mixer-dev-316822")
-
-# Only set bq_dataset if BigQuery is enabled
-if [[ "$use_bigquery" == "true" ]]; then
-    CMD+=("--bq_dataset=$(head -1 deploy/storage/bigquery.version)")
-fi
-
-CMD+=(
+CCMD=("go" "run" "cmd/main.go"
+    "--host_project=datcom-mixer-dev-316822"
+    "--bq_dataset=$(head -1 deploy/storage/bigquery.version)"
     "--base_bigtable_info=$(cat deploy/storage/base_bigtable_info.yaml)"
     "--schema_path=$PWD/deploy/mapping/"
     "--use_base_bigtable=true"

--- a/run_server.sh
+++ b/run_server.sh
@@ -68,6 +68,7 @@ done
 
 CMD=("go" "run" "cmd/main.go"
     "--host_project=datcom-mixer-dev-316822")
+
 # Only set bq_dataset if BigQuery is enabled
 if [[ "$use_bigquery" == "true" ]]; then
     CMD+=("--bq_dataset=$(head -1 deploy/storage/bigquery.version)")

--- a/run_server.sh
+++ b/run_server.sh
@@ -57,16 +57,7 @@ for arg in "$@"; do
   fi
 done
 
-# Check if BigQuery is disabled. It is enabled by default.
-use_bigquery=true
-for arg in "$@"; do
-  if [[ "$arg" == "--use_bigquery=false" ]]; then
-    use_bigquery=false
-    break
-  fi
-done
-
-CCMD=("go" "run" "cmd/main.go"
+CMD=("go" "run" "cmd/main.go"
     "--host_project=datcom-mixer-dev-316822"
     "--bq_dataset=$(head -1 deploy/storage/bigquery.version)"
     "--base_bigtable_info=$(cat deploy/storage/base_bigtable_info.yaml)"


### PR DESCRIPTION
This PR only sets the BQ dataset if BQ is enabled. While BQ is enabled by default in legacy configurations, in Spanner-based configurations it is disabled, however we're still setting the dataset in metadata, so this PR explicitly checks if it's enabled before setting the dataset. 