### PR TITLE
Wip

### DIFF
--- a/internal/server/spanner/dsutil.go
+++ b/internal/server/spanner/dsutil.go
@@ -397,12 +397,12 @@ func groupObservationsByVariableAndEntity(observations []*Observation) map[varia
 	return result
 }
 
-func generateObsResponse(variable *pbv2.DcidOrExpression, observations []*Observation, includeObs bool, shouldFilterInferiorFacets bool) *pbv2.ObservationResponse {
+func generateObsResponse(variable *pbv2.DcidOrExpression, observations []*Observation, includeObs bool, includeObsMetadata, shouldFilterInferiorFacets bool) *pbv2.ObservationResponse {
 	response := newObservationResponse(variable)
 
 	variableEntityObs := groupObservationsByVariableAndEntity(observations)
 	for variableEntity, obs := range variableEntityObs {
-		orderedFacets, facets := observationsToOrderedFacets(obs, includeObs, shouldFilterInferiorFacets)
+		orderedFacets, facets := observationsToOrderedFacets(obs, includeObs, includeObsMetadata, shouldFilterInferiorFacets)
 		variableObs, ok := response.ByVariable[variableEntity.variable]
 		if !ok {
 			variableObs = &pbv2.VariableObservation{
@@ -471,13 +471,25 @@ func mergeEntityOrderedFacets(
 	return result
 }
 
-func obsToObsResponse(req *pbv2.ObservationRequest, observations []*Observation) *pbv2.ObservationResponse {
-	// Whether the response should filter out low ranked facets from the response.
+// Whether the response should filter out low ranked facets from the response.
+func shouldFilterInferiorFacets(req *pbv2.ObservationRequest) bool {
 	isContainedInWithDate := (req.Entity.Expression != "" && req.Date != "")
 	isDirectWithLatestDate := (req.Entity.Expression == "" && req.Date == shared.LATEST)
-	shouldFilterInferiorFacets := isContainedInWithDate || isDirectWithLatestDate
 
-	response := generateObsResponse(req.Variable, observations, true /*includeObs*/, shouldFilterInferiorFacets)
+	return isContainedInWithDate || isDirectWithLatestDate
+}
+
+// Whether the response should filter out low ranked facets from the response.
+func includeObsMetadata(req *pbv2.ObservationRequest) bool {
+	isContainedInWithDate := (req.Entity.Expression != "" && req.Date != "")
+
+	return !isContainedInWithDate
+}
+
+func obsToObsResponse(req *pbv2.ObservationRequest, observations []*Observation) *pbv2.ObservationResponse {
+	includeObsMetadata := includeObsMetadata(req)
+	shouldFilterInferiorFacets := shouldFilterInferiorFacets(req)
+	response := generateObsResponse(req.Variable, observations, true /*includeObs*/, includeObsMetadata, shouldFilterInferiorFacets)
 
 	// Attach all requested entity dcids to response.
 	if len(req.Entity.Dcids) > 0 {
@@ -495,7 +507,8 @@ func obsToObsResponse(req *pbv2.ObservationRequest, observations []*Observation)
 }
 
 func obsToFacetResponse(req *pbv2.ObservationRequest, observations []*Observation) *pbv2.ObservationResponse {
-	response := generateObsResponse(req.Variable, observations, false /*includeObs*/, false /*shouldFilterInferiorFacets*/)
+	includeObsMetadata := includeObsMetadata(req)
+	response := generateObsResponse(req.Variable, observations, false /*includeObs*/, includeObsMetadata, false /*shouldFilterInferiorFacets*/)
 
 	if len(req.Entity.Dcids) > 0 {
 		return response
@@ -538,13 +551,14 @@ func obsToExistenceResponse(req *pbv2.ObservationRequest, observations []*Observ
 func observationsToOrderedFacets(
 	observations []*Observation,
 	includeObs bool,
+	includeObsMetadata bool,
 	shouldFilterInferiorFacets bool,
 ) ([]*pbv2.FacetObservation, map[string]*pb.Facet) {
 	facets := map[string]*pb.Facet{}
 	placeVariableFacets := []*pb.PlaceVariableFacet{}
 	facetIdToFacetObs := map[string]*pbv2.FacetObservation{}
 	for _, obs := range observations {
-		pvf, facetObs := observationToFacetObservation(obs, includeObs)
+		pvf, facetObs := observationToFacetObservation(obs, includeObs, includeObsMetadata)
 
 		// Skip rows with no time series.
 		if pvf == nil {
@@ -574,6 +588,7 @@ func observationsToOrderedFacets(
 func observationToFacetObservation(
 	observation *Observation,
 	includeObs bool,
+	includeObsMetadata bool,
 ) (*pb.PlaceVariableFacet, *pbv2.FacetObservation) {
 	facet := observationToFacet(observation)
 
@@ -600,14 +615,17 @@ func observationToFacetObservation(
 	}
 
 	facetObservation := &pbv2.FacetObservation{
-		FacetId:      observation.FacetId,
-		ObsCount:     *proto.Int32(int32(len(observations))),
-		EarliestDate: observations[0].Date,
-		LatestDate:   observations[len(observations)-1].Date,
+		FacetId: observation.FacetId,
 	}
 
 	if includeObs {
 		facetObservation.Observations = observations
+	}
+
+	if includeObsMetadata {
+		facetObservation.ObsCount = *proto.Int32(int32(len(observations)))
+		facetObservation.EarliestDate = observations[0].Date
+		facetObservation.LatestDate = observations[len(observations)-1].Date
 	}
 
 	placeVariableFacet := &pb.PlaceVariableFacet{

--- a/internal/server/spanner/golden/query_builder/get_multientity_obs_contained_in_place_both.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_obs_contained_in_place_both.sql
@@ -1,6 +1,6 @@
 		@{SCAN_METHOD=COLUMNAR, EXECUTION_METHOD=BATCH}
 		WITH places AS (
-			SELECT e.subject_id AS place_id
+			SELECT DISTINCT e.subject_id AS place_id
 			FROM Edge e
 			JOIN Edge e2 ON e.subject_id = e2.subject_id
 			WHERE e.predicate = 'linkedContainedInPlace'
@@ -26,6 +26,7 @@
 			) AS dates_and_values,
 			t.facet AS facets
 		FROM places p
+		CROSS JOIN ('AirPollutant_Cancer_Risk') AS target_variable
 		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} TimeSeries@{FORCE_INDEX=_BASE_TABLE} t
-			ON t.variable_measured IN ('AirPollutant_Cancer_Risk')
+			ON t.variable_measured = target_variable
 			AND t.entity1 = p.place_id

--- a/internal/server/spanner/golden/query_builder/get_multientity_obs_contained_in_place_both.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_obs_contained_in_place_both.sql
@@ -1,9 +1,12 @@
+		@{SCAN_METHOD=COLUMNAR, EXECUTION_METHOD=BATCH}
 		WITH places AS (
-			SELECT result.object_id AS place_id
-			FROM GRAPH_TABLE (
-				DCGraph MATCH <-[e:Edge WHERE e.object_id = 'geoId/10' AND e.predicate = 'linkedContainedInPlace']-()-[{predicate: 'typeOf', object_id: 'County'}]->
-				RETURN e.subject_id AS object_id
-			) result
+			SELECT e.subject_id AS place_id
+			FROM Edge e
+			JOIN Edge e2 ON e.subject_id = e2.subject_id
+			WHERE e.predicate = 'linkedContainedInPlace'
+				AND e.object_id = 'geoId/10'
+				AND e2.predicate = 'typeOf'
+				AND e2.object_id = 'County'
 		)
 		SELECT
 			t.variable_measured,
@@ -23,6 +26,6 @@
 			) AS dates_and_values,
 			t.facet AS facets
 		FROM places p
-		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} TimeSeries t
+		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} TimeSeries@{FORCE_INDEX=_BASE_TABLE} t
 			ON t.variable_measured IN ('AirPollutant_Cancer_Risk')
 			AND t.entity1 = p.place_id

--- a/internal/server/spanner/golden/query_builder/get_multientity_obs_contained_in_place_latest.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_obs_contained_in_place_latest.sql
@@ -1,6 +1,6 @@
 		@{SCAN_METHOD=COLUMNAR, EXECUTION_METHOD=BATCH}
 		WITH places AS (
-			SELECT e.subject_id AS place_id
+			SELECT DISTINCT e.subject_id AS place_id
 			FROM Edge e
 			JOIN Edge e2 ON e.subject_id = e2.subject_id
 			WHERE e.predicate = 'linkedContainedInPlace'
@@ -30,6 +30,7 @@
 			) AS dates_and_values,
 			t.facet AS facets
 		FROM places p
+		CROSS JOIN ('AirPollutant_Cancer_Risk') AS target_variable
 		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} TimeSeries@{FORCE_INDEX=_BASE_TABLE} t
-			ON t.variable_measured IN ('AirPollutant_Cancer_Risk')
+			ON t.variable_measured = target_variable
 			AND t.entity1 = p.place_id

--- a/internal/server/spanner/golden/query_builder/get_multientity_obs_contained_in_place_latest.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_obs_contained_in_place_latest.sql
@@ -1,9 +1,12 @@
+		@{SCAN_METHOD=COLUMNAR, EXECUTION_METHOD=BATCH}
 		WITH places AS (
-			SELECT result.object_id AS place_id
-			FROM GRAPH_TABLE (
-				DCGraph MATCH <-[e:Edge WHERE e.object_id = 'geoId/10' AND e.predicate = 'linkedContainedInPlace']-()-[{predicate: 'typeOf', object_id: 'County'}]->
-				RETURN e.subject_id AS object_id
-			) result
+			SELECT e.subject_id AS place_id
+			FROM Edge e
+			JOIN Edge e2 ON e.subject_id = e2.subject_id
+			WHERE e.predicate = 'linkedContainedInPlace'
+				AND e.object_id = 'geoId/10'
+				AND e2.predicate = 'typeOf'
+				AND e2.object_id = 'County'
 		)
 		SELECT
 			t.variable_measured,
@@ -27,6 +30,6 @@
 			) AS dates_and_values,
 			t.facet AS facets
 		FROM places p
-		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} TimeSeries t
+		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} TimeSeries@{FORCE_INDEX=_BASE_TABLE} t
 			ON t.variable_measured IN ('AirPollutant_Cancer_Risk')
 			AND t.entity1 = p.place_id

--- a/internal/server/spanner/query_multientity_test.go
+++ b/internal/server/spanner/query_multientity_test.go
@@ -346,6 +346,7 @@ func TestMultiEntityObservationResponseIncludesProvenanceID(t *testing.T) {
 		&pbv2.DcidOrExpression{Dcids: []string{"Count_Person"}},
 		observations,
 		true,  /* includeObs */
+		true,  /* includeObsMetadata */
 		false, /* shouldFilterInferiorFacets */
 	)
 	facet := resp.Facets["stored-facet-id"]

--- a/internal/server/spanner/statements_multientity.go
+++ b/internal/server/spanner/statements_multientity.go
@@ -214,12 +214,15 @@ func NewMultiEntityStatements(cfg TableConfig) (*MultiEntityStatements, error) {
 		WHERE t.entity1 IN UNNEST(@entities)`, cfg.ObservationTable, cfg.TimeSeriesTable),
 
 		// Contained in place query with variables filtered (full series)
-		getObsByContainedInPlaceBoth: fmt.Sprintf(`		WITH places AS (
-			SELECT result.object_id AS place_id
-			FROM GRAPH_TABLE (
-				DCGraph MATCH <-[e:Edge WHERE e.object_id = @ancestor AND e.predicate = 'linkedContainedInPlace']-()-[{predicate: 'typeOf', object_id: @childPlaceType}]->
-				RETURN e.subject_id AS object_id
-			) result
+		getObsByContainedInPlaceBoth: fmt.Sprintf(`		@{SCAN_METHOD=COLUMNAR, EXECUTION_METHOD=BATCH}
+		WITH places AS (
+			SELECT DISTINCT e.subject_id AS place_id
+			FROM Edge e
+			JOIN Edge e2 ON e.subject_id = e2.subject_id
+			WHERE e.predicate = 'linkedContainedInPlace'
+				AND e.object_id = @ancestor
+				AND e2.predicate = 'typeOf'
+				AND e2.object_id = @childPlaceType
 		)
 		SELECT
 			t.variable_measured,
@@ -239,17 +242,21 @@ func NewMultiEntityStatements(cfg TableConfig) (*MultiEntityStatements, error) {
 			) AS dates_and_values,
 			t.facet AS facets
 		FROM places p
-		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} %[2]s t
-			ON t.variable_measured IN UNNEST(@variables)
+		CROSS JOIN UNNEST(@variables) AS target_variable
+		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} %[2]s@{FORCE_INDEX=_BASE_TABLE} t
+			ON t.variable_measured = target_variable
 			AND t.entity1 = p.place_id`, cfg.ObservationTable, cfg.TimeSeriesTable),
 
 		// Contained in place query with variables filtered (specific date)
-		getObsByContainedInPlaceBothWithDate: fmt.Sprintf(`		WITH places AS (
-			SELECT result.object_id AS place_id
-			FROM GRAPH_TABLE (
-				DCGraph MATCH <-[e:Edge WHERE e.object_id = @ancestor AND e.predicate = 'linkedContainedInPlace']-()-[{predicate: 'typeOf', object_id: @childPlaceType}]->
-				RETURN e.subject_id AS object_id
-			) result
+		getObsByContainedInPlaceBothWithDate: fmt.Sprintf(`		@{SCAN_METHOD=COLUMNAR, EXECUTION_METHOD=BATCH}
+		WITH places AS (
+			SELECT DISTINCT e.subject_id AS place_id
+			FROM Edge e
+			JOIN Edge e2 ON e.subject_id = e2.subject_id
+			WHERE e.predicate = 'linkedContainedInPlace'
+				AND e.object_id = @ancestor
+				AND e2.predicate = 'typeOf'
+				AND e2.object_id = @childPlaceType
 		)
 		SELECT
 			t.variable_measured,
@@ -270,17 +277,21 @@ func NewMultiEntityStatements(cfg TableConfig) (*MultiEntityStatements, error) {
 			) AS dates_and_values,
 			t.facet AS facets
 		FROM places p
-		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} %[2]s t
-			ON t.variable_measured IN UNNEST(@variables)
+		CROSS JOIN UNNEST(@variables) AS target_variable
+		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} %[2]s@{FORCE_INDEX=_BASE_TABLE} t
+			ON t.variable_measured = target_variable
 			AND t.entity1 = p.place_id`, cfg.ObservationTable, cfg.TimeSeriesTable),
 
 		// Contained in place query with variables filtered (latest only)
-		getObsByContainedInPlaceBothLatest: fmt.Sprintf(`		WITH places AS (
-			SELECT result.object_id AS place_id
-			FROM GRAPH_TABLE (
-				DCGraph MATCH <-[e:Edge WHERE e.object_id = @ancestor AND e.predicate = 'linkedContainedInPlace']-()-[{predicate: 'typeOf', object_id: @childPlaceType}]->
-				RETURN e.subject_id AS object_id
-			) result
+		getObsByContainedInPlaceBothLatest: fmt.Sprintf(`		@{SCAN_METHOD=COLUMNAR, EXECUTION_METHOD=BATCH}
+		WITH places AS (
+			SELECT DISTINCT e.subject_id AS place_id
+			FROM Edge e
+			JOIN Edge e2 ON e.subject_id = e2.subject_id
+			WHERE e.predicate = 'linkedContainedInPlace'
+				AND e.object_id = @ancestor
+				AND e2.predicate = 'typeOf'
+				AND e2.object_id = @childPlaceType
 		)
 		SELECT
 			t.variable_measured,
@@ -304,8 +315,9 @@ func NewMultiEntityStatements(cfg TableConfig) (*MultiEntityStatements, error) {
 			) AS dates_and_values,
 			t.facet AS facets
 		FROM places p
-		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} %[2]s t
-			ON t.variable_measured IN UNNEST(@variables)
+		CROSS JOIN UNNEST(@variables) AS target_variable
+		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} %[2]s@{FORCE_INDEX=_BASE_TABLE} t
+			ON t.variable_measured = target_variable
 			AND t.entity1 = p.place_id`, cfg.ObservationTable, cfg.TimeSeriesTable),
 
 		getSdmxObs: fmt.Sprintf("\t\tSELECT \n"+`			t.variable_measured,


### PR DESCRIPTION
* use sql for place filtering
* use distinct for place filtering
* use columnar hint 
* use base table for time series 
* use cross join for variables (not sure if this is needed, but seemed to help when running parameterized - note that the generated sql goldens don't parse correctly)
* also updated mixer to not return extra metadata when selecting a date for containedInPlace (this doesn't relate to spanner, but matches prod and helps reduce the size of large responses)