### PR TITLE
Use IFNULL for nullable Node fields

### DIFF
--- a/internal/server/spanner/golden/query_builder/get_filtered_sv_import.sql
+++ b/internal/server/spanner/golden/query_builder/get_filtered_sv_import.sql
@@ -1,6 +1,6 @@
 		SELECT
 			n.subject_id,
-			n.name,
+			IFNULL(n.name, '') AS name,
 			'' AS definition
 		FROM Node n
 		JOIN (

--- a/internal/server/spanner/golden/query_builder/get_filtered_sv_places.sql
+++ b/internal/server/spanner/golden/query_builder/get_filtered_sv_places.sql
@@ -1,6 +1,6 @@
 		SELECT
 			n.subject_id,
-			n.name,
+			IFNULL(n.name, '') AS name,
 			'' AS definition
 		FROM Node n
 		JOIN (

--- a/internal/server/spanner/golden/query_builder/get_filtered_sv_with_definitions.sql
+++ b/internal/server/spanner/golden/query_builder/get_filtered_sv_with_definitions.sql
@@ -1,6 +1,6 @@
 		SELECT
 			n.subject_id,
-			n.name,
+			IFNULL(n.name, '') AS name,
 			IFNULL((
 				SELECT n_def.value
 				FROM Edge e_def

--- a/internal/server/spanner/golden/query_builder/get_filtered_svg_num_entities_existence.sql
+++ b/internal/server/spanner/golden/query_builder/get_filtered_svg_num_entities_existence.sql
@@ -1,6 +1,6 @@
 		SELECT
 			n.subject_id,
-			n.name,
+			IFNULL(n.name, '') AS name,
 			e_counts.descendent_stat_var_count
 		FROM Node n
 		JOIN (

--- a/internal/server/spanner/golden/query_builder/get_filtered_svg_place_import.sql
+++ b/internal/server/spanner/golden/query_builder/get_filtered_svg_place_import.sql
@@ -1,6 +1,6 @@
 		SELECT
 			n.subject_id,
-			n.name,
+			IFNULL(n.name, '') AS name,
 			'' AS definition
 		FROM Node n
 		JOIN (

--- a/internal/server/spanner/golden/query_builder/get_filtered_svg_places.sql
+++ b/internal/server/spanner/golden/query_builder/get_filtered_svg_places.sql
@@ -1,6 +1,6 @@
 		SELECT
 			n.subject_id,
-			n.name,
+			IFNULL(n.name, '') AS name,
 			e_counts.descendent_stat_var_count
 		FROM Node n
 		JOIN (

--- a/internal/server/spanner/golden/query_builder/get_multientity_filtered_sv_import.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_filtered_sv_import.sql
@@ -1,6 +1,6 @@
 		SELECT
 			n.subject_id,
-			n.name,
+			IFNULL(n.name, '') AS name,
 			'' AS definition
 		FROM Node n
 		JOIN (

--- a/internal/server/spanner/golden/query_builder/get_multientity_filtered_sv_place_import.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_filtered_sv_place_import.sql
@@ -1,6 +1,6 @@
 		SELECT
 			n.subject_id,
-			n.name,
+			IFNULL(n.name, '') AS name,
 			'' AS definition
 		FROM Node n
 		JOIN (

--- a/internal/server/spanner/golden/query_builder/get_multientity_filtered_sv_places.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_filtered_sv_places.sql
@@ -1,6 +1,6 @@
 		SELECT
 			n.subject_id,
-			n.name,
+			IFNULL(n.name, '') AS name,
 			'' AS definition
 		FROM Node n
 		JOIN (

--- a/internal/server/spanner/golden/query_builder/get_multientity_filtered_sv_with_definitions.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_filtered_sv_with_definitions.sql
@@ -1,6 +1,6 @@
 		SELECT
 			n.subject_id,
-			n.name,
+			IFNULL(n.name, '') AS name,
 			IFNULL((
 				SELECT n_def.value
 				FROM Edge e_def

--- a/internal/server/spanner/golden/query_builder/get_multientity_filtered_svg_import_num_entities_existence.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_filtered_svg_import_num_entities_existence.sql
@@ -1,6 +1,6 @@
 		SELECT
 			n.subject_id,
-			n.name,
+			IFNULL(n.name, '') AS name,
 			e_counts.descendent_stat_var_count
 		FROM Node n
 		JOIN (

--- a/internal/server/spanner/golden/query_builder/get_multientity_filtered_svg_num_entities_existence.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_filtered_svg_num_entities_existence.sql
@@ -1,6 +1,6 @@
 		SELECT
 			n.subject_id,
-			n.name,
+			IFNULL(n.name, '') AS name,
 			e_counts.descendent_stat_var_count
 		FROM Node n
 		JOIN (

--- a/internal/server/spanner/golden/query_builder/get_multientity_filtered_svg_places.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_filtered_svg_places.sql
@@ -1,6 +1,6 @@
 		SELECT
 			n.subject_id,
-			n.name,
+			IFNULL(n.name, '') AS name,
 			e_counts.descendent_stat_var_count
 		FROM Node n
 		JOIN (

--- a/internal/server/spanner/golden/query_builder/get_multientity_stat_var_group_node.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_stat_var_group_node.sql
@@ -37,7 +37,7 @@
 			SELECT
 				svg.svg,
 				n.subject_id,
-				n.name,
+				IFNULL(n.name, '') AS name,
 				c.descendent_stat_var_count,
 				FALSE AS has_data,
 				'' AS definition
@@ -50,7 +50,7 @@
 			SELECT
 				sv.svg,
 				n.subject_id,
-				n.name,
+				IFNULL(n.name, '') AS name,
 				-1 AS descendent_stat_var_count,
 				EXISTS (
 					SELECT 1

--- a/internal/server/spanner/golden/query_builder/get_multientity_stat_var_group_node_multi.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_stat_var_group_node_multi.sql
@@ -38,7 +38,7 @@
 			SELECT
 				svg.svg,
 				n.subject_id,
-				n.name,
+				IFNULL(n.name, '') AS name,
 				c.descendent_stat_var_count,
 				FALSE AS has_data,
 				'' AS definition
@@ -51,7 +51,7 @@
 			SELECT
 				sv.svg,
 				n.subject_id,
-				n.name,
+				IFNULL(n.name, '') AS name,
 				-1 AS descendent_stat_var_count,
 				EXISTS (
 					SELECT 1

--- a/internal/server/spanner/golden/query_builder/get_multientity_stat_var_group_node_with_definitions.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_stat_var_group_node_with_definitions.sql
@@ -37,7 +37,7 @@
 			SELECT
 				svg.svg,
 				n.subject_id,
-				n.name,
+				IFNULL(n.name, '') AS name,
 				c.descendent_stat_var_count,
 				FALSE AS has_data,
 				'' AS definition
@@ -50,7 +50,7 @@
 			SELECT
 				sv.svg,
 				n.subject_id,
-				n.name,
+				IFNULL(n.name, '') AS name,
 				-1 AS descendent_stat_var_count,
 				EXISTS (
 					SELECT 1

--- a/internal/server/spanner/golden/query_builder/get_node_edges_by_object_id.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_by_object_id.sql
@@ -5,10 +5,10 @@
 			m.subject_id,
 			e.predicate,
 			e.provenance,
-			n.value,
+			IFNULL(n.value, '') AS value,
 			n.bytes,
 			IFNULL(n.name, '') AS name,
-			n.types
+			IFNULL(n.types, []) AS types
 		ORDER BY
 			subject_id,
 			predicate,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_by_subject_id.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_by_subject_id.sql
@@ -5,10 +5,10 @@
 			m.subject_id,
 			e.predicate,
 			e.provenance,
-			n.value,
+			IFNULL(n.value, '') AS value,
 			n.bytes,
 			IFNULL(n.name, '') AS name,
-			n.types
+			IFNULL(n.types, []) AS types
 		ORDER BY
 			subject_id,
 			predicate,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_first_page.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_first_page.sql
@@ -7,10 +7,10 @@
 			m.subject_id,
 			e.predicate,
 			e.provenance,
-			n.value,
+			IFNULL(n.value, '') AS value,
 			n.bytes,
 			IFNULL(n.name, '') AS name,
-			n.types
+			IFNULL(n.types, []) AS types
 		ORDER BY
 			subject_id,
 			predicate,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_first_page_chain.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_first_page_chain.sql
@@ -13,10 +13,10 @@
 		  	subject_id,
 			'specializationOf+' AS predicate,
 			'' AS provenance,
-			n.value,
+			IFNULL(n.value, '') AS value,
 			n.bytes,
 			IFNULL(n.name, '') AS name,
-			n.types
+			IFNULL(n.types, []) AS types
 		ORDER BY
 			subject_id,
 			object_id

--- a/internal/server/spanner/golden/query_builder/get_node_edges_in_bracket_props.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_in_bracket_props.sql
@@ -7,10 +7,10 @@
 			m.subject_id,
 			e.predicate,
 			e.provenance,
-			n.value,
+			IFNULL(n.value, '') AS value,
 			n.bytes,
 			IFNULL(n.name, '') AS name,
-			n.types
+			IFNULL(n.types, []) AS types
 		ORDER BY
 			subject_id,
 			predicate,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_in_chain.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_in_chain.sql
@@ -13,10 +13,10 @@
 		  	subject_id,
 			'specializationOf+' AS predicate,
 			'' AS provenance,
-			n.value,
+			IFNULL(n.value, '') AS value,
 			n.bytes,
 			IFNULL(n.name, '') AS name,
-			n.types
+			IFNULL(n.types, []) AS types
 		ORDER BY
 			subject_id,
 			object_id

--- a/internal/server/spanner/golden/query_builder/get_node_edges_in_filter.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_in_filter.sql
@@ -21,10 +21,10 @@
 		  	subject_id,
 			predicate,
 			provenance,
-			ANY_VALUE(IFNULL(n.value, '')) AS value,
+			IFNULL(ANY_VALUE(n.value), '') AS value,
 			ANY_VALUE(n.bytes) AS bytes,
-			ANY_VALUE(IFNULL(n.name, '')) AS name,
-			ANY_VALUE(IFNULL(n.types, [])) AS types
+			IFNULL(ANY_VALUE(n.name), '') AS name,
+			IFNULL(ANY_VALUE(n.types), []) AS types
 		GROUP BY
 			subject_id,
 			predicate,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_in_filter.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_in_filter.sql
@@ -21,10 +21,10 @@
 		  	subject_id,
 			predicate,
 			provenance,
-			ANY_VALUE(n.value) AS value,
+			ANY_VALUE(IFNULL(n.value, '')) AS value,
 			ANY_VALUE(n.bytes) AS bytes,
 			ANY_VALUE(IFNULL(n.name, '')) AS name,
-			ANY_VALUE(n.types) AS types
+			ANY_VALUE(IFNULL(n.types, [])) AS types
 		GROUP BY
 			subject_id,
 			predicate,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_in_single_prop.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_in_single_prop.sql
@@ -7,10 +7,10 @@
 			m.subject_id,
 			e.predicate,
 			e.provenance,
-			n.value,
+			IFNULL(n.value, '') AS value,
 			n.bytes,
 			IFNULL(n.name, '') AS name,
-			n.types
+			IFNULL(n.types, []) AS types
 		ORDER BY
 			subject_id,
 			predicate,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_linked_contained_in_place.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_linked_contained_in_place.sql
@@ -19,10 +19,10 @@
 		  	subject_id,
 			predicate,
 			provenance,
-			ANY_VALUE(n.value) AS value,
+			ANY_VALUE(IFNULL(n.value, '')) AS value,
 			ANY_VALUE(n.bytes) AS bytes,
 			ANY_VALUE(IFNULL(n.name, '')) AS name,
-			ANY_VALUE(n.types) AS types
+			ANY_VALUE(IFNULL(n.types, [])) AS types
 		GROUP BY
 			subject_id,
 			predicate,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_linked_contained_in_place.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_linked_contained_in_place.sql
@@ -19,10 +19,10 @@
 		  	subject_id,
 			predicate,
 			provenance,
-			ANY_VALUE(IFNULL(n.value, '')) AS value,
+			IFNULL(ANY_VALUE(n.value), '') AS value,
 			ANY_VALUE(n.bytes) AS bytes,
-			ANY_VALUE(IFNULL(n.name, '')) AS name,
-			ANY_VALUE(IFNULL(n.types, [])) AS types
+			IFNULL(ANY_VALUE(n.name), '') AS name,
+			IFNULL(ANY_VALUE(n.types), []) AS types
 		GROUP BY
 			subject_id,
 			predicate,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_malicious.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_malicious.sql
@@ -19,10 +19,10 @@
 		  	subject_id,
 			predicate,
 			provenance,
-			ANY_VALUE(n.value) AS value,
+			ANY_VALUE(IFNULL(n.value, '')) AS value,
 			ANY_VALUE(n.bytes) AS bytes,
 			ANY_VALUE(IFNULL(n.name, '')) AS name,
-			ANY_VALUE(n.types) AS types
+			ANY_VALUE(IFNULL(n.types, [])) AS types
 		GROUP BY
 			subject_id,
 			predicate,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_malicious.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_malicious.sql
@@ -19,10 +19,10 @@
 		  	subject_id,
 			predicate,
 			provenance,
-			ANY_VALUE(IFNULL(n.value, '')) AS value,
+			IFNULL(ANY_VALUE(n.value), '') AS value,
 			ANY_VALUE(n.bytes) AS bytes,
-			ANY_VALUE(IFNULL(n.name, '')) AS name,
-			ANY_VALUE(IFNULL(n.types, [])) AS types
+			IFNULL(ANY_VALUE(n.name), '') AS name,
+			IFNULL(ANY_VALUE(n.types), []) AS types
 		GROUP BY
 			subject_id,
 			predicate,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_out_bracket_props.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_out_bracket_props.sql
@@ -7,10 +7,10 @@
 			m.subject_id,
 			e.predicate,
 			e.provenance,
-			n.value,
+			IFNULL(n.value, '') AS value,
 			n.bytes,
 			IFNULL(n.name, '') AS name,
-			n.types
+			IFNULL(n.types, []) AS types
 		ORDER BY
 			subject_id,
 			predicate,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_out_bracket_props_lang.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_out_bracket_props_lang.sql
@@ -7,10 +7,10 @@
 			m.subject_id,
 			e.predicate,
 			e.provenance,
-			n.value,
+			IFNULL(n.value, '') AS value,
 			n.bytes,
 			IFNULL(n.name, '') AS name,
-			n.types
+			IFNULL(n.types, []) AS types
 		ORDER BY
 			subject_id,
 			predicate,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_out_chain.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_out_chain.sql
@@ -13,10 +13,10 @@
 		  	subject_id,
 			'specializationOf+' AS predicate,
 			'' AS provenance,
-			n.value,
+			IFNULL(n.value, '') AS value,
 			n.bytes,
 			IFNULL(n.name, '') AS name,
-			n.types
+			IFNULL(n.types, []) AS types
 		ORDER BY
 			subject_id,
 			object_id

--- a/internal/server/spanner/golden/query_builder/get_node_edges_out_filter.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_out_filter.sql
@@ -21,10 +21,10 @@
 		  	subject_id,
 			predicate,
 			provenance,
-			ANY_VALUE(IFNULL(n.value, '')) AS value,
+			IFNULL(ANY_VALUE(n.value), '') AS value,
 			ANY_VALUE(n.bytes) AS bytes,
-			ANY_VALUE(IFNULL(n.name, '')) AS name,
-			ANY_VALUE(IFNULL(n.types, [])) AS types
+			IFNULL(ANY_VALUE(n.name), '') AS name,
+			IFNULL(ANY_VALUE(n.types), []) AS types
 		GROUP BY
 			subject_id,
 			predicate,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_out_filter.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_out_filter.sql
@@ -21,10 +21,10 @@
 		  	subject_id,
 			predicate,
 			provenance,
-			ANY_VALUE(n.value) AS value,
+			ANY_VALUE(IFNULL(n.value, '')) AS value,
 			ANY_VALUE(n.bytes) AS bytes,
 			ANY_VALUE(IFNULL(n.name, '')) AS name,
-			ANY_VALUE(n.types) AS types
+			ANY_VALUE(IFNULL(n.types, [])) AS types
 		GROUP BY
 			subject_id,
 			predicate,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_out_single_prop.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_out_single_prop.sql
@@ -7,10 +7,10 @@
 			m.subject_id,
 			e.predicate,
 			e.provenance,
-			n.value,
+			IFNULL(n.value, '') AS value,
 			n.bytes,
 			IFNULL(n.name, '') AS name,
-			n.types
+			IFNULL(n.types, []) AS types
 		ORDER BY
 			subject_id,
 			predicate,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_second_page.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_second_page.sql
@@ -7,10 +7,10 @@
 			m.subject_id,
 			e.predicate,
 			e.provenance,
-			n.value,
+			IFNULL(n.value, '') AS value,
 			n.bytes,
 			IFNULL(n.name, '') AS name,
-			n.types
+			IFNULL(n.types, []) AS types
 		ORDER BY
 			subject_id,
 			predicate,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_second_page_chain.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_second_page_chain.sql
@@ -13,10 +13,10 @@
 		  	subject_id,
 			'specializationOf+' AS predicate,
 			'' AS provenance,
-			n.value,
+			IFNULL(n.value, '') AS value,
 			n.bytes,
 			IFNULL(n.name, '') AS name,
-			n.types
+			IFNULL(n.types, []) AS types
 		ORDER BY
 			subject_id,
 			object_id

--- a/internal/server/spanner/golden/query_builder/get_stat_var_group_node.sql
+++ b/internal/server/spanner/golden/query_builder/get_stat_var_group_node.sql
@@ -37,7 +37,7 @@
 		SELECT 
 			svg.svg,
 			n.subject_id, 
-			n.name, 
+			IFNULL(n.name, '') AS name, 
 			c.descendent_stat_var_count,
 			FALSE AS has_data,
 			'' AS definition
@@ -50,7 +50,7 @@
 		SELECT 
 			sv.svg,
 			n.subject_id, 
-			n.name, 
+			IFNULL(n.name, '') AS name, 
 			-1 AS descendent_stat_var_count,
 			EXISTS (
 				SELECT 1 

--- a/internal/server/spanner/golden/query_builder/get_stat_var_group_node_multi.sql
+++ b/internal/server/spanner/golden/query_builder/get_stat_var_group_node_multi.sql
@@ -38,7 +38,7 @@
 		SELECT 
 			svg.svg,
 			n.subject_id, 
-			n.name, 
+			IFNULL(n.name, '') AS name, 
 			c.descendent_stat_var_count,
 			FALSE AS has_data,
 			'' AS definition
@@ -51,7 +51,7 @@
 		SELECT 
 			sv.svg,
 			n.subject_id, 
-			n.name, 
+			IFNULL(n.name, '') AS name, 
 			-1 AS descendent_stat_var_count,
 			EXISTS (
 				SELECT 1 

--- a/internal/server/spanner/golden/query_builder/get_stat_var_group_node_with_definitions.sql
+++ b/internal/server/spanner/golden/query_builder/get_stat_var_group_node_with_definitions.sql
@@ -37,7 +37,7 @@
 		SELECT 
 			svg.svg,
 			n.subject_id, 
-			n.name, 
+			IFNULL(n.name, '') AS name, 
 			c.descendent_stat_var_count,
 			FALSE AS has_data,
 			'' AS definition
@@ -50,7 +50,7 @@
 		SELECT 
 			sv.svg,
 			n.subject_id, 
-			n.name, 
+			IFNULL(n.name, '') AS name, 
 			-1 AS descendent_stat_var_count,
 			EXISTS (
 				SELECT 1 

--- a/internal/server/spanner/golden/query_builder/get_svg_children.sql
+++ b/internal/server/spanner/golden/query_builder/get_svg_children.sql
@@ -1,6 +1,6 @@
 		SELECT DISTINCT
 			n.subject_id,
-			n.name,
+			IFNULL(n.name, '') AS name,
 			e.predicate,
 			'' AS definition
 		FROM Node n

--- a/internal/server/spanner/golden/query_builder/get_svg_children_with_definitions.sql
+++ b/internal/server/spanner/golden/query_builder/get_svg_children_with_definitions.sql
@@ -1,6 +1,6 @@
 		SELECT DISTINCT
 			n.subject_id,
-			n.name,
+			IFNULL(n.name, '') AS name,
 			e.predicate,
 			IFNULL((
 				SELECT n_def.value

--- a/internal/server/spanner/golden/query_builder/resolve_dcid_to_prop.sql
+++ b/internal/server/spanner/golden/query_builder/resolve_dcid_to_prop.sql
@@ -4,4 +4,4 @@
 			AND o.predicate = 'unDataCode']->(n:Node)
 		RETURN
 			o.subject_id AS node,
-			n.value AS candidate
+			IFNULL(n.value, '') AS candidate

--- a/internal/server/spanner/golden/query_builder/resolve_prop_to_prop.sql
+++ b/internal/server/spanner/golden/query_builder/resolve_prop_to_prop.sql
@@ -6,4 +6,4 @@
 			o.predicate = 'wikidataId']->(n:Node)
 		RETURN
 			i.object_id AS node,
-			n.value AS candidate
+			IFNULL(n.value, '') AS candidate

--- a/internal/server/spanner/golden/query_builder/search_nodes_with_type.sql
+++ b/internal/server/spanner/golden/query_builder/search_nodes_with_type.sql
@@ -4,8 +4,8 @@
 		AND ARRAY_INCLUDES_ANY(n.types, ['StatisticalVariable'])
 		RETURN
 			n.subject_id, 
-			n.name,
-			n.types, 
+			IFNULL(n.name, '') AS name,
+			IFNULL(n.types, []) AS types, 
 			SCORE(n.name_tokenlist, 'income', enhance_query => TRUE) AS score 
 		ORDER BY 
 			score + IF(n.name = 'income', 1, 0) DESC,

--- a/internal/server/spanner/golden/query_builder/search_nodes_without_type.sql
+++ b/internal/server/spanner/golden/query_builder/search_nodes_without_type.sql
@@ -3,8 +3,8 @@
 			SEARCH(n.name_tokenlist, 'income')
 		RETURN
 			n.subject_id, 
-			n.name,
-			n.types, 
+			IFNULL(n.name, '') AS name,
+			IFNULL(n.types, []) AS types, 
 			SCORE(n.name_tokenlist, 'income', enhance_query => TRUE) AS score 
 		ORDER BY 
 			score + IF(n.name = 'income', 1, 0) DESC,

--- a/internal/server/spanner/statements.go
+++ b/internal/server/spanner/statements.go
@@ -255,10 +255,10 @@ var statements = struct {
 		  	subject_id,
 			predicate,
 			provenance,
-			ANY_VALUE(IFNULL(n.value, '')) AS value,
+			IFNULL(ANY_VALUE(n.value), '') AS value,
 			ANY_VALUE(n.bytes) AS bytes,
-			ANY_VALUE(IFNULL(n.name, '')) AS name,
-			ANY_VALUE(IFNULL(n.types, [])) AS types
+			IFNULL(ANY_VALUE(n.name), '') AS name,
+			IFNULL(ANY_VALUE(n.types), []) AS types
 		GROUP BY
 			subject_id,
 			predicate,

--- a/internal/server/spanner/statements.go
+++ b/internal/server/spanner/statements.go
@@ -215,10 +215,10 @@ var statements = struct {
 			m.subject_id,
 			e.predicate,
 			e.provenance,
-			n.value,
+			IFNULL(n.value, '') AS value,
 			n.bytes,
 			IFNULL(n.name, '') AS name,
-			n.types
+			IFNULL(n.types, []) AS types
 		ORDER BY
 			subject_id,
 			predicate,
@@ -235,10 +235,10 @@ var statements = struct {
 		  	subject_id,
 			@result_predicate AS predicate,
 			'' AS provenance,
-			n.value,
+			IFNULL(n.value, '') AS value,
 			n.bytes,
 			IFNULL(n.name, '') AS name,
-			n.types
+			IFNULL(n.types, []) AS types
 		ORDER BY
 			subject_id,
 			object_id`,
@@ -255,10 +255,10 @@ var statements = struct {
 		  	subject_id,
 			predicate,
 			provenance,
-			ANY_VALUE(n.value) AS value,
+			ANY_VALUE(IFNULL(n.value, '')) AS value,
 			ANY_VALUE(n.bytes) AS bytes,
 			ANY_VALUE(IFNULL(n.name, '')) AS name,
-			ANY_VALUE(n.types) AS types
+			ANY_VALUE(IFNULL(n.types, [])) AS types
 		GROUP BY
 			subject_id,
 			predicate,
@@ -325,8 +325,8 @@ var statements = struct {
 			SEARCH(n.name_tokenlist, @query)%s
 		RETURN
 			n.subject_id, 
-			n.name,
-			n.types, 
+			IFNULL(n.name, '') AS name,
+			IFNULL(n.types, []) AS types, 
 			SCORE(n.name_tokenlist, @query, enhance_query => TRUE) AS score 
 		ORDER BY 
 			score + IF(n.name = @query, 1, 0) DESC,
@@ -346,7 +346,7 @@ var statements = struct {
 			AND o.predicate = @outProp]->(n:Node)
 		RETURN
 			o.subject_id AS node,
-			n.value AS candidate`,
+			IFNULL(n.value, '') AS candidate`,
 	resolvePropToDcid: `		GRAPH DCGraph MATCH <-[i:Edge
 		WHERE
 			i.object_id IN UNNEST(@nodes)
@@ -362,7 +362,7 @@ var statements = struct {
 			o.predicate = @outProp]->(n:Node)
 		RETURN
 			i.object_id AS node,
-			n.value AS candidate`,
+			IFNULL(n.value, '') AS candidate`,
 	node: `(%[1]s:Node%[2]s)`,
 	nodeFilter: `
 		WHERE
@@ -446,7 +446,7 @@ var statements = struct {
 		SELECT 
 			svg.svg,
 			n.subject_id, 
-			n.name, 
+			IFNULL(n.name, '') AS name, 
 			c.descendent_stat_var_count,
 			FALSE AS has_data,
 			'' AS definition
@@ -459,7 +459,7 @@ var statements = struct {
 		SELECT 
 			sv.svg,
 			n.subject_id, 
-			n.name, 
+			IFNULL(n.name, '') AS name, 
 			-1 AS descendent_stat_var_count,
 			EXISTS (
 				SELECT 1 
@@ -508,7 +508,7 @@ var statements = struct {
 		SELECT 
 			svg.svg,
 			n.subject_id, 
-			n.name, 
+			IFNULL(n.name, '') AS name, 
 			c.descendent_stat_var_count,
 			FALSE AS has_data,
 			'' AS definition
@@ -521,7 +521,7 @@ var statements = struct {
 		SELECT 
 			sv.svg,
 			n.subject_id, 
-			n.name, 
+			IFNULL(n.name, '') AS name, 
 			-1 AS descendent_stat_var_count,
 			EXISTS (
 				SELECT 1 
@@ -549,7 +549,7 @@ var statements = struct {
 				FROM UNNEST(@nodes) AS node`,
 	getSVGChildren: `		SELECT DISTINCT
 			n.subject_id,
-			n.name,
+			IFNULL(n.name, '') AS name,
 			e.predicate,
 			'' AS definition
 		FROM Node n
@@ -560,7 +560,7 @@ var statements = struct {
 		) e ON n.subject_id = e.subject_id`,
 	getSVGChildrenWithDefinitions: `		SELECT DISTINCT
 			n.subject_id,
-			n.name,
+			IFNULL(n.name, '') AS name,
 			e.predicate,
 			IFNULL((
 				SELECT n_def.value
@@ -578,7 +578,7 @@ var statements = struct {
 		) e ON n.subject_id = e.subject_id`,
 	getFilteredChildSVs: `		SELECT
 			n.subject_id,
-			n.name,
+			IFNULL(n.name, '') AS name,
 			'' AS definition
 		FROM Node n
 		JOIN (
@@ -598,7 +598,7 @@ var statements = struct {
 			ON n.subject_id = e_existence.subject_id`,
 	getFilteredChildSVsWithDefinitions: `		SELECT
 			n.subject_id,
-			n.name,
+			IFNULL(n.name, '') AS name,
 			IFNULL((
 				SELECT n_def.value
 				FROM Edge e_def
@@ -625,7 +625,7 @@ var statements = struct {
 			ON n.subject_id = e_existence.subject_id`,
 	getFilteredChildSVGs: `		SELECT
 			n.subject_id,
-			n.name,
+			IFNULL(n.name, '') AS name,
 			e_counts.descendent_stat_var_count
 		FROM Node n
 		JOIN (

--- a/internal/server/spanner/statements_multientity.go
+++ b/internal/server/spanner/statements_multientity.go
@@ -490,7 +490,7 @@ func NewMultiEntityStatements(cfg TableConfig) (*MultiEntityStatements, error) {
 			SELECT
 				svg.svg,
 				n.subject_id,
-				n.name,
+				IFNULL(n.name, '') AS name,
 				c.descendent_stat_var_count,
 				FALSE AS has_data,
 				'' AS definition
@@ -503,7 +503,7 @@ func NewMultiEntityStatements(cfg TableConfig) (*MultiEntityStatements, error) {
 			SELECT
 				sv.svg,
 				n.subject_id,
-				n.name,
+				IFNULL(n.name, '') AS name,
 				-1 AS descendent_stat_var_count,
 				EXISTS (
 					SELECT 1
@@ -553,7 +553,7 @@ func NewMultiEntityStatements(cfg TableConfig) (*MultiEntityStatements, error) {
 			SELECT
 				svg.svg,
 				n.subject_id,
-				n.name,
+				IFNULL(n.name, '') AS name,
 				c.descendent_stat_var_count,
 				FALSE AS has_data,
 				'' AS definition
@@ -566,7 +566,7 @@ func NewMultiEntityStatements(cfg TableConfig) (*MultiEntityStatements, error) {
 			SELECT
 				sv.svg,
 				n.subject_id,
-				n.name,
+				IFNULL(n.name, '') AS name,
 				-1 AS descendent_stat_var_count,
 				EXISTS (
 					SELECT 1


### PR DESCRIPTION
For now, until determined if ingestion can enforce non nullability, use ifnull to set empty values for Node fields. This is to prevent queries with null fields from erroring