### PR TITLE
Optimize latest contained-in-place observation queries

### DIFF
--- a/internal/server/spanner/golden/query_builder/get_multientity_obs_basic.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_obs_basic.sql
@@ -21,5 +21,5 @@
 			) AS dates_and_values,
 			t.facet AS facets
 		FROM params p
-		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} TimeSeries t
+		JOIN@{JOIN_METHOD=APPLY_JOIN} TimeSeries t
 			ON t.variable_measured = p.var AND t.entity1 = p.ent

--- a/internal/server/spanner/golden/query_builder/get_multientity_obs_contained_in_place_both.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_obs_contained_in_place_both.sql
@@ -17,7 +17,7 @@
 				t.provenance,
 				t.facet
 			FROM places p
-			JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} TimeSeries@{FORCE_INDEX=_BASE_TABLE} t
+			JOIN@{JOIN_METHOD=APPLY_JOIN} TimeSeries@{FORCE_INDEX=_BASE_TABLE} t
 				ON t.variable_measured IN ('AirPollutant_Cancer_Risk')
 				AND t.entity1 = p.place_id
 		)
@@ -34,7 +34,7 @@
 			) AS dates_and_values,
 			ANY_VALUE(t.facet) AS facets
 		FROM series t
-		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} Observation o
+		JOIN@{JOIN_METHOD=APPLY_JOIN} Observation o
 		USING (variable_measured, entity1, extra_entities_id, facet_id)
 		GROUP BY
 			t.variable_measured,

--- a/internal/server/spanner/golden/query_builder/get_multientity_obs_contained_in_place_date.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_obs_contained_in_place_date.sql
@@ -17,7 +17,7 @@
 				t.provenance,
 				t.facet
 			FROM places p
-			JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} TimeSeries@{FORCE_INDEX=_BASE_TABLE} t
+			JOIN@{JOIN_METHOD=APPLY_JOIN} TimeSeries@{FORCE_INDEX=_BASE_TABLE} t
 				ON t.variable_measured IN ('AirPollutant_Cancer_Risk','Count_Person')
 				AND t.entity1 = p.place_id
 		)
@@ -33,6 +33,6 @@
 			) AS dates_and_values,
 			t.facet AS facets
 		FROM series t
-		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} Observation o
+		JOIN@{JOIN_METHOD=APPLY_JOIN} Observation o
 		USING (variable_measured, entity1, extra_entities_id, facet_id)
 		WHERE o.date = '2015'

--- a/internal/server/spanner/golden/query_builder/get_multientity_obs_contained_in_place_latest.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_obs_contained_in_place_latest.sql
@@ -17,7 +17,7 @@
 				t.provenance,
 				t.facet
 			FROM places p
-			JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} TimeSeries@{FORCE_INDEX=_BASE_TABLE} t
+			JOIN@{JOIN_METHOD=APPLY_JOIN} TimeSeries@{FORCE_INDEX=_BASE_TABLE} t
 				ON t.variable_measured IN ('AirPollutant_Cancer_Risk')
 				AND t.entity1 = p.place_id
 		)
@@ -25,24 +25,29 @@
 			t.variable_measured,
 			t.entity1 AS observation_about,
 			t.facet_id,
