### PR TITLE
Disable EnableSpannerSearchEmbeddings in staging feature flags

### DIFF
--- a/deploy/featureflags/staging.yaml
+++ b/deploy/featureflags/staging.yaml
@@ -6,4 +6,4 @@ flags:
   WriteUsageLogs: 1.0
   UseSpannerGraph: true
   SpannerGraphDatabase: dc_graph_2026_01_27
-  EnableSpannerSearchEmbeddings: true
+  EnableSpannerSearchEmbeddings: false

--- a/deploy/featureflags/staging_website.yaml
+++ b/deploy/featureflags/staging_website.yaml
@@ -7,4 +7,4 @@ flags:
   WriteUsageLogs: 1.0
   UseSpannerGraph: true
   SpannerGraphDatabase: dc_graph_2026_01_27
-  EnableSpannerSearchEmbeddings: true
+  EnableSpannerSearchEmbeddings: false


### PR DESCRIPTION
## Related PR

[1985](https://github.com/datacommonsorg/mixer/pull/1985)

## Description

After Spanner search embeddings were enabled on Staging, NL tests have started failing on prod (with significant result divergences).

See [failed test](https://github.com/datacommonsorg/website/pull/6451/checks?check_run_id=87455606562) as an example.