### PR TITLE
Migrate Spanner layer to KeyValueStore with feature toggle and clean up client constructor options

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -208,7 +208,7 @@ func main() {
 	var spannerClient spanner.SpannerClient
 	if shouldUseSpannerGraph {
 		var err error
-		spannerClient, err = spanner.NewSpannerClient(ctx, *spannerGraphInfo, flags.SpannerGraphDatabase, flags.UseMultiEntitySchema, flags.UseNewIngestionHistorySchema)
+		spannerClient, err = spanner.NewSpannerClient(ctx, *spannerGraphInfo, flags.SpannerGraphDatabase, flags.UseMultiEntitySchema, flags.UseNewIngestionHistorySchema, flags.UseSpannerKeyValueStore)
 		if err != nil {
 			slog.Error("Failed to create Spanner client", "error", err)
 			os.Exit(1)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -208,7 +208,12 @@ func main() {
 	var spannerClient spanner.SpannerClient
 	if shouldUseSpannerGraph {
 		var err error
-		spannerClient, err = spanner.NewSpannerClient(ctx, *spannerGraphInfo, flags.SpannerGraphDatabase, flags.UseMultiEntitySchema, flags.UseNewIngestionHistorySchema, flags.UseSpannerKeyValueStore)
+		spannerClient, err = spanner.NewSpannerClient(ctx, *spannerGraphInfo, &spanner.SpannerClientOptions{
+			DatabaseOverride:             flags.SpannerGraphDatabase,
+			UseMultiEntitySchema:         flags.UseMultiEntitySchema,
+			UseNewIngestionHistorySchema: flags.UseNewIngestionHistorySchema,
+			UseSpannerKeyValueStore:      flags.UseSpannerKeyValueStore,
+		})
 		if err != nil {
 			slog.Error("Failed to create Spanner client", "error", err)
 			os.Exit(1)

--- a/internal/featureflags/featureflags.go
+++ b/internal/featureflags/featureflags.go
@@ -54,6 +54,8 @@ type Flags struct {
 	EnableSpannerSearchEmbeddings bool `yaml:"EnableSpannerSearchEmbeddings"`
 	// Whether to use the new IngestionHistory schema with Timestamp.
 	UseNewIngestionHistorySchema bool `yaml:"UseNewIngestionHistorySchema"`
+	// Whether to read from KeyValueStore table instead of Cache table in Spanner.
+	UseSpannerKeyValueStore bool `yaml:"UseSpannerKeyValueStore"`
 }
 
 // setDefaultValues creates a new Flags struct with default values.
@@ -71,6 +73,7 @@ func setDefaultValues() *Flags {
 		EnableSDMXDataApi:             false,
 		EnableSpannerSearchEmbeddings: false,
 		UseNewIngestionHistorySchema:  false,
+		UseSpannerKeyValueStore:       false,
 	}
 }
 

--- a/internal/featureflags/featureflags.go
+++ b/internal/featureflags/featureflags.go
@@ -105,6 +105,9 @@ func (f *Flags) validateFlagValues() error {
 	if f.V2DivertFraction > 0 && !f.UseSpannerGraph {
 		return fmt.Errorf("V2DivertFraction > 0 requires UseSpannerGraph to be true")
 	}
+	if f.UseSpannerKeyValueStore && !f.UseSpannerGraph {
+		return fmt.Errorf("UseSpannerKeyValueStore requires UseSpannerGraph to be true")
+	}
 	return nil
 }
 

--- a/internal/featureflags/featureflags_test.go
+++ b/internal/featureflags/featureflags_test.go
@@ -171,6 +171,29 @@ flags:
 			want:    nil,
 			wantErr: true,
 		},
+		{
+			name: "validation error - UseSpannerKeyValueStore without UseSpannerGraph",
+			fileContent: `
+flags:
+  UseSpannerGraph: false
+  UseSpannerKeyValueStore: true
+`,
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "valid UseSpannerKeyValueStore with UseSpannerGraph",
+			fileContent: `
+flags:
+  UseSpannerGraph: true
+  UseSpannerKeyValueStore: true
+`,
+			want: expectedFlags(func(f *Flags) {
+				f.UseSpannerGraph = true
+				f.UseSpannerKeyValueStore = true
+			}),
+			wantErr: false,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/server/spanner/client.go
+++ b/internal/server/spanner/client.go
@@ -94,12 +94,23 @@ type spannerDatabaseClient struct {
 	dbInitialized atomic.Bool
 }
 
+// SpannerClientOptions holds optional configuration settings and feature toggles for SpannerClient.
+type SpannerClientOptions struct {
+	DatabaseOverride             string
+	UseMultiEntitySchema         bool
+	UseNewIngestionHistorySchema bool
+	UseSpannerKeyValueStore      bool
+}
+
 // newSpannerDatabaseClient creates a new spannerDatabaseClient.
-func newSpannerDatabaseClient(client *spanner.Client, useNewSchema bool, useKeyValueStore bool) (*spannerDatabaseClient, error) {
+func newSpannerDatabaseClient(client *spanner.Client, opts *SpannerClientOptions) (*spannerDatabaseClient, error) {
+	if opts == nil {
+		opts = &SpannerClientOptions{}
+	}
 	sc := &spannerDatabaseClient{
 		client:                       client,
-		useNewIngestionHistorySchema: useNewSchema,
-		useSpannerKeyValueStore:      useKeyValueStore,
+		useNewIngestionHistorySchema: opts.UseNewIngestionHistorySchema,
+		useSpannerKeyValueStore:      opts.UseSpannerKeyValueStore,
 		tracker:                      newStalenessTracker(noChangeLogThreshold, failureLogThreshold),
 	}
 
@@ -115,8 +126,11 @@ func newSpannerDatabaseClient(client *spanner.Client, useNewSchema bool, useKeyV
 
 // NewRawSpannerClient creates a new SpannerClient without the schema selector.
 // This is intended for testing and internal use where a direct client is needed.
-func NewRawSpannerClient(ctx context.Context, spannerConfigYaml, databaseOverride string, useNewSchema bool, useKeyValueStore bool) (SpannerClient, error) {
-	cfg, err := createSpannerConfig(spannerConfigYaml, databaseOverride)
+func NewRawSpannerClient(ctx context.Context, spannerConfigYaml string, opts *SpannerClientOptions) (SpannerClient, error) {
+	if opts == nil {
+		opts = &SpannerClientOptions{}
+	}
+	cfg, err := createSpannerConfig(spannerConfigYaml, opts.DatabaseOverride)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create spannerDatabaseClient: %w", err)
 	}
@@ -124,7 +138,7 @@ func NewRawSpannerClient(ctx context.Context, spannerConfigYaml, databaseOverrid
 	if err != nil {
 		return nil, fmt.Errorf("failed to create spannerDatabaseClient: %w", err)
 	}
-	return newSpannerDatabaseClient(client, useNewSchema, useKeyValueStore)
+	return newSpannerDatabaseClient(client, opts)
 }
 
 // TableConfig holds the names of multi-entity Spanner tables and indexes.
@@ -149,12 +163,15 @@ func DefaultTableConfig() TableConfig {
 	}
 }
 
-func NewSpannerClient(ctx context.Context, spannerConfigYaml, databaseOverride string, useMultiEntitySchema bool, useNewIngestionHistorySchema bool, useSpannerKeyValueStore bool) (SpannerClient, error) {
-	rawClient, err := NewRawSpannerClient(ctx, spannerConfigYaml, databaseOverride, useNewIngestionHistorySchema, useSpannerKeyValueStore)
+func NewSpannerClient(ctx context.Context, spannerConfigYaml string, opts *SpannerClientOptions) (SpannerClient, error) {
+	if opts == nil {
+		opts = &SpannerClientOptions{}
+	}
+	rawClient, err := NewRawSpannerClient(ctx, spannerConfigYaml, opts)
 	if err != nil {
 		return nil, err
 	}
-	cfg, err := createSpannerConfig(spannerConfigYaml, databaseOverride)
+	cfg, err := createSpannerConfig(spannerConfigYaml, opts.DatabaseOverride)
 	if err != nil {
 		return nil, err
 	}
@@ -179,7 +196,7 @@ func NewSpannerClient(ctx context.Context, spannerConfigYaml, databaseOverride s
 		tableCfg.TimeSeriesByProvenanceIndex = *cfg.TimeSeriesByProvenanceIndex
 	}
 
-	return NewSchemaSelectorClient(rawClient, useMultiEntitySchema, tableCfg)
+	return NewSchemaSelectorClient(rawClient, opts.UseMultiEntitySchema, tableCfg)
 }
 
 // createSpannerClient creates the database name string and initializes the Spanner client.

--- a/internal/server/spanner/client.go
+++ b/internal/server/spanner/client.go
@@ -84,6 +84,8 @@ type spannerDatabaseClient struct {
 
 	// Flag to control query logic for IngestionHistory table.
 	useNewIngestionHistorySchema bool
+	// Flag to control reading from KeyValueStore instead of Cache table.
+	useSpannerKeyValueStore bool
 
 	// Logging/State tracking for the timestamp poller.
 	tracker *stalenessTracker
@@ -93,10 +95,11 @@ type spannerDatabaseClient struct {
 }
 
 // newSpannerDatabaseClient creates a new spannerDatabaseClient.
-func newSpannerDatabaseClient(client *spanner.Client, useNewSchema bool) (*spannerDatabaseClient, error) {
+func newSpannerDatabaseClient(client *spanner.Client, useNewSchema bool, useKeyValueStore bool) (*spannerDatabaseClient, error) {
 	sc := &spannerDatabaseClient{
 		client:                       client,
 		useNewIngestionHistorySchema: useNewSchema,
+		useSpannerKeyValueStore:      useKeyValueStore,
 		tracker:                      newStalenessTracker(noChangeLogThreshold, failureLogThreshold),
 	}
 
@@ -112,7 +115,7 @@ func newSpannerDatabaseClient(client *spanner.Client, useNewSchema bool) (*spann
 
 // NewRawSpannerClient creates a new SpannerClient without the schema selector.
 // This is intended for testing and internal use where a direct client is needed.
-func NewRawSpannerClient(ctx context.Context, spannerConfigYaml, databaseOverride string, useNewSchema bool) (SpannerClient, error) {
+func NewRawSpannerClient(ctx context.Context, spannerConfigYaml, databaseOverride string, useNewSchema bool, useKeyValueStore bool) (SpannerClient, error) {
 	cfg, err := createSpannerConfig(spannerConfigYaml, databaseOverride)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create spannerDatabaseClient: %w", err)
@@ -121,7 +124,7 @@ func NewRawSpannerClient(ctx context.Context, spannerConfigYaml, databaseOverrid
 	if err != nil {
 		return nil, fmt.Errorf("failed to create spannerDatabaseClient: %w", err)
 	}
-	return newSpannerDatabaseClient(client, useNewSchema)
+	return newSpannerDatabaseClient(client, useNewSchema, useKeyValueStore)
 }
 
 // TableConfig holds the names of multi-entity Spanner tables and indexes.
@@ -146,8 +149,8 @@ func DefaultTableConfig() TableConfig {
 	}
 }
 
-func NewSpannerClient(ctx context.Context, spannerConfigYaml, databaseOverride string, useMultiEntitySchema bool, useNewIngestionHistorySchema bool) (SpannerClient, error) {
-	rawClient, err := NewRawSpannerClient(ctx, spannerConfigYaml, databaseOverride, useNewIngestionHistorySchema)
+func NewSpannerClient(ctx context.Context, spannerConfigYaml, databaseOverride string, useMultiEntitySchema bool, useNewIngestionHistorySchema bool, useSpannerKeyValueStore bool) (SpannerClient, error) {
+	rawClient, err := NewRawSpannerClient(ctx, spannerConfigYaml, databaseOverride, useNewIngestionHistorySchema, useSpannerKeyValueStore)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/spanner/client_selector.go
+++ b/internal/server/spanner/client_selector.go
@@ -79,7 +79,7 @@ func (s *schemaSelectorClient) CheckVariableExistence(ctx context.Context, varia
 
 // CheckVariableSourceExistence delegates to the embedded client.
 func (s *schemaSelectorClient) CheckVariableSourceExistence(ctx context.Context, variables []string, sources []string, predicate string) ([][]string, error) {
-	// Source existence is backed by Cache/Edge provenance data, not the
+	// Source existence is backed by KeyValueStore/Edge provenance data, not the
 	// observation storage schema. Delegate to the base client so source and
 	// dataset existence requests keep working when multi-entity observation
 	// reads are enabled.

--- a/internal/server/spanner/golden/emulator/suite_test.go
+++ b/internal/server/spanner/golden/emulator/suite_test.go
@@ -159,7 +159,9 @@ func newEmulatorSuite(ctx context.Context) (_ *emulatorSuite, err error) {
 	}
 
 	config := fmt.Sprintf("project: %s\ninstance: %s\ndatabase: %s\n", emulatorProjectID, instanceID, databaseID)
-	resources.spannerClient, err = mixerspanner.NewSpannerClient(ctx, config, "", true, false, false)
+	resources.spannerClient, err = mixerspanner.NewSpannerClient(ctx, config, &mixerspanner.SpannerClientOptions{
+		UseMultiEntitySchema: true,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/spanner/golden/emulator/suite_test.go
+++ b/internal/server/spanner/golden/emulator/suite_test.go
@@ -159,7 +159,7 @@ func newEmulatorSuite(ctx context.Context) (_ *emulatorSuite, err error) {
 	}
 
 	config := fmt.Sprintf("project: %s\ninstance: %s\ndatabase: %s\n", emulatorProjectID, instanceID, databaseID)
-	resources.spannerClient, err = mixerspanner.NewSpannerClient(ctx, config, "", true, false)
+	resources.spannerClient, err = mixerspanner.NewSpannerClient(ctx, config, "", true, false, false)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/spanner/golden/query_builder_test.go
+++ b/internal/server/spanner/golden/query_builder_test.go
@@ -164,20 +164,20 @@ func TestGetProvenanceSummaryQuery(t *testing.T) {
 		goldenFile := c.golden + ".sql"
 
 		runQueryBuilderGoldenTest(t, goldenFile, func(ctx context.Context) (interface{}, error) {
-			return spanner.GetCacheDataQuery(spanner.TypeProvenanceSummary, c.variables, false), nil
+			return spanner.GetKeyValueStoreQuery(spanner.TypeProvenanceSummary, c.variables, false), nil
 		})
 	}
 }
 
-func TestGetCacheDataQueryKeyValueStore(t *testing.T) {
+func TestGetKeyValueStoreQuery(t *testing.T) {
 	t.Parallel()
 
-	stmt := spanner.GetCacheDataQuery(spanner.TypeProvenanceSummary, []string{"foo"}, true)
+	stmt := spanner.GetKeyValueStoreQuery(spanner.TypeProvenanceSummary, []string{"foo"}, true)
 	if stmt == nil {
-		t.Fatal("GetCacheDataQuery returned nil statement")
+		t.Fatal("GetKeyValueStoreQuery returned nil statement")
 	}
 	if !strings.Contains(stmt.SQL, "FROM\n\t\t\tKeyValueStore") {
-		t.Errorf("GetCacheDataQuery(..., useKeyValueStore=true) SQL = %q, want it to contain KeyValueStore table", stmt.SQL)
+		t.Errorf("GetKeyValueStoreQuery(..., useKeyValueStore=true) SQL = %q, want it to contain KeyValueStore table", stmt.SQL)
 	}
 }
 

--- a/internal/server/spanner/golden/query_builder_test.go
+++ b/internal/server/spanner/golden/query_builder_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"path"
 	"runtime"
+	"strings"
 	"testing"
 
 	cloudSpanner "cloud.google.com/go/spanner"
@@ -163,8 +164,20 @@ func TestGetProvenanceSummaryQuery(t *testing.T) {
 		goldenFile := c.golden + ".sql"
 
 		runQueryBuilderGoldenTest(t, goldenFile, func(ctx context.Context) (interface{}, error) {
-			return spanner.GetCacheDataQuery(spanner.TypeProvenanceSummary, c.variables), nil
+			return spanner.GetCacheDataQuery(spanner.TypeProvenanceSummary, c.variables, false), nil
 		})
+	}
+}
+
+func TestGetCacheDataQueryKeyValueStore(t *testing.T) {
+	t.Parallel()
+
+	stmt := spanner.GetCacheDataQuery(spanner.TypeProvenanceSummary, []string{"foo"}, true)
+	if stmt == nil {
+		t.Fatal("GetCacheDataQuery returned nil statement")
+	}
+	if !strings.Contains(stmt.SQL, "FROM\n\t\t\tKeyValueStore") {
+		t.Errorf("GetCacheDataQuery(..., useKeyValueStore=true) SQL = %q, want it to contain KeyValueStore table", stmt.SQL)
 	}
 }
 

--- a/internal/server/spanner/model.go
+++ b/internal/server/spanner/model.go
@@ -24,8 +24,8 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-// CacheDataType represents the type of cache data.
-type CacheDataType string
+// KeyValueStoreType represents the type of KeyValueStore data.
+type KeyValueStoreType string
 
 const (
 	TypeProvenanceSummary = "ProvenanceSummary"

--- a/internal/server/spanner/query.go
+++ b/internal/server/spanner/query.go
@@ -207,15 +207,23 @@ func (sc *spannerDatabaseClient) CheckVariableSourceExistence(ctx context.Contex
 
 	var existenceQueryStmt spanner.Statement
 	if predicate == "" {
+		sql := statements.checkSVSourceExistence
+		if sc.useSpannerKeyValueStore {
+			sql = statements.checkSVSourceExistenceFromKV
+		}
 		existenceQueryStmt = spanner.Statement{
-			SQL: statements.checkSVSourceExistence,
+			SQL: sql,
 			Params: map[string]interface{}{
 				"variables": variables,
 			},
 		}
 	} else {
+		sql := statements.checkGroupSourceExistence
+		if sc.useSpannerKeyValueStore {
+			sql = statements.checkGroupSourceExistenceFromKV
+		}
 		existenceQueryStmt = spanner.Statement{
-			SQL: statements.checkGroupSourceExistence,
+			SQL: sql,
 			Params: map[string]interface{}{
 				"variables": variables,
 				"predicate": predicate,
@@ -698,7 +706,7 @@ func (sc *spannerDatabaseClient) GetProvenanceSummary(ctx context.Context, varia
 	results, err := queryCache(
 		ctx,
 		sc,
-		*GetCacheDataQuery(TypeProvenanceSummary, variables),
+		*GetCacheDataQuery(TypeProvenanceSummary, variables, sc.useSpannerKeyValueStore),
 		func() *pb.StatVarSummary_ProvenanceSummary {
 			return &pb.StatVarSummary_ProvenanceSummary{}
 		},

--- a/internal/server/spanner/query.go
+++ b/internal/server/spanner/query.go
@@ -703,10 +703,10 @@ func (sc *spannerDatabaseClient) GetProvenanceSummary(ctx context.Context, varia
 			nil
 	}
 
-	results, err := queryCache(
+	results, err := queryKeyValueStore(
 		ctx,
 		sc,
-		*GetCacheDataQuery(TypeProvenanceSummary, variables, sc.useSpannerKeyValueStore),
+		*GetKeyValueStoreQuery(TypeProvenanceSummary, variables, sc.useSpannerKeyValueStore),
 		func() *pb.StatVarSummary_ProvenanceSummary {
 			return &pb.StatVarSummary_ProvenanceSummary{}
 		},
@@ -1129,8 +1129,8 @@ func queryDynamic(
 	return rowData, err
 }
 
-// queryCache executes a query and maps the results to an input cache proto.
-func queryCache[T proto.Message](
+// queryKeyValueStore executes a query against KeyValueStore (or legacy Cache) and maps the results to a proto.
+func queryKeyValueStore[T proto.Message](
 	ctx context.Context,
 	sc *spannerDatabaseClient,
 	stmt spanner.Statement,
@@ -1138,7 +1138,7 @@ func queryCache[T proto.Message](
 ) (map[string]map[string]T, error) {
 	var data map[string]map[string]T
 	err := sc.executeQuery(ctx, stmt, func(iter *spanner.RowIterator) error {
-		result, err := processCacheRows(iter, newProto)
+		result, err := processKeyValueStoreRows(iter, newProto)
 		data = result
 		return err
 	})
@@ -1190,8 +1190,8 @@ func processDynamicRows(iter *spanner.RowIterator) ([][]string, error) {
 	return rowData, nil
 }
 
-// processCacheRows processes rows and maps them to a proto struct.
-func processCacheRows[T proto.Message](iter *spanner.RowIterator, newProto func() T) (map[string]map[string]T, error) {
+// processKeyValueStoreRows processes rows and maps them to a proto struct.
+func processKeyValueStoreRows[T proto.Message](iter *spanner.RowIterator, newProto func() T) (map[string]map[string]T, error) {
 	results := make(map[string]map[string]T)
 	unmarshaler := protojson.UnmarshalOptions{DiscardUnknown: true}
 

--- a/internal/server/spanner/query_builder.go
+++ b/internal/server/spanner/query_builder.go
@@ -497,7 +497,8 @@ func SparqlQuery(nodes []types.Node, queries []*types.Query, opts *types.QueryOp
 	}, nil
 }
 
-func GetCacheDataQuery(typeFilter CacheDataType, keys []string, useKeyValueStore bool) *spanner.Statement {
+// GetKeyValueStoreQuery builds a query targeting KeyValueStore (or legacy Cache table when useKeyValueStore is false).
+func GetKeyValueStoreQuery(typeFilter KeyValueStoreType, keys []string, useKeyValueStore bool) *spanner.Statement {
 	keyFilter, keyVal := getParamStatement("key", keys)
 	params := map[string]interface{}{
 		"type": string(typeFilter),

--- a/internal/server/spanner/query_builder.go
+++ b/internal/server/spanner/query_builder.go
@@ -497,15 +497,20 @@ func SparqlQuery(nodes []types.Node, queries []*types.Query, opts *types.QueryOp
 	}, nil
 }
 
-func GetCacheDataQuery(typeFilter CacheDataType, keys []string) *spanner.Statement {
+func GetCacheDataQuery(typeFilter CacheDataType, keys []string, useKeyValueStore bool) *spanner.Statement {
 	keyFilter, keyVal := getParamStatement("key", keys)
 	params := map[string]interface{}{
 		"type": string(typeFilter),
 		"key":  keyVal,
 	}
 
+	sql := statements.getCacheData
+	if useKeyValueStore {
+		sql = statements.getKeyValueStoreData
+	}
+
 	return &spanner.Statement{
-		SQL:    fmt.Sprintf(statements.getCacheData, keyFilter),
+		SQL:    fmt.Sprintf(sql, keyFilter),
 		Params: params,
 	}
 }

--- a/internal/server/spanner/statements.go
+++ b/internal/server/spanner/statements.go
@@ -91,6 +91,8 @@ var statements = struct {
 	triple string
 	// Get data from Cache table.
 	getCacheData string
+	// Get data from KeyValueStore table.
+	getKeyValueStoreData string
 	// Fetch event dates for a given type and location.
 	getEventCollectionDate string
 	// Fetch events for a given type, location and date.
@@ -131,8 +133,12 @@ var statements = struct {
 	filterNodesByTypes string
 	// Check existence of SVs against sources.
 	checkSVSourceExistence string
+	// Check existence of SVs against sources using KeyValueStore table.
+	checkSVSourceExistenceFromKV string
 	// Check existence of variable groups against sources.
 	checkGroupSourceExistence string
+	// Check existence of variable groups against sources using KeyValueStore table.
+	checkGroupSourceExistenceFromKV string
 	// Check existence of variable groups against places.
 	checkGroupPlaceExistence string
 }{
@@ -375,6 +381,15 @@ OR CreationTimestamp > (
 			TO_JSON_STRING(value) AS value,
 		FROM
 			Cache
+		WHERE
+			type = @type
+			AND key %s`,
+	getKeyValueStoreData: `		SELECT
+			key,
+			provenance,
+			TO_JSON_STRING(value) AS value,
+		FROM
+			KeyValueStore
 		WHERE
 			type = @type
 			AND key %s`,
@@ -701,6 +716,22 @@ OR CreationTimestamp > (
 		ORDER BY variable, source`,
 	checkGroupSourceExistence: `		SELECT DISTINCT e3.object_id AS variable, e2.object_id AS source
 		FROM Cache c
+		JOIN Edge e2 ON c.provenance = e2.subject_id
+		JOIN Edge@{FORCE_INDEX=InEdge} e3 ON c.key = e3.subject_id
+		WHERE c.type = 'ProvenanceSummary'
+		  AND e2.predicate IN ('source', 'isPartOf')
+		  AND e3.predicate = @predicate
+		  AND e3.object_id IN UNNEST(@variables)
+		ORDER BY variable, source`,
+	checkSVSourceExistenceFromKV: `		SELECT DISTINCT c.key AS variable, e2.object_id AS source
+		FROM KeyValueStore c
+		JOIN Edge e2 ON c.provenance = e2.subject_id
+		WHERE c.type = 'ProvenanceSummary'
+		  AND e2.predicate IN ('source', 'isPartOf')
+		  AND c.key IN UNNEST(@variables)
+		ORDER BY variable, source`,
+	checkGroupSourceExistenceFromKV: `		SELECT DISTINCT e3.object_id AS variable, e2.object_id AS source
+		FROM KeyValueStore c
 		JOIN Edge e2 ON c.provenance = e2.subject_id
 		JOIN Edge@{FORCE_INDEX=InEdge} e3 ON c.key = e3.subject_id
 		WHERE c.type = 'ProvenanceSummary'

--- a/internal/server/spanner/statements.go
+++ b/internal/server/spanner/statements.go
@@ -387,7 +387,7 @@ OR CreationTimestamp > (
 	getKeyValueStoreData: `		SELECT
 			key,
 			provenance,
-			TO_JSON_STRING(value) AS value,
+			TO_JSON_STRING(value) AS value
 		FROM
 			KeyValueStore
 		WHERE

--- a/internal/server/spanner/statements.go
+++ b/internal/server/spanner/statements.go
@@ -89,7 +89,7 @@ var statements = struct {
 	nodeFilter string
 	// Generic triple pattern.
 	triple string
-	// Get data from Cache table.
+	// Get data from legacy Cache table.
 	getCacheData string
 	// Get data from KeyValueStore table.
 	getKeyValueStoreData string

--- a/test/setup.go
+++ b/test/setup.go
@@ -449,7 +449,7 @@ func newSpannerClient(ctx context.Context, spannerGraphInfoYamlPath string) span
 		log.Fatalf("Failed to read spanner yaml: %v", err)
 	}
 	// Don't override spannerGraphInfoYaml.database for testing.
-	spannerClient, err := spanner.NewRawSpannerClient(ctx, string(spannerGraphInfoYaml), "", false, false)
+	spannerClient, err := spanner.NewRawSpannerClient(ctx, string(spannerGraphInfoYaml), nil)
 	if err != nil {
 		log.Fatalf("Failed to create SpannerClient: %v", err)
 	}

--- a/test/setup.go
+++ b/test/setup.go
@@ -449,7 +449,7 @@ func newSpannerClient(ctx context.Context, spannerGraphInfoYamlPath string) span
 		log.Fatalf("Failed to read spanner yaml: %v", err)
 	}
 	// Don't override spannerGraphInfoYaml.database for testing.
-	spannerClient, err := spanner.NewRawSpannerClient(ctx, string(spannerGraphInfoYaml), "", false)
+	spannerClient, err := spanner.NewRawSpannerClient(ctx, string(spannerGraphInfoYaml), "", false, false)
 	if err != nil {
 		log.Fatalf("Failed to create SpannerClient: %v", err)
 	}

--- a/tools/perf_test/main.go
+++ b/tools/perf_test/main.go
@@ -212,7 +212,7 @@ func initSpannerClient(ctx context.Context, configPath string) (spanner.SpannerC
 
 	// We reuse the logic from client.go by passing the YAML string directly.
 	// The client.go NewSpannerClient expects the YAML content.
-	return spanner.NewSpannerClient(ctx, string(yamlFile), "", false, false)
+	return spanner.NewSpannerClient(ctx, string(yamlFile), "", false, false, false)
 }
 
 // runParallelTest runs two operations in parallel and injects metadata headers.

--- a/tools/perf_test/main.go
+++ b/tools/perf_test/main.go
@@ -212,7 +212,7 @@ func initSpannerClient(ctx context.Context, configPath string) (spanner.SpannerC
 
 	// We reuse the logic from client.go by passing the YAML string directly.
 	// The client.go NewSpannerClient expects the YAML content.
-	return spanner.NewSpannerClient(ctx, string(yamlFile), "", false, false, false)
+	return spanner.NewSpannerClient(ctx, string(yamlFile), nil)
 }
 
 // runParallelTest runs two operations in parallel and injects metadata headers.


### PR DESCRIPTION
Adds feature flag `UseSpannerKeyValueStore` to enable reading from the Spanner `KeyValueStore` table instead of `Cache`, and refactors `SpannerClient` initialization to adhere to the Required Parameters + Options Struct pattern (`SpannerClientOptions`) documented in `docs/architecture.md`.

### Summary of Changes
- **Feature Flags**: Adds `UseSpannerKeyValueStore` flag (`false` by default) to read from `KeyValueStore`.
- **Spanner Statements**: Adds static queries (`getKeyValueStoreData`, `checkSVSourceExistenceFromKV`, and `checkGroupSourceExistenceFromKV`) targeting `KeyValueStore`.
- **Query Selection**: Switches `GetProvenanceSummary` and `CheckVariableSourceExistence` queries dynamically when `UseSpannerKeyValueStore` is enabled.
- **Constructor Refactoring (`SpannerClientOptions`)**: Resolves positional boolean overload on `NewSpannerClient` (`... bool, bool, bool`) by moving optional feature toggles and database URI overrides into a structured pointer options struct (`*SpannerClientOptions`). Callers and test utilities passing `nil` receive safe zero-value fallback behaviors.

### Verification
- Ran unit tests across `./internal/featureflags/...` and `./internal/server/spanner/...`.
- Ran full compilation build and short integration/golden tests across the repository (`go build ./... && go test -short ./...`).