-			ANY_VALUE(t.provenance) AS provenance,
+			t.provenance,
 			COALESCE(
-				ARRAY_AGG(
-					STRUCT(
-						o.date AS date,
-						o.value AS str_value
+				(
+					SELECT ARRAY(
+						SELECT AS STRUCT
+							o.date AS date,
+							o.value AS str_value
+						FROM Observation o
+						WHERE o.variable_measured = t.variable_measured
+							AND o.entity1 = t.entity1
+							AND o.extra_entities_id = t.extra_entities_id
+							AND o.facet_id = t.facet_id
+						ORDER BY o.date DESC
+						LIMIT 1
 					)
-					ORDER BY o.date DESC
-					LIMIT 1
 				),
-				ARRAY(SELECT AS STRUCT CAST(NULL AS STRING) AS date, CAST(NULL AS STRING) AS str_value FROM UNNEST([1]) WHERE FALSE)
+				ARRAY(
+					SELECT AS STRUCT
+						CAST(NULL AS STRING) AS date,
+						CAST(NULL AS STRING) AS str_value
+					FROM UNNEST([1])
+					WHERE FALSE
+				)
 			) AS dates_and_values,
-			ANY_VALUE(t.facet) AS facets
+			t.facet AS facets
 		FROM series t
-		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} Observation o
-		USING (variable_measured, entity1, extra_entities_id, facet_id)
-		GROUP BY
-			t.variable_measured,
-			t.entity1,
-			t.extra_entities_id,
-			t.facet_id

--- a/internal/server/spanner/golden/query_builder/get_multientity_obs_date.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_obs_date.sql
@@ -1,26 +1,33 @@
+		@{SCAN_METHOD=COLUMNAR, EXECUTION_METHOD=BATCH}
 		WITH params AS (
 			SELECT var, ent
 			FROM UNNEST(['AirPollutant_Cancer_Risk']) AS var
 			CROSS JOIN ('geoId/01001','geoId/02013') AS ent
+		),
+		series AS (
+			SELECT
+				t.variable_measured,
+				t.entity1,
+				t.extra_entities_id,
+				t.facet_id,
+				t.provenance,
+				t.facet
+			FROM params p
+			JOIN@{JOIN_METHOD=APPLY_JOIN} TimeSeries t
+				ON t.variable_measured = p.var AND t.entity1 = p.ent
 		)
 		SELECT
 			t.variable_measured,
 			t.entity1 AS observation_about,
 			t.facet_id,
 			t.provenance,
-			COALESCE(
-				(
-					SELECT ARRAY_AGG(STRUCT(date, value AS str_value))
-					FROM Observation o
-					WHERE o.variable_measured = t.variable_measured
-						AND o.entity1 = t.entity1
-						AND o.extra_entities_id = t.extra_entities_id
-						AND o.facet_id = t.facet_id
-						AND o.date = '2015'
-				),
-				ARRAY(SELECT AS STRUCT CAST(NULL AS STRING) AS date, CAST(NULL AS STRING) AS str_value FROM UNNEST([1]) WHERE FALSE)
+			ARRAY(
+				SELECT AS STRUCT
+					o.date AS date,
+					o.value AS str_value
 			) AS dates_and_values,
 			t.facet AS facets
-		FROM params p
-		JOIN@{JOIN_METHOD=APPLY_JOIN} TimeSeries t
-			ON t.variable_measured = p.var AND t.entity1 = p.ent
+		FROM series t
+		JOIN@{JOIN_METHOD=APPLY_JOIN} Observation o
+		USING (variable_measured, entity1, extra_entities_id, facet_id)
+		WHERE o.date = '2015'

--- a/internal/server/spanner/golden/query_builder/get_multientity_obs_date.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_obs_date.sql
@@ -22,5 +22,5 @@
 			) AS dates_and_values,
 			t.facet AS facets
 		FROM params p
-		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} TimeSeries t
+		JOIN@{JOIN_METHOD=APPLY_JOIN} TimeSeries t
 			ON t.variable_measured = p.var AND t.entity1 = p.ent

--- a/internal/server/spanner/golden/query_builder/get_multientity_obs_latest.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_obs_latest.sql
@@ -25,5 +25,5 @@
 			) AS dates_and_values,
 			t.facet AS facets
 		FROM params p
-		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} TimeSeries t
+		JOIN@{JOIN_METHOD=APPLY_JOIN} TimeSeries t
 			ON t.variable_measured = p.var AND t.entity1 = p.ent

--- a/internal/server/spanner/statements_multientity.go
+++ b/internal/server/spanner/statements_multientity.go
@@ -323,7 +323,7 @@ func NewMultiEntityStatements(cfg TableConfig) (*MultiEntityStatements, error) {
 				t.provenance,
 				t.facet
 			FROM places p
-			JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} %[2]s@{FORCE_INDEX=_BASE_TABLE} t
+			JOIN@{JOIN_METHOD=APPLY_JOIN} %[2]s@{FORCE_INDEX=_BASE_TABLE} t
 				ON t.variable_measured IN UNNEST(@variables)
 				AND t.entity1 = p.place_id
 		)
