### PR TITLE
[featureflags] Enable UseSpannerKeyValueStore in staging

### DIFF
--- a/deploy/featureflags/staging.yaml
+++ b/deploy/featureflags/staging.yaml
@@ -8,3 +8,4 @@ flags:
   SpannerGraphDatabase: projects/datcom-store/instances/dc-graph-staging/databases/dc_graph
   EnableSpannerSearchEmbeddings: false
   UseMultiEntitySchema: true
+  UseSpannerKeyValueStore: true

--- a/deploy/featureflags/staging_website.yaml
+++ b/deploy/featureflags/staging_website.yaml
@@ -9,3 +9,4 @@ flags:
   SpannerGraphDatabase: projects/datcom-store/instances/dc-graph-staging/databases/dc_graph
   EnableSpannerSearchEmbeddings: false
   UseMultiEntitySchema: true
+  UseSpannerKeyValueStore: true


### PR DESCRIPTION
This enables the `UseSpannerKeyValueStore` feature flag in mixer staging and website-mixer staging environments following PR #1992 and PR #2003.