### PR TITLE
Add dcp.yaml feature flags file

### DIFF
--- a/deploy/featureflags/dcp.yaml
+++ b/deploy/featureflags/dcp.yaml
@@ -1,0 +1,10 @@
+# Default feature flag configuration for Data Commons Platform (DCP) Spanner deployments.
+# NOTE: These defaults can be dynamically overridden by container environment variables configured in Terraform and applied via datacommonsorg/website:build/cdc_services/update_dcp_flags.py during container startup. 
+flags:
+  UseSpannerGraph: true
+  UseMultiEntitySchema: true
+  EnableSDMXDataApi: true
+  EnableEmbeddingsResolver: false
+  EnableSpannerSearchEmbeddings: true
+  UseNewIngestionHistorySchema: false
+  UseSpannerKeyValueStore: false


### PR DESCRIPTION
Introduces `deploy/featureflags/dcp.yaml` containing canonical feature flag baseline defaults for modern Data Commons Platform (DCP) Spanner deployments.

This configuration file replaces the legacy custom stack file naming (`custom.yaml`) and includes explicit baseline controls across all DCP serving features (including `EnableSpannerSearchEmbeddings: true` right by default and explicit entries for `UseNewIngestionHistorySchema` and `UseSpannerKeyValueStore`).

These baseline settings can be dynamically overridden by container environment variables configured in Terraform during container initialization (`update_dcp_flags.py`).