@@ -331,28 +331,32 @@ func NewMultiEntityStatements(cfg TableConfig) (*MultiEntityStatements, error) {
 			t.variable_measured,
 			t.entity1 AS observation_about,
 			t.facet_id,
-			ANY_VALUE(t.provenance) AS provenance,
+			t.provenance,
 			COALESCE(
-				ARRAY_AGG(
-					STRUCT(
-						o.date AS date,
-						o.value AS str_value
+				(
+					SELECT ARRAY(
+						SELECT AS STRUCT
+							o.date AS date,
+							o.value AS str_value
+						FROM %[1]s o
+						WHERE o.variable_measured = t.variable_measured
+							AND o.entity1 = t.entity1
+							AND o.extra_entities_id = t.extra_entities_id
+							AND o.facet_id = t.facet_id
+						ORDER BY o.date DESC
+						LIMIT 1
 					)
-					ORDER BY o.date DESC
-					LIMIT 1
 				),
-				ARRAY(SELECT AS STRUCT CAST(NULL AS STRING) AS date, CAST(NULL AS STRING) AS str_value FROM UNNEST([1]) WHERE FALSE)
+				ARRAY(
+					SELECT AS STRUCT
+						CAST(NULL AS STRING) AS date,
+						CAST(NULL AS STRING) AS str_value
+					FROM UNNEST([1])
+					WHERE FALSE
+				)
 			) AS dates_and_values,
-			ANY_VALUE(t.facet) AS facets
-		FROM series t
-		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} %[1]s o
-		USING (variable_measured, entity1, extra_entities_id, facet_id)
-		GROUP BY
-			t.variable_measured,
-			t.entity1,
-			t.extra_entities_id,
-			t.facet_id`, cfg.ObservationTable, cfg.TimeSeriesTable),
-
+			t.facet AS facets
+		FROM series t`, cfg.ObservationTable, cfg.TimeSeriesTable),
 		getSdmxObs: fmt.Sprintf("\t\tSELECT \n"+`			t.variable_measured,
 			t.entity1 AS observation_about,
 			t.facet_id,

--- a/internal/server/spanner/statements_multientity.go
+++ b/internal/server/spanner/statements_multientity.go
@@ -86,7 +86,7 @@ func NewMultiEntityStatements(cfg TableConfig) (*MultiEntityStatements, error) {
 			) AS dates_and_values,
 			t.facet AS facets
 		FROM params p
-		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} %[2]s t
+		JOIN@{JOIN_METHOD=APPLY_JOIN} %[2]s t
 			ON t.variable_measured = p.var AND t.entity1 = p.ent`, cfg.ObservationTable, cfg.TimeSeriesTable),
 
 		// Retrieve observations for a specific date (both variables and entities present)
@@ -114,7 +114,7 @@ func NewMultiEntityStatements(cfg TableConfig) (*MultiEntityStatements, error) {
 			) AS dates_and_values,
 			t.facet AS facets
 		FROM params p
-		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} %[2]s t
+		JOIN@{JOIN_METHOD=APPLY_JOIN} %[2]s t
 			ON t.variable_measured = p.var AND t.entity1 = p.ent`, cfg.ObservationTable, cfg.TimeSeriesTable),
 
 		// Retrieve latest observation (both variables and entities present)
@@ -145,7 +145,7 @@ func NewMultiEntityStatements(cfg TableConfig) (*MultiEntityStatements, error) {
 			) AS dates_and_values,
 			t.facet AS facets
 		FROM params p
-		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} %[2]s t
+		JOIN@{JOIN_METHOD=APPLY_JOIN} %[2]s t
 			ON t.variable_measured = p.var AND t.entity1 = p.ent`, cfg.ObservationTable, cfg.TimeSeriesTable),
 
 		// Retrieve observations where only entities are present (fetch all variables, full series)
@@ -236,7 +236,7 @@ func NewMultiEntityStatements(cfg TableConfig) (*MultiEntityStatements, error) {
 				t.provenance,
 				t.facet
 			FROM places p
-			JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} %[2]s@{FORCE_INDEX=_BASE_TABLE} t
+			JOIN@{JOIN_METHOD=APPLY_JOIN} %[2]s@{FORCE_INDEX=_BASE_TABLE} t
 				ON t.variable_measured IN UNNEST(@variables)
 				AND t.entity1 = p.place_id
 		)
@@ -253,7 +253,7 @@ func NewMultiEntityStatements(cfg TableConfig) (*MultiEntityStatements, error) {
 			) AS dates_and_values,
 			ANY_VALUE(t.facet) AS facets
 		FROM series t
