### PR TITLE
Simplify SDMX data and availability query generation

### DIFF
--- a/internal/server/spanner/golden/query_builder/get_sdmx_availability_destination_country.sql
+++ b/internal/server/spanner/golden/query_builder/get_sdmx_availability_destination_country.sql
@@ -1,6 +1,6 @@
 		SELECT DISTINCT t.entity1 AS value
 		FROM TimeSeries t
-		WHERE ((t.variable_measured = "Count_Household") OR (t.variable_measured = "Count_Person"))
+		WHERE (t.variable_measured IN ('Count_Household','Count_Person'))
 			AND t.entity1 IS NOT NULL
 			AND t.entity1 != ''
 		ORDER BY value

--- a/internal/server/spanner/golden/query_builder/get_sdmx_availability_filtered_destination_country.sql
+++ b/internal/server/spanner/golden/query_builder/get_sdmx_availability_filtered_destination_country.sql
@@ -1,6 +1,6 @@
 		SELECT DISTINCT t.entity1 AS value
 		FROM TimeSeries t
-		WHERE ((t.variable_measured = "var1" AND t.entity1 IN ('country/PRT','country/SGP') AND t.measurement_method IN ('Census','Survey') AND t.observation_period IN ('P1Y','P1M') AND t.provenance IN ('dc/base/one','dc/base/two') AND t.entity2 IN ('country/AGO','country/BRA') AND t.unit IN ('Percent','Count')) OR (t.variable_measured = "var2" AND t.entity1 IN ('country/PRT','country/SGP') AND t.measurement_method IN ('Census','Survey') AND t.observation_period IN ('P1Y','P1M') AND t.provenance IN ('dc/base/one','dc/base/two') AND t.entity2 IN ('country/AGO','country/BRA') AND t.unit IN ('Percent','Count')))
+		WHERE (t.variable_measured IN ('var1','var2') AND t.entity1 IN ('country/PRT','country/SGP') AND t.measurement_method IN ('Census','Survey') AND t.observation_period IN ('P1Y','P1M') AND t.provenance IN ('dc/base/one','dc/base/two') AND t.entity2 IN ('country/AGO','country/BRA') AND t.unit IN ('Percent','Count'))
 			AND t.entity1 IS NOT NULL
 			AND t.entity1 != ''
 		ORDER BY value

--- a/internal/server/spanner/golden/query_builder/get_sdmx_availability_measurement_method.sql
+++ b/internal/server/spanner/golden/query_builder/get_sdmx_availability_measurement_method.sql
@@ -1,6 +1,6 @@
 		SELECT DISTINCT t.measurement_method AS value
 		FROM TimeSeries t
-		WHERE ((t.variable_measured = "Count_Household") OR (t.variable_measured = "Count_Person"))
+		WHERE (t.variable_measured IN ('Count_Household','Count_Person'))
 			AND t.measurement_method IS NOT NULL
 			AND t.measurement_method != ''
 		ORDER BY value

--- a/internal/server/spanner/golden/query_builder/get_sdmx_availability_observation_about.sql
+++ b/internal/server/spanner/golden/query_builder/get_sdmx_availability_observation_about.sql
@@ -1,6 +1,6 @@
 		SELECT DISTINCT t.entity1 AS value
 		FROM TimeSeries t
-		WHERE ((t.variable_measured = "Count_Household") OR (t.variable_measured = "Count_Person"))
+		WHERE (t.variable_measured IN ('Count_Household','Count_Person'))
 			AND t.entity1 IS NOT NULL
 			AND t.entity1 != ''
 		ORDER BY value

--- a/internal/server/spanner/golden/query_builder/get_sdmx_availability_observation_period.sql
+++ b/internal/server/spanner/golden/query_builder/get_sdmx_availability_observation_period.sql
@@ -1,6 +1,6 @@
 		SELECT DISTINCT t.observation_period AS value
 		FROM TimeSeries t
-		WHERE ((t.variable_measured = "Count_Household") OR (t.variable_measured = "Count_Person"))
+		WHERE (t.variable_measured IN ('Count_Household','Count_Person'))
 			AND t.observation_period IS NOT NULL
 			AND t.observation_period != ''
 		ORDER BY value

--- a/internal/server/spanner/golden/query_builder/get_sdmx_availability_provenance.sql
+++ b/internal/server/spanner/golden/query_builder/get_sdmx_availability_provenance.sql
@@ -1,6 +1,6 @@
 		SELECT DISTINCT t.provenance AS value
 		FROM TimeSeries t
-		WHERE ((t.variable_measured = "Count_Household") OR (t.variable_measured = "Count_Person"))
+		WHERE (t.variable_measured IN ('Count_Household','Count_Person'))
 			AND t.provenance IS NOT NULL
 			AND t.provenance != ''
 		ORDER BY value

--- a/internal/server/spanner/golden/query_builder/get_sdmx_availability_unit.sql
+++ b/internal/server/spanner/golden/query_builder/get_sdmx_availability_unit.sql
@@ -1,6 +1,6 @@
 		SELECT DISTINCT t.unit AS value
 		FROM TimeSeries t
-		WHERE ((t.variable_measured = "Count_Household") OR (t.variable_measured = "Count_Person"))
+		WHERE (t.variable_measured IN ('Count_Household','Count_Person'))
 			AND t.unit IS NOT NULL
 			AND t.unit != ''
 		ORDER BY value

--- a/internal/server/spanner/golden/query_builder/get_sdmx_availability_variable_measured.sql
+++ b/internal/server/spanner/golden/query_builder/get_sdmx_availability_variable_measured.sql
@@ -1,6 +1,6 @@
 		SELECT DISTINCT t.variable_measured AS value
 		FROM TimeSeries t
-		WHERE ((t.variable_measured = "Count_Household") OR (t.variable_measured = "Count_Person"))
+		WHERE (t.variable_measured IN ('Count_Household','Count_Person'))
 			AND t.variable_measured IS NOT NULL
 			AND t.variable_measured != ''
 		ORDER BY value

--- a/internal/server/spanner/golden/query_builder/get_sdmx_obs_multi_var_slots.sql
+++ b/internal/server/spanner/golden/query_builder/get_sdmx_obs_multi_var_slots.sql
@@ -17,4 +17,4 @@
 			t.facet AS facets,
 			t.entities
 		FROM TimeSeries t
-		WHERE (t.variable_measured = "var1" AND t.entity2 IN ('country/PRT') AND t.entity1 IN ('country/AGO')) OR (t.variable_measured = "var2" AND t.entity1 IN ('country/PRT') AND t.entity2 IN ('country/AGO'))
+		WHERE t.variable_measured IN ('var1','var2') AND t.entity2 IN ('country/PRT') AND t.entity1 IN ('country/AGO')

--- a/internal/server/spanner/golden/query_builder/get_sdmx_obs_single_entity.sql
+++ b/internal/server/spanner/golden/query_builder/get_sdmx_obs_single_entity.sql
@@ -17,4 +17,4 @@
 			t.facet AS facets,
 			t.entities
 		FROM TimeSeries t
-		WHERE (t.variable_measured = "var1" AND t.entity1 IN ('wikidataId/Q119158'))
+		WHERE t.variable_measured IN ('var1') AND t.entity1 IN ('wikidataId/Q119158')

--- a/internal/server/spanner/golden/query_builder/get_sdmx_obs_slots_slicing.sql
+++ b/internal/server/spanner/golden/query_builder/get_sdmx_obs_slots_slicing.sql
@@ -17,4 +17,4 @@
 			t.facet AS facets,
 			t.entities
 		FROM TimeSeries t
