### PR TITLE
Sdmx containedInPlace+ support in data api

### DIFF
--- a/internal/server/datasources/sdmx_availability_test.go
+++ b/internal/server/datasources/sdmx_availability_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/testing/protocmp"
 )
 
 type availabilityDataSource struct {
@@ -110,6 +111,28 @@ func TestSdmxDataMergesIdenticalShapes(t *testing.T) {
 	}
 	if len(got.GetSeries()) != 2 {
 		t.Fatalf("len(SdmxData().Series) = %d, want 2", len(got.GetSeries()))
+	}
+}
+
+func TestSdmxDataMergesLocalResultWithEmptyRemoteResult(t *testing.T) {
+	shape := testSdmxShape([]string{datacommons.ComponentObservationAbout})
+	localResult := &sdmxpb.SdmxDataResult{
+		Shape: shape,
+		Series: []*sdmxpb.SdmxTimeSeries{
+			{Dimensions: map[string]string{datacommons.ComponentVariableMeasured: "Count_Person"}},
+		},
+	}
+	ds := NewDataSources([]datasource.DataSource{
+		&sdmxDataSource{id: "local", result: localResult},
+		&sdmxDataSource{id: "remote", result: &sdmxpb.SdmxDataResult{}},
+	}, nil)
+
+	got, err := ds.SdmxData(context.Background(), &sdmxpb.SdmxDataQuery{})
+	if err != nil {
+		t.Fatalf("SdmxData() error = %v", err)
+	}
+	if diff := cmp.Diff(localResult, got, protocmp.Transform()); diff != "" {
+		t.Fatalf("SdmxData() mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/internal/server/dispatcher/dispatcher.go
+++ b/internal/server/dispatcher/dispatcher.go
@@ -205,7 +205,7 @@ func newRequestContext(ctx context.Context, request proto.Message, requestType R
 
 // SdmxData handles SDMX Data requests.
 func (dispatcher *Dispatcher) SdmxData(ctx context.Context, in *sdmxpb.SdmxDataQuery) (*sdmxpb.SdmxDataResult, error) {
-	if err := datacommons.ValidateSupportedConstraints(in.GetConstraints()); err != nil {
+	if err := datacommons.ValidateDataConstraints(in.GetConstraints()); err != nil {
 		return nil, err
 	}
 	requestContext := newRequestContext(ctx, in, TypeSdmxData)
@@ -222,7 +222,7 @@ func (dispatcher *Dispatcher) SdmxData(ctx context.Context, in *sdmxpb.SdmxDataQ
 
 // SdmxAvailability handles SDMX Availability requests.
 func (dispatcher *Dispatcher) SdmxAvailability(ctx context.Context, in *sdmxpb.SdmxAvailabilityQuery) (*sdmxpb.SdmxAvailabilityResult, error) {
-	if err := datacommons.ValidateSupportedConstraints(in.GetConstraints()); err != nil {
+	if err := datacommons.ValidateAvailabilityConstraints(in.GetConstraints()); err != nil {
 		return nil, err
 	}
 	requestContext := newRequestContext(ctx, in, TypeSdmxAvailability)

--- a/internal/server/dispatcher/sdmx_availability_test.go
+++ b/internal/server/dispatcher/sdmx_availability_test.go
@@ -41,6 +41,24 @@ type sdmxAvailabilitySource struct {
 	result *sdmxpb.SdmxAvailabilityResult
 }
 
+type sdmxDataConstraintSource struct {
+	datasource.DataSource
+	got *sdmxpb.SdmxDataQuery
+}
+
+func (s *sdmxDataConstraintSource) Type() datasource.DataSourceType {
+	return datasource.TypeMock
+}
+
+func (s *sdmxDataConstraintSource) Id() string {
+	return "sdmx-data-constraint-test"
+}
+
+func (s *sdmxDataConstraintSource) SdmxData(ctx context.Context, req *sdmxpb.SdmxDataQuery) (*sdmxpb.SdmxDataResult, error) {
+	s.got = req
+	return &sdmxpb.SdmxDataResult{}, nil
+}
+
 func (s *sdmxAvailabilitySource) Type() datasource.DataSourceType {
 	return datasource.TypeMock
 }
@@ -98,53 +116,48 @@ func TestSdmxAvailabilityCallsDataSources(t *testing.T) {
 	}
 }
 
-func TestSdmxPropertyConstraintsUnimplemented(t *testing.T) {
-	componentConstraint := sdmxComponentConstraint("country/USA")
-	componentConstraint.PropertyConstraints = map[string]*sdmxpb.SdmxPropertyConstraint{
-		"typeOf": {
-			Predicates: []*sdmxpb.SdmxPredicate{{Value: "County"}},
+func TestSdmxDataPropertyConstraintsCallsDataSources(t *testing.T) {
+	componentConstraint := &sdmxpb.SdmxComponentConstraint{
+		PropertyConstraints: map[string]*sdmxpb.SdmxPropertyConstraint{
+			"containedInPlace": {
+				Predicates: []*sdmxpb.SdmxPredicate{{Value: "country/USA"}},
+				Transitive: true,
+			},
+			"typeOf": {Predicates: []*sdmxpb.SdmxPredicate{{Value: "County"}}},
 		},
 	}
-
-	tests := []struct {
-		name string
-		call func(*Dispatcher) error
-	}{
-		{
-			name: "data",
-			call: func(dispatcher *Dispatcher) error {
-				_, err := dispatcher.SdmxData(context.Background(), &sdmxpb.SdmxDataQuery{
-					Constraints: map[string]*sdmxpb.SdmxComponentConstraint{
-						"source": componentConstraint,
-					},
-				})
-				return err
-			},
-		},
-		{
-			name: "availability",
-			call: func(dispatcher *Dispatcher) error {
-				_, err := dispatcher.SdmxAvailability(context.Background(), &sdmxpb.SdmxAvailabilityQuery{
-					ComponentId: "source",
-					Constraints: map[string]*sdmxpb.SdmxComponentConstraint{
-						"source": componentConstraint,
-					},
-				})
-				return err
-			},
+	query := &sdmxpb.SdmxDataQuery{
+		Constraints: map[string]*sdmxpb.SdmxComponentConstraint{
+			"variableMeasured": sdmxComponentConstraint("Count_Person"),
+			"observationAbout": componentConstraint,
 		},
 	}
+	source := &sdmxDataConstraintSource{}
+	dispatcher := NewDispatcher(nil, datasources.NewDataSources([]datasource.DataSource{source}, nil))
+	if _, err := dispatcher.SdmxData(context.Background(), query); err != nil {
+		t.Fatalf("SdmxData() error = %v", err)
+	}
+	if diff := cmp.Diff(query, source.got, protocmp.Transform()); diff != "" {
+		t.Fatalf("SdmxData() request mismatch (-want +got):\n%s", diff)
+	}
+}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := tt.call(NewDispatcher(nil, nil))
-			if status.Code(err) != codes.Unimplemented {
-				t.Fatalf("code = %v, want %v; err = %v", status.Code(err), codes.Unimplemented, err)
-			}
-			if got, want := status.Convert(err).Message(), "SDMX property constraints are not implemented yet"; got != want {
-				t.Fatalf("message = %q, want %q", got, want)
-			}
-		})
+func TestSdmxAvailabilityPropertyConstraintsUnimplemented(t *testing.T) {
+	_, err := NewDispatcher(nil, nil).SdmxAvailability(context.Background(), &sdmxpb.SdmxAvailabilityQuery{
+		ComponentId: "source",
+		Constraints: map[string]*sdmxpb.SdmxComponentConstraint{
+			"source": {
+				PropertyConstraints: map[string]*sdmxpb.SdmxPropertyConstraint{
+					"typeOf": {Predicates: []*sdmxpb.SdmxPredicate{{Value: "County"}}},
+				},
+			},
+		},
+	})
+	if status.Code(err) != codes.Unimplemented {
+		t.Fatalf("code = %v, want %v; err = %v", status.Code(err), codes.Unimplemented, err)
+	}
+	if got, want := status.Convert(err).Message(), "SDMX property constraints are not implemented for availability yet"; got != want {
+		t.Fatalf("message = %q, want %q", got, want)
 	}
 }
 

--- a/internal/server/dispatcher/sdmx_availability_test.go
+++ b/internal/server/dispatcher/sdmx_availability_test.go
@@ -142,6 +142,57 @@ func TestSdmxDataPropertyConstraintsCallsDataSources(t *testing.T) {
 	}
 }
 
+func TestSdmxDataConstraintValidationBeforeSources(t *testing.T) {
+	propertyConstraint := &sdmxpb.SdmxComponentConstraint{
+		PropertyConstraints: map[string]*sdmxpb.SdmxPropertyConstraint{
+			"containedInPlace": {
+				Predicates: []*sdmxpb.SdmxPredicate{{Value: "country/USA"}},
+				Transitive: true,
+			},
+			"typeOf": {Predicates: []*sdmxpb.SdmxPredicate{{Value: "County"}}},
+		},
+	}
+	for _, tc := range []struct {
+		name        string
+		constraints map[string]*sdmxpb.SdmxComponentConstraint
+		wantCode    codes.Code
+	}{
+		{name: "missing variable measured", wantCode: codes.InvalidArgument},
+		{
+			name: "property on known non observation component",
+			constraints: map[string]*sdmxpb.SdmxComponentConstraint{
+				"variableMeasured": sdmxComponentConstraint("Count_Person"),
+				"unit":             propertyConstraint,
+			},
+			wantCode: codes.Unimplemented,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			source := &sdmxDataConstraintSource{}
+			dispatcher := NewDispatcher(nil, datasources.NewDataSources([]datasource.DataSource{source}, nil))
+			_, err := dispatcher.SdmxData(context.Background(), &sdmxpb.SdmxDataQuery{Constraints: tc.constraints})
+			if got := status.Code(err); got != tc.wantCode {
+				t.Fatalf("SdmxData() code = %v, want %v; err = %v", got, tc.wantCode, err)
+			}
+			if source.got != nil {
+				t.Fatalf("SdmxData() called source with %v", source.got)
+			}
+		})
+	}
+}
+
+func TestSdmxAvailabilityRequiresVariableMeasuredBeforeSources(t *testing.T) {
+	source := &sdmxAvailabilitySource{}
+	dispatcher := NewDispatcher(nil, datasources.NewDataSources([]datasource.DataSource{source}, nil))
+	_, err := dispatcher.SdmxAvailability(context.Background(), &sdmxpb.SdmxAvailabilityQuery{ComponentId: "observationAbout"})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("SdmxAvailability() code = %v, want %v; err = %v", status.Code(err), codes.InvalidArgument, err)
+	}
+	if source.got != nil {
+		t.Fatalf("SdmxAvailability() called source with %v", source.got)
+	}
+}
+
 func TestSdmxAvailabilityPropertyConstraintsUnimplemented(t *testing.T) {
 	_, err := NewDispatcher(nil, nil).SdmxAvailability(context.Background(), &sdmxpb.SdmxAvailabilityQuery{
 		ComponentId: "source",

--- a/internal/server/sdmx/datacommons/constraints.go
+++ b/internal/server/sdmx/datacommons/constraints.go
@@ -105,6 +105,9 @@ func ValidateDataConstraints(constraints map[string]*sdmxpb.SdmxComponentConstra
 			if !ok {
 				return status.Errorf(codes.Unimplemented, "SDMX property constraint %q is not implemented yet", propertyID)
 			}
+			if !componentMatchesScope(componentID, rule.Scope) {
+				return status.Errorf(codes.Unimplemented, "SDMX property constraints on component %q are not implemented yet", componentID)
+			}
 			if err := validatePropertyConstraint(componentID, propertyID, propertyConstraint, rule); err != nil {
 				return err
 			}
@@ -117,7 +120,7 @@ func ValidateDataConstraints(constraints map[string]*sdmxpb.SdmxComponentConstra
 			return status.Errorf(codes.InvalidArgument, "SDMX property filters on component %q require containedInPlace+ and typeOf", componentID)
 		}
 	}
-	return nil
+	return validateRequiredVariableMeasured(constraints)
 }
 
 // ValidateAvailabilityConstraints checks the predicate features supported by
@@ -137,7 +140,7 @@ func ValidateAvailabilityConstraints(constraints map[string]*sdmxpb.SdmxComponen
 			}
 		}
 	}
-	return nil
+	return validateRequiredVariableMeasured(constraints)
 }
 
 // ContainedInPlaceConstraints returns the validated containment pair for each
@@ -169,6 +172,32 @@ func validateComponentPredicates(constraints map[string]*sdmxpb.SdmxComponentCon
 		}
 	}
 	return nil
+}
+
+func validateRequiredVariableMeasured(constraints map[string]*sdmxpb.SdmxComponentConstraint) error {
+	constraint, ok := constraints[ComponentVariableMeasured]
+	if !ok || len(constraint.GetPredicates()) == 0 {
+		return status.Error(codes.InvalidArgument, "missing required SDMX component filter variableMeasured")
+	}
+	return nil
+}
+
+func componentMatchesScope(componentID string, scope ComponentScope) bool {
+	if scope == ComponentScopeAll {
+		return true
+	}
+
+	kind, known := DataComponentKind(componentID)
+	switch scope {
+	case ComponentScopeDimension:
+		return !known || kind == ComponentKindDimension
+	case ComponentScopeObservationProperty:
+		return componentID == ComponentObservationAbout || !known
+	case ComponentScopeAttribute:
+		return known && kind == ComponentKindAttribute
+	default:
+		return false
+	}
 }
 
 func validatePredicate(predicate *sdmxpb.SdmxPredicate, filter string) error {

--- a/internal/server/sdmx/datacommons/constraints.go
+++ b/internal/server/sdmx/datacommons/constraints.go
@@ -27,6 +27,8 @@ import (
 const (
 	PropertyContainedInPlace = "containedInPlace"
 	PropertyTypeOf           = "typeOf"
+
+	graphPredicateLinkedContainedInPlace = "linkedContainedInPlace"
 )
 
 type ComponentScope int
@@ -53,7 +55,7 @@ var dataConstraintConfig = constraintConfig{
 		PropertyContainedInPlace: {
 			Scope:          ComponentScopeObservationProperty,
 			Transitive:     true,
-			GraphPredicate: "linkedContainedInPlace",
+			GraphPredicate: graphPredicateLinkedContainedInPlace,
 		},
 		PropertyTypeOf: {
 			Scope:          ComponentScopeObservationProperty,

--- a/internal/server/sdmx/datacommons/constraints.go
+++ b/internal/server/sdmx/datacommons/constraints.go
@@ -15,23 +15,191 @@
 package datacommons
 
 import (
+	"maps"
+	"slices"
+	"strings"
+
 	sdmxpb "github.com/datacommonsorg/mixer/internal/proto/sdmx"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
-// ValidateSupportedConstraints checks that constraints only use SDMX features
-// currently supported by Data Commons.
-func ValidateSupportedConstraints(constraints map[string]*sdmxpb.SdmxComponentConstraint) error {
-	for _, constraint := range constraints {
-		if len(constraint.GetPropertyConstraints()) > 0 {
-			return status.Error(codes.Unimplemented, "SDMX property constraints are not implemented yet")
+const (
+	PropertyContainedInPlace = "containedInPlace"
+	PropertyTypeOf           = "typeOf"
+)
+
+type ComponentScope int
+
+const (
+	ComponentScopeAll ComponentScope = iota
+	ComponentScopeDimension
+	ComponentScopeObservationProperty
+	ComponentScopeAttribute
+)
+
+type PropertyRule struct {
+	Scope          ComponentScope
+	Transitive     bool
+	GraphPredicate string
+}
+
+type constraintConfig struct {
+	propertyRules map[string]PropertyRule
+}
+
+var dataConstraintConfig = constraintConfig{
+	propertyRules: map[string]PropertyRule{
+		PropertyContainedInPlace: {
+			Scope:          ComponentScopeObservationProperty,
+			Transitive:     true,
+			GraphPredicate: "linkedContainedInPlace",
+		},
+		PropertyTypeOf: {
+			Scope:          ComponentScopeObservationProperty,
+			Transitive:     false,
+			GraphPredicate: PropertyTypeOf,
+		},
+	},
+}
+
+var availabilityConstraintConfig = constraintConfig{propertyRules: map[string]PropertyRule{}}
+
+type ContainedInPlaceConstraint struct {
+	Ancestor       string
+	ChildPlaceType string
+}
+
+// DataPropertyRule returns the rule used to validate and compile an SDMX data
+// property constraint.
+func DataPropertyRule(propertyID string) (PropertyRule, bool) {
+	rule, ok := dataConstraintConfig.propertyRules[propertyID]
+	return rule, ok
+}
+
+// ValidateDataConstraints checks the predicate features supported by the SDMX
+// data endpoint.
+func ValidateDataConstraints(constraints map[string]*sdmxpb.SdmxComponentConstraint) error {
+	if err := validateComponentPredicates(constraints); err != nil {
+		return err
+	}
+
+	for _, componentID := range slices.Sorted(maps.Keys(constraints)) {
+		constraint := constraints[componentID]
+		properties := constraint.GetPropertyConstraints()
+		if len(properties) == 0 {
+			continue
 		}
-		for _, predicate := range constraint.GetPredicates() {
-			if predicate.GetOperator() != sdmxpb.SdmxOperator_SDMX_OPERATOR_EQ {
-				return status.Error(codes.Unimplemented, "SDMX operators other than EQ are not implemented yet")
+		if len(constraint.GetPredicates()) > 0 {
+			return status.Errorf(codes.InvalidArgument, "SDMX component filter %q cannot combine direct and property predicates", componentID)
+		}
+		_, hasContainedInPlace := properties[PropertyContainedInPlace]
+		_, hasTypeOf := properties[PropertyTypeOf]
+		if hasContainedInPlace && hasTypeOf && len(properties) != 2 {
+			return status.Errorf(codes.InvalidArgument, "SDMX component filter %q cannot include additional property predicates", componentID)
+		}
+
+		for _, propertyID := range slices.Sorted(maps.Keys(properties)) {
+			propertyConstraint := properties[propertyID]
+			rule, ok := DataPropertyRule(propertyID)
+			if !ok {
+				return status.Errorf(codes.Unimplemented, "SDMX property constraint %q is not implemented yet", propertyID)
+			}
+			if err := validatePropertyConstraint(componentID, propertyID, propertyConstraint, rule); err != nil {
+				return err
+			}
+		}
+
+		if !hasContainedInPlace {
+			return status.Errorf(codes.InvalidArgument, "SDMX property filters on component %q require containedInPlace+ and typeOf", componentID)
+		}
+		if !hasTypeOf {
+			return status.Errorf(codes.InvalidArgument, "SDMX property filters on component %q require containedInPlace+ and typeOf", componentID)
+		}
+	}
+	return nil
+}
+
+// ValidateAvailabilityConstraints checks the predicate features supported by
+// the SDMX availability endpoint.
+func ValidateAvailabilityConstraints(constraints map[string]*sdmxpb.SdmxComponentConstraint) error {
+	if err := validateComponentPredicates(constraints); err != nil {
+		return err
+	}
+	for _, componentID := range slices.Sorted(maps.Keys(constraints)) {
+		for _, propertyID := range slices.Sorted(maps.Keys(constraints[componentID].GetPropertyConstraints())) {
+			rule, ok := availabilityConstraintConfig.propertyRules[propertyID]
+			if !ok {
+				return status.Error(codes.Unimplemented, "SDMX property constraints are not implemented for availability yet")
+			}
+			if err := validatePropertyConstraint(componentID, propertyID, constraints[componentID].GetPropertyConstraints()[propertyID], rule); err != nil {
+				return err
 			}
 		}
 	}
 	return nil
+}
+
+// ContainedInPlaceConstraints returns the validated containment pair for each
+// constrained component.
+func ContainedInPlaceConstraints(constraints map[string]*sdmxpb.SdmxComponentConstraint) (map[string]ContainedInPlaceConstraint, error) {
+	if err := ValidateDataConstraints(constraints); err != nil {
+		return nil, err
+	}
+	result := map[string]ContainedInPlaceConstraint{}
+	for componentID, constraint := range constraints {
+		properties := constraint.GetPropertyConstraints()
+		if len(properties) == 0 {
+			continue
+		}
+		result[componentID] = ContainedInPlaceConstraint{
+			Ancestor:       properties[PropertyContainedInPlace].GetPredicates()[0].GetValue(),
+			ChildPlaceType: properties[PropertyTypeOf].GetPredicates()[0].GetValue(),
+		}
+	}
+	return result, nil
+}
+
+func validateComponentPredicates(constraints map[string]*sdmxpb.SdmxComponentConstraint) error {
+	for _, componentID := range slices.Sorted(maps.Keys(constraints)) {
+		for _, predicate := range constraints[componentID].GetPredicates() {
+			if err := validatePredicate(predicate, "SDMX component filter \""+componentID+"\""); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func validatePredicate(predicate *sdmxpb.SdmxPredicate, filter string) error {
+	if predicate.GetOperator() != sdmxpb.SdmxOperator_SDMX_OPERATOR_EQ {
+		return status.Error(codes.Unimplemented, "SDMX operators other than EQ are not implemented yet")
+	}
+	if strings.TrimSpace(predicate.GetValue()) == "" {
+		return status.Errorf(codes.InvalidArgument, "%s contains an empty value", filter)
+	}
+	return nil
+}
+
+func validatePropertyConstraint(
+	componentID string,
+	propertyID string,
+	constraint *sdmxpb.SdmxPropertyConstraint,
+	rule PropertyRule,
+) error {
+	if constraint == nil || len(constraint.GetPredicates()) != 1 {
+		return status.Errorf(codes.InvalidArgument, "SDMX property filter %q on component %q must have exactly one value", propertyID, componentID)
+	}
+	if constraint.GetTransitive() != rule.Transitive {
+		selector := propertyID
+		if constraint.GetTransitive() {
+			selector += "+"
+		}
+		return status.Errorf(codes.Unimplemented, "SDMX property constraint %q is not implemented yet", selector)
+	}
+	return validatePredicate(constraint.GetPredicates()[0], propertyFilterName(componentID, propertyID))
+}
+
+func propertyFilterName(componentID, propertyID string) string {
+	return "SDMX property filter " + componentID + "." + propertyID
 }

--- a/internal/server/sdmx/datacommons/constraints.go
+++ b/internal/server/sdmx/datacommons/constraints.go
@@ -113,12 +113,9 @@ func ValidateDataConstraints(constraints map[string]*sdmxpb.SdmxComponentConstra
 			}
 		}
 
-		if !hasContainedInPlace {
-			return status.Errorf(codes.InvalidArgument, "SDMX property filters on component %q require containedInPlace+ and typeOf", componentID)
-		}
-		if !hasTypeOf {
-			return status.Errorf(codes.InvalidArgument, "SDMX property filters on component %q require containedInPlace+ and typeOf", componentID)
-		}
+if !hasContainedInPlace || !hasTypeOf {
+	return status.Errorf(codes.InvalidArgument, "SDMX property filters on component %q require containedInPlace+ and typeOf", componentID)
+}
 	}
 	return validateRequiredVariableMeasured(constraints)
 }

--- a/internal/server/sdmx/datacommons/constraints.go
+++ b/internal/server/sdmx/datacommons/constraints.go
@@ -112,10 +112,9 @@ func ValidateDataConstraints(constraints map[string]*sdmxpb.SdmxComponentConstra
 				return err
 			}
 		}
-
-if !hasContainedInPlace || !hasTypeOf {
-	return status.Errorf(codes.InvalidArgument, "SDMX property filters on component %q require containedInPlace+ and typeOf", componentID)
-}
+		if !hasContainedInPlace || !hasTypeOf {
+			return status.Errorf(codes.InvalidArgument, "SDMX property filters on component %q require containedInPlace+ and typeOf", componentID)
+		}
 	}
 	return validateRequiredVariableMeasured(constraints)
 }

--- a/internal/server/sdmx/datacommons/constraints_test.go
+++ b/internal/server/sdmx/datacommons/constraints_test.go
@@ -107,7 +107,55 @@ func TestValidateDataConstraints(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			err := ValidateDataConstraints(map[string]*sdmxpb.SdmxComponentConstraint{"observationAbout": tc.constraint})
+			err := ValidateDataConstraints(map[string]*sdmxpb.SdmxComponentConstraint{
+				ComponentVariableMeasured: {Predicates: []*sdmxpb.SdmxPredicate{{Value: "Count_Person"}}},
+				ComponentObservationAbout: tc.constraint,
+			})
+			if got := status.Code(err); got != tc.wantCode {
+				t.Fatalf("ValidateDataConstraints() code = %v, want %v; err = %v", got, tc.wantCode, err)
+			}
+		})
+	}
+}
+
+func TestValidateDataConstraintsRequiresVariableMeasured(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		constraints map[string]*sdmxpb.SdmxComponentConstraint
+	}{
+		{name: "missing", constraints: nil},
+		{name: "no predicates", constraints: map[string]*sdmxpb.SdmxComponentConstraint{
+			ComponentVariableMeasured: {},
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateDataConstraints(tc.constraints)
+			if status.Code(err) != codes.InvalidArgument {
+				t.Fatalf("ValidateDataConstraints() code = %v, want %v; err = %v", status.Code(err), codes.InvalidArgument, err)
+			}
+			if got, want := status.Convert(err).Message(), "missing required SDMX component filter variableMeasured"; got != want {
+				t.Fatalf("ValidateDataConstraints() message = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestValidateDataConstraintsPropertyScopes(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		componentID string
+		wantCode    codes.Code
+	}{
+		{name: "observation about", componentID: ComponentObservationAbout},
+		{name: "dynamic observation property", componentID: "sourceCountry"},
+		{name: "known dimension", componentID: ComponentUnit, wantCode: codes.Unimplemented},
+		{name: "known attribute", componentID: ComponentFacetID, wantCode: codes.Unimplemented},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateDataConstraints(map[string]*sdmxpb.SdmxComponentConstraint{
+				ComponentVariableMeasured: {Predicates: []*sdmxpb.SdmxPredicate{{Value: "Count_Person"}}},
+				tc.componentID:            testContainedInPlaceConstraint("country/USA", "County"),
+			})
 			if got := status.Code(err); got != tc.wantCode {
 				t.Fatalf("ValidateDataConstraints() code = %v, want %v; err = %v", got, tc.wantCode, err)
 			}
@@ -138,5 +186,28 @@ func TestValidateAvailabilityConstraintsRejectsProperties(t *testing.T) {
 	})
 	if status.Code(err) != codes.Unimplemented {
 		t.Fatalf("ValidateAvailabilityConstraints() code = %v, want %v; err = %v", status.Code(err), codes.Unimplemented, err)
+	}
+}
+
+func TestValidateAvailabilityConstraintsRequiresVariableMeasured(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		constraints map[string]*sdmxpb.SdmxComponentConstraint
+		wantCode    codes.Code
+	}{
+		{name: "valid", constraints: map[string]*sdmxpb.SdmxComponentConstraint{
+			ComponentVariableMeasured: {Predicates: []*sdmxpb.SdmxPredicate{{Value: "Count_Person"}}},
+		}},
+		{name: "missing", wantCode: codes.InvalidArgument},
+		{name: "no predicates", constraints: map[string]*sdmxpb.SdmxComponentConstraint{
+			ComponentVariableMeasured: {},
+		}, wantCode: codes.InvalidArgument},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateAvailabilityConstraints(tc.constraints)
+			if got := status.Code(err); got != tc.wantCode {
+				t.Fatalf("ValidateAvailabilityConstraints() code = %v, want %v; err = %v", got, tc.wantCode, err)
+			}
+		})
 	}
 }

--- a/internal/server/sdmx/datacommons/constraints_test.go
+++ b/internal/server/sdmx/datacommons/constraints_test.go
@@ -1,0 +1,142 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datacommons
+
+import (
+	"testing"
+
+	sdmxpb "github.com/datacommonsorg/mixer/internal/proto/sdmx"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func testContainedInPlaceConstraint(ancestor, childPlaceType string) *sdmxpb.SdmxComponentConstraint {
+	return &sdmxpb.SdmxComponentConstraint{
+		PropertyConstraints: map[string]*sdmxpb.SdmxPropertyConstraint{
+			PropertyContainedInPlace: {
+				Predicates: []*sdmxpb.SdmxPredicate{{Value: ancestor}},
+				Transitive: true,
+			},
+			PropertyTypeOf: {
+				Predicates: []*sdmxpb.SdmxPredicate{{Value: childPlaceType}},
+			},
+		},
+	}
+}
+
+func TestValidateDataConstraints(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		constraint *sdmxpb.SdmxComponentConstraint
+		wantCode   codes.Code
+	}{
+		{name: "valid pair", constraint: testContainedInPlaceConstraint("country/USA", "County")},
+		{
+			name: "direct and property predicates",
+			constraint: func() *sdmxpb.SdmxComponentConstraint {
+				constraint := testContainedInPlaceConstraint("country/USA", "County")
+				constraint.Predicates = []*sdmxpb.SdmxPredicate{{Value: "geoId/06"}}
+				return constraint
+			}(),
+			wantCode: codes.InvalidArgument,
+		},
+		{
+			name: "missing type",
+			constraint: &sdmxpb.SdmxComponentConstraint{PropertyConstraints: map[string]*sdmxpb.SdmxPropertyConstraint{
+				PropertyContainedInPlace: {Predicates: []*sdmxpb.SdmxPredicate{{Value: "country/USA"}}, Transitive: true},
+			}},
+			wantCode: codes.InvalidArgument,
+		},
+		{
+			name: "multiple ancestors",
+			constraint: &sdmxpb.SdmxComponentConstraint{PropertyConstraints: map[string]*sdmxpb.SdmxPropertyConstraint{
+				PropertyContainedInPlace: {Predicates: []*sdmxpb.SdmxPredicate{{Value: "country/USA"}, {Value: "country/CAN"}}, Transitive: true},
+				PropertyTypeOf:           {Predicates: []*sdmxpb.SdmxPredicate{{Value: "County"}}},
+			}},
+			wantCode: codes.InvalidArgument,
+		},
+		{
+			name: "direct containment",
+			constraint: &sdmxpb.SdmxComponentConstraint{PropertyConstraints: map[string]*sdmxpb.SdmxPropertyConstraint{
+				PropertyContainedInPlace: {Predicates: []*sdmxpb.SdmxPredicate{{Value: "country/USA"}}},
+				PropertyTypeOf:           {Predicates: []*sdmxpb.SdmxPredicate{{Value: "County"}}},
+			}},
+			wantCode: codes.Unimplemented,
+		},
+		{
+			name: "transitive type",
+			constraint: &sdmxpb.SdmxComponentConstraint{PropertyConstraints: map[string]*sdmxpb.SdmxPropertyConstraint{
+				PropertyContainedInPlace: {Predicates: []*sdmxpb.SdmxPredicate{{Value: "country/USA"}}, Transitive: true},
+				PropertyTypeOf:           {Predicates: []*sdmxpb.SdmxPredicate{{Value: "County"}}, Transitive: true},
+			}},
+			wantCode: codes.Unimplemented,
+		},
+		{
+			name: "unknown property",
+			constraint: &sdmxpb.SdmxComponentConstraint{PropertyConstraints: map[string]*sdmxpb.SdmxPropertyConstraint{
+				"name": {Predicates: []*sdmxpb.SdmxPredicate{{Value: "California"}}},
+			}},
+			wantCode: codes.Unimplemented,
+		},
+		{
+			name: "additional property",
+			constraint: func() *sdmxpb.SdmxComponentConstraint {
+				constraint := testContainedInPlaceConstraint("country/USA", "County")
+				constraint.PropertyConstraints["name"] = &sdmxpb.SdmxPropertyConstraint{Predicates: []*sdmxpb.SdmxPredicate{{Value: "California"}}}
+				return constraint
+			}(),
+			wantCode: codes.InvalidArgument,
+		},
+		{
+			name:       "blank ancestor",
+			constraint: testContainedInPlaceConstraint(" ", "County"),
+			wantCode:   codes.InvalidArgument,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateDataConstraints(map[string]*sdmxpb.SdmxComponentConstraint{"observationAbout": tc.constraint})
+			if got := status.Code(err); got != tc.wantCode {
+				t.Fatalf("ValidateDataConstraints() code = %v, want %v; err = %v", got, tc.wantCode, err)
+			}
+		})
+	}
+}
+
+func TestContainedInPlaceConstraints(t *testing.T) {
+	constraints := map[string]*sdmxpb.SdmxComponentConstraint{
+		"observationAbout": testContainedInPlaceConstraint("country/USA", "County"),
+		"variableMeasured": {Predicates: []*sdmxpb.SdmxPredicate{{Value: "Count_Person"}}},
+	}
+	got, err := ContainedInPlaceConstraints(constraints)
+	if err != nil {
+		t.Fatalf("ContainedInPlaceConstraints() error = %v", err)
+	}
+	want := map[string]ContainedInPlaceConstraint{
+		"observationAbout": {Ancestor: "country/USA", ChildPlaceType: "County"},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("ContainedInPlaceConstraints() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestValidateAvailabilityConstraintsRejectsProperties(t *testing.T) {
+	err := ValidateAvailabilityConstraints(map[string]*sdmxpb.SdmxComponentConstraint{
+		"observationAbout": testContainedInPlaceConstraint("country/USA", "County"),
+	})
+	if status.Code(err) != codes.Unimplemented {
+		t.Fatalf("ValidateAvailabilityConstraints() code = %v, want %v; err = %v", status.Code(err), codes.Unimplemented, err)
+	}
+}

--- a/internal/server/sdmx/rest/v2/availability.go
+++ b/internal/server/sdmx/rest/v2/availability.go
@@ -17,13 +17,14 @@ package restv2
 import (
 	"net/url"
 
+	sdmxpb "github.com/datacommonsorg/mixer/internal/proto/sdmx"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
 type AvailabilityRequest struct {
 	Path        AvailabilityPath
-	Constraints map[string][]string
+	Constraints map[string]*sdmxpb.SdmxComponentConstraint
 }
 
 func ParseAvailabilityRequest(tail string, originalURI string) (*AvailabilityRequest, error) {
@@ -41,7 +42,7 @@ func ParseAvailabilityRequest(tail string, originalURI string) (*AvailabilityReq
 		return nil, err
 	}
 
-	constraints := map[string][]string{}
+	constraints := map[string]*sdmxpb.SdmxComponentConstraint{}
 	for _, param := range params {
 		ok, err := parseComponentFilter(param, constraints)
 		if err != nil {

--- a/internal/server/sdmx/rest/v2/availability_test.go
+++ b/internal/server/sdmx/rest/v2/availability_test.go
@@ -123,7 +123,7 @@ func TestParseAvailabilityRequest_Constraints(t *testing.T) {
 			if diff := cmp.Diff(tt.wantPath, got.Path); diff != "" {
 				t.Errorf("ParseAvailabilityRequest() path mismatch (-want +got):\n%s", diff)
 			}
-			if diff := cmp.Diff(tt.want, got.Constraints); diff != "" {
+			if diff := cmp.Diff(tt.want, componentConstraintValues(got.Constraints)); diff != "" {
 				t.Errorf("ParseAvailabilityRequest() constraints mismatch (-want +got):\n%s", diff)
 			}
 		})
@@ -233,6 +233,11 @@ func TestParseAvailabilityRequest_Errors(t *testing.T) {
 		{
 			name:        "operator unsupported",
 			originalURI: availabilityURI("observationAbout", "c[variableMeasured]=ge:2020"),
+			wantCode:    codes.Unimplemented,
+		},
+		{
+			name:        "property constraint unsupported",
+			originalURI: availabilityURI("observationAbout", "c[variableMeasured]=Count_Person&c[observationAbout.containedInPlace+]=country%2FUSA&c[observationAbout.typeOf]=County"),
 			wantCode:    codes.Unimplemented,
 		},
 		{

--- a/internal/server/sdmx/rest/v2/component.go
+++ b/internal/server/sdmx/rest/v2/component.go
@@ -17,6 +17,7 @@ package restv2
 import (
 	"strings"
 
+	sdmxpb "github.com/datacommonsorg/mixer/internal/proto/sdmx"
 	"github.com/datacommonsorg/mixer/internal/server/sdmx/datacommons"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -26,37 +27,82 @@ const (
 	dataContextDataflow = "dataflow"
 )
 
-func parseComponentFilter(param queryParam, constraints map[string][]string) (bool, error) {
-	componentID, ok, err := componentFilterName(param.Name)
+type componentSelector struct {
+	componentID string
+	propertyID  string
+	transitive  bool
+}
+
+func parseComponentFilter(param queryParam, constraints map[string]*sdmxpb.SdmxComponentConstraint) (bool, error) {
+	selector, ok, err := componentFilterName(param.Name)
 	if err != nil {
 		return false, err
 	}
 	if !ok {
 		return false, nil
 	}
-	if _, exists := constraints[componentID]; exists {
-		return true, status.Errorf(codes.InvalidArgument, "duplicate SDMX component filter %q", componentID)
-	}
 	values, err := parseComponentValues(param.Value)
 	if err != nil {
 		return true, err
 	}
-	constraints[componentID] = values
+	predicates := make([]*sdmxpb.SdmxPredicate, 0, len(values))
+	for _, value := range values {
+		predicates = append(predicates, &sdmxpb.SdmxPredicate{Value: value})
+	}
+
+	constraint := constraints[selector.componentID]
+	if constraint == nil {
+		constraint = &sdmxpb.SdmxComponentConstraint{}
+		constraints[selector.componentID] = constraint
+	}
+	if selector.propertyID == "" {
+		if len(constraint.GetPredicates()) > 0 {
+			return true, status.Errorf(codes.InvalidArgument, "duplicate SDMX component filter %q", selector.componentID)
+		}
+		constraint.Predicates = predicates
+		return true, nil
+	}
+
+	if constraint.PropertyConstraints == nil {
+		constraint.PropertyConstraints = map[string]*sdmxpb.SdmxPropertyConstraint{}
+	}
+	if _, exists := constraint.PropertyConstraints[selector.propertyID]; exists {
+		return true, status.Errorf(codes.InvalidArgument, "duplicate SDMX property filter %q", selector.componentID+"."+selector.propertyID)
+	}
+	constraint.PropertyConstraints[selector.propertyID] = &sdmxpb.SdmxPropertyConstraint{
+		Predicates: predicates,
+		Transitive: selector.transitive,
+	}
 	return true, nil
 }
 
-func componentFilterName(name string) (string, bool, error) {
+func componentFilterName(name string) (componentSelector, bool, error) {
 	if !strings.HasPrefix(name, "c[") {
-		return "", false, nil
+		return componentSelector{}, false, nil
 	}
 	if !strings.HasSuffix(name, "]") {
-		return "", false, status.Error(codes.InvalidArgument, "invalid SDMX component filter name")
+		return componentSelector{}, false, status.Error(codes.InvalidArgument, "invalid SDMX component filter name")
 	}
-	componentID := strings.TrimSuffix(strings.TrimPrefix(name, "c["), "]")
-	if componentID == "" {
-		return "", false, status.Error(codes.InvalidArgument, "invalid SDMX component filter name")
+	selectorName := strings.TrimSuffix(strings.TrimPrefix(name, "c["), "]")
+	parts := strings.Split(selectorName, ".")
+	if len(parts) > 2 || !isValidComponentID(parts[0]) {
+		return componentSelector{}, false, status.Errorf(codes.InvalidArgument, "invalid SDMX component filter %q", selectorName)
 	}
-	return componentID, true, nil
+	selector := componentSelector{componentID: parts[0]}
+	if len(parts) == 1 {
+		return selector, true, nil
+	}
+
+	propertyID := parts[1]
+	selector.transitive = strings.HasSuffix(propertyID, "+")
+	if selector.transitive {
+		propertyID = strings.TrimSuffix(propertyID, "+")
+	}
+	if !isValidComponentID(propertyID) {
+		return componentSelector{}, false, status.Errorf(codes.InvalidArgument, "invalid SDMX component filter %q", selectorName)
+	}
+	selector.propertyID = propertyID
+	return selector, true, nil
 }
 
 func parseComponentValues(value string) ([]string, error) {
@@ -95,7 +141,7 @@ func hasUnsupportedOperator(value string) bool {
 	}
 }
 
-func validateDataRequest(path ResourcePath, constraints map[string][]string) error {
+func validateDataRequest(path ResourcePath, constraints map[string]*sdmxpb.SdmxComponentConstraint) error {
 	if path.Context == "" {
 		return status.Error(codes.InvalidArgument, "SDMX data path is required")
 	}
@@ -106,10 +152,18 @@ func validateDataRequest(path ResourcePath, constraints map[string][]string) err
 		return status.Errorf(codes.InvalidArgument, "unsupported SDMX dataflow version %q", path.Version)
 	}
 
-	return validateComponentFilters(constraints, isFilterableDataComponentCandidate)
+	if err := validateComponentFilters(constraints, isFilterableDataComponentCandidate); err != nil {
+		return err
+	}
+	for componentID, constraint := range constraints {
+		if len(constraint.GetPropertyConstraints()) > 0 && !isObservationPropertyCandidate(componentID) {
+			return status.Errorf(codes.Unimplemented, "SDMX property constraints on component %q are not implemented yet", componentID)
+		}
+	}
+	return datacommons.ValidateDataConstraints(constraints)
 }
 
-func validateAvailabilityRequest(path AvailabilityPath, constraints map[string][]string) error {
+func validateAvailabilityRequest(path AvailabilityPath, constraints map[string]*sdmxpb.SdmxComponentConstraint) error {
 	if path.Context == "" {
 		return status.Error(codes.InvalidArgument, "SDMX availability path is required")
 	}
@@ -126,10 +180,13 @@ func validateAvailabilityRequest(path AvailabilityPath, constraints map[string][
 		return status.Errorf(codes.Unimplemented, "unsupported SDMX availability component %q", path.ComponentID)
 	}
 
-	return validateComponentFilters(constraints, isFilterableDimensionCandidate)
+	if err := validateComponentFilters(constraints, isFilterableDimensionCandidate); err != nil {
+		return err
+	}
+	return datacommons.ValidateAvailabilityConstraints(constraints)
 }
 
-func validateComponentFilters(constraints map[string][]string, isFilterable func(string) bool) error {
+func validateComponentFilters(constraints map[string]*sdmxpb.SdmxComponentConstraint, isFilterable func(string) bool) error {
 	for componentID := range constraints {
 		if !isValidComponentID(componentID) {
 			return status.Errorf(codes.InvalidArgument, "invalid SDMX component filter %q", componentID)
@@ -178,4 +235,8 @@ func isDynamicEntityComponent(componentID string) bool {
 		return false
 	}
 	return true
+}
+
+func isObservationPropertyCandidate(componentID string) bool {
+	return componentID == datacommons.ComponentObservationAbout || isDynamicEntityComponent(componentID)
 }

--- a/internal/server/sdmx/rest/v2/component.go
+++ b/internal/server/sdmx/rest/v2/component.go
@@ -155,11 +155,6 @@ func validateDataRequest(path ResourcePath, constraints map[string]*sdmxpb.SdmxC
 	if err := validateComponentFilters(constraints, isFilterableDataComponentCandidate); err != nil {
 		return err
 	}
-	for componentID, constraint := range constraints {
-		if len(constraint.GetPropertyConstraints()) > 0 && !isObservationPropertyCandidate(componentID) {
-			return status.Errorf(codes.Unimplemented, "SDMX property constraints on component %q are not implemented yet", componentID)
-		}
-	}
 	return datacommons.ValidateDataConstraints(constraints)
 }
 
@@ -235,8 +230,4 @@ func isDynamicEntityComponent(componentID string) bool {
 		return false
 	}
 	return true
-}
-
-func isObservationPropertyCandidate(componentID string) bool {
-	return componentID == datacommons.ComponentObservationAbout || isDynamicEntityComponent(componentID)
 }

--- a/internal/server/sdmx/rest/v2/data.go
+++ b/internal/server/sdmx/rest/v2/data.go
@@ -17,13 +17,14 @@ package restv2
 import (
 	"net/url"
 
+	sdmxpb "github.com/datacommonsorg/mixer/internal/proto/sdmx"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
 type DataRequest struct {
 	Path        ResourcePath
-	Constraints map[string][]string
+	Constraints map[string]*sdmxpb.SdmxComponentConstraint
 	Format      string
 }
 
@@ -47,7 +48,7 @@ func ParseDataRequest(tail string, originalURI string) (*DataRequest, error) {
 		return nil, err
 	}
 
-	constraints := map[string][]string{}
+	constraints := map[string]*sdmxpb.SdmxComponentConstraint{}
 	format := ""
 	for _, param := range params {
 		ok, err := parseComponentFilter(param, constraints)

--- a/internal/server/sdmx/rest/v2/data_test.go
+++ b/internal/server/sdmx/rest/v2/data_test.go
@@ -332,6 +332,11 @@ func TestParseDataRequest_Errors(t *testing.T) {
 			wantCode:    codes.InvalidArgument,
 		},
 		{
+			name:        "property on known non observation component",
+			originalURI: dataURI("c[variableMeasured]=Count_Person&c[unit.containedInPlace+]=country%2FUSA&c[unit.typeOf]=County"),
+			wantCode:    codes.Unimplemented,
+		},
+		{
 			name:        "time period filter unsupported",
 			originalURI: dataURI("c[variableMeasured]=Count_Person&c[observationAbout]=country%2FUSA&c[TIME_PERIOD]=2020"),
 			wantCode:    codes.Unimplemented,

--- a/internal/server/sdmx/rest/v2/data_test.go
+++ b/internal/server/sdmx/rest/v2/data_test.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"testing"
 
+	sdmxpb "github.com/datacommonsorg/mixer/internal/proto/sdmx"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -122,11 +123,42 @@ func TestParseDataRequest_Constraints(t *testing.T) {
 			if err != nil {
 				t.Fatalf("ParseDataRequest() error = %v", err)
 			}
-			if diff := cmp.Diff(tt.want, got.Constraints); diff != "" {
+			if diff := cmp.Diff(tt.want, componentConstraintValues(got.Constraints)); diff != "" {
 				t.Errorf("ParseDataRequest() constraints mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
+}
+
+func TestParseDataRequest_PropertyConstraints(t *testing.T) {
+	for _, query := range []string{
+		"c[variableMeasured]=Count_Migration&c[sourceCountry.containedInPlace+]=country%2FUSA&c[sourceCountry.typeOf]=State",
+		"c%5BvariableMeasured%5D=Count_Migration&c%5BsourceCountry.containedInPlace%2B%5D=country%2FUSA&c%5BsourceCountry.typeOf%5D=State",
+	} {
+		got, err := ParseDataRequest(dataTail(), dataURI(query))
+		if err != nil {
+			t.Fatalf("ParseDataRequest() error = %v", err)
+		}
+		constraint := got.Constraints["sourceCountry"]
+		containedIn := constraint.GetPropertyConstraints()["containedInPlace"]
+		if !containedIn.GetTransitive() || containedIn.GetPredicates()[0].GetValue() != "country/USA" {
+			t.Fatalf("containedInPlace constraint = %v", containedIn)
+		}
+		typeOf := constraint.GetPropertyConstraints()["typeOf"]
+		if typeOf.GetTransitive() || typeOf.GetPredicates()[0].GetValue() != "State" {
+			t.Fatalf("typeOf constraint = %v", typeOf)
+		}
+	}
+}
+
+func componentConstraintValues(constraints map[string]*sdmxpb.SdmxComponentConstraint) map[string][]string {
+	result := map[string][]string{}
+	for componentID, constraint := range constraints {
+		for _, predicate := range constraint.GetPredicates() {
+			result[componentID] = append(result[componentID], predicate.GetValue())
+		}
+	}
+	return result
 }
 
 func TestParseDataRequest_Path(t *testing.T) {
@@ -273,6 +305,31 @@ func TestParseDataRequest_Errors(t *testing.T) {
 			name:        "operator unsupported",
 			originalURI: dataURI("c[variableMeasured]=Count_Person&c[observationAbout]=country%2FUSA&c[TIME_PERIOD]=ge:2020"),
 			wantCode:    codes.Unimplemented,
+		},
+		{
+			name:        "multi step property selector",
+			originalURI: dataURI("c[variableMeasured]=Count_Person&c[observationAbout.containedInPlace.typeOf]=County"),
+			wantCode:    codes.InvalidArgument,
+		},
+		{
+			name:        "direct containment unsupported",
+			originalURI: dataURI("c[variableMeasured]=Count_Person&c[observationAbout.containedInPlace]=country%2FUSA&c[observationAbout.typeOf]=County"),
+			wantCode:    codes.Unimplemented,
+		},
+		{
+			name:        "transitive type unsupported",
+			originalURI: dataURI("c[variableMeasured]=Count_Person&c[observationAbout.containedInPlace+]=country%2FUSA&c[observationAbout.typeOf+]=County"),
+			wantCode:    codes.Unimplemented,
+		},
+		{
+			name:        "multiple containment values",
+			originalURI: dataURI("c[variableMeasured]=Count_Person&c[observationAbout.containedInPlace+]=country%2FUSA,country%2FCAN&c[observationAbout.typeOf]=County"),
+			wantCode:    codes.InvalidArgument,
+		},
+		{
+			name:        "direct and property predicates",
+			originalURI: dataURI("c[variableMeasured]=Count_Person&c[observationAbout]=geoId%2F06&c[observationAbout.containedInPlace+]=country%2FUSA&c[observationAbout.typeOf]=County"),
+			wantCode:    codes.InvalidArgument,
 		},
 		{
 			name:        "time period filter unsupported",

--- a/internal/server/sdmx/service/mapper.go
+++ b/internal/server/sdmx/service/mapper.go
@@ -21,26 +21,14 @@ import (
 )
 
 func dataQueryFromREST(request *restv2.DataRequest) (*sdmxpb.SdmxDataQuery, error) {
-	return &sdmxpb.SdmxDataQuery{Constraints: constraintsFromRESTFilters(request.Constraints)}, nil
+	return &sdmxpb.SdmxDataQuery{Constraints: request.Constraints}, nil
 }
 
 func availabilityQueryFromREST(request *restv2.AvailabilityRequest) (*sdmxpb.SdmxAvailabilityQuery, error) {
 	return &sdmxpb.SdmxAvailabilityQuery{
 		ComponentId: request.Path.ComponentID,
-		Constraints: constraintsFromRESTFilters(request.Constraints),
+		Constraints: request.Constraints,
 	}, nil
-}
-
-func constraintsFromRESTFilters(filters map[string][]string) map[string]*sdmxpb.SdmxComponentConstraint {
-	constraints := map[string]*sdmxpb.SdmxComponentConstraint{}
-	for componentID, values := range filters {
-		predicates := make([]*sdmxpb.SdmxPredicate, 0, len(values))
-		for _, value := range values {
-			predicates = append(predicates, &sdmxpb.SdmxPredicate{Value: value})
-		}
-		constraints[componentID] = &sdmxpb.SdmxComponentConstraint{Predicates: predicates}
-	}
-	return constraints
 }
 
 func dataStructureID(path restv2.ResourcePath) string {

--- a/internal/server/sdmx/service/service_test.go
+++ b/internal/server/sdmx/service/service_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/datacommonsorg/mixer/internal/server/dispatcher"
 	"github.com/datacommonsorg/mixer/internal/server/sdmx/datacommons"
 	sdmxformat "github.com/datacommonsorg/mixer/internal/server/sdmx/format"
+	restv2 "github.com/datacommonsorg/mixer/internal/server/sdmx/rest/v2"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -42,20 +43,16 @@ func sdmxComponentConstraint(values ...string) *sdmxpb.SdmxComponentConstraint {
 	return &sdmxpb.SdmxComponentConstraint{Predicates: predicates}
 }
 
-func TestConstraintsFromRESTFiltersDefaultsToEquality(t *testing.T) {
-	constraint := constraintsFromRESTFilters(map[string][]string{
-		"source": {"india", "usa"},
-	})["source"]
-
-	gotValues := make([]string, 0, len(constraint.GetPredicates()))
-	for _, predicate := range constraint.GetPredicates() {
-		if got := predicate.GetOperator(); got != sdmxpb.SdmxOperator_SDMX_OPERATOR_EQ {
-			t.Fatalf("predicate operator = %v, want EQ", got)
-		}
-		gotValues = append(gotValues, predicate.GetValue())
+func TestDataQueryFromRESTPreservesConstraints(t *testing.T) {
+	constraints := map[string]*sdmxpb.SdmxComponentConstraint{
+		"source": sdmxComponentConstraint("india", "usa"),
 	}
-	if diff := cmp.Diff([]string{"india", "usa"}, gotValues); diff != "" {
-		t.Fatalf("predicate values mismatch (-want +got):\n%s", diff)
+	query, err := dataQueryFromREST(&restv2.DataRequest{Constraints: constraints})
+	if err != nil {
+		t.Fatalf("dataQueryFromREST() error = %v", err)
+	}
+	if diff := cmp.Diff(constraints, query.GetConstraints(), protocmp.Transform()); diff != "" {
+		t.Fatalf("dataQueryFromREST() constraints mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -149,10 +146,10 @@ func TestDataValidation(t *testing.T) {
 			wantErrSub: "SDMX component filter operators are not implemented yet",
 		},
 		{
-			name:       "Property selector remains unsupported",
+			name:       "Incomplete property selector pair",
 			request:    sdmxDataRequest("c[variableMeasured]=Count_Person&c[observationAbout.typeOf]=County"),
 			wantCode:   codes.InvalidArgument,
-			wantErrSub: "invalid SDMX component filter",
+			wantErrSub: "require containedInPlace+ and typeOf",
 		},
 		{
 			name:       "Unsupported observation value filter",

--- a/internal/server/spanner/golden/emulator/sdmx_test.go
+++ b/internal/server/spanner/golden/emulator/sdmx_test.go
@@ -91,6 +91,26 @@ func TestSDMXData(t *testing.T) {
 			query:  "c[variableMeasured]=Count_Migration&c[destinationCountry]=country%2FZZZ",
 			golden: "data_empty.csv",
 		},
+		{
+			name:   "contained destination on entity1",
+			query:  "c[variableMeasured]=Count_Migration&c[destinationCountry.containedInPlace+]=northamerica&c[destinationCountry.typeOf]=Country&c[sourceCountry]=country%2FUSA",
+			golden: "data_two_entities.csv",
+		},
+		{
+			name:   "contained source on entity2",
+			query:  "c[variableMeasured]=Count_Migration&c[destinationCountry]=country%2FCAN&c[sourceCountry.containedInPlace+]=northamerica&c[sourceCountry.typeOf]=Country",
+			golden: "data_two_entities.csv",
+		},
+		{
+			name:   "same containment on entity2 and entity3",
+			query:  "c[variableMeasured]=Count_MigrationByObservationAbout&c[observationAbout.containedInPlace+]=northamerica&c[observationAbout.typeOf]=Country&c[sourceCountry.containedInPlace+]=northamerica&c[sourceCountry.typeOf]=Country",
+			golden: "data_explicit_observation_about.csv",
+		},
+		{
+			name:   "empty containment result",
+			query:  "c[variableMeasured]=Count_Migration&c[sourceCountry.containedInPlace+]=oceania&c[sourceCountry.typeOf]=Country",
+			golden: "data_empty.csv",
+		},
 	}
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {

--- a/internal/server/spanner/golden/emulator/testdata/seed.sql
+++ b/internal/server/spanner/golden/emulator/testdata/seed.sql
@@ -6,7 +6,18 @@ VALUES
   ('Count_MigrationByTransportMode', 'Count_MigrationByTransportMode'),
   ('Count_Person', 'Count_Person'),
   ('Count_Refugee', 'Count_Refugee'),
-  ('destinationCountry', 'destinationCountry'),
+	('Country', 'Country'),
+	('State', 'State'),
+	('asia', 'asia'),
+	('country/CAN', 'country/CAN'),
+	('country/FRA', 'country/FRA'),
+	('country/GBR', 'country/GBR'),
+	('country/IND', 'country/IND'),
+	('country/MEX', 'country/MEX'),
+	('country/USA', 'country/USA'),
+	('destinationCountry', 'destinationCountry'),
+	('europe', 'europe'),
+	('northamerica', 'northamerica'),
   ('observationAbout', 'observationAbout'),
   ('sourceCountry', 'sourceCountry'),
   ('transportMode', 'transportMode');
@@ -22,7 +33,19 @@ VALUES
   ('Count_MigrationByTransportMode', 'observationProperties', 'sourceCountry', 'dc/base/HumanReadableStatVars'),
   ('Count_MigrationByObservationAbout', 'observationProperties', 'sourceCountry', 'dc/base/HumanReadableStatVars'),
   ('Count_MigrationByObservationAbout', 'observationProperties', 'observationAbout', 'dc/base/HumanReadableStatVars'),
-  ('Count_MigrationByObservationAbout', 'observationProperties', 'destinationCountry', 'dc/base/HumanReadableStatVars');
+	('Count_MigrationByObservationAbout', 'observationProperties', 'destinationCountry', 'dc/base/HumanReadableStatVars'),
+	('country/CAN', 'linkedContainedInPlace', 'northamerica', 'dc/base/WikidataOtherIdGeos'),
+	('country/CAN', 'typeOf', 'Country', 'dc/base/WikidataOtherIdGeos'),
+	('country/FRA', 'linkedContainedInPlace', 'europe', 'dc/base/WikidataOtherIdGeos'),
+	('country/FRA', 'typeOf', 'Country', 'dc/base/WikidataOtherIdGeos'),
+	('country/GBR', 'linkedContainedInPlace', 'europe', 'dc/base/WikidataOtherIdGeos'),
+	('country/GBR', 'typeOf', 'Country', 'dc/base/WikidataOtherIdGeos'),
+	('country/IND', 'linkedContainedInPlace', 'asia', 'dc/base/WikidataOtherIdGeos'),
+	('country/IND', 'typeOf', 'Country', 'dc/base/WikidataOtherIdGeos'),
+	('country/MEX', 'linkedContainedInPlace', 'northamerica', 'dc/base/WikidataOtherIdGeos'),
+	('country/MEX', 'typeOf', 'Country', 'dc/base/WikidataOtherIdGeos'),
+	('country/USA', 'linkedContainedInPlace', 'northamerica', 'dc/base/WikidataOtherIdGeos'),
+	('country/USA', 'typeOf', 'Country', 'dc/base/WikidataOtherIdGeos');
 
 INSERT INTO TimeSeries (variable_measured, extra_entities_id, facet_id, entities, facet, last_update_timestamp)
 VALUES

--- a/internal/server/spanner/golden/query_builder/get_sdmx_availability_filtered_destination_country.sql
+++ b/internal/server/spanner/golden/query_builder/get_sdmx_availability_filtered_destination_country.sql
@@ -1,6 +1,6 @@
 		SELECT DISTINCT t.entity1 AS value
 		FROM TimeSeries t
-		WHERE (t.variable_measured IN ('var1','var2') AND t.entity1 IN ('country/PRT','country/SGP') AND t.measurement_method IN ('Census','Survey') AND t.observation_period IN ('P1Y','P1M') AND t.provenance IN ('dc/base/one','dc/base/two') AND t.entity2 IN ('country/AGO','country/BRA') AND t.unit IN ('Percent','Count'))
+		WHERE (t.variable_measured IN ('var1','var2') AND t.entity1 IN ('country/PRT','country/SGP') AND t.entity2 IN ('country/AGO','country/BRA') AND t.measurement_method IN ('Census','Survey') AND t.observation_period IN ('P1Y','P1M') AND t.provenance IN ('dc/base/one','dc/base/two') AND t.unit IN ('Percent','Count'))
 			AND t.entity1 IS NOT NULL
 			AND t.entity1 != ''
 		ORDER BY value

--- a/internal/server/spanner/golden/query_builder/get_sdmx_obs_contained_entity1.sql
+++ b/internal/server/spanner/golden/query_builder/get_sdmx_obs_contained_entity1.sql
@@ -1,0 +1,39 @@
+		WITH contained_places_0 AS (
+			SELECT DISTINCT contained.subject_id AS place_id
+			FROM Edge contained
+			JOIN Edge typed ON contained.subject_id = typed.subject_id
+			WHERE contained.predicate = 'linkedContainedInPlace'
+				AND contained.object_id = 'country/USA'
+				AND typed.predicate = 'typeOf'
+				AND typed.object_id = 'County'
+		),
+		series AS (
+			SELECT
+				t.variable_measured,
+				t.entity1,
+				t.extra_entities_id,
+				t.facet_id,
+				t.provenance,
+				t.facet,
+				t.entities
+			FROM contained_places_0 anchor
+			JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} TimeSeries@{FORCE_INDEX=_BASE_TABLE} t
+				ON t.entity1 = anchor.place_id
+				AND t.variable_measured IN ('var1')
+		)
+		SELECT
+			t.variable_measured,
+			t.entity1 AS observation_about,
+			t.facet_id,
+			ANY_VALUE(t.provenance) AS provenance,
+			ARRAY_AGG(STRUCT(o.date AS date, o.value AS str_value)) AS dates_and_values,
+			ANY_VALUE(t.facet) AS facets,
+			ANY_VALUE(t.entities) AS entities
+		FROM series t
+		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} Observation o
+		USING (variable_measured, entity1, extra_entities_id, facet_id)
+		GROUP BY
+			t.variable_measured,
+			t.entity1,
+			t.extra_entities_id,
+			t.facet_id

--- a/internal/server/spanner/golden/query_builder/get_sdmx_obs_contained_entity1_multiple_sets.sql
+++ b/internal/server/spanner/golden/query_builder/get_sdmx_obs_contained_entity1_multiple_sets.sql
@@ -1,0 +1,49 @@
+		WITH contained_places_0 AS (
+			SELECT DISTINCT contained.subject_id AS place_id
+			FROM Edge contained
+			JOIN Edge typed ON contained.subject_id = typed.subject_id
+			WHERE contained.predicate = 'linkedContainedInPlace'
+				AND contained.object_id = 'country/CAN'
+				AND typed.predicate = 'typeOf'
+				AND typed.object_id = 'Province'
+		),
+		contained_places_1 AS (
+			SELECT DISTINCT contained.subject_id AS place_id
+			FROM Edge contained
+			JOIN Edge typed ON contained.subject_id = typed.subject_id
+			WHERE contained.predicate = 'linkedContainedInPlace'
+				AND contained.object_id = 'country/USA'
+				AND typed.predicate = 'typeOf'
+				AND typed.object_id = 'State'
+		),
+		series AS (
+			SELECT
+				t.variable_measured,
+				t.entity1,
+				t.extra_entities_id,
+				t.facet_id,
+				t.provenance,
+				t.facet,
+				t.entities
+			FROM contained_places_0 anchor
+			JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} TimeSeries@{FORCE_INDEX=_BASE_TABLE} t
+				ON t.entity1 = anchor.place_id
+				AND t.variable_measured IN ('var1')
+			WHERE t.entity3 IN (SELECT place_id FROM contained_places_1)
+		)
+		SELECT
+			t.variable_measured,
+			t.entity1 AS observation_about,
+			t.facet_id,
+			ANY_VALUE(t.provenance) AS provenance,
+			ARRAY_AGG(STRUCT(o.date AS date, o.value AS str_value)) AS dates_and_values,
+			ANY_VALUE(t.facet) AS facets,
+			ANY_VALUE(t.entities) AS entities
+		FROM series t
+		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} Observation o
+		USING (variable_measured, entity1, extra_entities_id, facet_id)
+		GROUP BY
+			t.variable_measured,
+			t.entity1,
+			t.extra_entities_id,
+			t.facet_id

--- a/internal/server/spanner/golden/query_builder/get_sdmx_obs_contained_entity2.sql
+++ b/internal/server/spanner/golden/query_builder/get_sdmx_obs_contained_entity2.sql
@@ -1,0 +1,41 @@
+		@{spanner_emulator.disable_query_null_filtered_index_check=true}
+		WITH contained_places_0 AS (
+			SELECT DISTINCT contained.subject_id AS place_id
+			FROM Edge contained
+			JOIN Edge typed ON contained.subject_id = typed.subject_id
+			WHERE contained.predicate = 'linkedContainedInPlace'
+				AND contained.object_id = 'country/USA'
+				AND typed.predicate = 'typeOf'
+				AND typed.object_id = 'State'
+		),
+		series AS (
+			SELECT
+				t.variable_measured,
+				t.entity1,
+				t.extra_entities_id,
+				t.facet_id,
+				t.provenance,
+				t.facet,
+				t.entities
+			FROM contained_places_0 anchor
+			JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} TimeSeries@{FORCE_INDEX=TimeSeriesByEntity2} t
+				ON t.entity2 = anchor.place_id
+				AND t.variable_measured IN ('var1') AND t.entity1 IN ('country/CAN')
+			WHERE t.entity2 IS NOT NULL
+		)
+		SELECT
+			t.variable_measured,
+			t.entity1 AS observation_about,
+			t.facet_id,
+			ANY_VALUE(t.provenance) AS provenance,
+			ARRAY_AGG(STRUCT(o.date AS date, o.value AS str_value)) AS dates_and_values,
+			ANY_VALUE(t.facet) AS facets,
+			ANY_VALUE(t.entities) AS entities
+		FROM series t
+		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} Observation o
+		USING (variable_measured, entity1, extra_entities_id, facet_id)
+		GROUP BY
+			t.variable_measured,
+			t.entity1,
+			t.extra_entities_id,
+			t.facet_id

--- a/internal/server/spanner/golden/query_builder/get_sdmx_obs_contained_entity3.sql
+++ b/internal/server/spanner/golden/query_builder/get_sdmx_obs_contained_entity3.sql
@@ -1,0 +1,42 @@
+		@{spanner_emulator.disable_query_null_filtered_index_check=true}
+		WITH contained_places_0 AS (
+			SELECT DISTINCT contained.subject_id AS place_id
+			FROM Edge contained
+			JOIN Edge typed ON contained.subject_id = typed.subject_id
+			WHERE contained.predicate = 'linkedContainedInPlace'
+				AND contained.object_id = 'northamerica'
+				AND typed.predicate = 'typeOf'
+				AND typed.object_id = 'TransportMode'
+		),
+		series AS (
+			SELECT
+				t.variable_measured,
+				t.entity1,
+				t.extra_entities_id,
+				t.facet_id,
+				t.provenance,
+				t.facet,
+				t.entities
+			FROM contained_places_0 anchor
+			JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} TimeSeries@{FORCE_INDEX=TimeSeriesByEntity3} t
+				ON t.entity3 = anchor.place_id
+				AND t.variable_measured IN ('var1')
+			WHERE t.entity3 IS NOT NULL
+				AND t.entity2 IS NOT NULL
+		)
+		SELECT
+			t.variable_measured,
+			t.entity1 AS observation_about,
+			t.facet_id,
+			ANY_VALUE(t.provenance) AS provenance,
+			ARRAY_AGG(STRUCT(o.date AS date, o.value AS str_value)) AS dates_and_values,
+			ANY_VALUE(t.facet) AS facets,
+			ANY_VALUE(t.entities) AS entities
+		FROM series t
+		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} Observation o
+		USING (variable_measured, entity1, extra_entities_id, facet_id)
+		GROUP BY
+			t.variable_measured,
+			t.entity1,
+			t.extra_entities_id,
+			t.facet_id

--- a/internal/server/spanner/golden/query_builder/get_sdmx_obs_contained_entity3_before_entity2.sql
+++ b/internal/server/spanner/golden/query_builder/get_sdmx_obs_contained_entity3_before_entity2.sql
@@ -1,0 +1,43 @@
+		@{spanner_emulator.disable_query_null_filtered_index_check=true}
+		WITH contained_places_0 AS (
+			SELECT DISTINCT contained.subject_id AS place_id
+			FROM Edge contained
+			JOIN Edge typed ON contained.subject_id = typed.subject_id
+			WHERE contained.predicate = 'linkedContainedInPlace'
+				AND contained.object_id = 'country/USA'
+				AND typed.predicate = 'typeOf'
+				AND typed.object_id = 'State'
+		),
+		series AS (
+			SELECT
+				t.variable_measured,
+				t.entity1,
+				t.extra_entities_id,
+				t.facet_id,
+				t.provenance,
+				t.facet,
+				t.entities
+			FROM contained_places_0 anchor
+			JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} TimeSeries@{FORCE_INDEX=TimeSeriesByEntity3} t
+				ON t.entity3 = anchor.place_id
+				AND t.variable_measured IN ('var1')
+			WHERE t.entity3 IS NOT NULL
+				AND t.entity2 IS NOT NULL
+				AND t.entity2 IN (SELECT place_id FROM contained_places_0)
+		)
+		SELECT
+			t.variable_measured,
+			t.entity1 AS observation_about,
+			t.facet_id,
+			ANY_VALUE(t.provenance) AS provenance,
+			ARRAY_AGG(STRUCT(o.date AS date, o.value AS str_value)) AS dates_and_values,
+			ANY_VALUE(t.facet) AS facets,
+			ANY_VALUE(t.entities) AS entities
+		FROM series t
+		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} Observation o
+		USING (variable_measured, entity1, extra_entities_id, facet_id)
+		GROUP BY
+			t.variable_measured,
+			t.entity1,
+			t.extra_entities_id,
+			t.facet_id

--- a/internal/server/spanner/golden/query_builder/get_sdmx_obs_multi_var_slots.sql
+++ b/internal/server/spanner/golden/query_builder/get_sdmx_obs_multi_var_slots.sql
@@ -17,4 +17,4 @@
 			t.facet AS facets,
 			t.entities
 		FROM TimeSeries t
-		WHERE t.variable_measured IN ('var1','var2') AND t.entity2 IN ('country/PRT') AND t.entity1 IN ('country/AGO')
+		WHERE t.variable_measured IN ('var1','var2') AND t.entity1 IN ('country/AGO') AND t.entity2 IN ('country/PRT')

--- a/internal/server/spanner/golden/query_builder/get_sdmx_obs_slots_slicing.sql
+++ b/internal/server/spanner/golden/query_builder/get_sdmx_obs_slots_slicing.sql
@@ -17,4 +17,4 @@
 			t.facet AS facets,
 			t.entities
 		FROM TimeSeries t
-		WHERE t.variable_measured IN ('var1') AND t.entity2 IN ('country/PRT','country/SGP') AND t.entity1 IN ('country/AGO')
+		WHERE t.variable_measured IN ('var1') AND t.entity1 IN ('country/AGO') AND t.entity2 IN ('country/PRT','country/SGP')

--- a/internal/server/spanner/golden/query_builder/get_sdmx_obs_with_facet_and_prov.sql
+++ b/internal/server/spanner/golden/query_builder/get_sdmx_obs_with_facet_and_prov.sql
@@ -17,4 +17,4 @@
 			t.facet AS facets,
 			t.entities
 		FROM TimeSeries t
-		WHERE t.variable_measured IN ('var1') AND t.entity2 IN ('country/PRT','country/SGP') AND t.facet_id IN ('facet','alternate-facet') AND t.measurement_method IN ('Census','Survey') AND t.observation_period IN ('P1Y','P1M') AND t.entity1 IN ('country/AGO','country/BRA') AND t.provenance IN ('dc/base/WTO_TradeConnectivity','dc/base/UN_Trade') AND t.unit IN ('Percent','Count')
+		WHERE t.variable_measured IN ('var1') AND t.entity1 IN ('country/AGO','country/BRA') AND t.entity2 IN ('country/PRT','country/SGP') AND t.facet_id IN ('facet','alternate-facet') AND t.measurement_method IN ('Census','Survey') AND t.observation_period IN ('P1Y','P1M') AND t.provenance IN ('dc/base/WTO_TradeConnectivity','dc/base/UN_Trade') AND t.unit IN ('Percent','Count')

--- a/internal/server/spanner/golden/query_builder_multientity_test.go
+++ b/internal/server/spanner/golden/query_builder_multientity_test.go
@@ -168,7 +168,7 @@ func TestMultiEntityGetSdmxObservationsQuery(t *testing.T) {
 				if err != nil {
 					return nil, err
 				}
-				stmt, err := builder.GetSdmxObservationsQuery(c.constraints, c.entitySlotByObservationProperty)
+				stmt, err := builder.GetSdmxObservationsQuery(c.constraints, c.observationPropertyToEntitySlot)
 				return stmt, err
 			})
 		})
@@ -187,10 +187,10 @@ func TestMultiEntityGetSdmxObservationsQuery_Validation(t *testing.T) {
 		"provenance":        sdmxComponentConstraint("dc/base/INPE_Fire_Event_Count"),
 		"observationPeriod": sdmxComponentConstraint("P1Y"),
 	}
-	entitySlotByObservationProperty := map[string]string{
+	observationPropertyToEntitySlot := map[string]string{
 		"observationAbout": "entity1",
 	}
-	_, err = builder.GetSdmxObservationsQuery(constraints, entitySlotByObservationProperty)
+	_, err = builder.GetSdmxObservationsQuery(constraints, observationPropertyToEntitySlot)
 	if err != nil {
 		t.Errorf("expected no error for valid constraint keys, got %v", err)
 	}
@@ -198,7 +198,7 @@ func TestMultiEntityGetSdmxObservationsQuery_Validation(t *testing.T) {
 	for _, tc := range []struct {
 		name                            string
 		constraints                     map[string]*sdmxpb.SdmxComponentConstraint
-		entitySlotByObservationProperty map[string]string
+		observationPropertyToEntitySlot map[string]string
 		want                            string
 	}{
 		{
@@ -258,7 +258,7 @@ func TestMultiEntityGetSdmxObservationsQuery_Validation(t *testing.T) {
 				"variableMeasured": sdmxComponentConstraint("var1"),
 				"customEntity":     sdmxComponentConstraint("value"),
 			},
-			entitySlotByObservationProperty: entitySlotByObservationProperty,
+			observationPropertyToEntitySlot: observationPropertyToEntitySlot,
 			want:                            `GetSdmxObservationsQuery: unsupported SDMX component filter "customEntity"`,
 		},
 		{
@@ -267,7 +267,7 @@ func TestMultiEntityGetSdmxObservationsQuery_Validation(t *testing.T) {
 				"variableMeasured":   sdmxComponentConstraint("var1"),
 				"destinationCountry": sdmxComponentConstraint("country/USA"),
 			},
-			entitySlotByObservationProperty: map[string]string{
+			observationPropertyToEntitySlot: map[string]string{
 				"destinationCountry": "entity4",
 			},
 			want: `GetSdmxObservationsQuery: SDMX observation property "destinationCountry" maps to unsupported entity slot "entity4"`,
@@ -275,7 +275,7 @@ func TestMultiEntityGetSdmxObservationsQuery_Validation(t *testing.T) {
 		{
 			name:        "observation about outside resolved properties",
 			constraints: constraints,
-			entitySlotByObservationProperty: map[string]string{
+			observationPropertyToEntitySlot: map[string]string{
 				"destinationCountry": "entity1", "sourceCountry": "entity2",
 			},
 			want: `GetSdmxObservationsQuery: unsupported SDMX component filter "observationAbout"`,
@@ -287,7 +287,7 @@ func TestMultiEntityGetSdmxObservationsQuery_Validation(t *testing.T) {
 				"destinationCountry": sdmxComponentConstraint("country/CAN"),
 				"sourceCountry":      sdmxComponentConstraint("country/USA"),
 			},
-			entitySlotByObservationProperty: map[string]string{
+			observationPropertyToEntitySlot: map[string]string{
 				"destinationCountry": "entity1",
 				"sourceCountry":      "entity1",
 			},
@@ -295,7 +295,7 @@ func TestMultiEntityGetSdmxObservationsQuery_Validation(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := builder.GetSdmxObservationsQuery(tc.constraints, tc.entitySlotByObservationProperty)
+			_, err := builder.GetSdmxObservationsQuery(tc.constraints, tc.observationPropertyToEntitySlot)
 			if status.Code(err) != codes.InvalidArgument {
 				t.Fatalf("GetSdmxObservationsQuery() code = %v, want %v; err = %v", status.Code(err), codes.InvalidArgument, err)
 			}
@@ -313,7 +313,7 @@ func TestMultiEntityGetSdmxObservationsQueryDoesNotUseFacetJSONFallback(t *testi
 	}
 
 	for _, c := range multiEntitySdmxObservationsTestCases {
-		stmt, err := builder.GetSdmxObservationsQuery(c.constraints, c.entitySlotByObservationProperty)
+		stmt, err := builder.GetSdmxObservationsQuery(c.constraints, c.observationPropertyToEntitySlot)
 		if err != nil {
 			t.Fatalf("GetSdmxObservationsQuery(%q) error = %v", c.name, err)
 		}
@@ -445,13 +445,13 @@ func TestMultiEntityGetSdmxAvailabilityQuery(t *testing.T) {
 	for _, c := range []struct {
 		name                            string
 		componentID                     string
-		entitySlotByObservationProperty map[string]string
+		observationPropertyToEntitySlot map[string]string
 		golden                          string
 	}{
 		{
 			name:        "observation about",
 			componentID: "observationAbout",
-			entitySlotByObservationProperty: map[string]string{
+			observationPropertyToEntitySlot: map[string]string{
 				"observationAbout": "entity1",
 			},
 			golden: "get_sdmx_availability_observation_about.sql",
@@ -459,7 +459,7 @@ func TestMultiEntityGetSdmxAvailabilityQuery(t *testing.T) {
 		{
 			name:        "dynamic observation property",
 			componentID: "destinationCountry",
-			entitySlotByObservationProperty: map[string]string{
+			observationPropertyToEntitySlot: map[string]string{
 				"destinationCountry": "entity1", "sourceCountry": "entity2",
 			},
 			golden: "get_sdmx_availability_destination_country.sql",
@@ -502,7 +502,7 @@ func TestMultiEntityGetSdmxAvailabilityQuery(t *testing.T) {
 					Constraints: map[string]*sdmxpb.SdmxComponentConstraint{
 						"variableMeasured": sdmxComponentConstraint("Count_Person", "Count_Household"),
 					},
-				}, c.entitySlotByObservationProperty)
+				}, c.observationPropertyToEntitySlot)
 			})
 		})
 	}
@@ -540,7 +540,7 @@ func TestMultiEntityGetSdmxAvailabilityQuery_Validation(t *testing.T) {
 	for _, tc := range []struct {
 		name                            string
 		req                             *sdmxpb.SdmxAvailabilityQuery
-		entitySlotByObservationProperty map[string]string
+		observationPropertyToEntitySlot map[string]string
 		want                            string
 	}{
 		{
@@ -625,7 +625,7 @@ func TestMultiEntityGetSdmxAvailabilityQuery_Validation(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := builder.GetSdmxAvailabilityQuery(tc.req, tc.entitySlotByObservationProperty)
+			_, err := builder.GetSdmxAvailabilityQuery(tc.req, tc.observationPropertyToEntitySlot)
 			if status.Code(err) != codes.InvalidArgument {
 				t.Fatalf("GetSdmxAvailabilityQuery() code = %v, want %v; err = %v", status.Code(err), codes.InvalidArgument, err)
 			}

--- a/internal/server/spanner/golden/query_builder_multientity_test.go
+++ b/internal/server/spanner/golden/query_builder_multientity_test.go
@@ -203,7 +203,7 @@ func TestMultiEntityGetSdmxObservationsQuery_Validation(t *testing.T) {
 	}{
 		{
 			name: "nil constraints",
-			want: "GetSdmxObservationsQuery: SDMX request constraints cannot be nil",
+			want: "GetSdmxObservationsQuery: missing required SDMX component filter variableMeasured",
 		},
 		{
 			name: "invalid key containing SQL injection payload",
@@ -250,7 +250,7 @@ func TestMultiEntityGetSdmxObservationsQuery_Validation(t *testing.T) {
 			constraints: map[string]*sdmxpb.SdmxComponentConstraint{
 				"unit": sdmxComponentConstraint("Percent"),
 			},
-			want: "GetSdmxObservationsQuery: SDMX component filter variableMeasured must be specified",
+			want: "GetSdmxObservationsQuery: missing required SDMX component filter variableMeasured",
 		},
 		{
 			name: "unsupported dynamic key",
@@ -262,15 +262,15 @@ func TestMultiEntityGetSdmxObservationsQuery_Validation(t *testing.T) {
 			want:                            `GetSdmxObservationsQuery: unsupported SDMX component filter "customEntity"`,
 		},
 		{
-			name: "empty dynamic component mapping",
+			name: "unsupported entity slot mapping",
 			constraints: map[string]*sdmxpb.SdmxComponentConstraint{
 				"variableMeasured":   sdmxComponentConstraint("var1"),
 				"destinationCountry": sdmxComponentConstraint("country/USA"),
 			},
 			entitySlotByObservationProperty: map[string]string{
-				"destinationCountry": "",
+				"destinationCountry": "entity4",
 			},
-			want: `GetSdmxObservationsQuery: unsupported SDMX component filter "destinationCountry"`,
+			want: `GetSdmxObservationsQuery: SDMX observation property "destinationCountry" maps to unsupported entity slot "entity4"`,
 		},
 		{
 			name:        "observation about outside resolved properties",
@@ -279,6 +279,19 @@ func TestMultiEntityGetSdmxObservationsQuery_Validation(t *testing.T) {
 				"destinationCountry": "entity1", "sourceCountry": "entity2",
 			},
 			want: `GetSdmxObservationsQuery: unsupported SDMX component filter "observationAbout"`,
+		},
+		{
+			name: "duplicate entity slot mapping",
+			constraints: map[string]*sdmxpb.SdmxComponentConstraint{
+				"variableMeasured":   sdmxComponentConstraint("var1"),
+				"destinationCountry": sdmxComponentConstraint("country/CAN"),
+				"sourceCountry":      sdmxComponentConstraint("country/USA"),
+			},
+			entitySlotByObservationProperty: map[string]string{
+				"destinationCountry": "entity1",
+				"sourceCountry":      "entity1",
+			},
+			want: `GetSdmxObservationsQuery: SDMX observation properties "destinationCountry" and "sourceCountry" map to the same entity slot "entity1"`,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -329,10 +342,10 @@ func TestMultiEntityGetSdmxObservationsQueryUsesResolvedObservationAboutSlot(t *
 	if err != nil {
 		t.Fatalf("GetSdmxObservationsQuery() error = %v", err)
 	}
-	if !strings.Contains(stmt.SQL, "t.entity2 IN UNNEST(@observationAbout)") {
+	if !strings.Contains(stmt.SQL, "t.entity2 IN UNNEST(@filter_entity2)") {
 		t.Fatalf("SQL = %s, want observationAbout filter on entity2", stmt.SQL)
 	}
-	if strings.Contains(stmt.SQL, "t.entity1 IN UNNEST(@observationAbout)") {
+	if strings.Contains(stmt.SQL, "t.entity1 IN UNNEST(@filter_entity1)") {
 		t.Fatalf("SQL = %s, want no observationAbout filter on entity1", stmt.SQL)
 	}
 }
@@ -539,7 +552,7 @@ func TestMultiEntityGetSdmxAvailabilityQuery_Validation(t *testing.T) {
 			req: &sdmxpb.SdmxAvailabilityQuery{
 				ComponentId: "observationAbout",
 			},
-			want: "GetSdmxAvailabilityQuery: SDMX request constraints cannot be nil",
+			want: "GetSdmxAvailabilityQuery: missing required SDMX component filter variableMeasured",
 		},
 		{
 			name: "missing variable measured",
@@ -547,7 +560,7 @@ func TestMultiEntityGetSdmxAvailabilityQuery_Validation(t *testing.T) {
 				ComponentId: "observationAbout",
 				Constraints: map[string]*sdmxpb.SdmxComponentConstraint{},
 			},
-			want: "GetSdmxAvailabilityQuery: SDMX component filter variableMeasured must be specified",
+			want: "GetSdmxAvailabilityQuery: missing required SDMX component filter variableMeasured",
 		},
 		{
 			name: "nil variable measured constraint",
@@ -557,7 +570,7 @@ func TestMultiEntityGetSdmxAvailabilityQuery_Validation(t *testing.T) {
 					"variableMeasured": nil,
 				},
 			},
-			want: `GetSdmxAvailabilityQuery: SDMX component filter "variableMeasured" must have at least one value`,
+			want: "GetSdmxAvailabilityQuery: missing required SDMX component filter variableMeasured",
 		},
 		{
 			name: "empty variable measured values",
@@ -567,7 +580,7 @@ func TestMultiEntityGetSdmxAvailabilityQuery_Validation(t *testing.T) {
 					"variableMeasured": &sdmxpb.SdmxComponentConstraint{},
 				},
 			},
-			want: `GetSdmxAvailabilityQuery: SDMX component filter "variableMeasured" must have at least one value`,
+			want: "GetSdmxAvailabilityQuery: missing required SDMX component filter variableMeasured",
 		},
 		{
 			name: "blank variable measured value",

--- a/internal/server/spanner/golden/query_builder_multientity_test.go
+++ b/internal/server/spanner/golden/query_builder_multientity_test.go
@@ -358,6 +358,18 @@ func TestMultiEntityQueryBuildersUseCustomTableConfig(t *testing.T) {
 	}
 	assertSQLContains(t, obsStmt.SQL, "CustomObsTable", "CustomTsTable")
 
+	sdmxStmt, err := builder.GetSdmxObservationsQuery(
+		map[string]*sdmxpb.SdmxComponentConstraint{
+			"variableMeasured": sdmxComponentConstraint("Count_Person"),
+			"source":           sdmxContainedInPlaceConstraint("country/USA", "State"),
+		},
+		map[string]string{"source": "entity2"},
+	)
+	if err != nil {
+		t.Fatalf("GetSdmxObservationsQuery() returned error: %v", err)
+	}
+	assertSQLContains(t, sdmxStmt.SQL, "CustomObsTable", "CustomTsTable", "CustomEntity2Index")
+
 	containedInStmt, err := builder.GetObservationsContainedInPlaceQuery(
 		[]string{"Count_Person"},
 		&v2.ContainedInPlace{Ancestor: "geoId/06", ChildPlaceType: "County"},

--- a/internal/server/spanner/golden/query_multientity_cases_test.go
+++ b/internal/server/spanner/golden/query_multientity_cases_test.go
@@ -26,6 +26,18 @@ func sdmxComponentConstraint(values ...string) *sdmxpb.SdmxComponentConstraint {
 	return &sdmxpb.SdmxComponentConstraint{Predicates: predicates}
 }
 
+func sdmxContainedInPlaceConstraint(ancestor, childPlaceType string) *sdmxpb.SdmxComponentConstraint {
+	return &sdmxpb.SdmxComponentConstraint{
+		PropertyConstraints: map[string]*sdmxpb.SdmxPropertyConstraint{
+			"containedInPlace": {
+				Predicates: []*sdmxpb.SdmxPredicate{{Value: ancestor}},
+				Transitive: true,
+			},
+			"typeOf": {Predicates: []*sdmxpb.SdmxPredicate{{Value: childPlaceType}}},
+		},
+	}
+}
+
 var multiEntityObservationsTestCases = []struct {
 	name      string
 	variables []string
@@ -376,5 +388,59 @@ var multiEntitySdmxObservationsTestCases = []struct {
 			"observationAbout": "entity1",
 		},
 		golden: "get_sdmx_obs_single_entity",
+	},
+	{
+		name: "contained observation about on entity1",
+		constraints: map[string]*sdmxpb.SdmxComponentConstraint{
+			"variableMeasured": sdmxComponentConstraint("var1"),
+			"observationAbout": sdmxContainedInPlaceConstraint("country/USA", "County"),
+		},
+		entitySlotByObservationProperty: map[string]string{"observationAbout": "entity1"},
+		golden:                          "get_sdmx_obs_contained_entity1",
+	},
+	{
+		name: "contained source on entity2 with direct entity1 filter",
+		constraints: map[string]*sdmxpb.SdmxComponentConstraint{
+			"variableMeasured":   sdmxComponentConstraint("var1"),
+			"destinationCountry": sdmxComponentConstraint("country/CAN"),
+			"sourceCountry":      sdmxContainedInPlaceConstraint("country/USA", "State"),
+		},
+		entitySlotByObservationProperty: map[string]string{
+			"destinationCountry": "entity1", "sourceCountry": "entity2",
+		},
+		golden: "get_sdmx_obs_contained_entity2",
+	},
+	{
+		name: "contained transport mode on entity3",
+		constraints: map[string]*sdmxpb.SdmxComponentConstraint{
+			"variableMeasured": sdmxComponentConstraint("var1"),
+			"transportMode":    sdmxContainedInPlaceConstraint("northamerica", "TransportMode"),
+		},
+		entitySlotByObservationProperty: map[string]string{"transportMode": "entity3"},
+		golden:                          "get_sdmx_obs_contained_entity3",
+	},
+	{
+		name: "entity3 anchors before entity2 and reuses place set",
+		constraints: map[string]*sdmxpb.SdmxComponentConstraint{
+			"variableMeasured": sdmxComponentConstraint("var1"),
+			"middle":           sdmxContainedInPlaceConstraint("country/USA", "State"),
+			"last":             sdmxContainedInPlaceConstraint("country/USA", "State"),
+		},
+		entitySlotByObservationProperty: map[string]string{
+			"first": "entity1", "middle": "entity2", "last": "entity3",
+		},
+		golden: "get_sdmx_obs_contained_entity3_before_entity2",
+	},
+	{
+		name: "entity1 anchors multiple place sets",
+		constraints: map[string]*sdmxpb.SdmxComponentConstraint{
+			"variableMeasured": sdmxComponentConstraint("var1"),
+			"first":            sdmxContainedInPlaceConstraint("country/CAN", "Province"),
+			"last":             sdmxContainedInPlaceConstraint("country/USA", "State"),
+		},
+		entitySlotByObservationProperty: map[string]string{
+			"first": "entity1", "middle": "entity2", "last": "entity3",
+		},
+		golden: "get_sdmx_obs_contained_entity1_multiple_sets",
 	},
 }

--- a/internal/server/spanner/golden/query_multientity_cases_test.go
+++ b/internal/server/spanner/golden/query_multientity_cases_test.go
@@ -315,7 +315,7 @@ var multiEntityFilteredTopicTestCases = []struct {
 var multiEntitySdmxObservationsTestCases = []struct {
 	name                            string
 	constraints                     map[string]*sdmxpb.SdmxComponentConstraint
-	entitySlotByObservationProperty map[string]string
+	observationPropertyToEntitySlot map[string]string
 	golden                          string
 }{
 	{
@@ -323,7 +323,7 @@ var multiEntitySdmxObservationsTestCases = []struct {
 		constraints: map[string]*sdmxpb.SdmxComponentConstraint{
 			"variableMeasured": sdmxComponentConstraint("var1"),
 		},
-		entitySlotByObservationProperty: map[string]string{},
+		observationPropertyToEntitySlot: map[string]string{},
 		golden:                          "get_sdmx_obs_var_only",
 	},
 	{
@@ -332,7 +332,7 @@ var multiEntitySdmxObservationsTestCases = []struct {
 			"variableMeasured": sdmxComponentConstraint("var1"),
 			"origin":           sdmxComponentConstraint("country/AGO"),
 		},
-		entitySlotByObservationProperty: map[string]string{
+		observationPropertyToEntitySlot: map[string]string{
 			"origin": "entity1",
 		},
 		golden: "get_sdmx_obs_var_and_origin",
@@ -344,7 +344,7 @@ var multiEntitySdmxObservationsTestCases = []struct {
 			"origin":           sdmxComponentConstraint("country/AGO"),
 			"destination":      sdmxComponentConstraint("country/PRT", "country/SGP"),
 		},
-		entitySlotByObservationProperty: map[string]string{
+		observationPropertyToEntitySlot: map[string]string{
 			"origin": "entity1", "destination": "entity2",
 		},
 		golden: "get_sdmx_obs_slots_slicing",
@@ -356,7 +356,7 @@ var multiEntitySdmxObservationsTestCases = []struct {
 			"origin":           sdmxComponentConstraint("country/AGO"),
 			"destination":      sdmxComponentConstraint("country/PRT"),
 		},
-		entitySlotByObservationProperty: map[string]string{
+		observationPropertyToEntitySlot: map[string]string{
 			"origin": "entity1", "destination": "entity2",
 		},
 		golden: "get_sdmx_obs_multi_var_slots",
@@ -373,7 +373,7 @@ var multiEntitySdmxObservationsTestCases = []struct {
 			"provenance":        sdmxComponentConstraint("dc/base/WTO_TradeConnectivity", "dc/base/UN_Trade"),
 			"unit":              sdmxComponentConstraint("Percent", "Count"),
 		},
-		entitySlotByObservationProperty: map[string]string{
+		observationPropertyToEntitySlot: map[string]string{
 			"origin": "entity1", "destination": "entity2",
 		},
 		golden: "get_sdmx_obs_with_facet_and_prov",
@@ -384,7 +384,7 @@ var multiEntitySdmxObservationsTestCases = []struct {
 			"variableMeasured": sdmxComponentConstraint("var1"),
 			"observationAbout": sdmxComponentConstraint("wikidataId/Q119158"),
 		},
-		entitySlotByObservationProperty: map[string]string{
+		observationPropertyToEntitySlot: map[string]string{
 			"observationAbout": "entity1",
 		},
 		golden: "get_sdmx_obs_single_entity",
@@ -395,7 +395,7 @@ var multiEntitySdmxObservationsTestCases = []struct {
 			"variableMeasured": sdmxComponentConstraint("var1"),
 			"observationAbout": sdmxContainedInPlaceConstraint("country/USA", "County"),
 		},
-		entitySlotByObservationProperty: map[string]string{"observationAbout": "entity1"},
+		observationPropertyToEntitySlot: map[string]string{"observationAbout": "entity1"},
 		golden:                          "get_sdmx_obs_contained_entity1",
 	},
 	{
@@ -405,7 +405,7 @@ var multiEntitySdmxObservationsTestCases = []struct {
 			"destinationCountry": sdmxComponentConstraint("country/CAN"),
 			"sourceCountry":      sdmxContainedInPlaceConstraint("country/USA", "State"),
 		},
-		entitySlotByObservationProperty: map[string]string{
+		observationPropertyToEntitySlot: map[string]string{
 			"destinationCountry": "entity1", "sourceCountry": "entity2",
 		},
 		golden: "get_sdmx_obs_contained_entity2",
@@ -416,7 +416,7 @@ var multiEntitySdmxObservationsTestCases = []struct {
 			"variableMeasured": sdmxComponentConstraint("var1"),
 			"transportMode":    sdmxContainedInPlaceConstraint("northamerica", "TransportMode"),
 		},
-		entitySlotByObservationProperty: map[string]string{"transportMode": "entity3"},
+		observationPropertyToEntitySlot: map[string]string{"transportMode": "entity3"},
 		golden:                          "get_sdmx_obs_contained_entity3",
 	},
 	{
@@ -426,7 +426,7 @@ var multiEntitySdmxObservationsTestCases = []struct {
 			"middle":           sdmxContainedInPlaceConstraint("country/USA", "State"),
 			"last":             sdmxContainedInPlaceConstraint("country/USA", "State"),
 		},
-		entitySlotByObservationProperty: map[string]string{
+		observationPropertyToEntitySlot: map[string]string{
 			"first": "entity1", "middle": "entity2", "last": "entity3",
 		},
 		golden: "get_sdmx_obs_contained_entity3_before_entity2",
@@ -438,7 +438,7 @@ var multiEntitySdmxObservationsTestCases = []struct {
 			"first":            sdmxContainedInPlaceConstraint("country/CAN", "Province"),
 			"last":             sdmxContainedInPlaceConstraint("country/USA", "State"),
 		},
-		entitySlotByObservationProperty: map[string]string{
+		observationPropertyToEntitySlot: map[string]string{
 			"first": "entity1", "middle": "entity2", "last": "entity3",
 		},
 		golden: "get_sdmx_obs_contained_entity1_multiple_sets",

--- a/internal/server/spanner/query_builder_multientity.go
+++ b/internal/server/spanner/query_builder_multientity.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"maps"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 
@@ -332,6 +333,12 @@ type compiledSdmxConstraints struct {
 	params map[string]interface{}
 }
 
+type resolvedSdmxDirectFilter struct {
+	componentID   string
+	spannerColumn string
+	values        []string
+}
+
 func sdmxConstraintValues(constraint *sdmxpb.SdmxComponentConstraint) []string {
 	predicates := constraint.GetPredicates()
 	values := make([]string, 0, len(predicates))
@@ -341,12 +348,43 @@ func sdmxConstraintValues(constraint *sdmxpb.SdmxComponentConstraint) []string {
 	return values
 }
 
+func validateSdmxEntitySlotMapping(entitySlotByObservationProperty map[string]string) error {
+	observationPropertyByEntitySlot := map[string]string{}
+	for _, observationProperty := range slices.Sorted(maps.Keys(entitySlotByObservationProperty)) {
+		entitySlot := entitySlotByObservationProperty[observationProperty]
+		switch entitySlot {
+		case "entity1", "entity2", "entity3":
+		default:
+			return status.Errorf(
+				codes.InvalidArgument,
+				"SDMX observation property %q maps to unsupported entity slot %q",
+				observationProperty,
+				entitySlot,
+			)
+		}
+		if existingObservationProperty, ok := observationPropertyByEntitySlot[entitySlot]; ok {
+			return status.Errorf(
+				codes.InvalidArgument,
+				"SDMX observation properties %q and %q map to the same entity slot %q",
+				existingObservationProperty,
+				observationProperty,
+				entitySlot,
+			)
+		}
+		observationPropertyByEntitySlot[entitySlot] = observationProperty
+	}
+	return nil
+}
+
 func compileSdmxConstraints(
 	constraints map[string]*sdmxpb.SdmxComponentConstraint,
 	entitySlotByObservationProperty map[string]string,
 ) (*compiledSdmxConstraints, error) {
 	if constraints == nil {
 		return nil, status.Error(codes.InvalidArgument, "SDMX request constraints cannot be nil")
+	}
+	if err := validateSdmxEntitySlotMapping(entitySlotByObservationProperty); err != nil {
+		return nil, err
 	}
 	for componentID, constraint := range constraints {
 		if !constraintKeyRegex.MatchString(componentID) {
@@ -381,20 +419,32 @@ func compileSdmxConstraints(
 	}
 	sort.Strings(componentIDs)
 
-	params := map[string]interface{}{
-		datacommons.ComponentVariableMeasured: statVarIDs,
-	}
-	for _, componentID := range componentIDs {
-		params[componentID] = sdmxConstraintValues(constraints[componentID])
-	}
-
-	clauses := []string{sdmxAllowedValuesClause("variable_measured", datacommons.ComponentVariableMeasured)}
+	filters := make([]resolvedSdmxDirectFilter, 0, len(componentIDs))
 	for _, componentID := range componentIDs {
 		spannerColumn, ok := sdmxDataFilterColumn(componentID, entitySlotByObservationProperty)
 		if !ok || spannerColumn == "" {
 			return nil, status.Errorf(codes.InvalidArgument, "unsupported SDMX component filter %q", componentID)
 		}
-		clauses = append(clauses, sdmxAllowedValuesClause(spannerColumn, componentID))
+		filters = append(filters, resolvedSdmxDirectFilter{
+			componentID:   componentID,
+			spannerColumn: spannerColumn,
+			values:        sdmxConstraintValues(constraints[componentID]),
+		})
+	}
+	sort.Slice(filters, func(i, j int) bool {
+		if filters[i].spannerColumn != filters[j].spannerColumn {
+			return filters[i].spannerColumn < filters[j].spannerColumn
+		}
+		return filters[i].componentID < filters[j].componentID
+	})
+	params := map[string]interface{}{
+		datacommons.ComponentVariableMeasured: statVarIDs,
+	}
+	clauses := []string{sdmxAllowedValuesClause("variable_measured", datacommons.ComponentVariableMeasured)}
+	for _, filter := range filters {
+		parameter := "filter_" + filter.spannerColumn
+		params[parameter] = filter.values
+		clauses = append(clauses, sdmxAllowedValuesClause(filter.spannerColumn, parameter))
 	}
 
 	return &compiledSdmxConstraints{
@@ -408,7 +458,6 @@ func sdmxAllowedValuesClause(spannerColumn string, parameter string) string {
 }
 
 type resolvedSdmxContainedInPlace struct {
-	componentID  string
 	entityColumn string
 	relation     datacommons.ContainedInPlaceConstraint
 	cteName      string
@@ -420,13 +469,13 @@ func (b *multiEntityQueryBuilder) getSdmxContainedInPlaceObservationsQuery(
 	compiled *compiledSdmxConstraints,
 ) (*spanner.Statement, error) {
 	resolved := make([]resolvedSdmxContainedInPlace, 0, len(constraints))
-	for componentID, relation := range constraints {
+	for _, componentID := range slices.Sorted(maps.Keys(constraints)) {
+		relation := constraints[componentID]
 		entityColumn, ok := entitySlotByObservationProperty[componentID]
-		if !ok || (entityColumn != "entity1" && entityColumn != "entity2" && entityColumn != "entity3") {
+		if !ok {
 			return nil, status.Errorf(codes.InvalidArgument, "unsupported SDMX property constraint component %q", componentID)
 		}
 		resolved = append(resolved, resolvedSdmxContainedInPlace{
-			componentID:  componentID,
 			entityColumn: entityColumn,
 			relation:     relation,
 		})
@@ -437,7 +486,7 @@ func (b *multiEntityQueryBuilder) getSdmxContainedInPlaceObservationsQuery(
 		if leftPriority != rightPriority {
 			return leftPriority < rightPriority
 		}
-		return resolved[i].componentID < resolved[j].componentID
+		return resolved[i].entityColumn < resolved[j].entityColumn
 	})
 
 	type relationKey struct {
@@ -459,8 +508,8 @@ func (b *multiEntityQueryBuilder) getSdmxContainedInPlaceObservationsQuery(
 			cteIndex := len(cteByRelation)
 			cteName = fmt.Sprintf("contained_places_%d", cteIndex)
 			cteByRelation[key] = cteName
-			ancestorParam := fmt.Sprintf("containedAncestor%d", cteIndex)
-			childPlaceTypeParam := fmt.Sprintf("containedChildPlaceType%d", cteIndex)
+			ancestorParam := fmt.Sprintf("containment_%d_ancestor", cteIndex)
+			childPlaceTypeParam := fmt.Sprintf("containment_%d_child_place_type", cteIndex)
 			params[ancestorParam] = key.ancestor
 			params[childPlaceTypeParam] = key.childPlaceType
 			cteDefinitions = append(cteDefinitions, fmt.Sprintf(`%s AS (

--- a/internal/server/spanner/query_builder_multientity.go
+++ b/internal/server/spanner/query_builder_multientity.go
@@ -300,20 +300,20 @@ var constraintKeyRegex = regexp.MustCompile(`^[a-zA-Z0-9_]+$`)
 // GetSdmxObservationsQuery builds the Spanner statement for SDMX observation lookup.
 func (b *multiEntityQueryBuilder) GetSdmxObservationsQuery(
 	constraints map[string]*sdmxpb.SdmxComponentConstraint,
-	entitySlotByObservationProperty map[string]string,
+	observationPropertyToEntitySlot map[string]string,
 ) (*spanner.Statement, error) {
 	containedInPlaceConstraints, err := datacommons.ContainedInPlaceConstraints(constraints)
 	if err != nil {
 		return nil, status.Errorf(status.Code(err), "GetSdmxObservationsQuery: %s", status.Convert(err).Message())
 	}
-	compiled, err := compileSdmxConstraints(constraints, entitySlotByObservationProperty)
+	compiled, err := compileSdmxConstraints(constraints, observationPropertyToEntitySlot)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "GetSdmxObservationsQuery: %s", status.Convert(err).Message())
 	}
 	if len(containedInPlaceConstraints) > 0 {
 		statement, err := b.getSdmxContainedInPlaceObservationsQuery(
 			containedInPlaceConstraints,
-			entitySlotByObservationProperty,
+			observationPropertyToEntitySlot,
 			compiled,
 		)
 		if err != nil {
@@ -348,10 +348,10 @@ func sdmxConstraintValues(constraint *sdmxpb.SdmxComponentConstraint) []string {
 	return values
 }
 
-func validateSdmxEntitySlotMapping(entitySlotByObservationProperty map[string]string) error {
-	observationPropertyByEntitySlot := map[string]string{}
-	for _, observationProperty := range slices.Sorted(maps.Keys(entitySlotByObservationProperty)) {
-		entitySlot := entitySlotByObservationProperty[observationProperty]
+func validateSdmxEntitySlotMapping(observationPropertyToEntitySlot map[string]string) error {
+	entitySlotToObservationProperty := map[string]string{}
+	for _, observationProperty := range slices.Sorted(maps.Keys(observationPropertyToEntitySlot)) {
+		entitySlot := observationPropertyToEntitySlot[observationProperty]
 		switch entitySlot {
 		case "entity1", "entity2", "entity3":
 		default:
@@ -362,7 +362,7 @@ func validateSdmxEntitySlotMapping(entitySlotByObservationProperty map[string]st
 				entitySlot,
 			)
 		}
-		if existingObservationProperty, ok := observationPropertyByEntitySlot[entitySlot]; ok {
+		if existingObservationProperty, ok := entitySlotToObservationProperty[entitySlot]; ok {
 			return status.Errorf(
 				codes.InvalidArgument,
 				"SDMX observation properties %q and %q map to the same entity slot %q",
@@ -371,19 +371,19 @@ func validateSdmxEntitySlotMapping(entitySlotByObservationProperty map[string]st
 				entitySlot,
 			)
 		}
-		observationPropertyByEntitySlot[entitySlot] = observationProperty
+		entitySlotToObservationProperty[entitySlot] = observationProperty
 	}
 	return nil
 }
 
 func compileSdmxConstraints(
 	constraints map[string]*sdmxpb.SdmxComponentConstraint,
-	entitySlotByObservationProperty map[string]string,
+	observationPropertyToEntitySlot map[string]string,
 ) (*compiledSdmxConstraints, error) {
 	if constraints == nil {
 		return nil, status.Error(codes.InvalidArgument, "SDMX request constraints cannot be nil")
 	}
-	if err := validateSdmxEntitySlotMapping(entitySlotByObservationProperty); err != nil {
+	if err := validateSdmxEntitySlotMapping(observationPropertyToEntitySlot); err != nil {
 		return nil, err
 	}
 	for componentID, constraint := range constraints {
@@ -421,7 +421,7 @@ func compileSdmxConstraints(
 
 	filters := make([]resolvedSdmxDirectFilter, 0, len(componentIDs))
 	for _, componentID := range componentIDs {
-		spannerColumn, ok := sdmxDataFilterColumn(componentID, entitySlotByObservationProperty)
+		spannerColumn, ok := sdmxDataFilterColumn(componentID, observationPropertyToEntitySlot)
 		if !ok || spannerColumn == "" {
 			return nil, status.Errorf(codes.InvalidArgument, "unsupported SDMX component filter %q", componentID)
 		}
@@ -465,13 +465,13 @@ type resolvedSdmxContainedInPlace struct {
 
 func (b *multiEntityQueryBuilder) getSdmxContainedInPlaceObservationsQuery(
 	constraints map[string]datacommons.ContainedInPlaceConstraint,
-	entitySlotByObservationProperty map[string]string,
+	observationPropertyToEntitySlot map[string]string,
 	compiled *compiledSdmxConstraints,
 ) (*spanner.Statement, error) {
 	resolved := make([]resolvedSdmxContainedInPlace, 0, len(constraints))
 	for _, componentID := range slices.Sorted(maps.Keys(constraints)) {
 		relation := constraints[componentID]
-		entityColumn, ok := entitySlotByObservationProperty[componentID]
+		entityColumn, ok := observationPropertyToEntitySlot[componentID]
 		if !ok {
 			return nil, status.Errorf(codes.InvalidArgument, "unsupported SDMX property constraint component %q", componentID)
 		}
@@ -493,7 +493,7 @@ func (b *multiEntityQueryBuilder) getSdmxContainedInPlaceObservationsQuery(
 		ancestor       string
 		childPlaceType string
 	}
-	cteByRelation := map[relationKey]string{}
+	relationToCTE := map[relationKey]string{}
 	cteDefinitions := []string{}
 	params := maps.Clone(compiled.params)
 	containedRule, _ := datacommons.DataPropertyRule(datacommons.PropertyContainedInPlace)
@@ -503,11 +503,11 @@ func (b *multiEntityQueryBuilder) getSdmxContainedInPlaceObservationsQuery(
 			ancestor:       resolved[i].relation.Ancestor,
 			childPlaceType: resolved[i].relation.ChildPlaceType,
 		}
-		cteName, ok := cteByRelation[key]
+		cteName, ok := relationToCTE[key]
 		if !ok {
-			cteIndex := len(cteByRelation)
+			cteIndex := len(relationToCTE)
 			cteName = fmt.Sprintf("contained_places_%d", cteIndex)
-			cteByRelation[key] = cteName
+			relationToCTE[key] = cteName
 			ancestorParam := fmt.Sprintf("containment_%d_ancestor", cteIndex)
 			childPlaceTypeParam := fmt.Sprintf("containment_%d_child_place_type", cteIndex)
 			params[ancestorParam] = key.ancestor
@@ -579,7 +579,7 @@ func sdmxContainmentAnchorPriority(entityColumn string) int {
 // GetSdmxAvailabilityQuery builds the SDMX availability lookup.
 func (b *multiEntityQueryBuilder) GetSdmxAvailabilityQuery(
 	req *sdmxpb.SdmxAvailabilityQuery,
-	entitySlotByObservationProperty map[string]string,
+	observationPropertyToEntitySlot map[string]string,
 ) (*spanner.Statement, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "SDMX availability request cannot be nil")
@@ -587,11 +587,11 @@ func (b *multiEntityQueryBuilder) GetSdmxAvailabilityQuery(
 	if err := datacommons.ValidateAvailabilityConstraints(req.GetConstraints()); err != nil {
 		return nil, status.Errorf(status.Code(err), "GetSdmxAvailabilityQuery: %s", status.Convert(err).Message())
 	}
-	compiled, err := compileSdmxConstraints(req.GetConstraints(), entitySlotByObservationProperty)
+	compiled, err := compileSdmxConstraints(req.GetConstraints(), observationPropertyToEntitySlot)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "GetSdmxAvailabilityQuery: %s", status.Convert(err).Message())
 	}
-	valueExpression, err := sdmxAvailabilityValueExpression(req.GetComponentId(), entitySlotByObservationProperty)
+	valueExpression, err := sdmxAvailabilityValueExpression(req.GetComponentId(), observationPropertyToEntitySlot)
 	if err != nil {
 		return nil, err
 	}
@@ -604,13 +604,13 @@ func (b *multiEntityQueryBuilder) GetSdmxAvailabilityQuery(
 
 func sdmxAvailabilityValueExpression(
 	componentID string,
-	entitySlotByObservationProperty map[string]string,
+	observationPropertyToEntitySlot map[string]string,
 ) (string, error) {
 	if componentID == datacommons.ComponentVariableMeasured {
 		return "t.variable_measured", nil
 	}
 
-	spannerColumn, ok := sdmxDataFilterColumn(componentID, entitySlotByObservationProperty)
+	spannerColumn, ok := sdmxDataFilterColumn(componentID, observationPropertyToEntitySlot)
 	if !ok || spannerColumn == "" {
 		return "", status.Errorf(codes.InvalidArgument, "unsupported SDMX availability component %q", componentID)
 	}

--- a/internal/server/spanner/query_builder_multientity.go
+++ b/internal/server/spanner/query_builder_multientity.go
@@ -16,6 +16,7 @@ package spanner
 
 import (
 	"fmt"
+	"maps"
 	"regexp"
 	"sort"
 	"strings"
@@ -30,7 +31,8 @@ import (
 )
 
 type multiEntityQueryBuilder struct {
-	statements *MultiEntityStatements
+	statements  *MultiEntityStatements
+	tableConfig TableConfig
 }
 
 // NewMultiEntityQueryBuilder builds a query builder using table-config-specific SQL templates.
@@ -39,7 +41,7 @@ func NewMultiEntityQueryBuilder(cfg TableConfig) (*multiEntityQueryBuilder, erro
 	if err != nil {
 		return nil, err
 	}
-	return &multiEntityQueryBuilder{statements: stmts}, nil
+	return &multiEntityQueryBuilder{statements: stmts, tableConfig: cfg}, nil
 }
 
 // GetObservationsQuery builds the observation lookup query with optional date filter.
@@ -299,9 +301,24 @@ func (b *multiEntityQueryBuilder) GetSdmxObservationsQuery(
 	constraints map[string]*sdmxpb.SdmxComponentConstraint,
 	entitySlotByObservationProperty map[string]string,
 ) (*spanner.Statement, error) {
+	containedInPlaceConstraints, err := datacommons.ContainedInPlaceConstraints(constraints)
+	if err != nil {
+		return nil, status.Errorf(status.Code(err), "GetSdmxObservationsQuery: %s", status.Convert(err).Message())
+	}
 	compiled, err := compileSdmxConstraints(constraints, entitySlotByObservationProperty)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "GetSdmxObservationsQuery: %s", status.Convert(err).Message())
+	}
+	if len(containedInPlaceConstraints) > 0 {
+		statement, err := b.getSdmxContainedInPlaceObservationsQuery(
+			containedInPlaceConstraints,
+			entitySlotByObservationProperty,
+			compiled,
+		)
+		if err != nil {
+			return nil, status.Errorf(status.Code(err), "GetSdmxObservationsQuery: %s", status.Convert(err).Message())
+		}
+		return statement, nil
 	}
 
 	return &spanner.Statement{
@@ -337,6 +354,9 @@ func compileSdmxConstraints(
 		}
 		values := sdmxConstraintValues(constraint)
 		if len(values) == 0 {
+			if len(constraint.GetPropertyConstraints()) > 0 {
+				continue
+			}
 			return nil, status.Errorf(codes.InvalidArgument, "SDMX component filter %q must have at least one value", componentID)
 		}
 		for _, value := range values {
@@ -354,8 +374,8 @@ func compileSdmxConstraints(
 	statVarIDs := sortedUniqueStrings(variableMeasuredValues)
 
 	componentIDs := []string{}
-	for componentID := range constraints {
-		if componentID != datacommons.ComponentVariableMeasured {
+	for componentID, constraint := range constraints {
+		if componentID != datacommons.ComponentVariableMeasured && len(constraint.GetPredicates()) > 0 {
 			componentIDs = append(componentIDs, componentID)
 		}
 	}
@@ -387,6 +407,145 @@ func sdmxAllowedValuesClause(spannerColumn string, parameter string) string {
 	return fmt.Sprintf("t.%s IN UNNEST(@%s)", spannerColumn, parameter)
 }
 
+type resolvedSdmxContainedInPlace struct {
+	componentID  string
+	entityColumn string
+	relation     datacommons.ContainedInPlaceConstraint
+	cteName      string
+}
+
+func (b *multiEntityQueryBuilder) getSdmxContainedInPlaceObservationsQuery(
+	constraints map[string]datacommons.ContainedInPlaceConstraint,
+	entitySlotByObservationProperty map[string]string,
+	compiled *compiledSdmxConstraints,
+) (*spanner.Statement, error) {
+	resolved := make([]resolvedSdmxContainedInPlace, 0, len(constraints))
+	for componentID, relation := range constraints {
+		entityColumn, ok := entitySlotByObservationProperty[componentID]
+		if !ok || (entityColumn != "entity1" && entityColumn != "entity2" && entityColumn != "entity3") {
+			return nil, status.Errorf(codes.InvalidArgument, "unsupported SDMX property constraint component %q", componentID)
+		}
+		resolved = append(resolved, resolvedSdmxContainedInPlace{
+			componentID:  componentID,
+			entityColumn: entityColumn,
+			relation:     relation,
+		})
+	}
+	sort.Slice(resolved, func(i, j int) bool {
+		leftPriority := sdmxContainmentAnchorPriority(resolved[i].entityColumn)
+		rightPriority := sdmxContainmentAnchorPriority(resolved[j].entityColumn)
+		if leftPriority != rightPriority {
+			return leftPriority < rightPriority
+		}
+		return resolved[i].componentID < resolved[j].componentID
+	})
+
+	type relationKey struct {
+		ancestor       string
+		childPlaceType string
+	}
+	cteByRelation := map[relationKey]string{}
+	cteDefinitions := []string{}
+	params := maps.Clone(compiled.params)
+	containedRule, _ := datacommons.DataPropertyRule(datacommons.PropertyContainedInPlace)
+	typeRule, _ := datacommons.DataPropertyRule(datacommons.PropertyTypeOf)
+	for i := range resolved {
+		key := relationKey{
+			ancestor:       resolved[i].relation.Ancestor,
+			childPlaceType: resolved[i].relation.ChildPlaceType,
+		}
+		cteName, ok := cteByRelation[key]
+		if !ok {
+			cteIndex := len(cteByRelation)
+			cteName = fmt.Sprintf("contained_places_%d", cteIndex)
+			cteByRelation[key] = cteName
+			ancestorParam := fmt.Sprintf("containedAncestor%d", cteIndex)
+			childPlaceTypeParam := fmt.Sprintf("containedChildPlaceType%d", cteIndex)
+			params[ancestorParam] = key.ancestor
+			params[childPlaceTypeParam] = key.childPlaceType
+			cteDefinitions = append(cteDefinitions, fmt.Sprintf(`%s AS (
+			SELECT DISTINCT contained.subject_id AS place_id
+			FROM Edge contained
+			JOIN Edge typed ON contained.subject_id = typed.subject_id
+			WHERE contained.predicate = '%s'
+				AND contained.object_id = @%s
+				AND typed.predicate = '%s'
+				AND typed.object_id = @%s
+		)`, cteName, containedRule.GraphPredicate, ancestorParam, typeRule.GraphPredicate, childPlaceTypeParam))
+		}
+		resolved[i].cteName = cteName
+	}
+
+	anchor := resolved[0]
+	index := "_BASE_TABLE"
+	statementHint := ""
+	whereClauses := []string{}
+	switch anchor.entityColumn {
+	case "entity2":
+		index = b.tableConfig.TimeSeriesByEntity2Index
+		statementHint = "@{spanner_emulator.disable_query_null_filtered_index_check=true}\n\t\t"
+		whereClauses = append(whereClauses, "t.entity2 IS NOT NULL")
+	case "entity3":
+		index = b.tableConfig.TimeSeriesByEntity3Index
+		statementHint = "@{spanner_emulator.disable_query_null_filtered_index_check=true}\n\t\t"
+		whereClauses = append(whereClauses, "t.entity3 IS NOT NULL", "t.entity2 IS NOT NULL")
+	}
+	for _, constraint := range resolved[1:] {
+		whereClauses = append(whereClauses, fmt.Sprintf("t.%s IN (SELECT place_id FROM %s)", constraint.entityColumn, constraint.cteName))
+	}
+	where := ""
+	if len(whereClauses) > 0 {
+		where = "\n\t\t\tWHERE " + strings.Join(whereClauses, "\n\t\t\t\tAND ")
+	}
+
+	seriesCTE := fmt.Sprintf(`series AS (
+			SELECT
+				t.variable_measured,
+				t.entity1,
+				t.extra_entities_id,
+				t.facet_id,
+				t.provenance,
+				t.facet,
+				t.entities
+			FROM %s anchor
+			JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} %s@{FORCE_INDEX=%s} t
+				ON t.%s = anchor.place_id
+				AND %s%s
+		)`, anchor.cteName, b.tableConfig.TimeSeriesTable, index, anchor.entityColumn, compiled.where, where)
+
+	sql := fmt.Sprintf(`		%sWITH %s,
+		%s
+		SELECT
+			t.variable_measured,
+			t.entity1 AS observation_about,
+			t.facet_id,
+			ANY_VALUE(t.provenance) AS provenance,
+			ARRAY_AGG(STRUCT(o.date AS date, o.value AS str_value)) AS dates_and_values,
+			ANY_VALUE(t.facet) AS facets,
+			ANY_VALUE(t.entities) AS entities
+		FROM series t
+		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} %s o
+		USING (variable_measured, entity1, extra_entities_id, facet_id)
+		GROUP BY
+			t.variable_measured,
+			t.entity1,
+			t.extra_entities_id,
+			t.facet_id`, statementHint, strings.Join(cteDefinitions, ",\n\t\t"), seriesCTE, b.tableConfig.ObservationTable)
+
+	return &spanner.Statement{SQL: sql, Params: params}, nil
+}
+
+func sdmxContainmentAnchorPriority(entityColumn string) int {
+	switch entityColumn {
+	case "entity1":
+		return 0
+	case "entity3":
+		return 1
+	default:
+		return 2
+	}
+}
+
 // GetSdmxAvailabilityQuery builds the SDMX availability lookup.
 func (b *multiEntityQueryBuilder) GetSdmxAvailabilityQuery(
 	req *sdmxpb.SdmxAvailabilityQuery,
@@ -394,6 +553,9 @@ func (b *multiEntityQueryBuilder) GetSdmxAvailabilityQuery(
 ) (*spanner.Statement, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "SDMX availability request cannot be nil")
+	}
+	if err := datacommons.ValidateAvailabilityConstraints(req.GetConstraints()); err != nil {
+		return nil, status.Errorf(status.Code(err), "GetSdmxAvailabilityQuery: %s", status.Convert(err).Message())
 	}
 	compiled, err := compileSdmxConstraints(req.GetConstraints(), entitySlotByObservationProperty)
 	if err != nil {

--- a/internal/server/spanner/query_builder_multientity.go
+++ b/internal/server/spanner/query_builder_multientity.go
@@ -512,15 +512,14 @@ func (b *multiEntityQueryBuilder) getSdmxContainedInPlaceObservationsQuery(
 			childPlaceTypeParam := fmt.Sprintf("containment_%d_child_place_type", cteIndex)
 			params[ancestorParam] = key.ancestor
 			params[childPlaceTypeParam] = key.childPlaceType
-			cteDefinitions = append(cteDefinitions, fmt.Sprintf(`%s AS (
-			SELECT DISTINCT contained.subject_id AS place_id
-			FROM Edge contained
-			JOIN Edge typed ON contained.subject_id = typed.subject_id
-			WHERE contained.predicate = '%s'
-				AND contained.object_id = @%s
-				AND typed.predicate = '%s'
-				AND typed.object_id = @%s
-		)`, cteName, containedRule.GraphPredicate, ancestorParam, typeRule.GraphPredicate, childPlaceTypeParam))
+			cteDefinitions = append(cteDefinitions, fmt.Sprintf(
+				b.statements.sdmxContainedPlacesCTE,
+				cteName,
+				containedRule.GraphPredicate,
+				ancestorParam,
+				typeRule.GraphPredicate,
+				childPlaceTypeParam,
+			))
 		}
 		resolved[i].cteName = cteName
 	}
@@ -547,39 +546,21 @@ func (b *multiEntityQueryBuilder) getSdmxContainedInPlaceObservationsQuery(
 		where = "\n\t\t\tWHERE " + strings.Join(whereClauses, "\n\t\t\t\tAND ")
 	}
 
-	seriesCTE := fmt.Sprintf(`series AS (
-			SELECT
-				t.variable_measured,
-				t.entity1,
-				t.extra_entities_id,
-				t.facet_id,
-				t.provenance,
-				t.facet,
-				t.entities
-			FROM %s anchor
-			JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} %s@{FORCE_INDEX=%s} t
-				ON t.%s = anchor.place_id
-				AND %s%s
-		)`, anchor.cteName, b.tableConfig.TimeSeriesTable, index, anchor.entityColumn, compiled.where, where)
+	seriesCTE := fmt.Sprintf(
+		b.statements.sdmxContainedSeriesCTE,
+		anchor.cteName,
+		index,
+		anchor.entityColumn,
+		compiled.where,
+		where,
+	)
 
-	sql := fmt.Sprintf(`		%sWITH %s,
-		%s
-		SELECT
-			t.variable_measured,
-			t.entity1 AS observation_about,
-			t.facet_id,
-			ANY_VALUE(t.provenance) AS provenance,
-			ARRAY_AGG(STRUCT(o.date AS date, o.value AS str_value)) AS dates_and_values,
-			ANY_VALUE(t.facet) AS facets,
-			ANY_VALUE(t.entities) AS entities
-		FROM series t
-		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} %s o
-		USING (variable_measured, entity1, extra_entities_id, facet_id)
-		GROUP BY
-			t.variable_measured,
-			t.entity1,
-			t.extra_entities_id,
-			t.facet_id`, statementHint, strings.Join(cteDefinitions, ",\n\t\t"), seriesCTE, b.tableConfig.ObservationTable)
+	sql := fmt.Sprintf(
+		b.statements.getSdmxContainedInPlace,
+		statementHint,
+		strings.Join(cteDefinitions, ",\n\t\t"),
+		seriesCTE,
+	)
 
 	return &spanner.Statement{SQL: sql, Params: params}, nil
 }

--- a/internal/server/spanner/query_multientity.go
+++ b/internal/server/spanner/query_multientity.go
@@ -652,12 +652,6 @@ func validateSdmxPropertyConstraintScopes(
 		if len(propertyConstraints) == 0 {
 			continue
 		}
-		for _, propertyID := range slices.Sorted(maps.Keys(propertyConstraints)) {
-			rule, ok := datacommons.DataPropertyRule(propertyID)
-			if ok && rule.Scope != datacommons.ComponentScopeObservationProperty {
-				return status.Errorf(codes.Unimplemented, "SDMX property constraints on component %q are not implemented yet", componentID)
-			}
-		}
 		if _, ok := entitySlotByObservationProperty[componentID]; !ok {
 			return status.Errorf(codes.Unimplemented, "SDMX property constraints on component %q are not implemented yet", componentID)
 		}

--- a/internal/server/spanner/query_multientity.go
+++ b/internal/server/spanner/query_multientity.go
@@ -545,8 +545,14 @@ func prepareSdmxObservationsQuery(
 	getNodeEdgesByID getNodeEdgesByIDFunc,
 	queryBuilder *multiEntityQueryBuilder,
 ) (*preparedSdmxObservationsQuery, error) {
+	if err := datacommons.ValidateDataConstraints(constraints); err != nil {
+		return nil, err
+	}
 	preparedShape, err := prepareSdmxShape(ctx, constraints, getNodeEdgesByID)
 	if err != nil {
+		return nil, err
+	}
+	if err := validateSdmxPropertyConstraintScopes(constraints, preparedShape.entitySlotByObservationProperty); err != nil {
 		return nil, err
 	}
 	if err := validateSdmxDataConstraintComponents(constraints, preparedShape.shape); err != nil {
@@ -572,9 +578,6 @@ func prepareSdmxShape(
 	constraints map[string]*sdmxpb.SdmxComponentConstraint,
 	getNodeEdgesByID getNodeEdgesByIDFunc,
 ) (*preparedSdmxShape, error) {
-	if err := datacommons.ValidateSupportedConstraints(constraints); err != nil {
-		return nil, err
-	}
 	if err := validateSdmxConstraintValues(constraints); err != nil {
 		return nil, err
 	}
@@ -623,14 +626,40 @@ func validateSdmxConstraintValues(constraints map[string]*sdmxpb.SdmxComponentCo
 	}
 
 	for _, componentID := range slices.Sorted(maps.Keys(constraints)) {
-		values := sdmxConstraintValues(constraints[componentID])
+		constraint := constraints[componentID]
+		values := sdmxConstraintValues(constraint)
 		if len(values) == 0 {
+			if len(constraint.GetPropertyConstraints()) > 0 {
+				continue
+			}
 			return status.Errorf(codes.InvalidArgument, "SDMX component filter %q must have at least one value", componentID)
 		}
 		for _, value := range values {
 			if strings.TrimSpace(value) == "" {
 				return status.Errorf(codes.InvalidArgument, "SDMX component filter %q contains an empty value", componentID)
 			}
+		}
+	}
+	return nil
+}
+
+func validateSdmxPropertyConstraintScopes(
+	constraints map[string]*sdmxpb.SdmxComponentConstraint,
+	entitySlotByObservationProperty map[string]string,
+) error {
+	for _, componentID := range slices.Sorted(maps.Keys(constraints)) {
+		propertyConstraints := constraints[componentID].GetPropertyConstraints()
+		if len(propertyConstraints) == 0 {
+			continue
+		}
+		for _, propertyID := range slices.Sorted(maps.Keys(propertyConstraints)) {
+			rule, ok := datacommons.DataPropertyRule(propertyID)
+			if ok && rule.Scope != datacommons.ComponentScopeObservationProperty {
+				return status.Errorf(codes.Unimplemented, "SDMX property constraints on component %q are not implemented yet", componentID)
+			}
+		}
+		if _, ok := entitySlotByObservationProperty[componentID]; !ok {
+			return status.Errorf(codes.Unimplemented, "SDMX property constraints on component %q are not implemented yet", componentID)
 		}
 	}
 	return nil
@@ -800,6 +829,9 @@ func prepareSdmxAvailabilityQuery(
 	getNodeEdgesByID getNodeEdgesByIDFunc,
 	queryBuilder *multiEntityQueryBuilder,
 ) (*spanner.Statement, error) {
+	if err := datacommons.ValidateAvailabilityConstraints(req.GetConstraints()); err != nil {
+		return nil, err
+	}
 	preparedShape, err := prepareSdmxShape(ctx, req.GetConstraints(), getNodeEdgesByID)
 	if err != nil {
 		return nil, err

--- a/internal/server/spanner/query_multientity.go
+++ b/internal/server/spanner/query_multientity.go
@@ -487,7 +487,7 @@ func (nc *multiEntityClient) GetSdmxObservations(
 		}
 
 		series := &sdmxpb.SdmxTimeSeries{
-			Dimensions: sdmxSeriesDimensions(r.VariableMeasured, entitySlotValues, prepared.entitySlotByObservationProperty),
+			Dimensions: sdmxSeriesDimensions(r.VariableMeasured, entitySlotValues, prepared.observationPropertyToEntitySlot),
 			Points:     []*sdmxpb.SdmxDataPoint{},
 		}
 		if r.ProvenanceID.Valid {
@@ -529,14 +529,14 @@ type getNodeEdgesByIDFunc func(
 
 type preparedSdmxObservationsQuery struct {
 	shape                           *sdmxpb.SdmxDataShape
-	entitySlotByObservationProperty map[string]string
+	observationPropertyToEntitySlot map[string]string
 	statement                       *spanner.Statement
 }
 
 type preparedSdmxShape struct {
 	shape                           *sdmxpb.SdmxDataShape
 	observationProperties           []string
-	entitySlotByObservationProperty map[string]string
+	observationPropertyToEntitySlot map[string]string
 }
 
 func prepareSdmxObservationsQuery(
@@ -552,7 +552,7 @@ func prepareSdmxObservationsQuery(
 	if err != nil {
 		return nil, err
 	}
-	if err := validateSdmxPropertyConstraintScopes(constraints, preparedShape.entitySlotByObservationProperty); err != nil {
+	if err := validateSdmxPropertyConstraintScopes(constraints, preparedShape.observationPropertyToEntitySlot); err != nil {
 		return nil, err
 	}
 	if err := validateSdmxDataConstraintComponents(constraints, preparedShape.shape); err != nil {
@@ -562,13 +562,13 @@ func prepareSdmxObservationsQuery(
 		return nil, err
 	}
 
-	statement, err := queryBuilder.GetSdmxObservationsQuery(constraints, preparedShape.entitySlotByObservationProperty)
+	statement, err := queryBuilder.GetSdmxObservationsQuery(constraints, preparedShape.observationPropertyToEntitySlot)
 	if err != nil {
 		return nil, err
 	}
 	return &preparedSdmxObservationsQuery{
 		shape:                           preparedShape.shape,
-		entitySlotByObservationProperty: preparedShape.entitySlotByObservationProperty,
+		observationPropertyToEntitySlot: preparedShape.observationPropertyToEntitySlot,
 		statement:                       statement,
 	}, nil
 }
@@ -587,11 +587,11 @@ func prepareSdmxShape(
 		Out:        true,
 		SingleProp: "observationProperties",
 	}
-	observationPropertyEdgesByStatVar, err := getNodeEdgesByID(ctx, statVarIDs, arc, observationPropertiesPageSize(len(statVarIDs)), 0)
+	statVarToObservationPropertyEdges, err := getNodeEdgesByID(ctx, statVarIDs, arc, observationPropertiesPageSize(len(statVarIDs)), 0)
 	if err != nil {
 		return nil, sdmxBackendError("failed to fetch observationProperties", err)
 	}
-	observationProperties, entitySlotByObservationProperty, err := resolveSdmxEntityShape(statVarIDs, observationPropertyEdgesByStatVar)
+	observationProperties, observationPropertyToEntitySlot, err := resolveSdmxEntityShape(statVarIDs, statVarToObservationPropertyEdges)
 	if err != nil {
 		return nil, err
 	}
@@ -599,19 +599,19 @@ func prepareSdmxShape(
 	return &preparedSdmxShape{
 		shape:                           shape,
 		observationProperties:           observationProperties,
-		entitySlotByObservationProperty: entitySlotByObservationProperty,
+		observationPropertyToEntitySlot: observationPropertyToEntitySlot,
 	}, nil
 }
 
 func sdmxSeriesDimensions(
 	variableMeasured string,
 	entitySlotValues map[string]string,
-	entitySlotByObservationProperty map[string]string,
+	observationPropertyToEntitySlot map[string]string,
 ) map[string]string {
 	dimensionValues := map[string]string{
 		datacommons.ComponentVariableMeasured: variableMeasured,
 	}
-	for observationProperty, entitySlot := range entitySlotByObservationProperty {
+	for observationProperty, entitySlot := range observationPropertyToEntitySlot {
 		if value, ok := entitySlotValues[entitySlot]; ok {
 			dimensionValues[observationProperty] = value
 		}
@@ -645,14 +645,14 @@ func validateSdmxConstraintValues(constraints map[string]*sdmxpb.SdmxComponentCo
 
 func validateSdmxPropertyConstraintScopes(
 	constraints map[string]*sdmxpb.SdmxComponentConstraint,
-	entitySlotByObservationProperty map[string]string,
+	observationPropertyToEntitySlot map[string]string,
 ) error {
 	for _, componentID := range slices.Sorted(maps.Keys(constraints)) {
 		propertyConstraints := constraints[componentID].GetPropertyConstraints()
 		if len(propertyConstraints) == 0 {
 			continue
 		}
-		if _, ok := entitySlotByObservationProperty[componentID]; !ok {
+		if _, ok := observationPropertyToEntitySlot[componentID]; !ok {
 			return status.Errorf(codes.Unimplemented, "SDMX property constraints on component %q are not implemented yet", componentID)
 		}
 	}
@@ -836,17 +836,17 @@ func prepareSdmxAvailabilityQuery(
 	if err := validateSdmxAvailabilityComponent(req.GetComponentId(), preparedShape.shape); err != nil {
 		return nil, err
 	}
-	return queryBuilder.GetSdmxAvailabilityQuery(req, preparedShape.entitySlotByObservationProperty)
+	return queryBuilder.GetSdmxAvailabilityQuery(req, preparedShape.observationPropertyToEntitySlot)
 }
 
 func resolveSdmxEntityShape(
 	statVarIDs []string,
-	observationPropertyEdgesByStatVar map[string][]*Edge,
+	statVarToObservationPropertyEdges map[string][]*Edge,
 ) ([]string, map[string]string, error) {
-	observationPropertiesByStatVar := map[string][]string{}
+	statVarToObservationProperties := map[string][]string{}
 	for _, statVarID := range statVarIDs {
 		observationPropertySet := map[string]struct{}{}
-		for _, edge := range observationPropertyEdgesByStatVar[statVarID] {
+		for _, edge := range statVarToObservationPropertyEdges[statVarID] {
 			if edge == nil {
 				continue
 			}
@@ -882,13 +882,13 @@ func resolveSdmxEntityShape(
 		if len(observationProperties) == 0 {
 			observationProperties = []string{datacommons.ComponentObservationAbout}
 		}
-		observationPropertiesByStatVar[statVarID] = observationProperties
+		statVarToObservationProperties[statVarID] = observationProperties
 	}
 
 	var resolvedObservationProperties []string
 	referenceStatVarID := ""
 	for _, statVarID := range statVarIDs {
-		observationProperties := observationPropertiesByStatVar[statVarID]
+		observationProperties := statVarToObservationProperties[statVarID]
 		if resolvedObservationProperties == nil {
 			resolvedObservationProperties = observationProperties
 			referenceStatVarID = statVarID
@@ -906,11 +906,11 @@ func resolveSdmxEntityShape(
 		}
 	}
 
-	entitySlotByObservationProperty := map[string]string{}
+	observationPropertyToEntitySlot := map[string]string{}
 	for i, observationProperty := range resolvedObservationProperties {
-		entitySlotByObservationProperty[observationProperty] = fmt.Sprintf("entity%d", i+1)
+		observationPropertyToEntitySlot[observationProperty] = fmt.Sprintf("entity%d", i+1)
 	}
-	return resolvedObservationProperties, entitySlotByObservationProperty, nil
+	return resolvedObservationProperties, observationPropertyToEntitySlot, nil
 }
 
 func sdmxBackendError(message string, err error) error {

--- a/internal/server/spanner/query_multientity_test.go
+++ b/internal/server/spanner/query_multientity_test.go
@@ -42,6 +42,18 @@ func sdmxComponentConstraint(values ...string) *sdmxpb.SdmxComponentConstraint {
 	return &sdmxpb.SdmxComponentConstraint{Predicates: predicates}
 }
 
+func sdmxContainedInPlaceConstraint(ancestor, childPlaceType string) *sdmxpb.SdmxComponentConstraint {
+	return &sdmxpb.SdmxComponentConstraint{
+		PropertyConstraints: map[string]*sdmxpb.SdmxPropertyConstraint{
+			datacommons.PropertyContainedInPlace: {
+				Predicates: []*sdmxpb.SdmxPredicate{{Value: ancestor}},
+				Transitive: true,
+			},
+			datacommons.PropertyTypeOf: {Predicates: []*sdmxpb.SdmxPredicate{{Value: childPlaceType}}},
+		},
+	}
+}
+
 func TestReconstructObservationsUsesStoredFacetID(t *testing.T) {
 	observations, err := reconstructObservations([]*rawObservation{
 		{
@@ -573,6 +585,76 @@ func TestPrepareSdmxObservationsQuery(t *testing.T) {
 	}
 }
 
+func TestPrepareSdmxObservationsQueryWithContainedInPlace(t *testing.T) {
+	queryBuilder, err := NewMultiEntityQueryBuilder(DefaultTableConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	constraints := map[string]*sdmxpb.SdmxComponentConstraint{
+		datacommons.ComponentVariableMeasured: sdmxComponentConstraint("Count_Migration"),
+		"destinationCountry":                  sdmxComponentConstraint("country/CAN"),
+		"sourceCountry":                       sdmxContainedInPlaceConstraint("country/USA", "State"),
+	}
+	prepared, err := prepareSdmxObservationsQuery(
+		context.Background(),
+		constraints,
+		func(_ context.Context, ids []string, arc *v2.Arc, pageSize int, offset int) (map[string][]*Edge, error) {
+			return map[string][]*Edge{
+				"Count_Migration": observationPropertiesEdges("destinationCountry", "sourceCountry"),
+			}, nil
+		},
+		queryBuilder,
+	)
+	if err != nil {
+		t.Fatalf("prepareSdmxObservationsQuery() error = %v", err)
+	}
+	wantParams := map[string]interface{}{
+		datacommons.ComponentVariableMeasured: []string{"Count_Migration"},
+		"destinationCountry":                  []string{"country/CAN"},
+		"containedAncestor0":                  "country/USA",
+		"containedChildPlaceType0":            "State",
+	}
+	if diff := cmp.Diff(wantParams, prepared.statement.Params); diff != "" {
+		t.Fatalf("prepareSdmxObservationsQuery() params mismatch (-want +got):\n%s", diff)
+	}
+	for _, fragment := range []string{
+		"contained.predicate = 'linkedContainedInPlace'",
+		"typed.predicate = 'typeOf'",
+		"TimeSeries@{FORCE_INDEX=TimeSeriesByEntity2}",
+		"ON t.entity2 = anchor.place_id",
+		"t.variable_measured IN UNNEST(@variableMeasured)",
+		"t.entity1 IN UNNEST(@destinationCountry)",
+		"t.entity2 IS NOT NULL",
+	} {
+		if !strings.Contains(prepared.statement.SQL, fragment) {
+			t.Errorf("prepareSdmxObservationsQuery() SQL does not contain %q:\n%s", fragment, prepared.statement.SQL)
+		}
+	}
+}
+
+func TestPrepareSdmxObservationsQueryRejectsPropertyConstraintOutsideObservationProperties(t *testing.T) {
+	queryBuilder, err := NewMultiEntityQueryBuilder(DefaultTableConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = prepareSdmxObservationsQuery(
+		context.Background(),
+		map[string]*sdmxpb.SdmxComponentConstraint{
+			datacommons.ComponentVariableMeasured: sdmxComponentConstraint("Count_Person"),
+			"customEntity":                        sdmxContainedInPlaceConstraint("country/USA", "County"),
+		},
+		func(_ context.Context, ids []string, arc *v2.Arc, pageSize int, offset int) (map[string][]*Edge, error) {
+			return map[string][]*Edge{
+				"Count_Person": observationPropertiesEdges(datacommons.ComponentObservationAbout),
+			}, nil
+		},
+		queryBuilder,
+	)
+	if status.Code(err) != codes.Unimplemented {
+		t.Fatalf("prepareSdmxObservationsQuery() code = %v, want %v; err = %v", status.Code(err), codes.Unimplemented, err)
+	}
+}
+
 func TestPrepareSdmxAvailabilityQuery(t *testing.T) {
 	queryBuilder, err := NewMultiEntityQueryBuilder(DefaultTableConfig())
 	if err != nil {
@@ -830,32 +912,12 @@ func TestMultiEntityGetSdmxAvailabilityNilConstraintsReturnsError(t *testing.T) 
 	}
 }
 
-func TestMultiEntitySdmxRejectsUnsupportedConstraints(t *testing.T) {
-	tests := []struct {
-		name       string
-		constraint *sdmxpb.SdmxComponentConstraint
-		want       string
-	}{
-		{
-			name: "property constraint",
-			constraint: &sdmxpb.SdmxComponentConstraint{
-				Predicates: []*sdmxpb.SdmxPredicate{{Value: "var1"}},
-				PropertyConstraints: map[string]*sdmxpb.SdmxPropertyConstraint{
-					"typeOf": {Predicates: []*sdmxpb.SdmxPredicate{{Value: "StatisticalVariable"}}},
-				},
-			},
-			want: "SDMX property constraints are not implemented yet",
-		},
-		{
-			name: "unsupported operator",
-			constraint: &sdmxpb.SdmxComponentConstraint{
-				Predicates: []*sdmxpb.SdmxPredicate{{
-					Operator: sdmxpb.SdmxOperator(1),
-					Value:    "var1",
-				}},
-			},
-			want: "SDMX operators other than EQ are not implemented yet",
-		},
+func TestMultiEntitySdmxRejectsUnsupportedOperator(t *testing.T) {
+	constraint := &sdmxpb.SdmxComponentConstraint{
+		Predicates: []*sdmxpb.SdmxPredicate{{
+			Operator: sdmxpb.SdmxOperator(1),
+			Value:    "var1",
+		}},
 	}
 	endpoints := []struct {
 		name string
@@ -887,17 +949,32 @@ func TestMultiEntitySdmxRejectsUnsupportedConstraints(t *testing.T) {
 	}
 
 	for _, endpoint := range endpoints {
-		for _, tt := range tests {
-			t.Run(endpoint.name+"/"+tt.name, func(t *testing.T) {
-				err := endpoint.call(&multiEntityClient{}, tt.constraint)
-				if status.Code(err) != codes.Unimplemented {
-					t.Fatalf("SDMX backend code = %v, want %v; err = %v", status.Code(err), codes.Unimplemented, err)
-				}
-				if got := status.Convert(err).Message(); got != tt.want {
-					t.Fatalf("SDMX backend message = %q, want %q", got, tt.want)
-				}
-			})
-		}
+		t.Run(endpoint.name, func(t *testing.T) {
+			err := endpoint.call(&multiEntityClient{}, constraint)
+			if status.Code(err) != codes.Unimplemented {
+				t.Fatalf("SDMX backend code = %v, want %v; err = %v", status.Code(err), codes.Unimplemented, err)
+			}
+			if got, want := status.Convert(err).Message(), "SDMX operators other than EQ are not implemented yet"; got != want {
+				t.Fatalf("SDMX backend message = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestMultiEntitySdmxAvailabilityRejectsPropertyConstraints(t *testing.T) {
+	_, err := (&multiEntityClient{}).GetSdmxAvailability(context.Background(), &sdmxpb.SdmxAvailabilityQuery{
+		ComponentId: datacommons.ComponentObservationAbout,
+		Constraints: map[string]*sdmxpb.SdmxComponentConstraint{
+			datacommons.ComponentVariableMeasured: sdmxComponentConstraint("Count_Person"),
+			datacommons.ComponentObservationAbout: {
+				PropertyConstraints: map[string]*sdmxpb.SdmxPropertyConstraint{
+					"typeOf": {Predicates: []*sdmxpb.SdmxPredicate{{Value: "County"}}},
+				},
+			},
+		},
+	})
+	if status.Code(err) != codes.Unimplemented {
+		t.Fatalf("GetSdmxAvailability() code = %v, want %v; err = %v", status.Code(err), codes.Unimplemented, err)
 	}
 }
 

--- a/internal/server/spanner/query_multientity_test.go
+++ b/internal/server/spanner/query_multientity_test.go
@@ -542,11 +542,11 @@ func TestPrepareSdmxObservationsQuery(t *testing.T) {
 	if diff := cmp.Diff(wantShape, prepared.shape, protocmp.Transform()); diff != "" {
 		t.Fatalf("prepareSdmxObservationsQuery() shape mismatch (-want +got):\n%s", diff)
 	}
-	wantEntitySlotByObservationProperty := map[string]string{
+	wantObservationPropertyToEntitySlot := map[string]string{
 		"destinationCountry": "entity1",
 		"sourceCountry":      "entity2",
 	}
-	if diff := cmp.Diff(wantEntitySlotByObservationProperty, prepared.entitySlotByObservationProperty); diff != "" {
+	if diff := cmp.Diff(wantObservationPropertyToEntitySlot, prepared.observationPropertyToEntitySlot); diff != "" {
 		t.Fatalf("prepareSdmxObservationsQuery() entity slots mismatch (-want +got):\n%s", diff)
 	}
 	wantParams := map[string]interface{}{
@@ -926,7 +926,7 @@ func TestSdmxAvailabilityValueExpressionValidation(t *testing.T) {
 	for _, tc := range []struct {
 		name                            string
 		componentID                     string
-		entitySlotByObservationProperty map[string]string
+		observationPropertyToEntitySlot map[string]string
 		want                            string
 	}{
 		{
@@ -937,14 +937,14 @@ func TestSdmxAvailabilityValueExpressionValidation(t *testing.T) {
 		{
 			name:        "empty component mapping",
 			componentID: "destinationCountry",
-			entitySlotByObservationProperty: map[string]string{
+			observationPropertyToEntitySlot: map[string]string{
 				"destinationCountry": "",
 			},
 			want: `unsupported SDMX availability component "destinationCountry"`,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := sdmxAvailabilityValueExpression(tc.componentID, tc.entitySlotByObservationProperty)
+			_, err := sdmxAvailabilityValueExpression(tc.componentID, tc.observationPropertyToEntitySlot)
 			if status.Code(err) != codes.InvalidArgument {
 				t.Fatalf("sdmxAvailabilityValueExpression() code = %v, want %v; err = %v", status.Code(err), codes.InvalidArgument, err)
 			}
@@ -1237,7 +1237,7 @@ func TestSdmxFacetComponentKind(t *testing.T) {
 }
 
 func TestResolveSdmxEntityShape(t *testing.T) {
-	observationPropertyEdgesByStatVar := map[string][]*Edge{
+	statVarToObservationPropertyEdges := map[string][]*Edge{
 		"var1": {
 			nil, // nil edge
 			// Input order is intentionally non-alphabetical; sorted properties define entity slots.
@@ -1270,7 +1270,7 @@ func TestResolveSdmxEntityShape(t *testing.T) {
 		},
 	}
 
-	gotObservationProperties, gotEntitySlotByObservationProperty, err := resolveSdmxEntityShape([]string{"var1"}, observationPropertyEdgesByStatVar)
+	gotObservationProperties, gotObservationPropertyToEntitySlot, err := resolveSdmxEntityShape([]string{"var1"}, statVarToObservationPropertyEdges)
 	if err != nil {
 		t.Fatalf("resolveSdmxEntityShape() error = %v", err)
 	}
@@ -1283,15 +1283,15 @@ func TestResolveSdmxEntityShape(t *testing.T) {
 			t.Fatalf("observationProperties = %v, want %v", gotObservationProperties, wantObservationProperties)
 		}
 	}
-	wantEntitySlotByObservationProperty := map[string]string{
+	wantObservationPropertyToEntitySlot := map[string]string{
 		"destinationCountry": "entity1",
 		"sourceCountry":      "entity2",
 	}
-	if diff := cmp.Diff(wantEntitySlotByObservationProperty, gotEntitySlotByObservationProperty); diff != "" {
+	if diff := cmp.Diff(wantObservationPropertyToEntitySlot, gotObservationPropertyToEntitySlot); diff != "" {
 		t.Fatalf("entity slot mapping mismatch (-want +got):\n%s", diff)
 	}
 
-	gotObservationProperties, gotEntitySlotByObservationProperty, err = resolveSdmxEntityShape([]string{"var2"}, observationPropertyEdgesByStatVar)
+	gotObservationProperties, gotObservationPropertyToEntitySlot, err = resolveSdmxEntityShape([]string{"var2"}, statVarToObservationPropertyEdges)
 	if err != nil {
 		t.Fatalf("resolveSdmxEntityShape() error = %v", err)
 	}
@@ -1299,21 +1299,21 @@ func TestResolveSdmxEntityShape(t *testing.T) {
 	if len(gotObservationProperties) != len(wantObservationProperties) || gotObservationProperties[0] != wantObservationProperties[0] {
 		t.Fatalf("observationProperties = %v, want %v", gotObservationProperties, wantObservationProperties)
 	}
-	wantEntitySlotByObservationProperty = map[string]string{
+	wantObservationPropertyToEntitySlot = map[string]string{
 		datacommons.ComponentObservationAbout: "entity1",
 	}
-	if diff := cmp.Diff(wantEntitySlotByObservationProperty, gotEntitySlotByObservationProperty); diff != "" {
+	if diff := cmp.Diff(wantObservationPropertyToEntitySlot, gotObservationPropertyToEntitySlot); diff != "" {
 		t.Fatalf("entity slot mapping mismatch (-want +got):\n%s", diff)
 	}
 }
 
 func TestResolveSdmxEntityShapeAcceptsSameTwoEntityShapeDifferentOrder(t *testing.T) {
-	observationPropertyEdgesByStatVar := map[string][]*Edge{
+	statVarToObservationPropertyEdges := map[string][]*Edge{
 		"var1": observationPropertiesEdges("sourceCountry", "destinationCountry"),
 		"var2": observationPropertiesEdges("destinationCountry", "sourceCountry"),
 	}
 
-	gotObservationProperties, gotEntitySlotByObservationProperty, err := resolveSdmxEntityShape([]string{"var1", "var2"}, observationPropertyEdgesByStatVar)
+	gotObservationProperties, gotObservationPropertyToEntitySlot, err := resolveSdmxEntityShape([]string{"var1", "var2"}, statVarToObservationPropertyEdges)
 	if err != nil {
 		t.Fatalf("resolveSdmxEntityShape() error = %v", err)
 	}
@@ -1322,22 +1322,22 @@ func TestResolveSdmxEntityShapeAcceptsSameTwoEntityShapeDifferentOrder(t *testin
 	if diff := cmp.Diff(wantObservationProperties, gotObservationProperties); diff != "" {
 		t.Fatalf("observationProperties mismatch (-want +got):\n%s", diff)
 	}
-	wantEntitySlotByObservationProperty := map[string]string{
+	wantObservationPropertyToEntitySlot := map[string]string{
 		"destinationCountry": "entity1",
 		"sourceCountry":      "entity2",
 	}
-	if diff := cmp.Diff(wantEntitySlotByObservationProperty, gotEntitySlotByObservationProperty); diff != "" {
+	if diff := cmp.Diff(wantObservationPropertyToEntitySlot, gotObservationPropertyToEntitySlot); diff != "" {
 		t.Fatalf("entity slot mapping mismatch (-want +got):\n%s", diff)
 	}
 }
 
 func TestResolveSdmxEntityShapeAcceptsSameThreeEntityShapeDifferentOrder(t *testing.T) {
-	observationPropertyEdgesByStatVar := map[string][]*Edge{
+	statVarToObservationPropertyEdges := map[string][]*Edge{
 		"var1": observationPropertiesEdges("sourceCountry", "transportMode", "destinationCountry"),
 		"var2": observationPropertiesEdges("transportMode", "destinationCountry", "sourceCountry"),
 	}
 
-	gotObservationProperties, gotEntitySlotByObservationProperty, err := resolveSdmxEntityShape([]string{"var1", "var2"}, observationPropertyEdgesByStatVar)
+	gotObservationProperties, gotObservationPropertyToEntitySlot, err := resolveSdmxEntityShape([]string{"var1", "var2"}, statVarToObservationPropertyEdges)
 	if err != nil {
 		t.Fatalf("resolveSdmxEntityShape() error = %v", err)
 	}
@@ -1346,22 +1346,22 @@ func TestResolveSdmxEntityShapeAcceptsSameThreeEntityShapeDifferentOrder(t *test
 	if diff := cmp.Diff(wantObservationProperties, gotObservationProperties); diff != "" {
 		t.Fatalf("observationProperties mismatch (-want +got):\n%s", diff)
 	}
-	wantEntitySlotByObservationProperty := map[string]string{
+	wantObservationPropertyToEntitySlot := map[string]string{
 		"destinationCountry": "entity1",
 		"sourceCountry":      "entity2",
 		"transportMode":      "entity3",
 	}
-	if diff := cmp.Diff(wantEntitySlotByObservationProperty, gotEntitySlotByObservationProperty); diff != "" {
+	if diff := cmp.Diff(wantObservationPropertyToEntitySlot, gotObservationPropertyToEntitySlot); diff != "" {
 		t.Fatalf("entity slot mapping mismatch (-want +got):\n%s", diff)
 	}
 }
 
 func TestResolveSdmxEntityShapeUsesExplicitObservationAboutProperty(t *testing.T) {
-	observationPropertyEdgesByStatVar := map[string][]*Edge{
+	statVarToObservationPropertyEdges := map[string][]*Edge{
 		"var1": observationPropertiesEdges(datacommons.ComponentObservationAbout),
 	}
 
-	gotObservationProperties, gotEntitySlotByObservationProperty, err := resolveSdmxEntityShape([]string{"var1"}, observationPropertyEdgesByStatVar)
+	gotObservationProperties, gotObservationPropertyToEntitySlot, err := resolveSdmxEntityShape([]string{"var1"}, statVarToObservationPropertyEdges)
 	if err != nil {
 		t.Fatalf("resolveSdmxEntityShape() error = %v", err)
 	}
@@ -1370,21 +1370,21 @@ func TestResolveSdmxEntityShapeUsesExplicitObservationAboutProperty(t *testing.T
 	if diff := cmp.Diff(wantObservationProperties, gotObservationProperties); diff != "" {
 		t.Fatalf("observationProperties mismatch (-want +got):\n%s", diff)
 	}
-	wantEntitySlotByObservationProperty := map[string]string{
+	wantObservationPropertyToEntitySlot := map[string]string{
 		datacommons.ComponentObservationAbout: "entity1",
 	}
-	if diff := cmp.Diff(wantEntitySlotByObservationProperty, gotEntitySlotByObservationProperty); diff != "" {
+	if diff := cmp.Diff(wantObservationPropertyToEntitySlot, gotObservationPropertyToEntitySlot); diff != "" {
 		t.Fatalf("entity slot mapping mismatch (-want +got):\n%s", diff)
 	}
 }
 
 func TestResolveSdmxEntityShapeAcceptsObservationAboutInMultiEntityShape(t *testing.T) {
-	observationPropertyEdgesByStatVar := map[string][]*Edge{
+	statVarToObservationPropertyEdges := map[string][]*Edge{
 		"var1": observationPropertiesEdges("sourceCountry", datacommons.ComponentObservationAbout, "destinationCountry"),
 		"var2": observationPropertiesEdges(datacommons.ComponentObservationAbout, "destinationCountry", "sourceCountry"),
 	}
 
-	gotObservationProperties, gotEntitySlotByObservationProperty, err := resolveSdmxEntityShape([]string{"var1", "var2"}, observationPropertyEdgesByStatVar)
+	gotObservationProperties, gotObservationPropertyToEntitySlot, err := resolveSdmxEntityShape([]string{"var1", "var2"}, statVarToObservationPropertyEdges)
 	if err != nil {
 		t.Fatalf("resolveSdmxEntityShape() error = %v", err)
 	}
@@ -1393,12 +1393,12 @@ func TestResolveSdmxEntityShapeAcceptsObservationAboutInMultiEntityShape(t *test
 	if diff := cmp.Diff(wantObservationProperties, gotObservationProperties); diff != "" {
 		t.Fatalf("observationProperties mismatch (-want +got):\n%s", diff)
 	}
-	wantEntitySlotByObservationProperty := map[string]string{
+	wantObservationPropertyToEntitySlot := map[string]string{
 		"destinationCountry":                  "entity1",
 		datacommons.ComponentObservationAbout: "entity2",
 		"sourceCountry":                       "entity3",
 	}
-	if diff := cmp.Diff(wantEntitySlotByObservationProperty, gotEntitySlotByObservationProperty); diff != "" {
+	if diff := cmp.Diff(wantObservationPropertyToEntitySlot, gotObservationPropertyToEntitySlot); diff != "" {
 		t.Fatalf("entity slot mapping mismatch (-want +got):\n%s", diff)
 	}
 }
@@ -1690,7 +1690,7 @@ func TestValidateSdmxConstraintValues(t *testing.T) {
 }
 
 func TestResolveSdmxEntityShapeTooManyProperties(t *testing.T) {
-	observationPropertyEdgesByStatVar := map[string][]*Edge{
+	statVarToObservationPropertyEdges := map[string][]*Edge{
 		"var1": {
 			{Predicate: "observationProperties", Value: "destinationCountry"},
 			{Predicate: "observationProperties", Value: "intermediaryCountry"},
@@ -1699,7 +1699,7 @@ func TestResolveSdmxEntityShapeTooManyProperties(t *testing.T) {
 		},
 	}
 
-	_, _, err := resolveSdmxEntityShape([]string{"var1"}, observationPropertyEdgesByStatVar)
+	_, _, err := resolveSdmxEntityShape([]string{"var1"}, statVarToObservationPropertyEdges)
 	if err == nil {
 		t.Fatal("resolveSdmxEntityShape() error = nil, want error")
 	}
@@ -1716,13 +1716,13 @@ func TestResolveSdmxEntityShapeIncompatibleVariables(t *testing.T) {
 	tests := []struct {
 		name                              string
 		vars                              []string
-		observationPropertyEdgesByStatVar map[string][]*Edge
+		statVarToObservationPropertyEdges map[string][]*Edge
 		want                              string
 	}{
 		{
 			name: "single and multi",
 			vars: []string{"multi", "single"},
-			observationPropertyEdgesByStatVar: map[string][]*Edge{
+			statVarToObservationPropertyEdges: map[string][]*Edge{
 				"single": nil,
 				"multi":  observationPropertiesEdges("destinationCountry", "sourceCountry"),
 			},
@@ -1731,7 +1731,7 @@ func TestResolveSdmxEntityShapeIncompatibleVariables(t *testing.T) {
 		{
 			name: "same count different property",
 			vars: []string{"var1", "var2"},
-			observationPropertyEdgesByStatVar: map[string][]*Edge{
+			statVarToObservationPropertyEdges: map[string][]*Edge{
 				"var1": observationPropertiesEdges("destinationCountry", "sourceCountry"),
 				"var2": observationPropertiesEdges("destinationCountry", "originCountry"),
 			},
@@ -1740,7 +1740,7 @@ func TestResolveSdmxEntityShapeIncompatibleVariables(t *testing.T) {
 		{
 			name: "different property count",
 			vars: []string{"var1", "var2"},
-			observationPropertyEdgesByStatVar: map[string][]*Edge{
+			statVarToObservationPropertyEdges: map[string][]*Edge{
 				"var1": observationPropertiesEdges("destinationCountry", "sourceCountry"),
 				"var2": observationPropertiesEdges("destinationCountry", "sourceCountry", "transportMode"),
 			},
@@ -1750,7 +1750,7 @@ func TestResolveSdmxEntityShapeIncompatibleVariables(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := resolveSdmxEntityShape(tt.vars, tt.observationPropertyEdgesByStatVar)
+			_, _, err := resolveSdmxEntityShape(tt.vars, tt.statVarToObservationPropertyEdges)
 			if err == nil {
 				t.Fatal("resolveSdmxEntityShape() error = nil, want error")
 			}

--- a/internal/server/spanner/query_multientity_test.go
+++ b/internal/server/spanner/query_multientity_test.go
@@ -460,12 +460,12 @@ func TestMultiEntityGetSdmxObservationsRejectsInvalidVariableMeasured(t *testing
 	}{
 		{
 			name: "nil constraint list",
-			want: "SDMX component filter variableMeasured must be specified",
+			want: "missing required SDMX component filter variableMeasured",
 		},
 		{
 			name:       "empty value list",
 			constraint: &sdmxpb.SdmxComponentConstraint{},
-			want:       "SDMX component filter variableMeasured must be specified",
+			want:       "missing required SDMX component filter variableMeasured",
 		},
 		{
 			name:       "blank value",
@@ -551,13 +551,13 @@ func TestPrepareSdmxObservationsQuery(t *testing.T) {
 	}
 	wantParams := map[string]interface{}{
 		datacommons.ComponentVariableMeasured: []string{"var1", "var2"},
-		"destinationCountry":                  []string{"country/CAN", "country/MEX"},
-		"sourceCountry":                       []string{"country/USA", "country/IND"},
-		"unit":                                []string{"Count", "Percent"},
-		"measurementMethod":                   []string{"Census", "Survey"},
-		"observationPeriod":                   []string{"P1Y", "P1M"},
-		"provenance":                          []string{"dc/base/one", "dc/base/two"},
-		"facetId":                             []string{"facet", "alternate-facet"},
+		"filter_entity1":                      []string{"country/CAN", "country/MEX"},
+		"filter_entity2":                      []string{"country/USA", "country/IND"},
+		"filter_unit":                         []string{"Count", "Percent"},
+		"filter_measurement_method":           []string{"Census", "Survey"},
+		"filter_observation_period":           []string{"P1Y", "P1M"},
+		"filter_provenance":                   []string{"dc/base/one", "dc/base/two"},
+		"filter_facet_id":                     []string{"facet", "alternate-facet"},
 	}
 	if diff := cmp.Diff(wantParams, prepared.statement.Params); diff != "" {
 		t.Fatalf("prepareSdmxObservationsQuery() params mismatch (-want +got):\n%s", diff)
@@ -585,6 +585,71 @@ func TestPrepareSdmxObservationsQuery(t *testing.T) {
 	}
 }
 
+func TestCompileSdmxConstraintsCanonicalizesObservationPropertyNames(t *testing.T) {
+	compile := func(observationProperty string) *compiledSdmxConstraints {
+		t.Helper()
+		compiled, err := compileSdmxConstraints(
+			map[string]*sdmxpb.SdmxComponentConstraint{
+				datacommons.ComponentVariableMeasured: sdmxComponentConstraint("Count_Person"),
+				observationProperty:                   sdmxComponentConstraint("country/USA"),
+				datacommons.ComponentUnit:             sdmxComponentConstraint("Count"),
+			},
+			map[string]string{observationProperty: "entity1"},
+		)
+		if err != nil {
+			t.Fatalf("compileSdmxConstraints() error = %v", err)
+		}
+		return compiled
+	}
+
+	beforeUnit := compile("aaaRegion")
+	afterUnit := compile("zzzRegion")
+	if diff := cmp.Diff(beforeUnit.where, afterUnit.where); diff != "" {
+		t.Fatalf("compileSdmxConstraints() SQL depends on observation property name (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(beforeUnit.params, afterUnit.params); diff != "" {
+		t.Fatalf("compileSdmxConstraints() params depend on observation property name (-want +got):\n%s", diff)
+	}
+	if got, want := beforeUnit.where, "t.variable_measured IN UNNEST(@variableMeasured) AND t.entity1 IN UNNEST(@filter_entity1) AND t.unit IN UNNEST(@filter_unit)"; got != want {
+		t.Fatalf("compileSdmxConstraints() where = %q, want %q", got, want)
+	}
+}
+
+func TestGetSdmxObservationsQueryCanonicalizesContainedInPlaceObservationPropertyNames(t *testing.T) {
+	queryBuilder, err := NewMultiEntityQueryBuilder(DefaultTableConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	build := func(directComponent, containedComponent string) *cloudspanner.Statement {
+		t.Helper()
+		statement, err := queryBuilder.GetSdmxObservationsQuery(
+			map[string]*sdmxpb.SdmxComponentConstraint{
+				datacommons.ComponentVariableMeasured: sdmxComponentConstraint("Count_Migration"),
+				directComponent:                       sdmxComponentConstraint("country/CAN"),
+				containedComponent:                    sdmxContainedInPlaceConstraint("northamerica", "Country"),
+			},
+			map[string]string{
+				directComponent:    "entity1",
+				containedComponent: "entity2",
+			},
+		)
+		if err != nil {
+			t.Fatalf("GetSdmxObservationsQuery() error = %v", err)
+		}
+		return statement
+	}
+
+	first := build("destinationCountry", "sourceCountry")
+	second := build("arrivalRegion", "originRegion")
+	if diff := cmp.Diff(first.SQL, second.SQL); diff != "" {
+		t.Fatalf("GetSdmxObservationsQuery() SQL depends on observation property names (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(first.Params, second.Params); diff != "" {
+		t.Fatalf("GetSdmxObservationsQuery() params depend on observation property names (-want +got):\n%s", diff)
+	}
+}
+
 func TestPrepareSdmxObservationsQueryWithContainedInPlace(t *testing.T) {
 	queryBuilder, err := NewMultiEntityQueryBuilder(DefaultTableConfig())
 	if err != nil {
@@ -592,7 +657,7 @@ func TestPrepareSdmxObservationsQueryWithContainedInPlace(t *testing.T) {
 	}
 	constraints := map[string]*sdmxpb.SdmxComponentConstraint{
 		datacommons.ComponentVariableMeasured: sdmxComponentConstraint("Count_Migration"),
-		"destinationCountry":                  sdmxComponentConstraint("country/CAN"),
+		"containedAncestor0":                  sdmxComponentConstraint("country/CAN"),
 		"sourceCountry":                       sdmxContainedInPlaceConstraint("country/USA", "State"),
 	}
 	prepared, err := prepareSdmxObservationsQuery(
@@ -600,7 +665,7 @@ func TestPrepareSdmxObservationsQueryWithContainedInPlace(t *testing.T) {
 		constraints,
 		func(_ context.Context, ids []string, arc *v2.Arc, pageSize int, offset int) (map[string][]*Edge, error) {
 			return map[string][]*Edge{
-				"Count_Migration": observationPropertiesEdges("destinationCountry", "sourceCountry"),
+				"Count_Migration": observationPropertiesEdges("containedAncestor0", "sourceCountry"),
 			}, nil
 		},
 		queryBuilder,
@@ -610,9 +675,9 @@ func TestPrepareSdmxObservationsQueryWithContainedInPlace(t *testing.T) {
 	}
 	wantParams := map[string]interface{}{
 		datacommons.ComponentVariableMeasured: []string{"Count_Migration"},
-		"destinationCountry":                  []string{"country/CAN"},
-		"containedAncestor0":                  "country/USA",
-		"containedChildPlaceType0":            "State",
+		"filter_entity1":                      []string{"country/CAN"},
+		"containment_0_ancestor":              "country/USA",
+		"containment_0_child_place_type":      "State",
 	}
 	if diff := cmp.Diff(wantParams, prepared.statement.Params); diff != "" {
 		t.Fatalf("prepareSdmxObservationsQuery() params mismatch (-want +got):\n%s", diff)
@@ -623,7 +688,7 @@ func TestPrepareSdmxObservationsQueryWithContainedInPlace(t *testing.T) {
 		"TimeSeries@{FORCE_INDEX=TimeSeriesByEntity2}",
 		"ON t.entity2 = anchor.place_id",
 		"t.variable_measured IN UNNEST(@variableMeasured)",
-		"t.entity1 IN UNNEST(@destinationCountry)",
+		"t.entity1 IN UNNEST(@filter_entity1)",
 		"t.entity2 IS NOT NULL",
 	} {
 		if !strings.Contains(prepared.statement.SQL, fragment) {
@@ -699,12 +764,12 @@ func TestPrepareSdmxAvailabilityQuery(t *testing.T) {
 
 	wantParams := map[string]interface{}{
 		datacommons.ComponentVariableMeasured: []string{"var1", "var2"},
-		"destinationCountry":                  []string{"country/CAN", "country/MEX"},
-		"sourceCountry":                       []string{"country/USA", "country/IND"},
-		"unit":                                []string{"Count", "Percent"},
-		"measurementMethod":                   []string{"Census", "Survey"},
-		"observationPeriod":                   []string{"P1Y", "P1M"},
-		"provenance":                          []string{"dc/base/one", "dc/base/two"},
+		"filter_entity1":                      []string{"country/CAN", "country/MEX"},
+		"filter_entity2":                      []string{"country/USA", "country/IND"},
+		"filter_unit":                         []string{"Count", "Percent"},
+		"filter_measurement_method":           []string{"Census", "Survey"},
+		"filter_observation_period":           []string{"P1Y", "P1M"},
+		"filter_provenance":                   []string{"dc/base/one", "dc/base/two"},
 	}
 	if diff := cmp.Diff(wantParams, stmt.Params); diff != "" {
 		t.Fatalf("prepareSdmxAvailabilityQuery() params mismatch (-want +got):\n%s", diff)
@@ -986,12 +1051,12 @@ func TestMultiEntityGetSdmxAvailabilityRejectsInvalidVariableMeasured(t *testing
 	}{
 		{
 			name: "nil constraint list",
-			want: "SDMX component filter variableMeasured must be specified",
+			want: "missing required SDMX component filter variableMeasured",
 		},
 		{
 			name:       "empty value list",
 			constraint: &sdmxpb.SdmxComponentConstraint{},
-			want:       "SDMX component filter variableMeasured must be specified",
+			want:       "missing required SDMX component filter variableMeasured",
 		},
 		{
 			name:       "blank value",

--- a/internal/server/spanner/sdmx_columns.go
+++ b/internal/server/spanner/sdmx_columns.go
@@ -33,8 +33,8 @@ func sdmxStaticDataFilterColumn(componentID string) (string, bool) {
 	}
 }
 
-func sdmxDataFilterColumn(componentID string, entitySlotByObservationProperty map[string]string) (string, bool) {
-	if entitySlot, ok := entitySlotByObservationProperty[componentID]; ok {
+func sdmxDataFilterColumn(componentID string, observationPropertyToEntitySlot map[string]string) (string, bool) {
+	if entitySlot, ok := observationPropertyToEntitySlot[componentID]; ok {
 		return entitySlot, true
 	}
 	return sdmxStaticDataFilterColumn(componentID)

--- a/internal/server/spanner/statements_multientity.go
+++ b/internal/server/spanner/statements_multientity.go
@@ -32,6 +32,9 @@ type MultiEntityStatements struct {
 	getObsByContainedInPlaceBothLatest             string
 	getSdmxObs                                     string
 	getSdmxAvailability                            string
+	getSdmxContainedInPlace                        string
+	sdmxContainedPlacesCTE                         string
+	sdmxContainedSeriesCTE                         string
 	getStatVarsByEntityBoth                        string
 	getStatVarsByEntityVarsOnly                    string
 	getStatVarsByEntityEntitiesOnly                string
@@ -376,6 +379,50 @@ func NewMultiEntityStatements(cfg TableConfig) (*MultiEntityStatements, error) {
 			AND %%[1]s IS NOT NULL
 			AND %%[1]s != ''
 		ORDER BY value`, cfg.TimeSeriesTable) + "\n",
+
+		sdmxContainedPlacesCTE: `%[1]s AS (
+			SELECT DISTINCT contained.subject_id AS place_id
+			FROM Edge contained
+			JOIN Edge typed ON contained.subject_id = typed.subject_id
+			WHERE contained.predicate = '%[2]s'
+				AND contained.object_id = @%[3]s
+				AND typed.predicate = '%[4]s'
+				AND typed.object_id = @%[5]s
+		)`,
+
+		sdmxContainedSeriesCTE: fmt.Sprintf(`series AS (
+			SELECT
+				t.variable_measured,
+				t.entity1,
+				t.extra_entities_id,
+				t.facet_id,
+				t.provenance,
+				t.facet,
+				t.entities
+			FROM %%[1]s anchor
+			JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} %s@{FORCE_INDEX=%%[2]s} t
+				ON t.%%[3]s = anchor.place_id
+				AND %%[4]s%%[5]s
+		)`, cfg.TimeSeriesTable),
+
+		getSdmxContainedInPlace: fmt.Sprintf(`		%%[1]sWITH %%[2]s,
+		%%[3]s
+		SELECT
+			t.variable_measured,
+			t.entity1 AS observation_about,
+			t.facet_id,
+			ANY_VALUE(t.provenance) AS provenance,
+			ARRAY_AGG(STRUCT(o.date AS date, o.value AS str_value)) AS dates_and_values,
+			ANY_VALUE(t.facet) AS facets,
+			ANY_VALUE(t.entities) AS entities
+		FROM series t
+		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} %s o
+		USING (variable_measured, entity1, extra_entities_id, facet_id)
+		GROUP BY
+			t.variable_measured,
+			t.entity1,
+			t.extra_entities_id,
+			t.facet_id`, cfg.ObservationTable),
 
 		// Check existence when both variables and entities are specified
 		getStatVarsByEntityBoth: fmt.Sprintf(`		WITH


### PR DESCRIPTION
Adds Data Commons containment filtering to the SDMX Data API.

- Parses one-step property selectors such as `c[sourceCountry.containedInPlace+]` and `c[sourceCountry.typeOf]`.
- Represents property filters through the existing dispatcher `SdmxComponentConstraint.property_constraints` structure.
- Supports the paired `containedInPlace+` and `typeOf` filters on observation-property dimensions, including `observationAbout`.
- Uses `linkedContainedInPlace` for transitive containment and `typeOf` for child-place filtering.
- Supports containment on multiple observation properties and reuses identical place-selection CTEs.
- Selects the appropriate TimeSeries access path based on the mapped entity slot.
- Canonicalizes SQL parameters and moves SDMX SQL templates into the shared statement definitions.
- Adds REST parsing, validation, dispatcher, query-builder, golden, and Spanner emulator coverage.

Current limitations:

- `containedInPlace+` and `typeOf` must be provided together.
- Each property accepts exactly one value.
- Property filters cannot be combined with a direct filter on the same component.
- Only observation-property components are supported.
- Property filtering remains unsupported for the Availability API.

## Sample SDMX request

```bash
curl -g \
  'http://localhost:8081/sdmx/v3/data/dataflow/DC/DF_OBS/1.0.0/*?c[variableMeasured]=Count_Migration&c[destinationCountry]=country/CAN&c[sourceCountry.containedInPlace+]=northamerica&c[sourceCountry.typeOf]=Country'
```

Meaning:

- Select `Count_Migration`.
- Require `destinationCountry = country/CAN`.
- Find `sourceCountry` values transitively contained in `northamerica `.
- Require those source countries to have `typeOf = Country`.

## Corresponding dispatcher request

`SdmxDataQuery`, shown using proto JSON field names:

```json
{
  "constraints": {
    "variableMeasured": {
      "predicates": [
        {
          "value": "Count_Migration"
        }
      ]
    },
    "destinationCountry": {
      "predicates": [
        {
          "value": "country/CAN"
        }
      ]
    },
    "sourceCountry": {
      "propertyConstraints": {
        "containedInPlace": {
          "predicates": [
            {
              "value": "northamerica"
            }
          ],
          "transitive": true
        },
        "typeOf": {
          "predicates": [
            {
              "value": "Country"
            }
          ]
        }
      }
    }
  }
}
```

The omitted predicate operator defaults to `SDMX_OPERATOR_EQ`.