-		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} %[1]s o
+		JOIN@{JOIN_METHOD=APPLY_JOIN} %[1]s o
 		USING (variable_measured, entity1, extra_entities_id, facet_id)
 		GROUP BY
 			t.variable_measured,
@@ -282,7 +282,7 @@ func NewMultiEntityStatements(cfg TableConfig) (*MultiEntityStatements, error) {
 				t.provenance,
 				t.facet
 			FROM places p
-			JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} %[2]s@{FORCE_INDEX=_BASE_TABLE} t
+			JOIN@{JOIN_METHOD=APPLY_JOIN} %[2]s@{FORCE_INDEX=_BASE_TABLE} t
 				ON t.variable_measured IN UNNEST(@variables)
 				AND t.entity1 = p.place_id
 		)
@@ -298,7 +298,7 @@ func NewMultiEntityStatements(cfg TableConfig) (*MultiEntityStatements, error) {
 			) AS dates_and_values,
 			t.facet AS facets
 		FROM series t
-		JOIN@{JOIN_METHOD=APPLY_JOIN, FORCE_JOIN_ORDER=TRUE} %[1]s o
+		JOIN@{JOIN_METHOD=APPLY_JOIN} %[1]s o
 		USING (variable_measured, entity1, extra_entities_id, facet_id)
 		WHERE o.date = @date`, cfg.ObservationTable, cfg.TimeSeriesTable),
 

--- a/internal/server/spanner/statements_multientity.go
+++ b/internal/server/spanner/statements_multientity.go
@@ -302,8 +302,8 @@ func NewMultiEntityStatements(cfg TableConfig) (*MultiEntityStatements, error) {
 		USING (variable_measured, entity1, extra_entities_id, facet_id)
 		WHERE o.date = @date`, cfg.ObservationTable, cfg.TimeSeriesTable),
 
-		// Join latest observations before aggregation. COALESCE is required because
-		// Spanner rejects ARRAY_AGG(... LIMIT 1) as a potentially null-valued ARRAY<STRUCT>.
+		// Retrieve the latest observation with a correlated full-key lookup so the
+		// date-descending child scan can stop after one row.
 		getObsByContainedInPlaceBothLatest: fmt.Sprintf(`		@{SCAN_METHOD=COLUMNAR, EXECUTION_METHOD=BATCH}
 		WITH places AS (
 			SELECT DISTINCT e.subject_id AS place_id

--- a/internal/server/spanner/statements_multientity.go
+++ b/internal/server/spanner/statements_multientity.go
@@ -90,32 +90,39 @@ func NewMultiEntityStatements(cfg TableConfig) (*MultiEntityStatements, error) {
 			ON t.variable_measured = p.var AND t.entity1 = p.ent`, cfg.ObservationTable, cfg.TimeSeriesTable),
 
 		// Retrieve observations for a specific date (both variables and entities present)
