### PR TITLE
Trigger topic cache sync on Spanner ingestion completions

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -572,9 +572,14 @@ func main() {
 	// Bind reactive ingestion callback and start background Spanner polling ONLY after server components are initialized
 	if spannerClient != nil {
 		spannerClient.SetOnIngestionUpdate(func(ctx context.Context) {
-			slog.Info("Executing reactive periodic hooks triggered by Spanner ingestion state change")
-			if err := mixerServer.RunPeriodicHooks(ctx); err != nil {
-				slog.Error("Reactive RunPeriodicHooks failed during Spanner sync", "error", err)
+			slog.Info("Executing reactive cache reloads triggered by Spanner ingestion state change")
+			if topicCacheManager != nil {
+				if _, err := topicCacheManager.LoadHierarchy(ctx); err != nil && !spanner.IsTableNotFoundError(err) {
+					slog.Error("Failed to reload topic cache hierarchy on Spanner ingestion update", "error", err)
+				}
+			}
+			if agentSvc := mixerServer.AgentService(); agentSvc != nil {
+				agentSvc.Reset()
 			}
 		})
 		spannerClient.Start()

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -571,17 +571,20 @@ func main() {
 
 	// Bind reactive ingestion callback and start background Spanner polling ONLY after server components are initialized
 	if spannerClient != nil {
-		spannerClient.SetOnIngestionUpdate(func(ctx context.Context) {
-			slog.Info("Executing reactive cache reloads triggered by Spanner ingestion state change")
-			if topicCacheManager != nil {
-				if _, err := topicCacheManager.LoadHierarchy(ctx); err != nil && !spanner.IsTableNotFoundError(err) {
-					slog.Error("Failed to reload topic cache hierarchy on Spanner ingestion update", "error", err)
+		if flags.EnableReactiveInMemoryCacheRefresh {
+			slog.Info("Enabling reactive in-memory cache reloads on Spanner ingestion state changes")
+			spannerClient.SetOnIngestionUpdate(func(ctx context.Context) {
+				slog.Info("Executing reactive in-memory cache reloads triggered by Spanner ingestion state change")
+				if topicCacheManager != nil {
+					if _, err := topicCacheManager.ReloadHierarchy(ctx); err != nil && !spanner.IsTableNotFoundError(err) {
+						slog.Error("Failed to reload topic cache hierarchy on Spanner ingestion update", "error", err)
+					}
 				}
-			}
-			if agentSvc := mixerServer.AgentService(); agentSvc != nil {
-				agentSvc.Reset()
-			}
-		})
+				if agentSvc := mixerServer.AgentService(); agentSvc != nil {
+					agentSvc.Reset()
+				}
+			})
+		}
 		spannerClient.Start()
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -235,7 +235,6 @@ func main() {
 			slog.Error("Failed to create Spanner client", "error", err)
 			os.Exit(1)
 		}
-		spannerClient.Start()
 		defer spannerClient.Close()
 	}
 	slog.Info("After Spanner client creation")
@@ -568,6 +567,17 @@ func main() {
 	if err := mixerServer.RunInitHooks(ctx); err != nil {
 		slog.Error("Failed to initialize server components during startup", "error", err)
 		os.Exit(1)
+	}
+
+	// Bind reactive ingestion callback and start background Spanner polling ONLY after server components are initialized
+	if spannerClient != nil {
+		spannerClient.SetOnIngestionUpdate(func(ctx context.Context) {
+			slog.Info("Executing reactive periodic hooks triggered by Spanner ingestion state change")
+			if err := mixerServer.RunPeriodicHooks(ctx); err != nil {
+				slog.Error("Reactive RunPeriodicHooks failed during Spanner sync", "error", err)
+			}
+		})
+		spannerClient.Start()
 	}
 
 	// Start the periodic scheduler

--- a/deploy/featureflags/dcp.yaml
+++ b/deploy/featureflags/dcp.yaml
@@ -8,3 +8,5 @@ flags:
   EnableSpannerSearchEmbeddings: true
   UseNewIngestionHistorySchema: false
   UseSpannerKeyValueStore: true
+  EnableReactiveInMemoryCacheRefresh: true
+

--- a/internal/featureflags/featureflags.go
+++ b/internal/featureflags/featureflags.go
@@ -62,6 +62,8 @@ type Flags struct {
 	ContainedInPlaceAncestorFirstTypes []string `yaml:"ContainedInPlaceAncestorFirstTypes"`
 	// Minimum number of unique variables that selects an entity1 range scan for core contained-in-place observation queries. Zero disables the optimization.
 	ContainedInPlaceEntityScanMinVariables int `yaml:"ContainedInPlaceEntityScanMinVariables"`
+	// Whether to trigger reactive reloads of in-memory caches (topic hierarchy and agent service) upon Spanner ingestion completion.
+	EnableReactiveInMemoryCacheRefresh bool `yaml:"EnableReactiveInMemoryCacheRefresh"`
 }
 
 // setDefaultValues creates a new Flags struct with default values.
@@ -83,6 +85,7 @@ func setDefaultValues() *Flags {
 		UseSpannerKeyValueStore:                false,
 		ContainedInPlaceAncestorFirstTypes:     []string{"Place"},
 		ContainedInPlaceEntityScanMinVariables: 50,
+		EnableReactiveInMemoryCacheRefresh:     false,
 	}
 }
 

--- a/internal/featureflags/featureflags_test.go
+++ b/internal/featureflags/featureflags_test.go
@@ -315,6 +315,17 @@ flags:
 			}),
 			wantErr: false,
 		},
+		{
+			name: "enable reactive in memory cache refresh flag",
+			fileContent: `
+flags:
+  EnableReactiveInMemoryCacheRefresh: true
+`,
+			want: expectedFlags(func(f *Flags) {
+				f.EnableReactiveInMemoryCacheRefresh = true
+			}),
+			wantErr: false,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -203,6 +203,12 @@ func (s *Server) RunInitHooks(ctx context.Context) error {
 	return runHooksInParallel(ctx, s.initHooks, true /* failOnError */)
 }
 
+// RunPeriodicHooks executes all registered periodic callbacks concurrently in parallel without aborting on first failure.
+func (s *Server) RunPeriodicHooks(ctx context.Context) error {
+	slog.Info("Executing all registered periodic hooks across components in parallel")
+	return runHooksInParallel(ctx, s.periodicHooks, false /* failOnError */)
+}
+
 // StartPeriodicRefresher starts the centralized background goroutine to trigger periodic reloads.
 func (s *Server) StartPeriodicRefresher(ctx context.Context, interval time.Duration) {
 	s.periodicOnce.Do(func() {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -203,7 +203,6 @@ func (s *Server) RunInitHooks(ctx context.Context) error {
 	return runHooksInParallel(ctx, s.initHooks, true /* failOnError */)
 }
 
-
 // StartPeriodicRefresher starts the centralized background goroutine to trigger periodic reloads.
 func (s *Server) StartPeriodicRefresher(ctx context.Context, interval time.Duration) {
 	s.periodicOnce.Do(func() {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -203,11 +203,6 @@ func (s *Server) RunInitHooks(ctx context.Context) error {
 	return runHooksInParallel(ctx, s.initHooks, true /* failOnError */)
 }
 
-// RunPeriodicHooks executes all registered periodic callbacks concurrently in parallel without aborting on first failure.
-func (s *Server) RunPeriodicHooks(ctx context.Context) error {
-	slog.Info("Executing all registered periodic hooks across components in parallel")
-	return runHooksInParallel(ctx, s.periodicHooks, false /* failOnError */)
-}
 
 // StartPeriodicRefresher starts the centralized background goroutine to trigger periodic reloads.
 func (s *Server) StartPeriodicRefresher(ctx context.Context, interval time.Duration) {

--- a/internal/server/spanner/client.go
+++ b/internal/server/spanner/client.go
@@ -61,6 +61,7 @@ type SpannerClient interface {
 	Id() string
 	Start()
 	Close()
+	SetOnIngestionUpdate(hook func(ctx context.Context))
 }
 
 const (
@@ -92,6 +93,10 @@ type spannerDatabaseClient struct {
 
 	// Flag to dynamically track if the Spanner schema has been initialized.
 	dbInitialized atomic.Bool
+
+	onIngestionUpdate func(ctx context.Context)
+	hookMutex         sync.Mutex
+	isReloading       atomic.Bool
 }
 
 // SpannerClientOptions holds optional configuration settings and feature toggles for SpannerClient.
@@ -265,6 +270,13 @@ func createSpannerConfig(spannerConfigYaml, databaseOverride string) (*SpannerCo
 	}
 
 	return &cfg, nil
+}
+
+// SetOnIngestionUpdate sets a callback to execute whenever a new ingestion timestamp or DB initialization is detected.
+func (sc *spannerDatabaseClient) SetOnIngestionUpdate(hook func(ctx context.Context)) {
+	sc.hookMutex.Lock()
+	defer sc.hookMutex.Unlock()
+	sc.onIngestionUpdate = hook
 }
 
 func (sc *spannerDatabaseClient) Id() string {

--- a/internal/server/spanner/client_selector.go
+++ b/internal/server/spanner/client_selector.go
@@ -196,6 +196,13 @@ func NewSchemaSelectorClient(baseClient SpannerClient, useMultiEntitySchema bool
 	}, nil
 }
 
+// SetOnIngestionUpdate forwards the callback to the embedded default Spanner client.
+func (s *schemaSelectorClient) SetOnIngestionUpdate(hook func(ctx context.Context)) {
+	if s.SpannerClient != nil {
+		s.SpannerClient.SetOnIngestionUpdate(hook)
+	}
+}
+
 func (s *schemaSelectorClient) selectSchema(ctx context.Context) (context.Context, bool) {
 	useMultiEntity := s.useMultiEntitySchema(ctx)
 	schemaName := legacySchemaName

--- a/internal/server/spanner/coordinate_resolve_test.go
+++ b/internal/server/spanner/coordinate_resolve_test.go
@@ -130,6 +130,7 @@ func (m *coordinateMockSpannerClient) FilterNodesByTypes(ctx context.Context, no
 func (m *coordinateMockSpannerClient) Id() string { return "mock" }
 func (m *coordinateMockSpannerClient) Start()     {}
 func (m *coordinateMockSpannerClient) Close()     {}
+func (m *coordinateMockSpannerClient) SetOnIngestionUpdate(hook func(ctx context.Context)) {}
 
 func TestResolveCoordinate(t *testing.T) {
 	t.Parallel()

--- a/internal/server/spanner/golden/datasource_test.go
+++ b/internal/server/spanner/golden/datasource_test.go
@@ -141,6 +141,7 @@ func (m *mockSpannerClient) GetFilteredTopic(ctx context.Context, nodes []string
 func (m *mockSpannerClient) Id() string { return "mock" }
 func (m *mockSpannerClient) Start()     {}
 func (m *mockSpannerClient) Close()     {}
+func (m *mockSpannerClient) SetOnIngestionUpdate(hook func(ctx context.Context)) {}
 
 func TestSpannerResolve(t *testing.T) {
 	client := test.NewSpannerClient()

--- a/internal/server/spanner/query.go
+++ b/internal/server/spanner/query.go
@@ -981,8 +981,6 @@ func (sc *spannerDatabaseClient) fetchAndUpdateTimestamp(ctx context.Context) er
 		maybeLogSpannerTimeout(queryCtx, err, time.Since(startTime), "Spanner timestamp polling")
 		return fmt.Errorf("failed to fetch row: %w", err)
 	}
-	sc.dbInitialized.Store(true)
-
 	var nullTime spanner.NullTime
 	if err := row.Column(0, &nullTime); err != nil {
 		return fmt.Errorf("failed to read Timestamp column: %w", err)
@@ -1013,11 +1011,64 @@ func (sc *spannerDatabaseClient) processStalenessTimestamp(ctx context.Context, 
 	timestamp := nullTime.Time
 
 	now := time.Now()
+	wasInitialized := sc.dbInitialized.Swap(true)
 	prevNano := sc.timestamp.Load()
 	newNano := timestamp.UnixNano()
 
-	if prevNano == 0 || prevNano != newNano {
-		sc.timestamp.Store(newNano)
+	if !wasInitialized || prevNano == 0 || prevNano != newNano {
+		sc.hookMutex.Lock()
+		if prevNano == 0 || prevNano != newNano {
+			sc.timestamp.Store(newNano)
+		}
+		hook := sc.onIngestionUpdate
+		isReloading := sc.isReloading.Load()
+		if hook != nil && !isReloading {
+			sc.isReloading.Store(true)
+		}
+		sc.hookMutex.Unlock()
+
+		if hook != nil {
+			if !isReloading {
+				slog.Info("Spanner ingestion state change detected; initiating reactive cache refresh",
+					"prev_timestamp", prevNano,
+					"new_timestamp", newNano,
+					"was_initialized", wasInitialized)
+
+				go func() {
+					var cleanExit bool
+					defer func() {
+						if !cleanExit {
+							sc.hookMutex.Lock()
+							sc.isReloading.Store(false)
+							sc.hookMutex.Unlock()
+							if r := recover(); r != nil {
+								slog.Error("Panic occurred inside reactive ingestion callback; reset reloading state", "panic", r)
+							}
+						}
+					}()
+					for {
+						sc.hookMutex.Lock()
+						targetTs := sc.timestamp.Load()
+						sc.hookMutex.Unlock()
+
+						hook(context.Background())
+
+						sc.hookMutex.Lock()
+						if sc.timestamp.Load() == targetTs {
+							sc.isReloading.Store(false)
+							cleanExit = true
+							sc.hookMutex.Unlock()
+							break
+						}
+						sc.hookMutex.Unlock()
+						slog.Info("Additional Spanner timestamp change observed during reload; draining subsequent update")
+					}
+				}()
+			} else {
+				slog.Info("Reactive cache refresh already in progress; active drain loop will pick up timestamp",
+					"new_timestamp", newNano)
+			}
+		}
 	}
 
 	if sc.tracker != nil {

--- a/internal/server/spanner/query.go
+++ b/internal/server/spanner/query.go
@@ -1051,7 +1051,9 @@ func (sc *spannerDatabaseClient) processStalenessTimestamp(ctx context.Context, 
 						targetTs := sc.timestamp.Load()
 						sc.hookMutex.Unlock()
 
-						hook(context.Background())
+						hookCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+						hook(hookCtx)
+						cancel()
 
 						sc.hookMutex.Lock()
 						if sc.timestamp.Load() == targetTs {

--- a/internal/server/spanner/query.go
+++ b/internal/server/spanner/query.go
@@ -1008,69 +1008,14 @@ func (sc *spannerDatabaseClient) processStalenessTimestamp(ctx context.Context, 
 		return nil
 	}
 
-	timestamp := nullTime.Time
-
 	now := time.Now()
 	wasInitialized := sc.dbInitialized.Swap(true)
 	prevNano := sc.timestamp.Load()
-	newNano := timestamp.UnixNano()
+	newNano := nullTime.Time.UnixNano()
 
 	if !wasInitialized || prevNano == 0 || prevNano != newNano {
-		sc.hookMutex.Lock()
-		if prevNano == 0 || prevNano != newNano {
-			sc.timestamp.Store(newNano)
-		}
-		hook := sc.onIngestionUpdate
-		isReloading := sc.isReloading.Load()
-		if hook != nil && !isReloading {
-			sc.isReloading.Store(true)
-		}
-		sc.hookMutex.Unlock()
-
-		if hook != nil {
-			if !isReloading {
-				slog.Info("Spanner ingestion state change detected; initiating reactive cache refresh",
-					"prev_timestamp", prevNano,
-					"new_timestamp", newNano,
-					"was_initialized", wasInitialized)
-
-				go func() {
-					var cleanExit bool
-					defer func() {
-						if !cleanExit {
-							sc.hookMutex.Lock()
-							sc.isReloading.Store(false)
-							sc.hookMutex.Unlock()
-							if r := recover(); r != nil {
-								slog.Error("Panic occurred inside reactive ingestion callback; reset reloading state", "panic", r)
-							}
-						}
-					}()
-					for {
-						sc.hookMutex.Lock()
-						targetTs := sc.timestamp.Load()
-						sc.hookMutex.Unlock()
-
-						hookCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-						hook(hookCtx)
-						cancel()
-
-						sc.hookMutex.Lock()
-						if sc.timestamp.Load() == targetTs {
-							sc.isReloading.Store(false)
-							cleanExit = true
-							sc.hookMutex.Unlock()
-							break
-						}
-						sc.hookMutex.Unlock()
-						slog.Info("Additional Spanner timestamp change observed during reload; draining subsequent update")
-					}
-				}()
-			} else {
-				slog.Info("Reactive cache refresh already in progress; active drain loop will pick up timestamp",
-					"new_timestamp", newNano)
-			}
-		}
+		sc.timestamp.Store(newNano)
+		sc.maybeTriggerReload(prevNano, newNano, wasInitialized)
 	}
 
 	if sc.tracker != nil {
@@ -1080,6 +1025,68 @@ func (sc *spannerDatabaseClient) processStalenessTimestamp(ctx context.Context, 
 	}
 
 	return nil
+}
+
+func (sc *spannerDatabaseClient) maybeTriggerReload(prevNano, newNano int64, wasInitialized bool) {
+	sc.hookMutex.Lock()
+	hook := sc.onIngestionUpdate
+	isReloading := sc.isReloading.Load()
+	if hook != nil && !isReloading {
+		sc.isReloading.Store(true)
+	}
+	sc.hookMutex.Unlock()
+
+	if hook == nil {
+		return
+	}
+
+	if isReloading {
+		slog.Info("Reactive cache refresh already in progress; active drain loop will pick up timestamp",
+			"new_timestamp", newNano)
+		return
+	}
+
+	slog.Info("Spanner ingestion state change detected; initiating reactive cache refresh",
+		"prev_timestamp", prevNano,
+		"new_timestamp", newNano,
+		"was_initialized", wasInitialized)
+
+	go sc.runIngestionReloadLoop(hook)
+}
+
+func (sc *spannerDatabaseClient) runIngestionReloadLoop(hook func(context.Context)) {
+	var cleanExit bool
+	defer func() {
+		if !cleanExit {
+			sc.hookMutex.Lock()
+			sc.isReloading.Store(false)
+			sc.hookMutex.Unlock()
+			if r := recover(); r != nil {
+				slog.Error("Panic occurred inside reactive ingestion callback; reset reloading state", "panic", r)
+			}
+		}
+	}()
+
+	for {
+		sc.hookMutex.Lock()
+		targetTs := sc.timestamp.Load()
+		sc.hookMutex.Unlock()
+
+		hookCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		hook(hookCtx)
+		cancel()
+
+		sc.hookMutex.Lock()
+		if sc.timestamp.Load() == targetTs {
+			sc.isReloading.Store(false)
+			cleanExit = true
+			sc.hookMutex.Unlock()
+			break
+		}
+		sc.hookMutex.Unlock()
+
+		slog.Info("Additional Spanner timestamp change observed during reload; draining subsequent update")
+	}
 }
 
 func (sc *spannerDatabaseClient) getStalenessTimestamp() (time.Time, error) {

--- a/internal/server/spanner/timestamp_test.go
+++ b/internal/server/spanner/timestamp_test.go
@@ -170,3 +170,65 @@ func TestTimestampResetOnNull(t *testing.T) {
 		t.Fatalf("Expected error when staleness timestamp is zero, but got nil")
 	}
 }
+
+func TestSetOnIngestionUpdate_TriggersOnTimestampChange(t *testing.T) {
+	t.Parallel()
+	mockTicker := NewMockTicker()
+	startTime := time.Date(2025, time.January, 1, 10, 0, 0, 0, time.UTC)
+	updatedTime := startTime.Add(1 * time.Hour)
+
+	sc := &spannerDatabaseClient{
+		ticker: mockTicker,
+		stopCh: make(chan struct{}),
+	}
+	sc.timestamp.Store(startTime.UnixNano())
+	sc.dbInitialized.Store(true)
+
+	callbackCalled := make(chan bool, 1)
+	sc.SetOnIngestionUpdate(func(ctx context.Context) {
+		callbackCalled <- true
+	})
+
+	err := sc.processStalenessTimestamp(context.Background(), spanner.NullTime{Valid: true, Time: updatedTime})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	select {
+	case <-callbackCalled:
+		// Success: callback was reactively invoked.
+	case <-time.After(1 * time.Second):
+		t.Fatalf("Timed out waiting for SetOnIngestionUpdate callback to be invoked")
+	}
+}
+
+func TestSetOnIngestionUpdate_UnchangedTimestampNoTrigger(t *testing.T) {
+	t.Parallel()
+	mockTicker := NewMockTicker()
+	startTime := time.Date(2025, time.January, 1, 10, 0, 0, 0, time.UTC)
+
+	sc := &spannerDatabaseClient{
+		ticker: mockTicker,
+		stopCh: make(chan struct{}),
+	}
+	sc.timestamp.Store(startTime.UnixNano())
+	sc.dbInitialized.Store(true)
+
+	callbackCalled := make(chan bool, 1)
+	sc.SetOnIngestionUpdate(func(ctx context.Context) {
+		callbackCalled <- true
+	})
+
+	err := sc.processStalenessTimestamp(context.Background(), spanner.NullTime{Valid: true, Time: startTime})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	select {
+	case <-callbackCalled:
+		t.Fatalf("Callback should NOT have been invoked when timestamp did not change")
+	case <-time.After(100 * time.Millisecond):
+		// Success: callback was NOT invoked.
+	}
+}
+

--- a/internal/server/spanner/timestamp_test.go
+++ b/internal/server/spanner/timestamp_test.go
@@ -232,3 +232,71 @@ func TestSetOnIngestionUpdate_UnchangedTimestampNoTrigger(t *testing.T) {
 	}
 }
 
+func TestSetOnIngestionUpdate_DrainsSubsequentUpdate(t *testing.T) {
+	t.Parallel()
+	mockTicker := NewMockTicker()
+	startTime := time.Date(2025, time.January, 1, 10, 0, 0, 0, time.UTC)
+	updatedTime1 := startTime.Add(1 * time.Hour)
+	updatedTime2 := startTime.Add(2 * time.Hour)
+
+	sc := &spannerDatabaseClient{
+		ticker: mockTicker,
+		stopCh: make(chan struct{}),
+	}
+	sc.timestamp.Store(startTime.UnixNano())
+	sc.dbInitialized.Store(true)
+
+	firstHookStarted := make(chan struct{})
+	allowFirstHookToFinish := make(chan struct{})
+	hookCallCount := make(chan int, 10)
+
+	var callNum int
+	sc.SetOnIngestionUpdate(func(ctx context.Context) {
+		callNum++
+		currentCall := callNum
+		if currentCall == 1 {
+			close(firstHookStarted)
+			<-allowFirstHookToFinish
+		}
+		hookCallCount <- currentCall
+	})
+
+	// First timestamp update triggers first execution of hook
+	err := sc.processStalenessTimestamp(context.Background(), spanner.NullTime{Valid: true, Time: updatedTime1})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Wait until hook has entered execution
+	<-firstHookStarted
+
+	// While hook 1 is still executing, send a second timestamp update
+	err = sc.processStalenessTimestamp(context.Background(), spanner.NullTime{Valid: true, Time: updatedTime2})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Now allow hook 1 to finish
+	close(allowFirstHookToFinish)
+
+	// Verify hook was executed twice (once for initial trigger, once for drained update)
+	select {
+	case c := <-hookCallCount:
+		if c != 1 {
+			t.Fatalf("Expected first hook call to be 1, got %d", c)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatalf("Timed out waiting for first hook call")
+	}
+
+	select {
+	case c := <-hookCallCount:
+		if c != 2 {
+			t.Fatalf("Expected second hook call to be 2, got %d", c)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatalf("Timed out waiting for second drained hook call")
+	}
+}
+
+

--- a/internal/server/topic/topic_cache.go
+++ b/internal/server/topic/topic_cache.go
@@ -263,3 +263,45 @@ func (m *TopicCacheManager) LoadHierarchy(ctx context.Context) (*pb.TopicHierarc
 
 	return hierarchy, nil
 }
+
+// ReloadHierarchy forces a synchronous reload of the TopicHierarchy from the KG,
+// bypassing any L2 Redis cache read, and updates both L1 memory and L2 Redis caches.
+func (m *TopicCacheManager) ReloadHierarchy(ctx context.Context) (*pb.TopicHierarchy, error) {
+	defer util.TimeTrack(time.Now(), "topic: ReloadHierarchy")
+	if m.fetcher == nil {
+		return nil, fmt.Errorf("topic cache manager uninitialized: fetcher is nil")
+	}
+
+	slog.Info("Reloading topic cache synchronously from KG (bypassing Redis cache read)")
+	hierarchy, err := m.FetchTopicsFromKG(ctx)
+	if err != nil {
+		slog.Error("Failed to reload topic cache from KG", "error", err)
+		return nil, fmt.Errorf("failed to reload topic cache from KG: %w", err)
+	}
+
+	if hierarchy == nil {
+		hierarchy = &pb.TopicHierarchy{}
+	}
+	if len(hierarchy.GetTopics()) == 0 {
+		slog.Warn("Loaded empty topic hierarchy during reload.")
+		// Fail-safe preservation: never overwrite an existing functional L1 cache with an empty structure
+		if existing := m.CachedHierarchy(); len(existing.GetTopics()) > 0 {
+			slog.Warn("Retaining existing fully populated topic cache (fail-safe preservation against empty yield)")
+			return existing, nil
+		}
+	}
+
+	m.Update(hierarchy)
+
+	// Populate Redis warm L2 cache
+	if m.redisClient != nil && len(hierarchy.GetTopics()) > 0 {
+		if err := m.redisClient.CacheResponse(ctx, redisCacheKeyProto, hierarchy); err != nil {
+			slog.Error("Failed to write topic cache to Redis", "error", err)
+		} else {
+			slog.Info("Saved topic cache in Redis successfully")
+		}
+	}
+
+	return hierarchy, nil
+}
+

--- a/internal/server/topic/topic_cache.go
+++ b/internal/server/topic/topic_cache.go
@@ -243,6 +243,11 @@ func (m *TopicCacheManager) LoadHierarchy(ctx context.Context) (*pb.TopicHierarc
 	}
 	if len(hierarchy.GetTopics()) == 0 {
 		slog.Warn("Loaded empty topic hierarchy.")
+		// Fail-safe preservation: never overwrite an existing functional L1 cache with an empty structure
+		if existing := m.CachedHierarchy(); len(existing.GetTopics()) > 0 {
+			slog.Warn("Retaining existing fully populated topic cache (fail-safe preservation against empty yield)")
+			return existing, nil
+		}
 	}
 
 	m.Update(hierarchy)


### PR DESCRIPTION
## Goal
Implements event-driven reactive in-memory cache synchronization (topic hierarchy and agent service) in `datcom-mixer` by hooking into the Spanner `IngestionHistory` timestamp poller.

## Key Aspects of the Approach
* **Spanner Timestamp Trigger (`query.go`)**: Detects DB initialization transitions (`wasInitialized == false -> true`) and timestamp jumps (`prevNano != newNano`) to trigger registered `SetOnIngestionUpdate` callbacks.
* **Thread-Safe Drain Loop (`query.go`)**: Isolates in-memory cache reloading into `maybeTriggerReload` and `runIngestionReloadLoop`. Uses `sc.hookMutex` and atomic state flags to drain burst updates safely without lost updates or concurrent goroutine storms.
* **Redis Bypass for Fresh In-Memory Loading (`topic_cache.go` & `cmd/main.go`)**: Adds `ReloadHierarchy` to bypass stale L2 Redis cache reads during ingestion updates, loading fresh topic data directly into L1 in-memory cache and re-warming L2 Redis.
* **Fail-Safe In-Memory Preservation (`topic_cache.go`)**: Retains existing populated in-memory topic hierarchy if Spanner transiently returns zero topics.

## Edge Cases, Errors & Logging
* Gracefully ignores table-not-found on uninitialized DB boot.
* Deferred panic recovery resets reloading flags safely if callbacks fail.
* 2-minute context timeout bounds each reactive reload execution.

## Testing & Verification
* **Unit Tests**: Pass cleanly across `internal/server/...`, including concurrent update draining (`TestSetOnIngestionUpdate_DrainsSubsequentUpdate`).
* **E2E Verification**: Tested against live Spanner database (`test-latest-dcp-dc-db`), reloading topic graphs in memory within ~30s of `datacommons admin ingest` completion without pod restart.
