### PR TITLE
[featureflags] Enable UseSpannerKeyValueStore in autopush and dev

### DIFF
--- a/deploy/featureflags/autopush.yaml
+++ b/deploy/featureflags/autopush.yaml
@@ -9,3 +9,4 @@ flags:
   EnableSpannerSearchEmbeddings: true
   UseMultiEntitySchema: true
   EnableSDMXDataApi: true
+  UseSpannerKeyValueStore: true

--- a/deploy/featureflags/autopush_website.yaml
+++ b/deploy/featureflags/autopush_website.yaml
@@ -10,3 +10,4 @@ flags:
   EnableSpannerSearchEmbeddings: true
   UseMultiEntitySchema: true
   EnableSDMXDataApi: true
+  UseSpannerKeyValueStore: true

--- a/deploy/featureflags/dev.yaml
+++ b/deploy/featureflags/dev.yaml
@@ -10,3 +10,4 @@ flags:
   UseMultiEntitySchema: true  
   V2DivertFraction: 1.0
   EnableSDMXDataApi: true
+  UseSpannerKeyValueStore: true

--- a/deploy/featureflags/dev_website.yaml
+++ b/deploy/featureflags/dev_website.yaml
@@ -10,3 +10,4 @@ flags:
   EnableSpannerSearchEmbeddings: true
   UseMultiEntitySchema: true
   V2DivertFraction: 1.0
+  UseSpannerKeyValueStore: true


### PR DESCRIPTION
This follows https://github.com/datacommonsorg/mixer/pull/1992 to rename Cache table to KeyValueStore