-		getObsBothWithDate: fmt.Sprintf(`		WITH params AS (
+		getObsBothWithDate: fmt.Sprintf(`		@{SCAN_METHOD=COLUMNAR, EXECUTION_METHOD=BATCH}
+		WITH params AS (
 			SELECT var, ent
 			FROM UNNEST(@variables) AS var
 			CROSS JOIN UNNEST(@entities) AS ent
+		),
+		series AS (
+			SELECT
+				t.variable_measured,
+				t.entity1,
+				t.extra_entities_id,
+				t.facet_id,
+				t.provenance,
+				t.facet
+			FROM params p
+			JOIN@{JOIN_METHOD=APPLY_JOIN} %[2]s t
+				ON t.variable_measured = p.var AND t.entity1 = p.ent
 		)
 		SELECT
 			t.variable_measured,
 			t.entity1 AS observation_about,
 			t.facet_id,
 			t.provenance,
-			COALESCE(
-				(
-					SELECT ARRAY_AGG(STRUCT(date, value AS str_value))
-					FROM %[1]s o
-					WHERE o.variable_measured = t.variable_measured
-						AND o.entity1 = t.entity1
-						AND o.extra_entities_id = t.extra_entities_id
-						AND o.facet_id = t.facet_id
-						AND o.date = @date
-				),
-				ARRAY(SELECT AS STRUCT CAST(NULL AS STRING) AS date, CAST(NULL AS STRING) AS str_value FROM UNNEST([1]) WHERE FALSE)
+			ARRAY(
+				SELECT AS STRUCT
+					o.date AS date,
+					o.value AS str_value
 			) AS dates_and_values,
 			t.facet AS facets
-		FROM params p
-		JOIN@{JOIN_METHOD=APPLY_JOIN} %[2]s t
-			ON t.variable_measured = p.var AND t.entity1 = p.ent`, cfg.ObservationTable, cfg.TimeSeriesTable),
+		FROM series t
+		JOIN@{JOIN_METHOD=APPLY_JOIN} %[1]s o
+		USING (variable_measured, entity1, extra_entities_id, facet_id)
+		WHERE o.date = @date`, cfg.ObservationTable, cfg.TimeSeriesTable),
 
 		// Retrieve latest observation (both variables and entities present)
 		getObsBothLatest: fmt.Sprintf(`		WITH params AS (
@@ -170,26 +177,33 @@ func NewMultiEntityStatements(cfg TableConfig) (*MultiEntityStatements, error) {
 		WHERE t.entity1 IN UNNEST(@entities)`, cfg.ObservationTable, cfg.TimeSeriesTable),
 
 		// Retrieve observations where only entities are present (fetch all variables, specific date)
-		getObsEntitiesOnlyWithDate: fmt.Sprintf(`		SELECT
+		getObsEntitiesOnlyWithDate: fmt.Sprintf(`		@{SCAN_METHOD=COLUMNAR, EXECUTION_METHOD=BATCH}
+		WITH series AS (
+			SELECT
+				t.variable_measured,
+				t.entity1,
+				t.extra_entities_id,
+				t.facet_id,
+				t.provenance,
+				t.facet
+			FROM %[2]s t
+			WHERE t.entity1 IN UNNEST(@entities)
+		)
+		SELECT
 			t.variable_measured,
 			t.entity1 AS observation_about,
 			t.facet_id,
 			t.provenance,
-			COALESCE(
-				(
-					SELECT ARRAY_AGG(STRUCT(date, value AS str_value))
-					FROM %[1]s o
-					WHERE o.variable_measured = t.variable_measured
-						AND o.entity1 = t.entity1
-						AND o.extra_entities_id = t.extra_entities_id
-						AND o.facet_id = t.facet_id
-						AND o.date = @date
-				),
-				ARRAY(SELECT AS STRUCT CAST(NULL AS STRING) AS date, CAST(NULL AS STRING) AS str_value FROM UNNEST([1]) WHERE FALSE)
+			ARRAY(
+				SELECT AS STRUCT
+					o.date AS date,
+					o.value AS str_value
 			) AS dates_and_values,
 			t.facet AS facets
-		FROM %[2]s t
-		WHERE t.entity1 IN UNNEST(@entities)`, cfg.ObservationTable, cfg.TimeSeriesTable),
+		FROM series t
+		JOIN@{JOIN_METHOD=APPLY_JOIN} %[1]s o
+		USING (variable_measured, entity1, extra_entities_id, facet_id)
+		WHERE o.date = @date`, cfg.ObservationTable, cfg.TimeSeriesTable),
 
 		// Retrieve observations where only entities are present (fetch all variables, latest only)
 		getObsEntitiesOnlyLatest: fmt.Sprintf(`		SELECT


### PR DESCRIPTION
 ## Summary

  - Replace the joined Observation aggregation with a correlated full-key lookup using `ORDER BY date DESC LIMIT 1`.
  - Allow Spanner to optimize the join order (removed FORCE_JOIN_ORDER)so interleaved Observation reads execute locally.
  - Update the query-builder golden SQL.

  ## Performance

  For the Earth/Country workload:

  - Elapsed time decreased from 64.87s to 4.16s—a 93.6% reduction, or approximately 15.6x faster.
  - Total rows scanned decreased from 5,221,675 to 35,338.
  - Observation rows scanned decreased from 5,203,574 to 17,163.
  - Remote server calls decreased from 40,220 to 23,388.
  - The correlated forced-order and final unforced-order queries returned the same 17,163 rows using the same optimizer version and statistics package.

  ## API impact

  This optimizes V2/V3 Observation API requests using a contained-in-place entity expression with `LATEST` on the multi-entity Spanner path. The response contract and output shape are unchanged.

  ## Testing

  - Query-builder golden test
  - Spanner package tests
  - GolangCI lint