### PR TITLE
Force InEdge for filter queries

### DIFF
--- a/internal/server/spanner/golden/query_builder/get_node_edges_in_filter.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_in_filter.sql
@@ -1,11 +1,11 @@
 		GRAPH DCGraph MATCH (m:Node
 		WHERE
 			m.subject_id = 'Farm')<-[e:Edge]-(n:Node),
-		(n)-[filter0:Edge
+		(n)-[@{FORCE_INDEX=InEdge}filter0:Edge
 		WHERE
 			filter0.predicate = 'farmInventoryType'
 			AND filter0.object_id IN ('Melon','Melon:mxuMmhySOejKGXRXFbMXdorKlNV934EOop6b21kOJGw=')]->,
-		(n)-[filter1:Edge
+		(n)-[@{FORCE_INDEX=InEdge}filter1:Edge
 		WHERE
 			filter1.predicate = 'name'
 			AND filter1.object_id IN ('Area of Farm: Melon','Area of Farm: Me:xblU8pfFl5m+cg9tsR1EsW19+PLlpqfNhwYkFu0mgzE=')]->

--- a/internal/server/spanner/golden/query_builder/get_node_edges_linked_contained_in_place.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_linked_contained_in_place.sql
@@ -3,7 +3,7 @@
 			m.subject_id = 'country/USA')<-[e:Edge
 		WHERE
 			e.predicate = 'linkedContainedInPlace']-(n:Node),
-		(n)-[filter0:Edge
+		(n)-[@{FORCE_INDEX=InEdge}filter0:Edge
 		WHERE
 			filter0.predicate = 'typeOf'
 			AND filter0.object_id IN ('County','County:E2yH3sRpXO/vAw/W3Hwy+utigKeV/acLAXGXtg47eHM=')]->

--- a/internal/server/spanner/golden/query_builder/get_node_edges_malicious.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_malicious.sql
@@ -3,7 +3,7 @@
 			m.subject_id = 'foo OR 1=1;')<-[e:Edge
 		WHERE
 			e.predicate = 'foo OR 1=1;']-(n:Node),
-		(n)-[filter0:Edge
+		(n)-[@{FORCE_INDEX=InEdge}filter0:Edge
 		WHERE
 			filter0.predicate = 'foo OR 1=1;'
 			AND filter0.object_id IN ('foo OR 1=1;','foo OR 1=1;:OG7012T2qe10jzYRBvG6dgUEx5fj7uIxT+RkGvxpn/U=')]->

--- a/internal/server/spanner/golden/query_builder/get_node_edges_out_filter.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_out_filter.sql
@@ -1,11 +1,11 @@
 		GRAPH DCGraph MATCH (m:Node
 		WHERE
 			m.subject_id = 'nuts/UKI1')-[e:Edge]->(n:Node),
-		(n)-[filter0:Edge
+		(n)-[@{FORCE_INDEX=InEdge}filter0:Edge
 		WHERE
 			filter0.predicate = 'name'
 			AND filter0.object_id IN ('AdministrativeArea2','AdministrativeAr:4cB0ui47vrAeY7MO/uBAvpsajxkYlJo3EW8fStdW4ko=')]->,
-		(n)-[filter1:Edge
+		(n)-[@{FORCE_INDEX=InEdge}filter1:Edge
 		WHERE
 			filter1.predicate = 'subClassOf'
 			AND filter1.object_id IN ('AdministrativeArea','AdministrativeAr:WXALAhw8j+Uz/Tw7uR3ClTolVepyj0tjRCKr6Xkw60s=')]->

--- a/internal/server/spanner/query_builder.go
+++ b/internal/server/spanner/query_builder.go
@@ -183,7 +183,11 @@ func GetNodeEdgesByIDQuery(ids []string, arc *v2.Arc, pageSize, offset int) *spa
 					params["val"+strconv.Itoa(i)] = filterVal
 				}
 			}
-			subqueries = append(subqueries, fmt.Sprintf(statements.filterProperty, i, objectFilter))
+			indexHint := ""
+			if len(filterVal) > 0 {
+				indexHint = "@{FORCE_INDEX=InEdge}"
+			}
+			subqueries = append(subqueries, fmt.Sprintf(statements.filterProperty, i, indexHint, objectFilter))
 			i++
 		}
 	}

--- a/internal/server/spanner/statements.go
+++ b/internal/server/spanner/statements.go
@@ -203,9 +203,9 @@ var statements = struct {
 	filterPredicates: `
 		WHERE
 			e.predicate IN UNNEST(@predicate)`,
-	filterProperty: `(n)-[filter%[1]d:Edge
+	filterProperty: `(n)-[%[2]sfilter%[1]d:Edge
 		WHERE
-			filter%[1]d.predicate = @prop%[1]d%s]->`,
+			filter%[1]d.predicate = @prop%[1]d%[3]s]->`,
 	filterValue: `
 			AND filter%[1]d.object_id = @val%[1]d`,
 	filterValues: `


### PR DESCRIPTION
There was a regression in query plans for filter queries where the base table was being used, force a more stable query plan for filter queries, specifically using InEdge index.

