### PR TITLE
Fix: UnrollParameters false-matching "JOIN UNNEST" as "IN UNNEST"

### DIFF
--- a/internal/server/spanner/golden/query_builder/get_multientity_obs_basic.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_obs_basic.sql
@@ -1,7 +1,7 @@
 		WITH params AS (
 			SELECT var, ent
 			FROM UNNEST(['AirPollutant_Cancer_Risk']) AS var
-			CROSS JOIN ('geoId/01001','geoId/02013') AS ent
+			CROSS JOIN UNNEST(['geoId/01001','geoId/02013']) AS ent
 		)
 		SELECT
 			t.variable_measured,

--- a/internal/server/spanner/golden/query_builder/get_multientity_obs_date.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_obs_date.sql
@@ -2,7 +2,7 @@
 		WITH params AS (
 			SELECT var, ent
 			FROM UNNEST(['AirPollutant_Cancer_Risk']) AS var
-			CROSS JOIN ('geoId/01001','geoId/02013') AS ent
+			CROSS JOIN UNNEST(['geoId/01001','geoId/02013']) AS ent
 		),
 		series AS (
 			SELECT

--- a/internal/server/spanner/golden/query_builder/get_multientity_obs_latest.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_obs_latest.sql
@@ -1,7 +1,7 @@
 		WITH params AS (
 			SELECT var, ent
 			FROM UNNEST(['AirPollutant_Cancer_Risk']) AS var
-			CROSS JOIN ('geoId/01001','geoId/02013') AS ent
+			CROSS JOIN UNNEST(['geoId/01001','geoId/02013']) AS ent
 		)
 		SELECT
 			t.variable_measured,

--- a/internal/server/spanner/sql_util.go
+++ b/internal/server/spanner/sql_util.go
@@ -19,24 +19,45 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"sync"
+	"unicode"
 
 	cloudSpanner "cloud.google.com/go/spanner"
 )
 
-// inUnnestRegex returns a regex that matches "IN UNNEST(@paramKey)" where IN
-// is a standalone SQL keyword (preceded by whitespace or start-of-line),
+// notInPrefixRegex matches a leading NOT keyword within a regex match.
+var notInPrefixRegex = regexp.MustCompile(`(?i)(?:^|\s)NOT\s+IN`)
+
+// inUnnestRegexCache caches compiled regexes by param key to avoid
+// recompiling on every query execution.
+var inUnnestRegexCache sync.Map
+
+// inUnnestRegex returns a regex that matches "IN UNNEST(@paramKey)" or
+// "NOT IN UNNEST(@paramKey)" where IN is a standalone SQL keyword
+// (preceded by whitespace or start-of-line, optionally preceded by NOT),
 // preventing false matches with "JOIN UNNEST(@paramKey)" where JOIN ends with IN.
