### PR TITLE
temporarily disabling the v3 mirror

### DIFF
--- a/deploy/featureflags/prod.yaml
+++ b/deploy/featureflags/prod.yaml
@@ -3,7 +3,7 @@ clusters:
 liveUrl: https://api.datacommons.org
 flags:
   EnableV3: true
-  V3MirrorFraction: 0.8
+  V3MirrorFraction: 0.0
   WriteUsageLogs: 1.0
   UseSpannerGraph: true
   SpannerGraphDatabase: dc_graph_2026_01_27

--- a/deploy/featureflags/prod_website.yaml
+++ b/deploy/featureflags/prod_website.yaml
@@ -5,7 +5,7 @@ clusters:
 liveUrl: https://datacommons.org
 flags:
   EnableV3: true
-  V3MirrorFraction: 0.8
+  V3MirrorFraction: 0.0
   WriteUsageLogs: 1.0
   UseSpannerGraph: true
   SpannerGraphDatabase: dc_graph_2026_01_27


### PR DESCRIPTION
Doing a latency test for NL server with spanner embeddings on vector search, needs to avoid the v3 mirror impact for multiple instance of search