### PR TITLE
chore: Remove deprecated deploy/featureflags/custom.yaml configuration

### DIFF
--- a/deploy/featureflags/custom.yaml
+++ b/deploy/featureflags/custom.yaml
@@ -1,6 +1,0 @@
-# This is read in for DCP deployments when resolve via spanner is enabled. It is not used for CDC.
-flags:
-  UseMultiEntitySchema: true
-  EnableSDMXDataApi: true
-  EnableEmbeddingsResolver: false
-  EnableSpannerSearchEmbeddings: true


### PR DESCRIPTION
Deletes the legacy custom stack configuration file (`deploy/featureflags/custom.yaml`), completely replacing it with canonical feature flag file `deploy/featureflags/dcp.yaml` across modern Data Commons Platform (DCP) serving containers.

---

### 🚨 Critical Merge Dependencies / Blockers
This pull request depends on two prior pull requests being merged and built into active downstream serving container releases first to prevent breaking container boot verification:
1. **[Mixer PR #1997](https://github.com/datacommonsorg/mixer/pull/1997)** (`dcp.yaml` baseline introduction)
2. **[Website PR #6459](https://github.com/datacommonsorg/website/pull/6459)** (`cdc_services/update_dcp_flags.py` and `run.sh` transition to `dcp.yaml`)
