### PR TITLE
Update spanner timeouts to default to esp timeout

### DIFF
--- a/internal/server/mirror.go
+++ b/internal/server/mirror.go
@@ -81,14 +81,6 @@ func (s *Server) mirrorV3(
 		v3WaitGroup.Add(1)
 	}
 
-	var mirrorDeadline time.Time
-	if deadline, ok := ctx.Deadline(); ok {
-		mirrorDeadline = deadline
-	} else {
-		slog.Warn("Original context has no deadline; using default API timeout", "timeout", spanner.ApiTimeout.String())
-		mirrorDeadline = time.Now().Add(spanner.ApiTimeout)
-	}
-
 	// This is run in a separate goroutine to not block the response to the original
 	// request.
 	go func() {
@@ -99,8 +91,9 @@ func (s *Server) mirrorV3(
 		// with the original request.
 		baseMirrorCtx := metrics.NewContext(context.WithoutCancel(ctx))
 
-		// Re-apply the deadline to the detached context
-		mirrorCtx, cancel := context.WithDeadline(baseMirrorCtx, mirrorDeadline)
+		// Apply a strict timeout to this background task so it doesn't leak if V3 hangs.
+		// Because this is detached from ESP, we must use our hardcoded ApiTimeout.
+		mirrorCtx, cancel := context.WithTimeout(baseMirrorCtx, spanner.ApiTimeout)
 		defer cancel()
 
 		// First call, without skipping cache

--- a/internal/server/spanner/query.go
+++ b/internal/server/spanner/query.go
@@ -942,7 +942,6 @@ func (sc *spannerDatabaseClient) fetchAndUpdateTimestamp(ctx context.Context) er
 	iter := sc.client.Single().Query(queryCtx, *GetCompletionTimestampQuery(sc.useNewIngestionHistorySchema))
 	defer iter.Stop()
 	row, err := iter.Next()
-	duration := time.Since(startTime)
 
 	// Handle missing or empty table cases gracefully
 	var warnMsg string
@@ -961,7 +960,7 @@ func (sc *spannerDatabaseClient) fetchAndUpdateTimestamp(ctx context.Context) er
 	if err != nil {
 		if isTimeoutOrCanceled(err) {
 			slog.ErrorContext(queryCtx, "Spanner timestamp polling aborted.",
-				"duration", duration.String(),
+				"duration", time.Since(startTime).String(),
 				"error", err.Error(),
 			)
 		}

--- a/internal/server/spanner/query.go
+++ b/internal/server/spanner/query.go
@@ -938,10 +938,11 @@ func (sc *spannerDatabaseClient) fetchAndUpdateTimestamp(ctx context.Context) er
 	queryCtx, cancel := context.WithTimeout(ctx, timestampPollingTimeout)
 	defer cancel()
 
+	startTime := time.Now()
 	iter := sc.client.Single().Query(queryCtx, *GetCompletionTimestampQuery(sc.useNewIngestionHistorySchema))
 	defer iter.Stop()
-
 	row, err := iter.Next()
+	duration := time.Since(startTime)
 
 	// Handle missing or empty table cases gracefully
 	var warnMsg string
@@ -958,9 +959,9 @@ func (sc *spannerDatabaseClient) fetchAndUpdateTimestamp(ctx context.Context) er
 	}
 
 	if err != nil {
-		if isTimeoutError(err) {
-			slog.ErrorContext(queryCtx, "Spanner timestamp polling timed out",
-				"timeout_duration", timestampPollingTimeout.String(),
+		if isTimeoutOrCanceled(err) {
+			slog.ErrorContext(queryCtx, "Spanner timestamp polling aborted.",
+				"duration", duration.String(),
 				"error", err.Error(),
 			)
 		}
@@ -1007,12 +1008,13 @@ func (sc *spannerDatabaseClient) executeQuery(
 	var cancel context.CancelFunc
 
 	if _, ok := ctx.Deadline(); ok {
+		// If the client explicitly provided a deadline, respect it.
 		queryCtx, cancel = context.WithCancel(ctx)
 	} else {
-		// Fallback if the parent context surprisingly has no deadline.
-		// Using the default API timeout.
-		slog.Warn("Parent context has no deadline; using default API timeout", "timeout", ApiTimeout.String())
-		queryCtx, cancel = context.WithTimeout(ctx, ApiTimeout)
+		// Apply an absolute upper bound with a small buffer to protect the DB
+		// in case ESP is bypassed.
+		fallbackLimit := ApiTimeout + (5 * time.Second)
+		queryCtx, cancel = context.WithTimeout(ctx, fallbackLimit)
 	}
 	defer cancel()
 
@@ -1040,10 +1042,11 @@ func (sc *spannerDatabaseClient) executeQuery(
 			fmt.Println("================================================")
 		}
 
-		// Log slow Spanner queries that timed out.
-		if isTimeoutError(err) {
-			slog.ErrorContext(queryCtx, "Spanner query timed out",
+		// Log slow Spanner queries that timed out or were canceled.
+		if isTimeoutOrCanceled(err) {
+			slog.ErrorContext(queryCtx, "Spanner query aborted.",
 				"sql", stmt.SQL,
+				"duration", duration.String(),
 				"error", err.Error(),
 			)
 		}
@@ -1201,7 +1204,14 @@ func processCacheRows[T proto.Message](iter *spanner.RowIterator, newProto func(
 	return results, nil
 }
 
-// isTimeoutError checks if an error is a timeout error from Spanner or context.
-func isTimeoutError(err error) bool {
-	return spanner.ErrCode(err) == codes.DeadlineExceeded || errors.Is(err, context.DeadlineExceeded)
+// isTimeoutOrCanceled checks if the error is a formal timeout (DeadlineExceeded)
+// or a dropped connection (Canceled).
+func isTimeoutOrCanceled(err error) bool {
+	if err == nil {
+		return false
+	}
+	return spanner.ErrCode(err) == codes.DeadlineExceeded ||
+		errors.Is(err, context.DeadlineExceeded) ||
+		spanner.ErrCode(err) == codes.Canceled ||
+		errors.Is(err, context.Canceled)
 }


### PR DESCRIPTION
Previously we were checking for a deadline and falling back / logging whenever it wasn't set. However, ESP will not set the deadline, so we were always using the fallback timeout and causing lots of log clutter.

ESP will still cancel the spanner query once it hits its timeout, so many of the logs were unnecessary.

This PR updates
* Always set the default timeout for mirrored requests. This is because we're bypassing the ESP cancel, so still want to avoid wasting spanner resources on long-running queries.
* Increase the default timeout by a few seconds in other requests (set to timeout + 5s), to avoid race conditions with the ESP timeout (for better debug). In general the ESP timeout should win, but this is in case we ever bypass it.
* Update the timeout logging to also catch cases where ESP cancels the request (now called IsTimeoutOrCanceled) 
* Note we'll still prefer timeouts if they're explicitly provided by the client, in case we ever support this