### PR TITLE
Optimize multi-entity contained-in-place observation queries

### DIFF
--- a/internal/server/spanner/dsutil.go
+++ b/internal/server/spanner/dsutil.go
@@ -489,10 +489,10 @@ func includeObsMetadata(req *pbv2.ObservationRequest) bool {
 func obsToObsResponse(req *pbv2.ObservationRequest, observations []*Observation) *pbv2.ObservationResponse {
 	includeMetadata := includeObsMetadata(req)
 	filterInferiorFacets := shouldFilterInferiorFacets(req)
-	response := generateObsResponse(req.Variable, observations, true /*includeObs*/, includeMetadata, filterInferiorFacets)
+	response := generateObsResponse(req.GetVariable(), observations, true /*includeObs*/, includeMetadata, filterInferiorFacets)
 
 	// Attach all requested entity dcids to response.
-	if len(req.Entity.Dcids) > 0 {
+	if len(req.GetEntity().GetDcids()) > 0 {
 		for _, variableObs := range response.ByVariable {
 			for _, entity := range req.Entity.Dcids {
 				_, ok := variableObs.ByEntity[entity]

--- a/internal/server/spanner/dsutil.go
+++ b/internal/server/spanner/dsutil.go
@@ -508,7 +508,7 @@ func obsToObsResponse(req *pbv2.ObservationRequest, observations []*Observation)
 
 func obsToFacetResponse(req *pbv2.ObservationRequest, observations []*Observation) *pbv2.ObservationResponse {
 	includeMetadata := includeObsMetadata(req)
-	response := generateObsResponse(req.Variable, observations, false /*includeObs*/, includeMetadata, false /*shouldFilterInferiorFacets*/)
+	response := generateObsResponse(req.GetVariable(), observations, false /*includeObs*/, includeMetadata, false /*shouldFilterInferiorFacets*/)
 
 	if len(req.Entity.Dcids) > 0 {
 		return response

--- a/internal/server/spanner/dsutil.go
+++ b/internal/server/spanner/dsutil.go
@@ -397,12 +397,12 @@ func groupObservationsByVariableAndEntity(observations []*Observation) map[varia
 	return result
 }
 
-func generateObsResponse(variable *pbv2.DcidOrExpression, observations []*Observation, includeObs bool, shouldFilterInferiorFacets bool) *pbv2.ObservationResponse {
+func generateObsResponse(variable *pbv2.DcidOrExpression, observations []*Observation, includeObs bool, includeObsMetadata, shouldFilterInferiorFacets bool) *pbv2.ObservationResponse {
 	response := newObservationResponse(variable)
 
 	variableEntityObs := groupObservationsByVariableAndEntity(observations)
 	for variableEntity, obs := range variableEntityObs {
-		orderedFacets, facets := observationsToOrderedFacets(obs, includeObs, shouldFilterInferiorFacets)
+		orderedFacets, facets := observationsToOrderedFacets(obs, includeObs, includeObsMetadata, shouldFilterInferiorFacets)
 		variableObs, ok := response.ByVariable[variableEntity.variable]
 		if !ok {
 			variableObs = &pbv2.VariableObservation{
@@ -471,13 +471,25 @@ func mergeEntityOrderedFacets(
 	return result
 }
 
-func obsToObsResponse(req *pbv2.ObservationRequest, observations []*Observation) *pbv2.ObservationResponse {
-	// Whether the response should filter out low ranked facets from the response.
-	isContainedInWithDate := (req.Entity.Expression != "" && req.Date != "")
-	isDirectWithLatestDate := (req.Entity.Expression == "" && req.Date == shared.LATEST)
-	shouldFilterInferiorFacets := isContainedInWithDate || isDirectWithLatestDate
+// shouldFilterInferiorFacets reports whether the response should omit low-ranked facets.
+func shouldFilterInferiorFacets(req *pbv2.ObservationRequest) bool {
+	entityExpression := req.GetEntity().GetExpression()
+	date := req.GetDate()
+	isContainedInWithDate := entityExpression != "" && date != ""
+	isDirectWithLatestDate := entityExpression == "" && date == shared.LATEST
 
-	response := generateObsResponse(req.Variable, observations, true /*includeObs*/, shouldFilterInferiorFacets)
+	return isContainedInWithDate || isDirectWithLatestDate
+}
+
+// includeObsMetadata reports whether observation count and date bounds should be returned.
+func includeObsMetadata(req *pbv2.ObservationRequest) bool {
+	return req.GetEntity().GetExpression() == "" || req.GetDate() == ""
+}
+
+func obsToObsResponse(req *pbv2.ObservationRequest, observations []*Observation) *pbv2.ObservationResponse {
+	includeMetadata := includeObsMetadata(req)
+	filterInferiorFacets := shouldFilterInferiorFacets(req)
+	response := generateObsResponse(req.Variable, observations, true /*includeObs*/, includeMetadata, filterInferiorFacets)
 
 	// Attach all requested entity dcids to response.
 	if len(req.Entity.Dcids) > 0 {
@@ -495,7 +507,8 @@ func obsToObsResponse(req *pbv2.ObservationRequest, observations []*Observation)
 }
 
 func obsToFacetResponse(req *pbv2.ObservationRequest, observations []*Observation) *pbv2.ObservationResponse {
-	response := generateObsResponse(req.Variable, observations, false /*includeObs*/, false /*shouldFilterInferiorFacets*/)
+	includeMetadata := includeObsMetadata(req)
+	response := generateObsResponse(req.Variable, observations, false /*includeObs*/, includeMetadata, false /*shouldFilterInferiorFacets*/)
 
 	if len(req.Entity.Dcids) > 0 {
 		return response
@@ -538,13 +551,14 @@ func obsToExistenceResponse(req *pbv2.ObservationRequest, observations []*Observ
 func observationsToOrderedFacets(
 	observations []*Observation,
 	includeObs bool,
+	includeObsMetadata bool,
 	shouldFilterInferiorFacets bool,
 ) ([]*pbv2.FacetObservation, map[string]*pb.Facet) {
 	facets := map[string]*pb.Facet{}
 	placeVariableFacets := []*pb.PlaceVariableFacet{}
 	facetIdToFacetObs := map[string]*pbv2.FacetObservation{}
 	for _, obs := range observations {
-		pvf, facetObs := observationToFacetObservation(obs, includeObs)
+		pvf, facetObs := observationToFacetObservation(obs, includeObs, includeObsMetadata)
 
 		// Skip rows with no time series.
 		if pvf == nil {
@@ -574,6 +588,7 @@ func observationsToOrderedFacets(
 func observationToFacetObservation(
 	observation *Observation,
 	includeObs bool,
+	includeObsMetadata bool,
 ) (*pb.PlaceVariableFacet, *pbv2.FacetObservation) {
 	facet := observationToFacet(observation)
 
@@ -599,23 +614,30 @@ func observationToFacetObservation(
 		return nil, nil
 	}
 
+	obsCount := int32(len(observations))
+	earliestDate := observations[0].Date
+	latestDate := observations[len(observations)-1].Date
+
 	facetObservation := &pbv2.FacetObservation{
-		FacetId:      observation.FacetId,
-		ObsCount:     *proto.Int32(int32(len(observations))),
-		EarliestDate: observations[0].Date,
-		LatestDate:   observations[len(observations)-1].Date,
+		FacetId: observation.FacetId,
 	}
 
 	if includeObs {
 		facetObservation.Observations = observations
 	}
 
+	if includeObsMetadata {
+		facetObservation.ObsCount = obsCount
+		facetObservation.EarliestDate = earliestDate
+		facetObservation.LatestDate = latestDate
+	}
+
 	placeVariableFacet := &pb.PlaceVariableFacet{
 		Facet:        facet,
 		FacetId:      observation.FacetId,
-		ObsCount:     facetObservation.ObsCount,
-		EarliestDate: facetObservation.EarliestDate,
-		LatestDate:   facetObservation.LatestDate,
+		ObsCount:     obsCount,
+		EarliestDate: earliestDate,
+		LatestDate:   latestDate,
 	}
 
 	return placeVariableFacet, facetObservation

--- a/internal/server/spanner/dsutil_test.go
+++ b/internal/server/spanner/dsutil_test.go
@@ -263,3 +263,119 @@ func TestFilterObservationsByDateAndFacet(t *testing.T) {
 	}
 }
 
+func TestIncludeObsMetadata(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *pbv2.ObservationRequest
+		want bool
+	}{
+		{
+			name: "contained in all dates",
+			req: &pbv2.ObservationRequest{
+				Entity: &pbv2.DcidOrExpression{Expression: "geoId/06<-containedInPlace+{typeOf:County}"},
+			},
+			want: true,
+		},
+		{
+			name: "contained in specific date",
+			req: &pbv2.ObservationRequest{
+				Entity: &pbv2.DcidOrExpression{Expression: "geoId/06<-containedInPlace+{typeOf:County}"},
+				Date:   "2020",
+			},
+			want: false,
+		},
+		{
+			name: "contained in latest",
+			req: &pbv2.ObservationRequest{
+				Entity: &pbv2.DcidOrExpression{Expression: "geoId/06<-containedInPlace+{typeOf:County}"},
+				Date:   "LATEST",
+			},
+			want: false,
+		},
+		{
+			name: "direct latest",
+			req: &pbv2.ObservationRequest{
+				Entity: &pbv2.DcidOrExpression{Dcids: []string{"geoId/06"}},
+				Date:   "LATEST",
+			},
+			want: true,
+		},
+		{
+			name: "missing entity",
+			req:  &pbv2.ObservationRequest{},
+			want: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := includeObsMetadata(tc.req); got != tc.want {
+				t.Errorf("includeObsMetadata() = %t, want %t", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDatedExpressionResponseOmitsMetadataAndPreservesFacetRanking(t *testing.T) {
+	const (
+		variable = "Count_Person"
+		entity   = "geoId/06001"
+	)
+	observations := []*Observation{
+		{
+			VariableMeasured:  variable,
+			ObservationAbout:  entity,
+			FacetId:           "latest-facet",
+			ImportName:        "CensusACS5YearSurvey",
+			MeasurementMethod: "CensusACS5yrSurvey",
+			ProvenanceURL:     "z.example",
+			Observations:      TimeSeries{{Date: "2020", Value: "2"}},
+		},
+		{
+			VariableMeasured:  variable,
+			ObservationAbout:  entity,
+			FacetId:           "older-facet",
+			ImportName:        "CensusACS5YearSurvey",
+			MeasurementMethod: "CensusACS5yrSurvey",
+			ProvenanceURL:     "a.example",
+			Observations:      TimeSeries{{Date: "2019", Value: "1"}},
+		},
+	}
+	containedInReq := &pbv2.ObservationRequest{
+		Variable: &pbv2.DcidOrExpression{Dcids: []string{variable}},
+		Entity:   &pbv2.DcidOrExpression{Expression: "geoId/06<-containedInPlace+{typeOf:County}"},
+		Date:     "LATEST",
+	}
+
+	response := obsToObsResponse(containedInReq, observations)
+	orderedFacets := response.ByVariable[variable].ByEntity[entity].OrderedFacets
+	if got, want := len(orderedFacets), 2; got != want {
+		t.Fatalf("len(orderedFacets) = %d, want %d", got, want)
+	}
+	if got, want := orderedFacets[0].FacetId, "latest-facet"; got != want {
+		t.Errorf("orderedFacets[0].FacetId = %q, want %q", got, want)
+	}
+	for _, facet := range orderedFacets {
+		if facet.ObsCount != 0 || facet.EarliestDate != "" || facet.LatestDate != "" {
+			t.Errorf("facet %q metadata = (%d, %q, %q), want omitted", facet.FacetId, facet.ObsCount, facet.EarliestDate, facet.LatestDate)
+		}
+	}
+
+	facetResponse := obsToFacetResponse(containedInReq, observations)
+	for _, facet := range facetResponse.ByVariable[variable].ByEntity[entityPlaceholder].OrderedFacets {
+		if facet.ObsCount != 0 || facet.EarliestDate != "" || facet.LatestDate != "" {
+			t.Errorf("facet-only response metadata = (%d, %q, %q), want omitted", facet.ObsCount, facet.EarliestDate, facet.LatestDate)
+		}
+	}
+
+	directReq := &pbv2.ObservationRequest{
+		Variable: &pbv2.DcidOrExpression{Dcids: []string{variable}},
+		Entity:   &pbv2.DcidOrExpression{Dcids: []string{entity}},
+		Date:     "LATEST",
+	}
+	directResponse := obsToObsResponse(directReq, observations)
+	directFacet := directResponse.ByVariable[variable].ByEntity[entity].OrderedFacets[0]
+	if directFacet.ObsCount == 0 || directFacet.EarliestDate == "" || directFacet.LatestDate == "" {
+		t.Errorf("direct response metadata = (%d, %q, %q), want populated", directFacet.ObsCount, directFacet.EarliestDate, directFacet.LatestDate)
+	}
+}

--- a/internal/server/spanner/golden/query_builder/get_multientity_obs_contained_in_place_both.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_obs_contained_in_place_both.sql
@@ -7,25 +7,37 @@
 				AND e.object_id = 'geoId/10'
 				AND e2.predicate = 'typeOf'
 				AND e2.object_id = 'County'
+		),
+		series AS (
+			SELECT
+				t.variable_measured,
+				t.entity1,
+				t.extra_entities_id,
+				t.facet_id,
+				t.provenance,
+				t.facet
+			FROM places p
+			JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} TimeSeries@{FORCE_INDEX=_BASE_TABLE} t
+				ON t.variable_measured IN ('AirPollutant_Cancer_Risk')
+				AND t.entity1 = p.place_id
 		)
 		SELECT
 			t.variable_measured,
 			t.entity1 AS observation_about,
 			t.facet_id,
-			t.provenance,
-			COALESCE(
-				(
-					SELECT ARRAY_AGG(STRUCT(date, value AS str_value))
-					FROM Observation o
-					WHERE o.variable_measured = t.variable_measured
-						AND o.entity1 = t.entity1
-						AND o.extra_entities_id = t.extra_entities_id
-						AND o.facet_id = t.facet_id
-				),
-				ARRAY(SELECT AS STRUCT CAST(NULL AS STRING) AS date, CAST(NULL AS STRING) AS str_value FROM UNNEST([1]) WHERE FALSE)
+			ANY_VALUE(t.provenance) AS provenance,
+			ARRAY_AGG(
+				STRUCT(
+					o.date AS date,
+					o.value AS str_value
+				)
 			) AS dates_and_values,
-			t.facet AS facets
-		FROM places p
-		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} TimeSeries@{FORCE_INDEX=_BASE_TABLE} t
-			ON t.variable_measured IN ('AirPollutant_Cancer_Risk')
-			AND t.entity1 = p.place_id
+			ANY_VALUE(t.facet) AS facets
+		FROM series t
+		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} Observation o
+		USING (variable_measured, entity1, extra_entities_id, facet_id)
+		GROUP BY
+			t.variable_measured,
+			t.entity1,
+			t.extra_entities_id,
+			t.facet_id

--- a/internal/server/spanner/golden/query_builder/get_multientity_obs_contained_in_place_date.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_obs_contained_in_place_date.sql
@@ -21,11 +21,12 @@
 						AND o.entity1 = t.entity1
 						AND o.extra_entities_id = t.extra_entities_id
 						AND o.facet_id = t.facet_id
+						AND o.date = '2015'
 				),
 				ARRAY(SELECT AS STRUCT CAST(NULL AS STRING) AS date, CAST(NULL AS STRING) AS str_value FROM UNNEST([1]) WHERE FALSE)
 			) AS dates_and_values,
 			t.facet AS facets
 		FROM places p
 		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} TimeSeries@{FORCE_INDEX=_BASE_TABLE} t
-			ON t.variable_measured IN ('AirPollutant_Cancer_Risk')
+			ON t.variable_measured IN ('AirPollutant_Cancer_Risk','Count_Person')
 			AND t.entity1 = p.place_id

--- a/internal/server/spanner/golden/query_builder/get_multientity_obs_contained_in_place_date.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_obs_contained_in_place_date.sql
@@ -7,26 +7,32 @@
 				AND e.object_id = 'geoId/10'
 				AND e2.predicate = 'typeOf'
 				AND e2.object_id = 'County'
+		),
+		series AS (
+			SELECT
+				t.variable_measured,
+				t.entity1,
+				t.extra_entities_id,
+				t.facet_id,
+				t.provenance,
+				t.facet
+			FROM places p
+			JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} TimeSeries@{FORCE_INDEX=_BASE_TABLE} t
+				ON t.variable_measured IN ('AirPollutant_Cancer_Risk','Count_Person')
+				AND t.entity1 = p.place_id
 		)
 		SELECT
 			t.variable_measured,
 			t.entity1 AS observation_about,
 			t.facet_id,
 			t.provenance,
-			COALESCE(
-				(
-					SELECT ARRAY_AGG(STRUCT(date, value AS str_value))
-					FROM Observation o
-					WHERE o.variable_measured = t.variable_measured
-						AND o.entity1 = t.entity1
-						AND o.extra_entities_id = t.extra_entities_id
-						AND o.facet_id = t.facet_id
-						AND o.date = '2015'
-				),
-				ARRAY(SELECT AS STRUCT CAST(NULL AS STRING) AS date, CAST(NULL AS STRING) AS str_value FROM UNNEST([1]) WHERE FALSE)
+			ARRAY(
+				SELECT AS STRUCT
+					o.date AS date,
+					o.value AS str_value
 			) AS dates_and_values,
 			t.facet AS facets
-		FROM places p
-		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} TimeSeries@{FORCE_INDEX=_BASE_TABLE} t
-			ON t.variable_measured IN ('AirPollutant_Cancer_Risk','Count_Person')
-			AND t.entity1 = p.place_id
+		FROM series t
+		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} Observation o
+		USING (variable_measured, entity1, extra_entities_id, facet_id)
+		WHERE o.date = '2015'

--- a/internal/server/spanner/golden/query_builder/get_multientity_obs_contained_in_place_latest.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_obs_contained_in_place_latest.sql
@@ -1,9 +1,12 @@
+		@{SCAN_METHOD=COLUMNAR, EXECUTION_METHOD=BATCH}
 		WITH places AS (
-			SELECT result.object_id AS place_id
-			FROM GRAPH_TABLE (
-				DCGraph MATCH <-[e:Edge WHERE e.object_id = 'geoId/10' AND e.predicate = 'linkedContainedInPlace']-()-[{predicate: 'typeOf', object_id: 'County'}]->
-				RETURN e.subject_id AS object_id
-			) result
+			SELECT DISTINCT e.subject_id AS place_id
+			FROM Edge e
+			JOIN Edge e2 ON e.subject_id = e2.subject_id
+			WHERE e.predicate = 'linkedContainedInPlace'
+				AND e.object_id = 'geoId/10'
+				AND e2.predicate = 'typeOf'
+				AND e2.object_id = 'County'
 		)
 		SELECT
 			t.variable_measured,
@@ -27,6 +30,6 @@
 			) AS dates_and_values,
 			t.facet AS facets
 		FROM places p
-		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} TimeSeries t
+		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} TimeSeries@{FORCE_INDEX=_BASE_TABLE} t
 			ON t.variable_measured IN ('AirPollutant_Cancer_Risk')
 			AND t.entity1 = p.place_id

--- a/internal/server/spanner/golden/query_builder/get_multientity_obs_contained_in_place_latest.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_obs_contained_in_place_latest.sql
@@ -7,29 +7,42 @@
 				AND e.object_id = 'geoId/10'
 				AND e2.predicate = 'typeOf'
 				AND e2.object_id = 'County'
+		),
+		series AS (
+			SELECT
+				t.variable_measured,
+				t.entity1,
+				t.extra_entities_id,
+				t.facet_id,
+				t.provenance,
+				t.facet
+			FROM places p
+			JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} TimeSeries@{FORCE_INDEX=_BASE_TABLE} t
+				ON t.variable_measured IN ('AirPollutant_Cancer_Risk')
+				AND t.entity1 = p.place_id
 		)
 		SELECT
 			t.variable_measured,
 			t.entity1 AS observation_about,
 			t.facet_id,
-			t.provenance,
+			ANY_VALUE(t.provenance) AS provenance,
 			COALESCE(
-				(
-					SELECT ARRAY(
-						SELECT AS STRUCT date, value AS str_value
-						FROM Observation o
-						WHERE o.variable_measured = t.variable_measured
-							AND o.entity1 = t.entity1
-							AND o.extra_entities_id = t.extra_entities_id
-							AND o.facet_id = t.facet_id
-						ORDER BY date DESC
-						LIMIT 1
+				ARRAY_AGG(
+					STRUCT(
+						o.date AS date,
+						o.value AS str_value
 					)
+					ORDER BY o.date DESC
+					LIMIT 1
 				),
 				ARRAY(SELECT AS STRUCT CAST(NULL AS STRING) AS date, CAST(NULL AS STRING) AS str_value FROM UNNEST([1]) WHERE FALSE)
 			) AS dates_and_values,
-			t.facet AS facets
-		FROM places p
-		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} TimeSeries@{FORCE_INDEX=_BASE_TABLE} t
-			ON t.variable_measured IN ('AirPollutant_Cancer_Risk')
-			AND t.entity1 = p.place_id
+			ANY_VALUE(t.facet) AS facets
+		FROM series t
+		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} Observation o
+		USING (variable_measured, entity1, extra_entities_id, facet_id)
+		GROUP BY
+			t.variable_measured,
+			t.entity1,
+			t.extra_entities_id,
+			t.facet_id

--- a/internal/server/spanner/golden/query_builder_multientity_test.go
+++ b/internal/server/spanner/golden/query_builder_multientity_test.go
@@ -233,6 +233,19 @@ func TestMultiEntityQueryBuildersUseCustomTableConfig(t *testing.T) {
 	}
 	assertSQLContains(t, obsStmt.SQL, "CustomObsTable", "CustomTsTable")
 
+	containedInStmt, err := builder.GetObservationsContainedInPlaceQuery(
+		[]string{"Count_Person"},
+		&v2.ContainedInPlace{Ancestor: "geoId/06", ChildPlaceType: "County"},
+		"",
+	)
+	if err != nil {
+		t.Fatalf("GetObservationsContainedInPlaceQuery() returned error: %v", err)
+	}
+	assertSQLContains(t, containedInStmt.SQL,
+		"CustomObsTable",
+		"CustomTsTable@{FORCE_INDEX=_BASE_TABLE}",
+	)
+
 	existenceStmt, err := builder.GetStatVarsByEntityQuery(
 		[]string{"Count_Person"},
 		[]string{"geoId/06"},

--- a/internal/server/spanner/golden/query_multientity_cases_test.go
+++ b/internal/server/spanner/golden/query_multientity_cases_test.go
@@ -128,6 +128,14 @@ var multiEntityObservationsContainedInPlaceTestCases = []struct {
 		date:           "latest",
 		golden:         "get_multientity_obs_contained_in_place_latest",
 	},
+	{
+		name:           "contained in place specific date with variables",
+		variables:      []string{"AirPollutant_Cancer_Risk", "Count_Person"},
+		ancestor:       "geoId/10",
+		childPlaceType: "County",
+		date:           "2015",
+		golden:         "get_multientity_obs_contained_in_place_date",
+	},
 }
 
 var multiEntityStatVarGroupNodeTestCases = []struct {

--- a/internal/server/spanner/query_multientity_test.go
+++ b/internal/server/spanner/query_multientity_test.go
@@ -66,6 +66,49 @@ func TestReconstructObservationsUsesStoredFacetID(t *testing.T) {
 	}
 }
 
+func TestReconstructObservationsSortsDates(t *testing.T) {
+	observations, err := reconstructObservations([]*rawObservation{
+		{
+			VariableMeasured: "Count_Person",
+			ObservationAbout: "geoId/06",
+			FacetId:          "stored-facet-id",
+			DatesAndValues: []*spannerObservation{
+				{Date: "2021", Value: "3"},
+				{Date: "2019", Value: "1"},
+				{Date: "2020", Value: "2"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("reconstructObservations() = %v", err)
+	}
+
+	got := observations[0].Observations
+	want := []struct {
+		date  string
+		value string
+	}{
+		{date: "2019", value: "1"},
+		{date: "2020", value: "2"},
+		{date: "2021", value: "3"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("len(Observations) = %d, want %d", len(got), len(want))
+	}
+	for i, expected := range want {
+		if got[i].Date != expected.date || got[i].Value != expected.value {
+			t.Errorf(
+				"Observations[%d] = (%q, %q), want (%q, %q)",
+				i,
+				got[i].Date,
+				got[i].Value,
+				expected.date,
+				expected.value,
+			)
+		}
+	}
+}
+
 func TestReconstructObservationsAttributes(t *testing.T) {
 	for _, tc := range []struct {
 		name       string

--- a/internal/server/spanner/query_multientity_test.go
+++ b/internal/server/spanner/query_multientity_test.go
@@ -346,6 +346,7 @@ func TestMultiEntityObservationResponseIncludesProvenanceID(t *testing.T) {
 		&pbv2.DcidOrExpression{Dcids: []string{"Count_Person"}},
 		observations,
 		true,  /* includeObs */
+		true,  /* includeObsMetadata */
 		false, /* shouldFilterInferiorFacets */
 	)
 	facet := resp.Facets["stored-facet-id"]

--- a/internal/server/spanner/statements_multientity.go
+++ b/internal/server/spanner/statements_multientity.go
@@ -213,7 +213,8 @@ func NewMultiEntityStatements(cfg TableConfig) (*MultiEntityStatements, error) {
 		FROM %[2]s t
 		WHERE t.entity1 IN UNNEST(@entities)`, cfg.ObservationTable, cfg.TimeSeriesTable),
 
-		// Contained in place query with variables filtered (full series)
+		// Keep full-series aggregation correlated per TimeSeries so Spanner can
+		// stream completed series without a global hash aggregate.
 		getObsByContainedInPlaceBoth: fmt.Sprintf(`		@{SCAN_METHOD=COLUMNAR, EXECUTION_METHOD=BATCH}
 		WITH places AS (
 			SELECT DISTINCT e.subject_id AS place_id
@@ -246,7 +247,8 @@ func NewMultiEntityStatements(cfg TableConfig) (*MultiEntityStatements, error) {
 			ON t.variable_measured IN UNNEST(@variables)
 			AND t.entity1 = p.place_id`, cfg.ObservationTable, cfg.TimeSeriesTable),
 
-		// Contained in place query with variables filtered (specific date)
+		// Join the exact-date query to Observation so TimeSeries without the
+		// requested date are discarded in Spanner.
 		getObsByContainedInPlaceBothWithDate: fmt.Sprintf(`		@{SCAN_METHOD=COLUMNAR, EXECUTION_METHOD=BATCH}
 		WITH places AS (
 			SELECT DISTINCT e.subject_id AS place_id
@@ -256,31 +258,38 @@ func NewMultiEntityStatements(cfg TableConfig) (*MultiEntityStatements, error) {
 				AND e.object_id = @ancestor
 				AND e2.predicate = 'typeOf'
 				AND e2.object_id = @childPlaceType
+		),
+		series AS (
+			SELECT
+				t.variable_measured,
+				t.entity1,
+				t.extra_entities_id,
+				t.facet_id,
+				t.provenance,
+				t.facet
+			FROM places p
+			JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} %[2]s@{FORCE_INDEX=_BASE_TABLE} t
+				ON t.variable_measured IN UNNEST(@variables)
+				AND t.entity1 = p.place_id
 		)
 		SELECT
 			t.variable_measured,
 			t.entity1 AS observation_about,
 			t.facet_id,
 			t.provenance,
-			COALESCE(
-				(
-					SELECT ARRAY_AGG(STRUCT(date, value AS str_value))
-					FROM %[1]s o
-					WHERE o.variable_measured = t.variable_measured
-						AND o.entity1 = t.entity1
-						AND o.extra_entities_id = t.extra_entities_id
-						AND o.facet_id = t.facet_id
-						AND o.date = @date
-				),
-				ARRAY(SELECT AS STRUCT CAST(NULL AS STRING) AS date, CAST(NULL AS STRING) AS str_value FROM UNNEST([1]) WHERE FALSE)
+			ARRAY(
+				SELECT AS STRUCT
+					o.date AS date,
+					o.value AS str_value
 			) AS dates_and_values,
 			t.facet AS facets
-		FROM places p
-		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} %[2]s@{FORCE_INDEX=_BASE_TABLE} t
-			ON t.variable_measured IN UNNEST(@variables)
-			AND t.entity1 = p.place_id`, cfg.ObservationTable, cfg.TimeSeriesTable),
+		FROM series t
+		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} %[1]s o
+		USING (variable_measured, entity1, extra_entities_id, facet_id)
+		WHERE o.date = @date`, cfg.ObservationTable, cfg.TimeSeriesTable),
 
-		// Contained in place query with variables filtered (latest only)
+		// Keep latest correlated per TimeSeries so the date-descending child key
+		// can satisfy LIMIT 1 without a global hash aggregate.
 		getObsByContainedInPlaceBothLatest: fmt.Sprintf(`		@{SCAN_METHOD=COLUMNAR, EXECUTION_METHOD=BATCH}
 		WITH places AS (
 			SELECT DISTINCT e.subject_id AS place_id

--- a/internal/server/spanner/statements_multientity.go
+++ b/internal/server/spanner/statements_multientity.go
@@ -214,12 +214,15 @@ func NewMultiEntityStatements(cfg TableConfig) (*MultiEntityStatements, error) {
 		WHERE t.entity1 IN UNNEST(@entities)`, cfg.ObservationTable, cfg.TimeSeriesTable),
 
 		// Contained in place query with variables filtered (full series)
-		getObsByContainedInPlaceBoth: fmt.Sprintf(`		WITH places AS (
-			SELECT result.object_id AS place_id
-			FROM GRAPH_TABLE (
-				DCGraph MATCH <-[e:Edge WHERE e.object_id = @ancestor AND e.predicate = 'linkedContainedInPlace']-()-[{predicate: 'typeOf', object_id: @childPlaceType}]->
-				RETURN e.subject_id AS object_id
-			) result
+		getObsByContainedInPlaceBoth: fmt.Sprintf(`		@{SCAN_METHOD=COLUMNAR, EXECUTION_METHOD=BATCH}
+		WITH places AS (
+			SELECT DISTINCT e.subject_id AS place_id
+			FROM Edge e
+			JOIN Edge e2 ON e.subject_id = e2.subject_id
+			WHERE e.predicate = 'linkedContainedInPlace'
+				AND e.object_id = @ancestor
+				AND e2.predicate = 'typeOf'
+				AND e2.object_id = @childPlaceType
 		)
 		SELECT
 			t.variable_measured,
@@ -239,17 +242,20 @@ func NewMultiEntityStatements(cfg TableConfig) (*MultiEntityStatements, error) {
 			) AS dates_and_values,
 			t.facet AS facets
 		FROM places p
-		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} %[2]s t
+		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} %[2]s@{FORCE_INDEX=_BASE_TABLE} t
 			ON t.variable_measured IN UNNEST(@variables)
 			AND t.entity1 = p.place_id`, cfg.ObservationTable, cfg.TimeSeriesTable),
 
 		// Contained in place query with variables filtered (specific date)
-		getObsByContainedInPlaceBothWithDate: fmt.Sprintf(`		WITH places AS (
-			SELECT result.object_id AS place_id
-			FROM GRAPH_TABLE (
-				DCGraph MATCH <-[e:Edge WHERE e.object_id = @ancestor AND e.predicate = 'linkedContainedInPlace']-()-[{predicate: 'typeOf', object_id: @childPlaceType}]->
-				RETURN e.subject_id AS object_id
-			) result
+		getObsByContainedInPlaceBothWithDate: fmt.Sprintf(`		@{SCAN_METHOD=COLUMNAR, EXECUTION_METHOD=BATCH}
+		WITH places AS (
+			SELECT DISTINCT e.subject_id AS place_id
+			FROM Edge e
+			JOIN Edge e2 ON e.subject_id = e2.subject_id
+			WHERE e.predicate = 'linkedContainedInPlace'
+				AND e.object_id = @ancestor
+				AND e2.predicate = 'typeOf'
+				AND e2.object_id = @childPlaceType
 		)
 		SELECT
 			t.variable_measured,
@@ -270,17 +276,20 @@ func NewMultiEntityStatements(cfg TableConfig) (*MultiEntityStatements, error) {
 			) AS dates_and_values,
 			t.facet AS facets
 		FROM places p
-		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} %[2]s t
+		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} %[2]s@{FORCE_INDEX=_BASE_TABLE} t
 			ON t.variable_measured IN UNNEST(@variables)
 			AND t.entity1 = p.place_id`, cfg.ObservationTable, cfg.TimeSeriesTable),
 
 		// Contained in place query with variables filtered (latest only)
-		getObsByContainedInPlaceBothLatest: fmt.Sprintf(`		WITH places AS (
-			SELECT result.object_id AS place_id
-			FROM GRAPH_TABLE (
-				DCGraph MATCH <-[e:Edge WHERE e.object_id = @ancestor AND e.predicate = 'linkedContainedInPlace']-()-[{predicate: 'typeOf', object_id: @childPlaceType}]->
-				RETURN e.subject_id AS object_id
-			) result
+		getObsByContainedInPlaceBothLatest: fmt.Sprintf(`		@{SCAN_METHOD=COLUMNAR, EXECUTION_METHOD=BATCH}
+		WITH places AS (
+			SELECT DISTINCT e.subject_id AS place_id
+			FROM Edge e
+			JOIN Edge e2 ON e.subject_id = e2.subject_id
+			WHERE e.predicate = 'linkedContainedInPlace'
+				AND e.object_id = @ancestor
+				AND e2.predicate = 'typeOf'
+				AND e2.object_id = @childPlaceType
 		)
 		SELECT
 			t.variable_measured,
@@ -304,7 +313,7 @@ func NewMultiEntityStatements(cfg TableConfig) (*MultiEntityStatements, error) {
 			) AS dates_and_values,
 			t.facet AS facets
 		FROM places p
-		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} %[2]s t
+		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} %[2]s@{FORCE_INDEX=_BASE_TABLE} t
 			ON t.variable_measured IN UNNEST(@variables)
 			AND t.entity1 = p.place_id`, cfg.ObservationTable, cfg.TimeSeriesTable),
 

--- a/internal/server/spanner/statements_multientity.go
+++ b/internal/server/spanner/statements_multientity.go
@@ -213,8 +213,7 @@ func NewMultiEntityStatements(cfg TableConfig) (*MultiEntityStatements, error) {
 		FROM %[2]s t
 		WHERE t.entity1 IN UNNEST(@entities)`, cfg.ObservationTable, cfg.TimeSeriesTable),
 
-		// Keep full-series aggregation correlated per TimeSeries so Spanner can
-		// stream completed series without a global hash aggregate.
+		// Join all dates before aggregation to optimize total result throughput.
 		getObsByContainedInPlaceBoth: fmt.Sprintf(`		@{SCAN_METHOD=COLUMNAR, EXECUTION_METHOD=BATCH}
 		WITH places AS (
 			SELECT DISTINCT e.subject_id AS place_id
@@ -224,28 +223,40 @@ func NewMultiEntityStatements(cfg TableConfig) (*MultiEntityStatements, error) {
 				AND e.object_id = @ancestor
 				AND e2.predicate = 'typeOf'
 				AND e2.object_id = @childPlaceType
+		),
+		series AS (
+			SELECT
+				t.variable_measured,
+				t.entity1,
+				t.extra_entities_id,
+				t.facet_id,
+				t.provenance,
+				t.facet
+			FROM places p
+			JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} %[2]s@{FORCE_INDEX=_BASE_TABLE} t
+				ON t.variable_measured IN UNNEST(@variables)
+				AND t.entity1 = p.place_id
 		)
 		SELECT
 			t.variable_measured,
 			t.entity1 AS observation_about,
 			t.facet_id,
-			t.provenance,
-			COALESCE(
-				(
-					SELECT ARRAY_AGG(STRUCT(date, value AS str_value))
-					FROM %[1]s o
-					WHERE o.variable_measured = t.variable_measured
-						AND o.entity1 = t.entity1
-						AND o.extra_entities_id = t.extra_entities_id
-						AND o.facet_id = t.facet_id
-				),
-				ARRAY(SELECT AS STRUCT CAST(NULL AS STRING) AS date, CAST(NULL AS STRING) AS str_value FROM UNNEST([1]) WHERE FALSE)
+			ANY_VALUE(t.provenance) AS provenance,
+			ARRAY_AGG(
+				STRUCT(
+					o.date AS date,
+					o.value AS str_value
+				)
 			) AS dates_and_values,
-			t.facet AS facets
-		FROM places p
-		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} %[2]s@{FORCE_INDEX=_BASE_TABLE} t
-			ON t.variable_measured IN UNNEST(@variables)
-			AND t.entity1 = p.place_id`, cfg.ObservationTable, cfg.TimeSeriesTable),
+			ANY_VALUE(t.facet) AS facets
+		FROM series t
+		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} %[1]s o
+		USING (variable_measured, entity1, extra_entities_id, facet_id)
+		GROUP BY
+			t.variable_measured,
+			t.entity1,
+			t.extra_entities_id,
+			t.facet_id`, cfg.ObservationTable, cfg.TimeSeriesTable),
 
 		// Join the exact-date query to Observation so TimeSeries without the
 		// requested date are discarded in Spanner.
@@ -288,8 +299,7 @@ func NewMultiEntityStatements(cfg TableConfig) (*MultiEntityStatements, error) {
 		USING (variable_measured, entity1, extra_entities_id, facet_id)
 		WHERE o.date = @date`, cfg.ObservationTable, cfg.TimeSeriesTable),
 
-		// Keep latest correlated per TimeSeries so the date-descending child key
-		// can satisfy LIMIT 1 without a global hash aggregate.
+		// Join latest observations before aggregation while preserving a non-null array.
 		getObsByContainedInPlaceBothLatest: fmt.Sprintf(`		@{SCAN_METHOD=COLUMNAR, EXECUTION_METHOD=BATCH}
 		WITH places AS (
 			SELECT DISTINCT e.subject_id AS place_id
@@ -299,32 +309,45 @@ func NewMultiEntityStatements(cfg TableConfig) (*MultiEntityStatements, error) {
 				AND e.object_id = @ancestor
 				AND e2.predicate = 'typeOf'
 				AND e2.object_id = @childPlaceType
+		),
+		series AS (
+			SELECT
+				t.variable_measured,
+				t.entity1,
+				t.extra_entities_id,
+				t.facet_id,
+				t.provenance,
+				t.facet
+			FROM places p
+			JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} %[2]s@{FORCE_INDEX=_BASE_TABLE} t
+				ON t.variable_measured IN UNNEST(@variables)
+				AND t.entity1 = p.place_id
 		)
 		SELECT
 			t.variable_measured,
 			t.entity1 AS observation_about,
 			t.facet_id,
-			t.provenance,
+			ANY_VALUE(t.provenance) AS provenance,
 			COALESCE(
-				(
-					SELECT ARRAY(
-						SELECT AS STRUCT date, value AS str_value
-						FROM %[1]s o
-						WHERE o.variable_measured = t.variable_measured
-							AND o.entity1 = t.entity1
-							AND o.extra_entities_id = t.extra_entities_id
-							AND o.facet_id = t.facet_id
-						ORDER BY date DESC
-						LIMIT 1
+				ARRAY_AGG(
+					STRUCT(
+						o.date AS date,
+						o.value AS str_value
 					)
+					ORDER BY o.date DESC
+					LIMIT 1
 				),
 				ARRAY(SELECT AS STRUCT CAST(NULL AS STRING) AS date, CAST(NULL AS STRING) AS str_value FROM UNNEST([1]) WHERE FALSE)
 			) AS dates_and_values,
-			t.facet AS facets
-		FROM places p
-		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} %[2]s@{FORCE_INDEX=_BASE_TABLE} t
-			ON t.variable_measured IN UNNEST(@variables)
-			AND t.entity1 = p.place_id`, cfg.ObservationTable, cfg.TimeSeriesTable),
+			ANY_VALUE(t.facet) AS facets
+		FROM series t
+		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} %[1]s o
+		USING (variable_measured, entity1, extra_entities_id, facet_id)
+		GROUP BY
+			t.variable_measured,
+			t.entity1,
+			t.extra_entities_id,
+			t.facet_id`, cfg.ObservationTable, cfg.TimeSeriesTable),
 
 		getSdmxObs: fmt.Sprintf("\t\tSELECT \n"+`			t.variable_measured,
 			t.entity1 AS observation_about,

--- a/internal/server/spanner/statements_multientity.go
+++ b/internal/server/spanner/statements_multientity.go
@@ -299,7 +299,8 @@ func NewMultiEntityStatements(cfg TableConfig) (*MultiEntityStatements, error) {
 		USING (variable_measured, entity1, extra_entities_id, facet_id)
 		WHERE o.date = @date`, cfg.ObservationTable, cfg.TimeSeriesTable),
 
-		// Join latest observations before aggregation while preserving a non-null array.
+		// Join latest observations before aggregation. COALESCE is required because
+		// Spanner rejects ARRAY_AGG(... LIMIT 1) as a potentially null-valued ARRAY<STRUCT>.
 		getObsByContainedInPlaceBothLatest: fmt.Sprintf(`		@{SCAN_METHOD=COLUMNAR, EXECUTION_METHOD=BATCH}
 		WITH places AS (
 			SELECT DISTINCT e.subject_id AS place_id


### PR DESCRIPTION
 Optimize multi-entity Spanner queries for contained-in-place observation requests.

  - Replace the graph query used for place expansion with SQL joins over `Edge`.
  - Use `DISTINCT` to deduplicate matching places.
  - Enable columnar scanning and batch execution.
  - Read TimeSeries from the base table using an ordered apply join.
  - Select candidate TimeSeries first, then join Observation using the complete series key:
    - `variable_measured`
    - `entity1`
    - `extra_entities_id`
    - `facet_id`
  - Preserve the existing SQL result shape returned to Mixer.
  - Keep variable filtering in the TimeSeries join; no variable cross join is introduced.

  All three multi-entity contained-in-place date modes are handled in SQL:

  - **All dates:** Join Observation and aggregate datapoints into one row per TimeSeries.
  - **Latest date:** Join Observation and use ordered `ARRAY_AGG ... LIMIT 1`, with a typed empty-array fallback to
  prevent nullable-array query errors.
  - **Exact date:** Apply the date predicate to Observation so TimeSeries without that date are excluded before
  results reach Mixer.

  The response builder also omits observation count and date-bound metadata for dated contained-in-place expressions.
  This matches production behavior and reduces large response sizes while preserving facet ranking and retaining
  metadata for direct-entity requests.

  SDMX query paths are unchanged.

  ## Why

  The previous correlated Observation subquery performed one scalar aggregation and child-range lookup per
  TimeSeries. Although it could return the first Spanner row earlier, its total throughput was lower for large
  nationwide requests, and Mixer waits for the complete Spanner result before responding.

  Joining and aggregating Observation rows allows Spanner to process the workload using distributed local and global
  aggregation. In testing, the nationwide all-dates `Count_Person` request improved from approximately 35 seconds
  with the correlated query to approximately 11 seconds with the joined query.

  For exact-date requests, joining Observation also prevents nonmatching TimeSeries from being transferred and
  reconstructed in Mixer. A tested request returned only the 166,950 series containing the requested date and
  completed in approximately 10 seconds, instead of returning 333,900 candidate series with empty arrays for
  nonmatches.