+// Compiled regexes are cached since the set of param keys is small and reused.
 func inUnnestRegex(paramKey string) *regexp.Regexp {
-	return regexp.MustCompile(`(?i)(^|\s)IN\s+UNNEST\(@` + regexp.QuoteMeta(paramKey) + `\)`)
+	if cached, ok := inUnnestRegexCache.Load(paramKey); ok {
+		return cached.(*regexp.Regexp)
+	}
+	compiled := regexp.MustCompile(`(?i)(^|\s)(?:NOT\s+)?IN\s+UNNEST\(@` + regexp.QuoteMeta(paramKey) + `\)`)
+	actual, _ := inUnnestRegexCache.LoadOrStore(paramKey, compiled)
+	return actual.(*regexp.Regexp)
 }
 
 // extractLeadingSpace returns the leading whitespace character from a regex
 // match, or empty string if the match starts at the beginning of the string.
 func extractLeadingSpace(match string) string {
-	if len(match) > 0 && (match[0] == ' ' || match[0] == '\t' || match[0] == '\n') {
+	if len(match) > 0 && unicode.IsSpace(rune(match[0])) {
 		return string(match[0])
 	}
 	return ""
+}
+
+// hasNotPrefix returns true if the regex match includes a preceding NOT keyword.
+func hasNotPrefix(match string) bool {
+	return notInPrefixRegex.MatchString(match)
 }
 
 // quoteSQLString returns a SQL-escaped string literal.
@@ -85,12 +106,15 @@ func InterpolateSQL(stmt *cloudSpanner.Statement) string {
 				quotedValues = append(quotedValues, quoteSQLString(s))
 			}
 			parenthesized := "(" + strings.Join(quotedValues, ",") + ")"
-			// Replace "IN UNNEST(@key)" with "IN (...)" using word-boundary matching.
+			// Replace "IN UNNEST(@key)" (or "NOT IN UNNEST(@key)") using word-boundary matching.
 			sqlString = inUnnestRegex(key).ReplaceAllStringFunc(sqlString, func(match string) string {
-				return extractLeadingSpace(match) + "IN " + parenthesized
+				prefix := "IN "
+				if hasNotPrefix(match) {
+					prefix = "NOT IN "
+				}
+				return extractLeadingSpace(match) + prefix + parenthesized
 			})
 			// For remaining @key references (e.g. FROM UNNEST(@key)), use array literal.
-			placeholder = "@" + key
 			formattedValue = "[" + strings.Join(quotedValues, ",") + "]"
 		case []float64:
 			var stringValues []string
@@ -133,15 +157,21 @@ func UnrollParameters(stmt *cloudSpanner.Statement) {
 		if l == 0 || l > UnrollArrayParamsMaxLength {
 			continue
 		}
-		// Use regex to match "IN UNNEST(@key)" where IN is a standalone keyword.
-		// This prevents false matches like "JOIN UNNEST(@key)" where JOIN ends with IN.
+		// Use regex to match "IN UNNEST(@key)" (or "NOT IN UNNEST(@key)") where
+		// IN is a standalone keyword. This prevents false matches like
+		// "JOIN UNNEST(@key)" where JOIN ends with IN.
 		regex := inUnnestRegex(key)
 		stmt.SQL = regex.ReplaceAllStringFunc(stmt.SQL, func(match string) string {
 			leadingSpace := extractLeadingSpace(match)
+			notPrefix := hasNotPrefix(match)
 			if l == 1 {
-				newName := fmt.Sprintf("%s_0", key)
+				newName := key + "_0"
 				newParams[newName] = v[0]
-				return leadingSpace + "= @" + newName
+				eqOp := "="
+				if notPrefix {
+					eqOp = "!="
+				}
+				return leadingSpace + eqOp + " @" + newName
 			}
 			var paramNames []string
 			for i, val := range v {
@@ -149,7 +179,11 @@ func UnrollParameters(stmt *cloudSpanner.Statement) {
 				paramNames = append(paramNames, "@"+newName)
 				newParams[newName] = val
 			}
-			return leadingSpace + "IN (" + strings.Join(paramNames, ",") + ")"
+			inPrefix := "IN ("
+			if notPrefix {
+				inPrefix = "NOT IN ("
+			}
+			return leadingSpace + inPrefix + strings.Join(paramNames, ",") + ")"
 		})
 	}
 	stmt.Params = newParams

--- a/internal/server/spanner/sql_util.go
+++ b/internal/server/spanner/sql_util.go
@@ -20,7 +20,6 @@ import (
 	"sort"
 	"strings"
 	"sync"
-	"unicode"
 
 	cloudSpanner "cloud.google.com/go/spanner"
 )
@@ -49,8 +48,11 @@ func inUnnestRegex(paramKey string) *regexp.Regexp {
 // extractLeadingSpace returns the leading whitespace character from a regex
 // match, or empty string if the match starts at the beginning of the string.
 func extractLeadingSpace(match string) string {
-	if len(match) > 0 && unicode.IsSpace(rune(match[0])) {
-		return string(match[0])
+	if len(match) > 0 {
+		switch match[0] {
+		case ' ', '\t', '\n', '\v', '\f', '\r':
+			return string(match[0])
+		}
 	}
 	return ""
 }

--- a/internal/server/spanner/sql_util.go
+++ b/internal/server/spanner/sql_util.go
@@ -16,10 +16,33 @@ package spanner
 
 import (
 	"fmt"
+	"regexp"
+	"sort"
 	"strings"
 
 	cloudSpanner "cloud.google.com/go/spanner"
 )
+
+// inUnnestRegex returns a regex that matches "IN UNNEST(@paramKey)" where IN
+// is a standalone SQL keyword (preceded by whitespace or start-of-line),
+// preventing false matches with "JOIN UNNEST(@paramKey)" where JOIN ends with IN.
+func inUnnestRegex(paramKey string) *regexp.Regexp {
+	return regexp.MustCompile(`(?i)(^|\s)IN\s+UNNEST\(@` + regexp.QuoteMeta(paramKey) + `\)`)
+}
+
+// extractLeadingSpace returns the leading whitespace character from a regex
+// match, or empty string if the match starts at the beginning of the string.
+func extractLeadingSpace(match string) string {
+	if len(match) > 0 && (match[0] == ' ' || match[0] == '\t' || match[0] == '\n') {
+		return string(match[0])
+	}
+	return ""
+}
+
+// quoteSQLString returns a SQL-escaped string literal.
+func quoteSQLString(s string) string {
+	return fmt.Sprintf("'%s'", strings.ReplaceAll(s, "'", "''"))
+}
 
 // InterpolateSQL replaces params with values in SQL.
 // This is primarily used for debugging and testing to see the final query.
@@ -37,18 +60,15 @@ func InterpolateSQL(stmt *cloudSpanner.Statement) string {
 
 	sqlString := stmtCopy.SQL
 
-	// Sort keys by length descending to prevent replacing substrings (e.g. @param before @param_0)
+	// Sort keys by length descending to prevent replacing substrings
+	// (e.g. @param before @param_0).
 	var keys []string
 	for k := range stmtCopy.Params {
 		keys = append(keys, k)
 	}
-	for i := 0; i < len(keys); i++ {
-		for j := i + 1; j < len(keys); j++ {
-			if len(keys[i]) < len(keys[j]) {
-				keys[i], keys[j] = keys[j], keys[i]
-			}
-		}
-	}
+	sort.Slice(keys, func(i, j int) bool {
+		return len(keys[i]) > len(keys[j])
+	})
 
 	for _, key := range keys {
 		value := stmtCopy.Params[key]
@@ -57,18 +77,20 @@ func InterpolateSQL(stmt *cloudSpanner.Statement) string {
 
 		switch v := value.(type) {
 		case string:
-			formattedValue = fmt.Sprintf("'%s'", strings.ReplaceAll(v, "'", "''"))
+			formattedValue = quoteSQLString(v)
 		case []string:
-			// For UNNEST, represent the array as a comma-separated list
-			// enclosed in parentheses or brackets for clarity.
+			// For IN UNNEST(@key), represent the array as a parenthesized list.
 			var quotedValues []string
 			for _, s := range v {
-				quotedValues = append(quotedValues, fmt.Sprintf("'%s'", strings.ReplaceAll(s, "'", "''")))
+				quotedValues = append(quotedValues, quoteSQLString(s))
 			}
-			formattedValue = "(" + strings.Join(quotedValues, ",") + ")"
-			// Need to handle both UNNEST(@key) and @key
-			sqlString = strings.ReplaceAll(sqlString, "IN UNNEST("+placeholder+")", "IN "+formattedValue)
-			placeholder = "@" + key // Ensure we don't mess up UNNEST replacement
+			parenthesized := "(" + strings.Join(quotedValues, ",") + ")"
+			// Replace "IN UNNEST(@key)" with "IN (...)" using word-boundary matching.
+			sqlString = inUnnestRegex(key).ReplaceAllStringFunc(sqlString, func(match string) string {
+				return extractLeadingSpace(match) + "IN " + parenthesized
+			})
+			// For remaining @key references (e.g. FROM UNNEST(@key)), use array literal.
+			placeholder = "@" + key
 			formattedValue = "[" + strings.Join(quotedValues, ",") + "]"
 		case []float64:
 			var stringValues []string
@@ -76,9 +98,7 @@ func InterpolateSQL(stmt *cloudSpanner.Statement) string {
 				stringValues = append(stringValues, fmt.Sprintf("%v", f))
 			}
 			formattedValue = "[" + strings.Join(stringValues, ",") + "]"
-		// ... add more cases for int64, float64, bool, etc.
 		default:
-			// Catch-all for other types
 			formattedValue = fmt.Sprintf("%v", v)
 		}
 		sqlString = strings.ReplaceAll(sqlString, placeholder, formattedValue)
@@ -90,9 +110,10 @@ func InterpolateSQL(stmt *cloudSpanner.Statement) string {
 const UnrollArrayParamsMaxLength = 10
 
 // UnrollParameters modifies the given Spanner statement to unroll array parameters
-// of length <= UnrollArrayParamsMaxLength. It replaces "IN UNNEST(@param)" with "IN (@param_0, @param_1, ...)"
-// (or "= @param_0" if length is 1) and populates the params map with the individual values.
-// The original array parameter is kept in case it is referenced elsewhere in the query (e.g. UNNEST(@param) without IN).
+// of length <= UnrollArrayParamsMaxLength. It replaces "IN UNNEST(@param)" with
+// "IN (@param_0, @param_1, ...)" (or "= @param_0" if length is 1) and populates
+// the params map with the individual values. The original array parameter is kept
+// in case it is referenced elsewhere in the query (e.g. UNNEST(@param) without IN).
 func UnrollParameters(stmt *cloudSpanner.Statement) {
 	if stmt.Params == nil {
 		return
@@ -104,29 +125,32 @@ func UnrollParameters(stmt *cloudSpanner.Statement) {
 	}
 
 	for key, value := range stmt.Params {
-		switch v := value.(type) {
-		case []string:
-			l := len(v)
-			if l > 0 && l <= UnrollArrayParamsMaxLength {
-				placeholder := "IN UNNEST(@" + key + ")"
-				if strings.Contains(stmt.SQL, placeholder) {
-					if l == 1 {
-						newName := fmt.Sprintf("%s_0", key)
-						newParams[newName] = v[0]
-						stmt.SQL = strings.ReplaceAll(stmt.SQL, placeholder, "= @"+newName)
-					} else {
-						var paramNames []string
-						for i, val := range v {
-							newName := fmt.Sprintf("%s_%d", key, i)
-							paramNames = append(paramNames, "@"+newName)
-							newParams[newName] = val
-						}
-						replacement := "IN (" + strings.Join(paramNames, ",") + ")"
-						stmt.SQL = strings.ReplaceAll(stmt.SQL, placeholder, replacement)
-					}
-				}
-			}
+		v, ok := value.([]string)
+		if !ok {
+			continue
 		}
+		l := len(v)
+		if l == 0 || l > UnrollArrayParamsMaxLength {
+			continue
+		}
+		// Use regex to match "IN UNNEST(@key)" where IN is a standalone keyword.
+		// This prevents false matches like "JOIN UNNEST(@key)" where JOIN ends with IN.
+		regex := inUnnestRegex(key)
+		stmt.SQL = regex.ReplaceAllStringFunc(stmt.SQL, func(match string) string {
+			leadingSpace := extractLeadingSpace(match)
+			if l == 1 {
+				newName := fmt.Sprintf("%s_0", key)
+				newParams[newName] = v[0]
+				return leadingSpace + "= @" + newName
+			}
+			var paramNames []string
+			for i, val := range v {
+				newName := fmt.Sprintf("%s_%d", key, i)
+				paramNames = append(paramNames, "@"+newName)
+				newParams[newName] = val
+			}
+			return leadingSpace + "IN (" + strings.Join(paramNames, ",") + ")"
+		})
 	}
 	stmt.Params = newParams
 }

--- a/internal/server/spanner/sql_util_test.go
+++ b/internal/server/spanner/sql_util_test.go
@@ -1,0 +1,312 @@
+package spanner
+
+import (
+	"strings"
+	"testing"
+
+	cloudSpanner "cloud.google.com/go/spanner"
+)
+
+func TestUnrollParameters(t *testing.T) {
+	tests := []struct {
+		name    string
+		sql     string
+		params  map[string]interface{}
+		wantSQL string
+		wantNew map[string]interface{} // new params that should be added (subset check)
+	}{
+		// --- IN UNNEST cases ---
+		{
+			name:    "IN UNNEST single element -> equality",
+			sql:     "WHERE x IN UNNEST(@vals)",
+			params:  map[string]interface{}{"vals": []string{"a"}},
+			wantSQL: "WHERE x = @vals_0",
+			wantNew: map[string]interface{}{"vals_0": "a"},
+		},
+		{
+			name:    "IN UNNEST multiple elements -> IN list",
+			sql:     "WHERE x IN UNNEST(@vals)",
+			params:  map[string]interface{}{"vals": []string{"a", "b"}},
+			wantSQL: "WHERE x IN (@vals_0,@vals_1)",
+			wantNew: map[string]interface{}{"vals_0": "a", "vals_1": "b"},
+		},
+		{
+			name:    "IN UNNEST at start of string",
+			sql:     "IN UNNEST(@vals) AS x",
+			params:  map[string]interface{}{"vals": []string{"a", "b"}},
+			wantSQL: "IN (@vals_0,@vals_1) AS x",
+			wantNew: map[string]interface{}{"vals_0": "a", "vals_1": "b"},
+		},
+		{
+			name:    "JOIN UNNEST should NOT be unrolled",
+			sql:     "CROSS JOIN UNNEST(@vals) AS ent",
+			params:  map[string]interface{}{"vals": []string{"a", "b"}},
+			wantSQL: "CROSS JOIN UNNEST(@vals) AS ent",
+			wantNew: map[string]interface{}{},
+		},
+		{
+			name:    "JOIN UNNEST single element should NOT be unrolled",
+			sql:     "CROSS JOIN UNNEST(@vals) AS ent",
+			params:  map[string]interface{}{"vals": []string{"a"}},
+			wantSQL: "CROSS JOIN UNNEST(@vals) AS ent",
+			wantNew: map[string]interface{}{},
+		},
+		{
+			name:    "FROM UNNEST should NOT be unrolled",
+			sql:     "FROM UNNEST(@vals) AS var",
+			params:  map[string]interface{}{"vals": []string{"a", "b"}},
+			wantSQL: "FROM UNNEST(@vals) AS var",
+			wantNew: map[string]interface{}{},
+		},
+		{
+			name:    "ON ... IN UNNEST (ON prefix should not match)",
+			sql:     "ON t.var IN UNNEST(@vals)",
+			params:  map[string]interface{}{"vals": []string{"a", "b"}},
+			wantSQL: "ON t.var IN (@vals_0,@vals_1)",
+			wantNew: map[string]interface{}{"vals_0": "a", "vals_1": "b"},
+		},
+		{
+			name:    "AND ... IN UNNEST",
+			sql:     "AND x IN UNNEST(@vals)",
+			params:  map[string]interface{}{"vals": []string{"a", "b"}},
+			wantSQL: "AND x IN (@vals_0,@vals_1)",
+			wantNew: map[string]interface{}{"vals_0": "a", "vals_1": "b"},
+		},
+		{
+			name:    "WHERE ... IN UNNEST",
+			sql:     "WHERE x IN UNNEST(@vals)",
+			params:  map[string]interface{}{"vals": []string{"a", "b"}},
+			wantSQL: "WHERE x IN (@vals_0,@vals_1)",
+			wantNew: map[string]interface{}{"vals_0": "a", "vals_1": "b"},
+		},
+		{
+			name:    "Multiple IN UNNEST with same param",
+			sql:     "WHERE x IN UNNEST(@vals) AND y IN UNNEST(@vals)",
+			params:  map[string]interface{}{"vals": []string{"a", "b"}},
+			wantSQL: "WHERE x IN (@vals_0,@vals_1) AND y IN (@vals_0,@vals_1)",
+			wantNew: map[string]interface{}{"vals_0": "a", "vals_1": "b"},
+		},
+		{
+			name:    "Multiple IN UNNEST with different params",
+			sql:     "WHERE x IN UNNEST(@vars) AND y IN UNNEST(@ents)",
+			params:  map[string]interface{}{"vars": []string{"a"}, "ents": []string{"b", "c"}},
+			wantSQL: "WHERE x = @vars_0 AND y IN (@ents_0,@ents_1)",
+			wantNew: map[string]interface{}{"vars_0": "a", "ents_0": "b", "ents_1": "c"},
+		},
+		{
+			name:    "Mixed: IN UNNEST and JOIN UNNEST with same param",
+			sql:     "CROSS JOIN UNNEST(@vals) AS ent WHERE x IN UNNEST(@vals)",
+			params:  map[string]interface{}{"vals": []string{"a", "b"}},
+			wantSQL: "CROSS JOIN UNNEST(@vals) AS ent WHERE x IN (@vals_0,@vals_1)",
+			wantNew: map[string]interface{}{"vals_0": "a", "vals_1": "b"},
+		},
+		// --- NOT IN UNNEST cases ---
+		{
+			name:    "NOT IN UNNEST single element -> !=",
+			sql:     "WHERE x NOT IN UNNEST(@vals)",
+			params:  map[string]interface{}{"vals": []string{"a"}},
+			wantSQL: "WHERE x != @vals_0",
+			wantNew: map[string]interface{}{"vals_0": "a"},
+		},
+		{
+			name:    "NOT IN UNNEST multiple elements -> NOT IN list",
+			sql:     "WHERE x NOT IN UNNEST(@vals)",
+			params:  map[string]interface{}{"vals": []string{"a", "b"}},
+			wantSQL: "WHERE x NOT IN (@vals_0,@vals_1)",
+			wantNew: map[string]interface{}{"vals_0": "a", "vals_1": "b"},
+		},
+		{
+			name:    "NOT IN UNNEST at start of string",
+			sql:     "NOT IN UNNEST(@vals)",
+			params:  map[string]interface{}{"vals": []string{"a", "b"}},
+			wantSQL: "NOT IN (@vals_0,@vals_1)",
+			wantNew: map[string]interface{}{"vals_0": "a", "vals_1": "b"},
+		},
+		{
+			name:    "AND NOT IN UNNEST single element",
+			sql:     "AND x NOT IN UNNEST(@vals)",
+			params:  map[string]interface{}{"vals": []string{"a"}},
+			wantSQL: "AND x != @vals_0",
+			wantNew: map[string]interface{}{"vals_0": "a"},
+		},
+		// --- Case insensitivity ---
+		{
+			name:    "lowercase in unnest",
+			sql:     "WHERE x in unnest(@vals)",
+			params:  map[string]interface{}{"vals": []string{"a", "b"}},
+			wantSQL: "WHERE x IN (@vals_0,@vals_1)",
+			wantNew: map[string]interface{}{"vals_0": "a", "vals_1": "b"},
+		},
+		{
+			name:    "mixed case NOT IN UNNEST",
+			sql:     "WHERE x Not In UNNEST(@vals)",
+			params:  map[string]interface{}{"vals": []string{"a"}},
+			wantSQL: "WHERE x != @vals_0",
+			wantNew: map[string]interface{}{"vals_0": "a"},
+		},
+		// --- Edge cases ---
+		{
+			name:    "Empty array should not be unrolled",
+			sql:     "WHERE x IN UNNEST(@vals)",
+			params:  map[string]interface{}{"vals": []string{}},
+			wantSQL: "WHERE x IN UNNEST(@vals)",
+			wantNew: map[string]interface{}{},
+		},
+		{
+			name:    "Array > 10 should not be unrolled",
+			sql:     "WHERE x IN UNNEST(@vals)",
+			params:  map[string]interface{}{"vals": []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"}},
+			wantSQL: "WHERE x IN UNNEST(@vals)",
+			wantNew: map[string]interface{}{},
+		},
+		{
+			name:    "Exactly 10 elements should be unrolled",
+			sql:     "WHERE x IN UNNEST(@vals)",
+			params:  map[string]interface{}{"vals": []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"}},
+			wantSQL: "WHERE x IN (@vals_0,@vals_1,@vals_2,@vals_3,@vals_4,@vals_5,@vals_6,@vals_7,@vals_8,@vals_9)",
+			wantNew: map[string]interface{}{"vals_0": "a", "vals_9": "j"},
+		},
+		{
+			name:    "Non-string array param should not be unrolled",
+			sql:     "WHERE x IN UNNEST(@vals)",
+			params:  map[string]interface{}{"vals": []float64{1.0, 2.0}},
+			wantSQL: "WHERE x IN UNNEST(@vals)",
+			wantNew: map[string]interface{}{},
+		},
+		{
+			name:    "No UNNEST in SQL should be a no-op",
+			sql:     "SELECT * FROM Foo WHERE x = @val",
+			params:  map[string]interface{}{"val": "test", "vals": []string{"a", "b"}},
+			wantSQL: "SELECT * FROM Foo WHERE x = @val",
+			wantNew: map[string]interface{}{},
+		},
+		{
+			name:    "Param key with special regex chars should be safe",
+			sql:     "WHERE x IN UNNEST(@val.1)",
+			params:  map[string]interface{}{"val.1": []string{"a", "b"}},
+			wantSQL: "WHERE x IN (@val.1_0,@val.1_1)",
+			wantNew: map[string]interface{}{"val.1_0": "a", "val.1_1": "b"},
+		},
+		{
+			name:    "Newline-separated IN UNNEST",
+			sql:     "WHERE\nx\nIN UNNEST(@vals)",
+			params:  map[string]interface{}{"vals": []string{"a", "b"}},
+			wantSQL: "WHERE\nx\nIN (@vals_0,@vals_1)",
+			wantNew: map[string]interface{}{"vals_0": "a", "vals_1": "b"},
+		},
+		{
+			name:    "Tab-separated IN UNNEST",
+			sql:     "WHERE\tx\tIN UNNEST(@vals)",
+			params:  map[string]interface{}{"vals": []string{"a", "b"}},
+			wantSQL: "WHERE\tx\tIN (@vals_0,@vals_1)",
+			wantNew: map[string]interface{}{"vals_0": "a", "vals_1": "b"},
+		},
+		{
+			name:    "Original param still present after unrolling",
+			sql:     "WHERE x IN UNNEST(@vals)",
+			params:  map[string]interface{}{"vals": []string{"a", "b"}},
+			wantSQL: "WHERE x IN (@vals_0,@vals_1)",
+			wantNew: map[string]interface{}{"vals": []string{"a", "b"}, "vals_0": "a", "vals_1": "b"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stmt := &cloudSpanner.Statement{
+				SQL:    tc.sql,
+				Params: tc.params,
+			}
+			UnrollParameters(stmt)
+
+			if stmt.SQL != tc.wantSQL {
+				t.Errorf("SQL mismatch:\n  got:  %q\n  want: %q", stmt.SQL, tc.wantSQL)
+			}
+
+			// Verify expected new params exist
+			for k, v := range tc.wantNew {
+				got, ok := stmt.Params[k]
+				if !ok {
+					t.Errorf("missing param %q in result params: %v", k, stmt.Params)
+					continue
+				}
+				// For []string comparison, use reflect.DeepEqual via fmt
+				gotStr := toString(got)
+				wantStr := toString(v)
+				if gotStr != wantStr {
+					t.Errorf("param %q mismatch:\n  got:  %v\n  want: %v", k, got, v)
+				}
+			}
+		})
+	}
+}
+
+func TestInterpolateSQL(t *testing.T) {
+	tests := []struct {
+		name   string
+		sql    string
+		params map[string]interface{}
+		want   string
+	}{
+		{
+			name:   "JOIN UNNEST preserved with IN UNNEST unrolled",
+			sql:    "FROM UNNEST(@vars) AS var CROSS JOIN UNNEST(@ents) AS ent WHERE x IN UNNEST(@ents)",
+			params: map[string]interface{}{"vars": []string{"v1"}, "ents": []string{"e1", "e2"}},
+			want:   "FROM UNNEST(['v1']) AS var CROSS JOIN UNNEST(['e1','e2']) AS ent WHERE x IN ('e1','e2')",
+		},
+		{
+			name:   "NOT IN UNNEST single element",
+			sql:    "WHERE x NOT IN UNNEST(@vals)",
+			params: map[string]interface{}{"vals": []string{"a"}},
+			want:   "WHERE x != 'a'",
+		},
+		{
+			name:   "NOT IN UNNEST multiple elements",
+			sql:    "WHERE x NOT IN UNNEST(@vals)",
+			params: map[string]interface{}{"vals": []string{"a", "b"}},
+			want:   "WHERE x NOT IN ('a','b')",
+		},
+		{
+			name:   "JOIN UNNEST with single element (should keep UNNEST)",
+			sql:    "CROSS JOIN UNNEST(@ents) AS ent",
+			params: map[string]interface{}{"ents": []string{"e1"}},
+			want:   "CROSS JOIN UNNEST(['e1']) AS ent",
+		},
+		{
+			name:   "String with single quote escaped",
+			sql:    "WHERE x IN UNNEST(@vals)",
+			params: map[string]interface{}{"vals": []string{"it's"}},
+			want:   "WHERE x = 'it''s'",
+		},
+		{
+			name:   "Mixed JOIN UNNEST + NOT IN UNNEST + IN UNNEST",
+			sql:    "CROSS JOIN UNNEST(@ents) AS ent WHERE x IN UNNEST(@vars) AND y NOT IN UNNEST(@vars)",
+			params: map[string]interface{}{"ents": []string{"e1", "e2"}, "vars": []string{"v1", "v2"}},
+			want:   "CROSS JOIN UNNEST(['e1','e2']) AS ent WHERE x IN ('v1','v2') AND y NOT IN ('v1','v2')",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stmt := &cloudSpanner.Statement{
+				SQL:    tc.sql,
+				Params: tc.params,
+			}
+			got := InterpolateSQL(stmt)
+			if got != tc.want {
+				t.Errorf("SQL mismatch:\n  got:  %q\n  want: %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// toString is a helper for comparing param values that may be string or []string.
+func toString(v interface{}) string {
+	switch val := v.(type) {
+	case string:
+		return val
+	case []string:
+		return strings.Join(val, ",")
+	default:
+		return ""
+	}
+}


### PR DESCRIPTION
Issue: The UnrollParameters function (introduced in #1993) used strings.Contains to find IN UNNEST(@param) patterns in SQL. However, the SQL keyword JOIN ends with the letters IN, so JOIN UNNEST(@entities) contains the substring IN UNNEST(@entities)‚ causing a false match.

Fix: Explicitly check for "IN" with whitespace via regex matching. Also handle cases like NOT IN UNNEST -> != for single parameters (this isn't used anywhere yet, but just to be safe) 

Also add unit tests for various parameter situations