-		WHERE (t.variable_measured = "var1" AND t.entity2 IN ('country/PRT','country/SGP') AND t.entity1 IN ('country/AGO'))
+		WHERE t.variable_measured IN ('var1') AND t.entity2 IN ('country/PRT','country/SGP') AND t.entity1 IN ('country/AGO')

--- a/internal/server/spanner/golden/query_builder/get_sdmx_obs_var_and_origin.sql
+++ b/internal/server/spanner/golden/query_builder/get_sdmx_obs_var_and_origin.sql
@@ -17,4 +17,4 @@
 			t.facet AS facets,
 			t.entities
 		FROM TimeSeries t
-		WHERE (t.variable_measured = "var1" AND t.entity1 IN ('country/AGO'))
+		WHERE t.variable_measured IN ('var1') AND t.entity1 IN ('country/AGO')

--- a/internal/server/spanner/golden/query_builder/get_sdmx_obs_var_only.sql
+++ b/internal/server/spanner/golden/query_builder/get_sdmx_obs_var_only.sql
@@ -17,4 +17,4 @@
 			t.facet AS facets,
 			t.entities
 		FROM TimeSeries t
-		WHERE (t.variable_measured = "var1")
+		WHERE t.variable_measured IN ('var1')

--- a/internal/server/spanner/golden/query_builder/get_sdmx_obs_with_facet_and_prov.sql
+++ b/internal/server/spanner/golden/query_builder/get_sdmx_obs_with_facet_and_prov.sql
@@ -17,4 +17,4 @@
 			t.facet AS facets,
 			t.entities
 		FROM TimeSeries t
-		WHERE (t.variable_measured = "var1" AND t.entity2 IN ('country/PRT','country/SGP') AND t.facet_id IN ('facet','alternate-facet') AND t.measurement_method IN ('Census','Survey') AND t.observation_period IN ('P1Y','P1M') AND t.entity1 IN ('country/AGO','country/BRA') AND t.provenance IN ('dc/base/WTO_TradeConnectivity','dc/base/UN_Trade') AND t.unit IN ('Percent','Count'))
+		WHERE t.variable_measured IN ('var1') AND t.entity2 IN ('country/PRT','country/SGP') AND t.facet_id IN ('facet','alternate-facet') AND t.measurement_method IN ('Census','Survey') AND t.observation_period IN ('P1Y','P1M') AND t.entity1 IN ('country/AGO','country/BRA') AND t.provenance IN ('dc/base/WTO_TradeConnectivity','dc/base/UN_Trade') AND t.unit IN ('Percent','Count')

--- a/internal/server/spanner/golden/query_builder_multientity_test.go
+++ b/internal/server/spanner/golden/query_builder_multientity_test.go
@@ -168,7 +168,7 @@ func TestMultiEntityGetSdmxObservationsQuery(t *testing.T) {
 				if err != nil {
 					return nil, err
 				}
-				stmt, err := builder.GetSdmxObservationsQuery(c.constraints, c.entitySlotsByStatVar)
+				stmt, err := builder.GetSdmxObservationsQuery(c.constraints, c.entitySlotByObservationProperty)
 				return stmt, err
 			})
 		})
@@ -187,19 +187,19 @@ func TestMultiEntityGetSdmxObservationsQuery_Validation(t *testing.T) {
 		"provenance":        sdmxComponentConstraint("dc/base/INPE_Fire_Event_Count"),
 		"observationPeriod": sdmxComponentConstraint("P1Y"),
 	}
-	entitySlotsByStatVar := map[string]map[string]string{
-		"var1": {"observationAbout": "entity1"},
+	entitySlotByObservationProperty := map[string]string{
+		"observationAbout": "entity1",
 	}
-	_, err = builder.GetSdmxObservationsQuery(constraints, entitySlotsByStatVar)
+	_, err = builder.GetSdmxObservationsQuery(constraints, entitySlotByObservationProperty)
 	if err != nil {
 		t.Errorf("expected no error for valid constraint keys, got %v", err)
 	}
 
 	for _, tc := range []struct {
-		name                 string
-		constraints          map[string]*sdmxpb.SdmxComponentConstraint
-		entitySlotsByStatVar map[string]map[string]string
-		want                 string
+		name                            string
+		constraints                     map[string]*sdmxpb.SdmxComponentConstraint
+		entitySlotByObservationProperty map[string]string
+		want                            string
 	}{
 		{
 			name: "nil constraints",
@@ -258,20 +258,20 @@ func TestMultiEntityGetSdmxObservationsQuery_Validation(t *testing.T) {
 				"variableMeasured": sdmxComponentConstraint("var1"),
 				"customEntity":     sdmxComponentConstraint("value"),
 			},
-			entitySlotsByStatVar: entitySlotsByStatVar,
-			want:                 `GetSdmxObservationsQuery: unsupported SDMX component filter "customEntity"`,
+			entitySlotByObservationProperty: entitySlotByObservationProperty,
+			want:                            `GetSdmxObservationsQuery: unsupported SDMX component filter "customEntity"`,
 		},
 		{
 			name:        "observation about outside resolved properties",
 			constraints: constraints,
-			entitySlotsByStatVar: map[string]map[string]string{
-				"var1": {"destinationCountry": "entity1", "sourceCountry": "entity2"},
+			entitySlotByObservationProperty: map[string]string{
+				"destinationCountry": "entity1", "sourceCountry": "entity2",
 			},
 			want: `GetSdmxObservationsQuery: unsupported SDMX component filter "observationAbout"`,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := builder.GetSdmxObservationsQuery(tc.constraints, tc.entitySlotsByStatVar)
+			_, err := builder.GetSdmxObservationsQuery(tc.constraints, tc.entitySlotByObservationProperty)
 			if status.Code(err) != codes.InvalidArgument {
 				t.Fatalf("GetSdmxObservationsQuery() code = %v, want %v; err = %v", status.Code(err), codes.InvalidArgument, err)
 			}
@@ -289,7 +289,7 @@ func TestMultiEntityGetSdmxObservationsQueryDoesNotUseFacetJSONFallback(t *testi
 	}
 
 	for _, c := range multiEntitySdmxObservationsTestCases {
-		stmt, err := builder.GetSdmxObservationsQuery(c.constraints, c.entitySlotsByStatVar)
+		stmt, err := builder.GetSdmxObservationsQuery(c.constraints, c.entitySlotByObservationProperty)
 		if err != nil {
 			t.Fatalf("GetSdmxObservationsQuery(%q) error = %v", c.name, err)
 		}
@@ -310,11 +310,9 @@ func TestMultiEntityGetSdmxObservationsQueryUsesResolvedObservationAboutSlot(t *
 			"variableMeasured": sdmxComponentConstraint("var1"),
 			"observationAbout": sdmxComponentConstraint("country/USA"),
 		},
-		map[string]map[string]string{
-			"var1": {
-				"destinationCountry": "entity1",
-				"observationAbout":   "entity2",
-			},
+		map[string]string{
+			"destinationCountry": "entity1",
+			"observationAbout":   "entity2",
 		},
 	)
 	if err != nil {
@@ -387,8 +385,8 @@ func TestMultiEntityQueryBuildersUseCustomTableConfig(t *testing.T) {
 		Constraints: map[string]*sdmxpb.SdmxComponentConstraint{
 			"variableMeasured": sdmxComponentConstraint("Count_Person"),
 		},
-	}, map[string]map[string]string{
-		"Count_Person": {"observationAbout": "entity1"},
+	}, map[string]string{
+		"observationAbout": "entity1",
 	})
 	if err != nil {
 		t.Fatalf("GetSdmxAvailabilityQuery() returned error: %v", err)
@@ -409,26 +407,24 @@ func TestMultiEntityGetSdmxAvailabilityQuery(t *testing.T) {
 	t.Parallel()
 
 	for _, c := range []struct {
-		name                 string
-		componentID          string
-		entitySlotsByStatVar map[string]map[string]string
-		golden               string
+		name                            string
+		componentID                     string
+		entitySlotByObservationProperty map[string]string
+		golden                          string
 	}{
 		{
 			name:        "observation about",
 			componentID: "observationAbout",
-			entitySlotsByStatVar: map[string]map[string]string{
-				"Count_Household": {"observationAbout": "entity1"},
-				"Count_Person":    {"observationAbout": "entity1"},
+			entitySlotByObservationProperty: map[string]string{
+				"observationAbout": "entity1",
 			},
 			golden: "get_sdmx_availability_observation_about.sql",
 		},
 		{
 			name:        "dynamic observation property",
 			componentID: "destinationCountry",
-			entitySlotsByStatVar: map[string]map[string]string{
-				"Count_Household": {"destinationCountry": "entity1", "sourceCountry": "entity2"},
-				"Count_Person":    {"destinationCountry": "entity1", "sourceCountry": "entity2"},
+			entitySlotByObservationProperty: map[string]string{
+				"destinationCountry": "entity1", "sourceCountry": "entity2",
 			},
 			golden: "get_sdmx_availability_destination_country.sql",
 		},
@@ -470,7 +466,7 @@ func TestMultiEntityGetSdmxAvailabilityQuery(t *testing.T) {
 					Constraints: map[string]*sdmxpb.SdmxComponentConstraint{
 						"variableMeasured": sdmxComponentConstraint("Count_Person", "Count_Household"),
 					},
-				}, c.entitySlotsByStatVar)
+				}, c.entitySlotByObservationProperty)
 			})
 		})
 	}
@@ -493,9 +489,8 @@ func TestMultiEntityGetSdmxAvailabilityQueryWithDimensionFilters(t *testing.T) {
 				"provenance":         sdmxComponentConstraint("dc/base/one", "dc/base/two"),
 				"unit":               sdmxComponentConstraint("Percent", "Count"),
 			},
-		}, map[string]map[string]string{
-			"var1": {"destinationCountry": "entity1", "sourceCountry": "entity2"},
-			"var2": {"destinationCountry": "entity1", "sourceCountry": "entity2"},
+		}, map[string]string{
+			"destinationCountry": "entity1", "sourceCountry": "entity2",
 		})
 	})
 }
