### PR TITLE
[NL2SQL] Adds a new secret for NL2SQL App ID, and propagates header param to disable Spanner

### DIFF
--- a/deploy/apigee/deploy_apigee.sh
+++ b/deploy/apigee/deploy_apigee.sh
@@ -170,7 +170,7 @@ function terraform_plan_and_maybe_apply() {
   cd "$ENV_BASE_DIR"
   PLAN_FILE="$TMP_DIR/tfplan_$TIMESTAMP"
 
-  terraform init -upgrade
+  terraform init
 
   # The -detailed-exitcode flag will cause 'plan' to return:
   # 0 = Succeeded with empty diff

--- a/deploy/apigee/deploy_apigee.sh
+++ b/deploy/apigee/deploy_apigee.sh
@@ -170,7 +170,7 @@ function terraform_plan_and_maybe_apply() {
   cd "$ENV_BASE_DIR"
   PLAN_FILE="$TMP_DIR/tfplan_$TIMESTAMP"
 
-  terraform init
+  terraform init -upgrade
 
   # The -detailed-exitcode flag will cause 'plan' to return:
   # 0 = Succeeded with empty diff

--- a/deploy/apigee/envs/nonprod.yaml
+++ b/deploy/apigee/envs/nonprod.yaml
@@ -14,6 +14,7 @@ proxies:
       - block-deprecated-endpoints
       - set-content-type-to-json
       - extract-json-params
+      - set-disable-spanner-header
     proxy_endpoints:
       - api
     target_endpoints:

--- a/deploy/apigee/envs/prod.yaml
+++ b/deploy/apigee/envs/prod.yaml
@@ -14,6 +14,7 @@ proxies:
       - block-deprecated-endpoints
       - set-content-type-to-json
       - extract-json-params
+      - set-disable-spanner-header
     proxy_endpoints:
       - api
     target_endpoints:

--- a/deploy/apigee/policies/set-disable-spanner-header.xml
+++ b/deploy/apigee/policies/set-disable-spanner-header.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!-- TODO(gmechali): Remove policy once NL2SQL legacy client migration is complete. -->
+<AssignMessage continueOnError="false" enabled="true" name="set-disable-spanner-header">
+  <DisplayName>set-disable-spanner-header</DisplayName>
+  <Set>
+    <Headers>
+      <Header name="X-Disable-Spanner">true</Header>
+    </Headers>
+  </Set>
+</AssignMessage>

--- a/deploy/apigee/proxies/api.xml
+++ b/deploy/apigee/proxies/api.xml
@@ -14,6 +14,9 @@
     <Policy>strip-api-key-header-and-params</Policy>
     <Policy>block-internal-only-endpoints</Policy>
     <Policy>block-deprecated-endpoints</Policy>
+    <Policy>set-content-type-to-json</Policy>
+    <Policy>extract-json-params</Policy>
+    <Policy>set-disable-spanner-header</Policy>
   </Policies>
   <ProxyEndpoints>
     <ProxyEndpoint>api</ProxyEndpoint>

--- a/deploy/apigee/sample.env
+++ b/deploy/apigee/sample.env
@@ -7,3 +7,5 @@ TRIAL_KEY_QUOTA_INTERVAL_MINUTES=<Length of quota interval for trial key in minu
 API_PORTAL_URL=<Link to where to register to get a non-trial API key>
 MCP_SERVICE_URL=<Hostname (domain) of MCP Cloud Run service>
 DEPLOYMENT_SERVICE_ACCOUNT=<Service Account email for Apigee deployment>
+# TODO(gmechali): Remove LEGACY_CLIENT_APP_ID once NL2SQL legacy client migration is complete.
+LEGACY_CLIENT_APP_ID=<Apigee Developer App ID for legacy client needing Spanner disabled>

--- a/deploy/apigee/target_endpoints/api.template.xml
+++ b/deploy/apigee/target_endpoints/api.template.xml
@@ -139,6 +139,14 @@
           </Condition>
           <Name>enforce-quota-limit</Name>
         </Step>
+        <Step>
+          <!-- TODO(gmechali): Remove set-disable-spanner-header step once NL2SQL legacy client migration is complete. -->
+          <Condition>
+            (developer.app.id = "REPLACE_WITH_LEGACY_CLIENT_APP_ID") OR
+            (verifyapikey.verify-api-key-in-header.developer.app.id = "REPLACE_WITH_LEGACY_CLIENT_APP_ID")
+          </Condition>
+          <Name>set-disable-spanner-header</Name>
+        </Step>
       </Request>
     </Flow>
   </Flows>


### PR DESCRIPTION
The NL2SQL needs more time to migrate off the facet IDs. This approach will allow us to forward a new header param on requests only from them.

In a follow up, once this is submitted, I will push a new secret to our prod.env secret to include their App ID.

Tested using one of our test keys in staging and verified that Apigee propagated the new header param.