@@ -507,10 +502,10 @@ func TestMultiEntityGetSdmxAvailabilityQuery_Validation(t *testing.T) {
 	}
 
 	for _, tc := range []struct {
-		name                 string
-		req                  *sdmxpb.SdmxAvailabilityQuery
-		entitySlotsByStatVar map[string]map[string]string
-		want                 string
+		name                            string
+		req                             *sdmxpb.SdmxAvailabilityQuery
+		entitySlotByObservationProperty map[string]string
+		want                            string
 	}{
 		{
 			name: "nil request",
@@ -569,7 +564,7 @@ func TestMultiEntityGetSdmxAvailabilityQuery_Validation(t *testing.T) {
 					"variableMeasured": sdmxComponentConstraint("Count_Person"),
 				},
 			},
-			want: `unsupported SDMX availability component "TIME_PERIOD" for variableMeasured "Count_Person"`,
+			want: `unsupported SDMX availability component "TIME_PERIOD"`,
 		},
 		{
 			name: "unsupported constraint",
@@ -590,25 +585,11 @@ func TestMultiEntityGetSdmxAvailabilityQuery_Validation(t *testing.T) {
 					"variableMeasured": sdmxComponentConstraint("var1"),
 				},
 			},
-			want: `unsupported SDMX availability component "destinationCountry" for variableMeasured "var1"`,
-		},
-		{
-			name: "inconsistent target mapping",
-			req: &sdmxpb.SdmxAvailabilityQuery{
-				ComponentId: "destinationCountry",
-				Constraints: map[string]*sdmxpb.SdmxComponentConstraint{
-					"variableMeasured": sdmxComponentConstraint("var1", "var2"),
-				},
-			},
-			entitySlotsByStatVar: map[string]map[string]string{
-				"var1": {"destinationCountry": "entity1"},
-				"var2": {"destinationCountry": "entity2"},
-			},
-			want: `SDMX availability component "destinationCountry" has incompatible entity mappings across variableMeasured values [var1 var2]`,
+			want: `unsupported SDMX availability component "destinationCountry"`,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := builder.GetSdmxAvailabilityQuery(tc.req, tc.entitySlotsByStatVar)
+			_, err := builder.GetSdmxAvailabilityQuery(tc.req, tc.entitySlotByObservationProperty)
 			if status.Code(err) != codes.InvalidArgument {
 				t.Fatalf("GetSdmxAvailabilityQuery() code = %v, want %v; err = %v", status.Code(err), codes.InvalidArgument, err)
 			}

--- a/internal/server/spanner/golden/query_builder_multientity_test.go
+++ b/internal/server/spanner/golden/query_builder_multientity_test.go
@@ -262,6 +262,17 @@ func TestMultiEntityGetSdmxObservationsQuery_Validation(t *testing.T) {
 			want:                            `GetSdmxObservationsQuery: unsupported SDMX component filter "customEntity"`,
 		},
 		{
+			name: "empty dynamic component mapping",
+			constraints: map[string]*sdmxpb.SdmxComponentConstraint{
+				"variableMeasured":   sdmxComponentConstraint("var1"),
+				"destinationCountry": sdmxComponentConstraint("country/USA"),
+			},
+			entitySlotByObservationProperty: map[string]string{
+				"destinationCountry": "",
+			},
+			want: `GetSdmxObservationsQuery: unsupported SDMX component filter "destinationCountry"`,
+		},
+		{
 			name:        "observation about outside resolved properties",
 			constraints: constraints,
 			entitySlotByObservationProperty: map[string]string{

--- a/internal/server/spanner/golden/query_multientity_cases_test.go
+++ b/internal/server/spanner/golden/query_multientity_cases_test.go
@@ -301,18 +301,18 @@ var multiEntityFilteredTopicTestCases = []struct {
 }
 
 var multiEntitySdmxObservationsTestCases = []struct {
-	name                 string
-	constraints          map[string]*sdmxpb.SdmxComponentConstraint
-	entitySlotsByStatVar map[string]map[string]string
-	golden               string
+	name                            string
+	constraints                     map[string]*sdmxpb.SdmxComponentConstraint
+	entitySlotByObservationProperty map[string]string
+	golden                          string
 }{
 	{
 		name: "variable measured only",
 		constraints: map[string]*sdmxpb.SdmxComponentConstraint{
 			"variableMeasured": sdmxComponentConstraint("var1"),
 		},
-		entitySlotsByStatVar: map[string]map[string]string{},
-		golden:               "get_sdmx_obs_var_only",
+		entitySlotByObservationProperty: map[string]string{},
+		golden:                          "get_sdmx_obs_var_only",
 	},
 	{
 		name: "variable measured and origin slot",
@@ -320,8 +320,8 @@ var multiEntitySdmxObservationsTestCases = []struct {
 			"variableMeasured": sdmxComponentConstraint("var1"),
 			"origin":           sdmxComponentConstraint("country/AGO"),
 		},
-		entitySlotsByStatVar: map[string]map[string]string{
-			"var1": {"origin": "entity1"},
+		entitySlotByObservationProperty: map[string]string{
+			"origin": "entity1",
 		},
 		golden: "get_sdmx_obs_var_and_origin",
 	},
@@ -332,21 +332,20 @@ var multiEntitySdmxObservationsTestCases = []struct {
 			"origin":           sdmxComponentConstraint("country/AGO"),
 			"destination":      sdmxComponentConstraint("country/PRT", "country/SGP"),
 		},
-		entitySlotsByStatVar: map[string]map[string]string{
-			"var1": {"origin": "entity1", "destination": "entity2"},
+		entitySlotByObservationProperty: map[string]string{
+			"origin": "entity1", "destination": "entity2",
 		},
 		golden: "get_sdmx_obs_slots_slicing",
 	},
 	{
-		name: "multiple variables with different slot mappings",
+		name: "multiple variables with common slot mapping",
 		constraints: map[string]*sdmxpb.SdmxComponentConstraint{
 			"variableMeasured": sdmxComponentConstraint("var1", "var2"),
 			"origin":           sdmxComponentConstraint("country/AGO"),
 			"destination":      sdmxComponentConstraint("country/PRT"),
 		},
-		entitySlotsByStatVar: map[string]map[string]string{
-			"var1": {"origin": "entity1", "destination": "entity2"},
-			"var2": {"origin": "entity2", "destination": "entity1"}, // reversed mapping for var2
+		entitySlotByObservationProperty: map[string]string{
+			"origin": "entity1", "destination": "entity2",
 		},
 		golden: "get_sdmx_obs_multi_var_slots",
 	},
@@ -362,8 +361,8 @@ var multiEntitySdmxObservationsTestCases = []struct {
 			"provenance":        sdmxComponentConstraint("dc/base/WTO_TradeConnectivity", "dc/base/UN_Trade"),
 			"unit":              sdmxComponentConstraint("Percent", "Count"),
 		},
-		entitySlotsByStatVar: map[string]map[string]string{
-			"var1": {"origin": "entity1", "destination": "entity2"},
+		entitySlotByObservationProperty: map[string]string{
+			"origin": "entity1", "destination": "entity2",
 		},
 		golden: "get_sdmx_obs_with_facet_and_prov",
 	},
@@ -373,8 +372,8 @@ var multiEntitySdmxObservationsTestCases = []struct {
 			"variableMeasured": sdmxComponentConstraint("var1"),
 			"observationAbout": sdmxComponentConstraint("wikidataId/Q119158"),
 		},
-		entitySlotsByStatVar: map[string]map[string]string{
-			"var1": {"observationAbout": "entity1"},
+		entitySlotByObservationProperty: map[string]string{
+			"observationAbout": "entity1",
 		},
 		golden: "get_sdmx_obs_single_entity",
 	},

--- a/internal/server/spanner/query_builder_multientity.go
+++ b/internal/server/spanner/query_builder_multientity.go
@@ -371,7 +371,7 @@ func compileSdmxConstraints(
 	clauses := []string{sdmxAllowedValuesClause("variable_measured", datacommons.ComponentVariableMeasured)}
 	for _, componentID := range componentIDs {
 		spannerColumn, ok := sdmxDataFilterColumn(componentID, entitySlotByObservationProperty)
-		if !ok {
+		if !ok || spannerColumn == "" {
 			return nil, status.Errorf(codes.InvalidArgument, "unsupported SDMX component filter %q", componentID)
 		}
 		clauses = append(clauses, sdmxAllowedValuesClause(spannerColumn, componentID))

--- a/internal/server/spanner/query_builder_multientity.go
+++ b/internal/server/spanner/query_builder_multientity.go
@@ -22,6 +22,7 @@ import (
 
 	"cloud.google.com/go/spanner"
 	sdmxpb "github.com/datacommonsorg/mixer/internal/proto/sdmx"
+	"github.com/datacommonsorg/mixer/internal/server/sdmx/datacommons"
 	v2 "github.com/datacommonsorg/mixer/internal/server/v2"
 	"github.com/datacommonsorg/mixer/internal/server/v2/shared"
 	"google.golang.org/grpc/codes"
@@ -296,9 +297,9 @@ var constraintKeyRegex = regexp.MustCompile(`^[a-zA-Z0-9_]+$`)
 // GetSdmxObservationsQuery builds the Spanner statement for SDMX observation lookup.
 func (b *multiEntityQueryBuilder) GetSdmxObservationsQuery(
 	constraints map[string]*sdmxpb.SdmxComponentConstraint,
-	entitySlotsByStatVar map[string]map[string]string,
+	entitySlotByObservationProperty map[string]string,
 ) (*spanner.Statement, error) {
-	compiled, err := compileSdmxConstraints(constraints, entitySlotsByStatVar)
+	compiled, err := compileSdmxConstraints(constraints, entitySlotByObservationProperty)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "GetSdmxObservationsQuery: %s", status.Convert(err).Message())
 	}
@@ -310,9 +311,8 @@ func (b *multiEntityQueryBuilder) GetSdmxObservationsQuery(
 }
 
 type compiledSdmxConstraints struct {
-	where      string
-	params     map[string]interface{}
-	statVarIDs []string
+	where  string
+	params map[string]interface{}
 }
 
 func sdmxConstraintValues(constraint *sdmxpb.SdmxComponentConstraint) []string {
@@ -326,7 +326,7 @@ func sdmxConstraintValues(constraint *sdmxpb.SdmxComponentConstraint) []string {
 
 func compileSdmxConstraints(
 	constraints map[string]*sdmxpb.SdmxComponentConstraint,
-	entitySlotsByStatVar map[string]map[string]string,
+	entitySlotByObservationProperty map[string]string,
 ) (*compiledSdmxConstraints, error) {
 	if constraints == nil {
 		return nil, status.Error(codes.InvalidArgument, "SDMX request constraints cannot be nil")
@@ -346,7 +346,7 @@ func compileSdmxConstraints(
 		}
 	}
 
-	variableMeasured, ok := constraints["variableMeasured"]
+	variableMeasured, ok := constraints[datacommons.ComponentVariableMeasured]
 	variableMeasuredValues := sdmxConstraintValues(variableMeasured)
 	if !ok || len(variableMeasuredValues) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "SDMX component filter variableMeasured must be specified")
@@ -355,35 +355,31 @@ func compileSdmxConstraints(
 
 	componentIDs := []string{}
 	for componentID := range constraints {
-		if componentID != "variableMeasured" {
+		if componentID != datacommons.ComponentVariableMeasured {
 			componentIDs = append(componentIDs, componentID)
 		}
 	}
 	sort.Strings(componentIDs)
 
-	params := map[string]interface{}{}
+	params := map[string]interface{}{
+		datacommons.ComponentVariableMeasured: statVarIDs,
+	}
 	for _, componentID := range componentIDs {
 		params[componentID] = sdmxConstraintValues(constraints[componentID])
 	}
 
-	statVarBranches := make([]string, 0, len(statVarIDs))
-	for _, statVarID := range statVarIDs {
-		clauses := []string{fmt.Sprintf("t.variable_measured = %q", statVarID)}
-		entitySlots := entitySlotsByStatVar[statVarID]
-		for _, componentID := range componentIDs {
-			spannerColumn, ok := sdmxDataFilterColumn(componentID, entitySlots)
-			if !ok {
-				return nil, status.Errorf(codes.InvalidArgument, "unsupported SDMX component filter %q", componentID)
-			}
-			clauses = append(clauses, sdmxAllowedValuesClause(spannerColumn, componentID))
+	clauses := []string{sdmxAllowedValuesClause("variable_measured", datacommons.ComponentVariableMeasured)}
+	for _, componentID := range componentIDs {
+		spannerColumn, ok := sdmxDataFilterColumn(componentID, entitySlotByObservationProperty)
+		if !ok {
+			return nil, status.Errorf(codes.InvalidArgument, "unsupported SDMX component filter %q", componentID)
 		}
-		statVarBranches = append(statVarBranches, "("+strings.Join(clauses, " AND ")+")")
+		clauses = append(clauses, sdmxAllowedValuesClause(spannerColumn, componentID))
 	}
 
 	return &compiledSdmxConstraints{
-		where:      strings.Join(statVarBranches, " OR "),
-		params:     params,
-		statVarIDs: statVarIDs,
+		where:  strings.Join(clauses, " AND "),
+		params: params,
 	}, nil
 }
 
@@ -394,16 +390,16 @@ func sdmxAllowedValuesClause(spannerColumn string, parameter string) string {
 // GetSdmxAvailabilityQuery builds the SDMX availability lookup.
 func (b *multiEntityQueryBuilder) GetSdmxAvailabilityQuery(
 	req *sdmxpb.SdmxAvailabilityQuery,
-	entitySlotsByStatVar map[string]map[string]string,
+	entitySlotByObservationProperty map[string]string,
 ) (*spanner.Statement, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "SDMX availability request cannot be nil")
 	}
-	compiled, err := compileSdmxConstraints(req.GetConstraints(), entitySlotsByStatVar)
+	compiled, err := compileSdmxConstraints(req.GetConstraints(), entitySlotByObservationProperty)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "GetSdmxAvailabilityQuery: %s", status.Convert(err).Message())
 	}
-	valueExpression, err := sdmxAvailabilityValueExpression(req.GetComponentId(), compiled.statVarIDs, entitySlotsByStatVar)
+	valueExpression, err := sdmxAvailabilityValueExpression(req.GetComponentId(), entitySlotByObservationProperty)
 	if err != nil {
 		return nil, err
 	}
@@ -416,31 +412,14 @@ func (b *multiEntityQueryBuilder) GetSdmxAvailabilityQuery(
 
 func sdmxAvailabilityValueExpression(
 	componentID string,
-	statVarIDs []string,
-	entitySlotsByStatVar map[string]map[string]string,
+	entitySlotByObservationProperty map[string]string,
 ) (string, error) {
-	if len(statVarIDs) == 0 {
-		return "", status.Error(codes.InvalidArgument, "SDMX availability requires at least one variableMeasured value")
-	}
-	if componentID == "variableMeasured" {
+	if componentID == datacommons.ComponentVariableMeasured {
 		return "t.variable_measured", nil
 	}
 
-	spannerColumn := ""
-	for _, statVarID := range statVarIDs {
-		column, ok := sdmxDataFilterColumn(componentID, entitySlotsByStatVar[statVarID])
-		if !ok {
-			return "", status.Errorf(codes.InvalidArgument, "unsupported SDMX availability component %q for variableMeasured %q", componentID, statVarID)
-		}
-		if spannerColumn == "" {
-			spannerColumn = column
-			continue
-		}
-		if column != spannerColumn {
-			return "", status.Errorf(codes.InvalidArgument, "SDMX availability component %q has incompatible entity mappings across variableMeasured values %v", componentID, statVarIDs)
-		}
-	}
-	if spannerColumn == "" {
+	spannerColumn, ok := sdmxDataFilterColumn(componentID, entitySlotByObservationProperty)
+	if !ok || spannerColumn == "" {
 		return "", status.Errorf(codes.InvalidArgument, "unsupported SDMX availability component %q", componentID)
 	}
 	return "t." + spannerColumn, nil

--- a/internal/server/spanner/query_multientity.go
+++ b/internal/server/spanner/query_multientity.go
@@ -487,7 +487,7 @@ func (nc *multiEntityClient) GetSdmxObservations(
 		}
 
 		series := &sdmxpb.SdmxTimeSeries{
-			Dimensions: sdmxSeriesDimensions(r.VariableMeasured, entitySlotValues, prepared.entitySlotsByStatVar),
+			Dimensions: sdmxSeriesDimensions(r.VariableMeasured, entitySlotValues, prepared.entitySlotByObservationProperty),
 			Points:     []*sdmxpb.SdmxDataPoint{},
 		}
 		if r.ProvenanceID.Valid {
@@ -528,15 +528,15 @@ type getNodeEdgesByIDFunc func(
 ) (map[string][]*Edge, error)
 
 type preparedSdmxObservationsQuery struct {
-	shape                *sdmxpb.SdmxDataShape
-	entitySlotsByStatVar map[string]map[string]string
-	statement            *spanner.Statement
+	shape                           *sdmxpb.SdmxDataShape
+	entitySlotByObservationProperty map[string]string
+	statement                       *spanner.Statement
 }
 
 type preparedSdmxShape struct {
-	shape                 *sdmxpb.SdmxDataShape
-	observationProperties []string
-	entitySlotsByStatVar  map[string]map[string]string
+	shape                           *sdmxpb.SdmxDataShape
+	observationProperties           []string
+	entitySlotByObservationProperty map[string]string
 }
 
 func prepareSdmxObservationsQuery(
@@ -556,14 +556,14 @@ func prepareSdmxObservationsQuery(
 		return nil, err
 	}
 
-	statement, err := queryBuilder.GetSdmxObservationsQuery(constraints, preparedShape.entitySlotsByStatVar)
+	statement, err := queryBuilder.GetSdmxObservationsQuery(constraints, preparedShape.entitySlotByObservationProperty)
 	if err != nil {
 		return nil, err
 	}
 	return &preparedSdmxObservationsQuery{
-		shape:                preparedShape.shape,
-		entitySlotsByStatVar: preparedShape.entitySlotsByStatVar,
-		statement:            statement,
+		shape:                           preparedShape.shape,
+		entitySlotByObservationProperty: preparedShape.entitySlotByObservationProperty,
+		statement:                       statement,
 	}, nil
 }
 
@@ -588,27 +588,27 @@ func prepareSdmxShape(
 	if err != nil {
 		return nil, sdmxBackendError("failed to fetch observationProperties", err)
 	}
-	observationProperties, entitySlotsByStatVar, err := resolveSdmxEntityShape(statVarIDs, observationPropertyEdgesByStatVar)
+	observationProperties, entitySlotByObservationProperty, err := resolveSdmxEntityShape(statVarIDs, observationPropertyEdgesByStatVar)
 	if err != nil {
 		return nil, err
 	}
 	shape := sdmxDataShape(observationProperties)
 	return &preparedSdmxShape{
-		shape:                 shape,
-		observationProperties: observationProperties,
-		entitySlotsByStatVar:  entitySlotsByStatVar,
+		shape:                           shape,
+		observationProperties:           observationProperties,
+		entitySlotByObservationProperty: entitySlotByObservationProperty,
 	}, nil
 }
 
 func sdmxSeriesDimensions(
 	variableMeasured string,
 	entitySlotValues map[string]string,
-	entitySlotsByStatVar map[string]map[string]string,
+	entitySlotByObservationProperty map[string]string,
 ) map[string]string {
 	dimensionValues := map[string]string{
 		datacommons.ComponentVariableMeasured: variableMeasured,
 	}
-	for observationProperty, entitySlot := range entitySlotsByStatVar[variableMeasured] {
+	for observationProperty, entitySlot := range entitySlotByObservationProperty {
 		if value, ok := entitySlotValues[entitySlot]; ok {
 			dimensionValues[observationProperty] = value
 		}
@@ -810,13 +810,13 @@ func prepareSdmxAvailabilityQuery(
 	if err := validateSdmxAvailabilityComponent(req.GetComponentId(), preparedShape.shape); err != nil {
 		return nil, err
 	}
-	return queryBuilder.GetSdmxAvailabilityQuery(req, preparedShape.entitySlotsByStatVar)
+	return queryBuilder.GetSdmxAvailabilityQuery(req, preparedShape.entitySlotByObservationProperty)
 }
 
 func resolveSdmxEntityShape(
 	statVarIDs []string,
 	observationPropertyEdgesByStatVar map[string][]*Edge,
-) ([]string, map[string]map[string]string, error) {
+) ([]string, map[string]string, error) {
 	observationPropertiesByStatVar := map[string][]string{}
 	for _, statVarID := range statVarIDs {
 		observationPropertySet := map[string]struct{}{}
@@ -880,15 +880,11 @@ func resolveSdmxEntityShape(
 		}
 	}
 
-	entitySlotsByStatVar := map[string]map[string]string{}
-	for statVarID, observationProperties := range observationPropertiesByStatVar {
-		entitySlots := map[string]string{}
-		for i, observationProperty := range observationProperties {
-			entitySlots[observationProperty] = fmt.Sprintf("entity%d", i+1)
-		}
-		entitySlotsByStatVar[statVarID] = entitySlots
+	entitySlotByObservationProperty := map[string]string{}
+	for i, observationProperty := range resolvedObservationProperties {
+		entitySlotByObservationProperty[observationProperty] = fmt.Sprintf("entity%d", i+1)
 	}
-	return resolvedObservationProperties, entitySlotsByStatVar, nil
+	return resolvedObservationProperties, entitySlotByObservationProperty, nil
 }
 
 func sdmxBackendError(message string, err error) error {

--- a/internal/server/spanner/query_multientity_test.go
+++ b/internal/server/spanner/query_multientity_test.go
@@ -530,43 +530,42 @@ func TestPrepareSdmxObservationsQuery(t *testing.T) {
 	if diff := cmp.Diff(wantShape, prepared.shape, protocmp.Transform()); diff != "" {
 		t.Fatalf("prepareSdmxObservationsQuery() shape mismatch (-want +got):\n%s", diff)
 	}
-	wantEntitySlotsByStatVar := map[string]map[string]string{
-		"var1": {
-			"destinationCountry": "entity1",
-			"sourceCountry":      "entity2",
-		},
-		"var2": {
-			"destinationCountry": "entity1",
-			"sourceCountry":      "entity2",
-		},
+	wantEntitySlotByObservationProperty := map[string]string{
+		"destinationCountry": "entity1",
+		"sourceCountry":      "entity2",
 	}
-	if diff := cmp.Diff(wantEntitySlotsByStatVar, prepared.entitySlotsByStatVar); diff != "" {
+	if diff := cmp.Diff(wantEntitySlotByObservationProperty, prepared.entitySlotByObservationProperty); diff != "" {
 		t.Fatalf("prepareSdmxObservationsQuery() entity slots mismatch (-want +got):\n%s", diff)
 	}
 	wantParams := map[string]interface{}{
-		"destinationCountry": []string{"country/CAN", "country/MEX"},
-		"sourceCountry":      []string{"country/USA", "country/IND"},
-		"unit":               []string{"Count", "Percent"},
-		"measurementMethod":  []string{"Census", "Survey"},
-		"observationPeriod":  []string{"P1Y", "P1M"},
-		"provenance":         []string{"dc/base/one", "dc/base/two"},
-		"facetId":            []string{"facet", "alternate-facet"},
+		datacommons.ComponentVariableMeasured: []string{"var1", "var2"},
+		"destinationCountry":                  []string{"country/CAN", "country/MEX"},
+		"sourceCountry":                       []string{"country/USA", "country/IND"},
+		"unit":                                []string{"Count", "Percent"},
+		"measurementMethod":                   []string{"Census", "Survey"},
+		"observationPeriod":                   []string{"P1Y", "P1M"},
+		"provenance":                          []string{"dc/base/one", "dc/base/two"},
+		"facetId":                             []string{"facet", "alternate-facet"},
 	}
 	if diff := cmp.Diff(wantParams, prepared.statement.Params); diff != "" {
 		t.Fatalf("prepareSdmxObservationsQuery() params mismatch (-want +got):\n%s", diff)
 	}
+	if !strings.Contains(prepared.statement.SQL, "t.variable_measured IN UNNEST(@variableMeasured)") {
+		t.Fatalf("prepareSdmxObservationsQuery() SQL does not parameterize variableMeasured:\n%s", prepared.statement.SQL)
+	}
+	if strings.Contains(prepared.statement.SQL, `t.variable_measured =`) {
+		t.Fatalf("prepareSdmxObservationsQuery() SQL contains a variableMeasured literal branch:\n%s", prepared.statement.SQL)
+	}
 
 	interpolatedSQL := InterpolateSQL(prepared.statement)
 	for _, fragment := range []string{
-		`t.variable_measured = "var1" AND t.entity1 IN ('country/CAN','country/MEX')`,
-		`t.variable_measured = "var2" AND t.entity1 IN ('country/CAN','country/MEX')`,
+		`t.variable_measured IN ('var1','var2') AND t.entity1 IN ('country/CAN','country/MEX')`,
 		`t.entity2 IN ('country/USA','country/IND')`,
 		`t.facet_id IN ('facet','alternate-facet')`,
 		`t.measurement_method IN ('Census','Survey')`,
 		`t.observation_period IN ('P1Y','P1M')`,
 		`t.provenance IN ('dc/base/one','dc/base/two')`,
 		`t.unit IN ('Count','Percent')`,
-		`) OR (`,
 	} {
 		if !strings.Contains(interpolatedSQL, fragment) {
 			t.Errorf("prepareSdmxObservationsQuery() SQL does not contain %q:\n%s", fragment, interpolatedSQL)
@@ -617,24 +616,29 @@ func TestPrepareSdmxAvailabilityQuery(t *testing.T) {
 	}
 
 	wantParams := map[string]interface{}{
-		"destinationCountry": []string{"country/CAN", "country/MEX"},
-		"sourceCountry":      []string{"country/USA", "country/IND"},
-		"unit":               []string{"Count", "Percent"},
-		"measurementMethod":  []string{"Census", "Survey"},
-		"observationPeriod":  []string{"P1Y", "P1M"},
-		"provenance":         []string{"dc/base/one", "dc/base/two"},
+		datacommons.ComponentVariableMeasured: []string{"var1", "var2"},
+		"destinationCountry":                  []string{"country/CAN", "country/MEX"},
+		"sourceCountry":                       []string{"country/USA", "country/IND"},
+		"unit":                                []string{"Count", "Percent"},
+		"measurementMethod":                   []string{"Census", "Survey"},
+		"observationPeriod":                   []string{"P1Y", "P1M"},
+		"provenance":                          []string{"dc/base/one", "dc/base/two"},
 	}
 	if diff := cmp.Diff(wantParams, stmt.Params); diff != "" {
 		t.Fatalf("prepareSdmxAvailabilityQuery() params mismatch (-want +got):\n%s", diff)
 	}
+	if !strings.Contains(stmt.SQL, "t.variable_measured IN UNNEST(@variableMeasured)") {
+		t.Fatalf("prepareSdmxAvailabilityQuery() SQL does not parameterize variableMeasured:\n%s", stmt.SQL)
+	}
+	if strings.Contains(stmt.SQL, `t.variable_measured =`) {
+		t.Fatalf("prepareSdmxAvailabilityQuery() SQL contains a variableMeasured literal branch:\n%s", stmt.SQL)
+	}
 	interpolatedSQL := InterpolateSQL(stmt)
 	for _, fragment := range []string{
 		"SELECT DISTINCT t.entity1 AS value",
-		`t.variable_measured = "var1" AND t.entity1 IN ('country/CAN','country/MEX')`,
-		`t.variable_measured = "var2" AND t.entity1 IN ('country/CAN','country/MEX')`,
+		`t.variable_measured IN ('var1','var2') AND t.entity1 IN ('country/CAN','country/MEX')`,
 		`t.entity2 IN ('country/USA','country/IND')`,
 		`t.measurement_method IN ('Census','Survey')`,
-		`) OR (`,
 	} {
 		if !strings.Contains(interpolatedSQL, fragment) {
 			t.Errorf("prepareSdmxAvailabilityQuery() SQL does not contain %q:\n%s", fragment, interpolatedSQL)
@@ -773,45 +777,27 @@ func TestSdmxBackendError(t *testing.T) {
 
 func TestSdmxAvailabilityValueExpressionValidation(t *testing.T) {
 	for _, tc := range []struct {
-		name                 string
-		componentID          string
-		statVarIDs           []string
-		entitySlotsByStatVar map[string]map[string]string
-		want                 string
+		name                            string
+		componentID                     string
+		entitySlotByObservationProperty map[string]string
+		want                            string
 	}{
-		{
-			name:        "missing variable measured values",
-			componentID: datacommons.ComponentVariableMeasured,
-			want:        "SDMX availability requires at least one variableMeasured value",
-		},
 		{
 			name:        "missing component mapping",
 			componentID: "destinationCountry",
-			statVarIDs:  []string{"var1"},
-			want:        `unsupported SDMX availability component "destinationCountry" for variableMeasured "var1"`,
-		},
-		{
-			name:        "inconsistent component mapping",
-			componentID: "destinationCountry",
-			statVarIDs:  []string{"var1", "var2"},
-			entitySlotsByStatVar: map[string]map[string]string{
-				"var1": {"destinationCountry": "entity1"},
-				"var2": {"destinationCountry": "entity2"},
-			},
-			want: `SDMX availability component "destinationCountry" has incompatible entity mappings across variableMeasured values [var1 var2]`,
+			want:        `unsupported SDMX availability component "destinationCountry"`,
 		},
 		{
 			name:        "empty component mapping",
 			componentID: "destinationCountry",
-			statVarIDs:  []string{"var1"},
-			entitySlotsByStatVar: map[string]map[string]string{
-				"var1": {"destinationCountry": ""},
+			entitySlotByObservationProperty: map[string]string{
+				"destinationCountry": "",
 			},
 			want: `unsupported SDMX availability component "destinationCountry"`,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := sdmxAvailabilityValueExpression(tc.componentID, tc.statVarIDs, tc.entitySlotsByStatVar)
+			_, err := sdmxAvailabilityValueExpression(tc.componentID, tc.entitySlotByObservationProperty)
 			if status.Code(err) != codes.InvalidArgument {
 				t.Fatalf("sdmxAvailabilityValueExpression() code = %v, want %v; err = %v", status.Code(err), codes.InvalidArgument, err)
 			}
@@ -1142,7 +1128,7 @@ func TestResolveSdmxEntityShape(t *testing.T) {
 		},
 	}
 
-	gotObservationProperties, gotEntitySlotsByStatVar, err := resolveSdmxEntityShape([]string{"var1"}, observationPropertyEdgesByStatVar)
+	gotObservationProperties, gotEntitySlotByObservationProperty, err := resolveSdmxEntityShape([]string{"var1"}, observationPropertyEdgesByStatVar)
 	if err != nil {
 		t.Fatalf("resolveSdmxEntityShape() error = %v", err)
 	}
@@ -1155,28 +1141,15 @@ func TestResolveSdmxEntityShape(t *testing.T) {
 			t.Fatalf("observationProperties = %v, want %v", gotObservationProperties, wantObservationProperties)
 		}
 	}
-	wantEntitySlotsByStatVar := map[string]map[string]string{
-		"var1": {
-			"destinationCountry": "entity1",
-			"sourceCountry":      "entity2",
-		},
+	wantEntitySlotByObservationProperty := map[string]string{
+		"destinationCountry": "entity1",
+		"sourceCountry":      "entity2",
 	}
-	if len(gotEntitySlotsByStatVar) != len(wantEntitySlotsByStatVar) {
-		t.Fatalf("entity slot mappings = %v, want %v", gotEntitySlotsByStatVar, wantEntitySlotsByStatVar)
-	}
-	for statVarID, gotEntitySlots := range gotEntitySlotsByStatVar {
-		wantEntitySlots := wantEntitySlotsByStatVar[statVarID]
-		if len(gotEntitySlots) != len(wantEntitySlots) {
-			t.Fatalf("Entity slot mapping for %s = %v, want %v", statVarID, gotEntitySlots, wantEntitySlots)
-		}
-		for k, v := range gotEntitySlots {
-			if wantEntitySlots[k] != v {
-				t.Errorf("Entity slot mapping for %s[%q] = %q, want %q", statVarID, k, v, wantEntitySlots[k])
-			}
-		}
+	if diff := cmp.Diff(wantEntitySlotByObservationProperty, gotEntitySlotByObservationProperty); diff != "" {
+		t.Fatalf("entity slot mapping mismatch (-want +got):\n%s", diff)
 	}
 
-	gotObservationProperties, gotEntitySlotsByStatVar, err = resolveSdmxEntityShape([]string{"var2"}, observationPropertyEdgesByStatVar)
+	gotObservationProperties, gotEntitySlotByObservationProperty, err = resolveSdmxEntityShape([]string{"var2"}, observationPropertyEdgesByStatVar)
 	if err != nil {
 		t.Fatalf("resolveSdmxEntityShape() error = %v", err)
 	}
@@ -1184,13 +1157,11 @@ func TestResolveSdmxEntityShape(t *testing.T) {
 	if len(gotObservationProperties) != len(wantObservationProperties) || gotObservationProperties[0] != wantObservationProperties[0] {
 		t.Fatalf("observationProperties = %v, want %v", gotObservationProperties, wantObservationProperties)
 	}
-	wantEntitySlotsByStatVar = map[string]map[string]string{
-		"var2": {
-			datacommons.ComponentObservationAbout: "entity1",
-		},
+	wantEntitySlotByObservationProperty = map[string]string{
+		datacommons.ComponentObservationAbout: "entity1",
 	}
-	if diff := cmp.Diff(wantEntitySlotsByStatVar, gotEntitySlotsByStatVar); diff != "" {
-		t.Fatalf("entity slot mappings mismatch (-want +got):\n%s", diff)
+	if diff := cmp.Diff(wantEntitySlotByObservationProperty, gotEntitySlotByObservationProperty); diff != "" {
+		t.Fatalf("entity slot mapping mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -1200,7 +1171,7 @@ func TestResolveSdmxEntityShapeAcceptsSameTwoEntityShapeDifferentOrder(t *testin
 		"var2": observationPropertiesEdges("destinationCountry", "sourceCountry"),
 	}
 
-	gotObservationProperties, gotEntitySlotsByStatVar, err := resolveSdmxEntityShape([]string{"var1", "var2"}, observationPropertyEdgesByStatVar)
+	gotObservationProperties, gotEntitySlotByObservationProperty, err := resolveSdmxEntityShape([]string{"var1", "var2"}, observationPropertyEdgesByStatVar)
 	if err != nil {
 		t.Fatalf("resolveSdmxEntityShape() error = %v", err)
 	}
@@ -1209,18 +1180,12 @@ func TestResolveSdmxEntityShapeAcceptsSameTwoEntityShapeDifferentOrder(t *testin
 	if diff := cmp.Diff(wantObservationProperties, gotObservationProperties); diff != "" {
 		t.Fatalf("observationProperties mismatch (-want +got):\n%s", diff)
 	}
-	wantEntitySlotsByStatVar := map[string]map[string]string{
-		"var1": {
-			"destinationCountry": "entity1",
-			"sourceCountry":      "entity2",
-		},
-		"var2": {
-			"destinationCountry": "entity1",
-			"sourceCountry":      "entity2",
-		},
+	wantEntitySlotByObservationProperty := map[string]string{
+		"destinationCountry": "entity1",
+		"sourceCountry":      "entity2",
 	}
-	if diff := cmp.Diff(wantEntitySlotsByStatVar, gotEntitySlotsByStatVar); diff != "" {
-		t.Fatalf("entity slot mappings mismatch (-want +got):\n%s", diff)
+	if diff := cmp.Diff(wantEntitySlotByObservationProperty, gotEntitySlotByObservationProperty); diff != "" {
+		t.Fatalf("entity slot mapping mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -1230,7 +1195,7 @@ func TestResolveSdmxEntityShapeAcceptsSameThreeEntityShapeDifferentOrder(t *test
 		"var2": observationPropertiesEdges("transportMode", "destinationCountry", "sourceCountry"),
 	}
 
-	gotObservationProperties, gotEntitySlotsByStatVar, err := resolveSdmxEntityShape([]string{"var1", "var2"}, observationPropertyEdgesByStatVar)
+	gotObservationProperties, gotEntitySlotByObservationProperty, err := resolveSdmxEntityShape([]string{"var1", "var2"}, observationPropertyEdgesByStatVar)
 	if err != nil {
 		t.Fatalf("resolveSdmxEntityShape() error = %v", err)
 	}
@@ -1239,20 +1204,13 @@ func TestResolveSdmxEntityShapeAcceptsSameThreeEntityShapeDifferentOrder(t *test
 	if diff := cmp.Diff(wantObservationProperties, gotObservationProperties); diff != "" {
 		t.Fatalf("observationProperties mismatch (-want +got):\n%s", diff)
 	}
-	wantEntitySlotsByStatVar := map[string]map[string]string{
-		"var1": {
-			"destinationCountry": "entity1",
-			"sourceCountry":      "entity2",
-			"transportMode":      "entity3",
-		},
-		"var2": {
-			"destinationCountry": "entity1",
-			"sourceCountry":      "entity2",
-			"transportMode":      "entity3",
-		},
+	wantEntitySlotByObservationProperty := map[string]string{
+		"destinationCountry": "entity1",
+		"sourceCountry":      "entity2",
+		"transportMode":      "entity3",
 	}
-	if diff := cmp.Diff(wantEntitySlotsByStatVar, gotEntitySlotsByStatVar); diff != "" {
-		t.Fatalf("entity slot mappings mismatch (-want +got):\n%s", diff)
+	if diff := cmp.Diff(wantEntitySlotByObservationProperty, gotEntitySlotByObservationProperty); diff != "" {
+		t.Fatalf("entity slot mapping mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -1261,7 +1219,7 @@ func TestResolveSdmxEntityShapeUsesExplicitObservationAboutProperty(t *testing.T
 		"var1": observationPropertiesEdges(datacommons.ComponentObservationAbout),
 	}
 
-	gotObservationProperties, gotEntitySlotsByStatVar, err := resolveSdmxEntityShape([]string{"var1"}, observationPropertyEdgesByStatVar)
+	gotObservationProperties, gotEntitySlotByObservationProperty, err := resolveSdmxEntityShape([]string{"var1"}, observationPropertyEdgesByStatVar)
 	if err != nil {
 		t.Fatalf("resolveSdmxEntityShape() error = %v", err)
 	}
@@ -1270,13 +1228,11 @@ func TestResolveSdmxEntityShapeUsesExplicitObservationAboutProperty(t *testing.T
 	if diff := cmp.Diff(wantObservationProperties, gotObservationProperties); diff != "" {
 		t.Fatalf("observationProperties mismatch (-want +got):\n%s", diff)
 	}
-	wantEntitySlotsByStatVar := map[string]map[string]string{
-		"var1": {
-			datacommons.ComponentObservationAbout: "entity1",
-		},
+	wantEntitySlotByObservationProperty := map[string]string{
+		datacommons.ComponentObservationAbout: "entity1",
 	}
-	if diff := cmp.Diff(wantEntitySlotsByStatVar, gotEntitySlotsByStatVar); diff != "" {
-		t.Fatalf("entity slot mappings mismatch (-want +got):\n%s", diff)
+	if diff := cmp.Diff(wantEntitySlotByObservationProperty, gotEntitySlotByObservationProperty); diff != "" {
+		t.Fatalf("entity slot mapping mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -1286,7 +1242,7 @@ func TestResolveSdmxEntityShapeAcceptsObservationAboutInMultiEntityShape(t *test
 		"var2": observationPropertiesEdges(datacommons.ComponentObservationAbout, "destinationCountry", "sourceCountry"),
 	}
 
-	gotObservationProperties, gotEntitySlotsByStatVar, err := resolveSdmxEntityShape([]string{"var1", "var2"}, observationPropertyEdgesByStatVar)
+	gotObservationProperties, gotEntitySlotByObservationProperty, err := resolveSdmxEntityShape([]string{"var1", "var2"}, observationPropertyEdgesByStatVar)
 	if err != nil {
 		t.Fatalf("resolveSdmxEntityShape() error = %v", err)
 	}
@@ -1295,20 +1251,13 @@ func TestResolveSdmxEntityShapeAcceptsObservationAboutInMultiEntityShape(t *test
 	if diff := cmp.Diff(wantObservationProperties, gotObservationProperties); diff != "" {
 		t.Fatalf("observationProperties mismatch (-want +got):\n%s", diff)
 	}
-	wantEntitySlotsByStatVar := map[string]map[string]string{
-		"var1": {
-			"destinationCountry":                  "entity1",
-			datacommons.ComponentObservationAbout: "entity2",
-			"sourceCountry":                       "entity3",
-		},
-		"var2": {
-			"destinationCountry":                  "entity1",
-			datacommons.ComponentObservationAbout: "entity2",
-			"sourceCountry":                       "entity3",
-		},
+	wantEntitySlotByObservationProperty := map[string]string{
+		"destinationCountry":                  "entity1",
+		datacommons.ComponentObservationAbout: "entity2",
+		"sourceCountry":                       "entity3",
 	}
-	if diff := cmp.Diff(wantEntitySlotsByStatVar, gotEntitySlotsByStatVar); diff != "" {
-		t.Fatalf("entity slot mappings mismatch (-want +got):\n%s", diff)
+	if diff := cmp.Diff(wantEntitySlotByObservationProperty, gotEntitySlotByObservationProperty); diff != "" {
+		t.Fatalf("entity slot mapping mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -1319,11 +1268,9 @@ func TestSdmxSeriesDimensionsUsesEntitySlotMapping(t *testing.T) {
 			"entity1": "country/MEX",
 			"entity2": "country/USA",
 		},
-		map[string]map[string]string{
-			"var1": {
-				"destinationCountry":                  "entity1",
-				datacommons.ComponentObservationAbout: "entity2",
-			},
+		map[string]string{
+			"destinationCountry":                  "entity1",
+			datacommons.ComponentObservationAbout: "entity2",
 		},
 	)
 


### PR DESCRIPTION
## Summary

  - Use a single canonical observation-property-to-entity-slot mapping after validating that selected statistical variables have
    the same shape.

  - Replace repeated per-variable OR branches with a parameterized variable_measured IN UNNEST(@variableMeasured) filter.
  - Compile shared component constraints once for both SDMX data and availability queries.
  - Update unit tests and SQL goldens for the simplified query structure.

  ## Public APIs affected

  - SDMX data API
  - SDMX availability API

  There are no request or response contract changes.

  ## Testing

  - go test ./internal/server/spanner ./internal/server/spanner/golden -count=1
  - ./scripts/run_spanner_emulator_tests.sh
  - ./run_test.sh -f
