### PR TITLE
Optimize multi-entity contained-in-place queries for large stat variable lists

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -209,10 +209,11 @@ func main() {
 	if shouldUseSpannerGraph {
 		var err error
 		spannerClient, err = spanner.NewSpannerClient(ctx, *spannerGraphInfo, &spanner.SpannerClientOptions{
-			DatabaseOverride:             flags.SpannerGraphDatabase,
-			UseMultiEntitySchema:         flags.UseMultiEntitySchema,
-			UseNewIngestionHistorySchema: flags.UseNewIngestionHistorySchema,
-			UseSpannerKeyValueStore:      flags.UseSpannerKeyValueStore,
+			DatabaseOverride:                   flags.SpannerGraphDatabase,
+			UseMultiEntitySchema:               flags.UseMultiEntitySchema,
+			UseNewIngestionHistorySchema:       flags.UseNewIngestionHistorySchema,
+			UseSpannerKeyValueStore:            flags.UseSpannerKeyValueStore,
+			ContainedInPlaceAncestorFirstTypes: flags.ContainedInPlaceAncestorFirstTypes,
 		})
 		if err != nil {
 			slog.Error("Failed to create Spanner client", "error", err)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -209,11 +209,14 @@ func main() {
 	if shouldUseSpannerGraph {
 		var err error
 		spannerClient, err = spanner.NewSpannerClient(ctx, *spannerGraphInfo, &spanner.SpannerClientOptions{
-			DatabaseOverride:                   flags.SpannerGraphDatabase,
-			UseMultiEntitySchema:               flags.UseMultiEntitySchema,
-			UseNewIngestionHistorySchema:       flags.UseNewIngestionHistorySchema,
-			UseSpannerKeyValueStore:            flags.UseSpannerKeyValueStore,
-			ContainedInPlaceAncestorFirstTypes: flags.ContainedInPlaceAncestorFirstTypes,
+			DatabaseOverride:             flags.SpannerGraphDatabase,
+			UseMultiEntitySchema:         flags.UseMultiEntitySchema,
+			UseNewIngestionHistorySchema: flags.UseNewIngestionHistorySchema,
+			UseSpannerKeyValueStore:      flags.UseSpannerKeyValueStore,
+			MultiEntityQueryConfig: spanner.MultiEntityQueryConfig{
+				ContainedInPlaceAncestorFirstTypes:     flags.ContainedInPlaceAncestorFirstTypes,
+				ContainedInPlaceEntityScanMinVariables: flags.ContainedInPlaceEntityScanMinVariables,
+			},
 		})
 		if err != nil {
 			slog.Error("Failed to create Spanner client", "error", err)

--- a/internal/featureflags/featureflags.go
+++ b/internal/featureflags/featureflags.go
@@ -58,25 +58,28 @@ type Flags struct {
 	UseNewIngestionHistorySchema bool `yaml:"UseNewIngestionHistorySchema"`
 	// Whether to read from KeyValueStore table instead of Cache table in Spanner.
 	UseSpannerKeyValueStore bool `yaml:"UseSpannerKeyValueStore"`
+	// Child place types whose core contained-in-place observation queries should filter by ancestor before type.
+	ContainedInPlaceAncestorFirstTypes []string `yaml:"ContainedInPlaceAncestorFirstTypes"`
 }
 
 // setDefaultValues creates a new Flags struct with default values.
 func setDefaultValues() *Flags {
 	return &Flags{
-		EnableV3:                      false,
-		V3MirrorFraction:              0.0,
-		UseSpannerGraph:               false,
-		UseMultiEntitySchema:          false,
-		SpannerGraphDatabase:          "",
-		UseStaleReads:                 false,
-		EnableEmbeddingsResolver:      true,
-		V2DivertFraction:              0.0,
-		UseStatisticalCalculation:     false,
-		EnableSDMXDataApi:             false,
-		SDMXRemotePlaceExpansionLimit: 10000,
-		EnableSpannerSearchEmbeddings: false,
-		UseNewIngestionHistorySchema:  false,
-		UseSpannerKeyValueStore:       false,
+		EnableV3:                           false,
+		V3MirrorFraction:                   0.0,
+		UseSpannerGraph:                    false,
+		UseMultiEntitySchema:               false,
+		SpannerGraphDatabase:               "",
+		UseStaleReads:                      false,
+		EnableEmbeddingsResolver:           true,
+		V2DivertFraction:                   0.0,
+		UseStatisticalCalculation:          false,
+		EnableSDMXDataApi:                  false,
+		SDMXRemotePlaceExpansionLimit:      10000,
+		EnableSpannerSearchEmbeddings:      false,
+		UseNewIngestionHistorySchema:       false,
+		UseSpannerKeyValueStore:            false,
+		ContainedInPlaceAncestorFirstTypes: []string{"Place"},
 	}
 }
 
@@ -113,6 +116,11 @@ func (f *Flags) validateFlagValues() error {
 	}
 	if f.SDMXRemotePlaceExpansionLimit <= 0 {
 		return fmt.Errorf("SDMXRemotePlaceExpansionLimit must be positive")
+	}
+	for _, placeType := range f.ContainedInPlaceAncestorFirstTypes {
+		if strings.TrimSpace(placeType) == "" {
+			return fmt.Errorf("ContainedInPlaceAncestorFirstTypes must not contain empty values")
+		}
 	}
 	return nil
 }

--- a/internal/featureflags/featureflags.go
+++ b/internal/featureflags/featureflags.go
@@ -60,26 +60,29 @@ type Flags struct {
 	UseSpannerKeyValueStore bool `yaml:"UseSpannerKeyValueStore"`
 	// Child place types whose core contained-in-place observation queries should filter by ancestor before type.
 	ContainedInPlaceAncestorFirstTypes []string `yaml:"ContainedInPlaceAncestorFirstTypes"`
+	// Minimum number of unique variables that selects an entity1 range scan for core contained-in-place observation queries. Zero disables the optimization.
+	ContainedInPlaceEntityScanMinVariables int `yaml:"ContainedInPlaceEntityScanMinVariables"`
 }
 
 // setDefaultValues creates a new Flags struct with default values.
 func setDefaultValues() *Flags {
 	return &Flags{
-		EnableV3:                           false,
-		V3MirrorFraction:                   0.0,
-		UseSpannerGraph:                    false,
-		UseMultiEntitySchema:               false,
-		SpannerGraphDatabase:               "",
-		UseStaleReads:                      false,
-		EnableEmbeddingsResolver:           true,
-		V2DivertFraction:                   0.0,
-		UseStatisticalCalculation:          false,
-		EnableSDMXDataApi:                  false,
-		SDMXRemotePlaceExpansionLimit:      10000,
-		EnableSpannerSearchEmbeddings:      false,
-		UseNewIngestionHistorySchema:       false,
-		UseSpannerKeyValueStore:            false,
-		ContainedInPlaceAncestorFirstTypes: []string{"Place"},
+		EnableV3:                               false,
+		V3MirrorFraction:                       0.0,
+		UseSpannerGraph:                        false,
+		UseMultiEntitySchema:                   false,
+		SpannerGraphDatabase:                   "",
+		UseStaleReads:                          false,
+		EnableEmbeddingsResolver:               true,
+		V2DivertFraction:                       0.0,
+		UseStatisticalCalculation:              false,
+		EnableSDMXDataApi:                      false,
+		SDMXRemotePlaceExpansionLimit:          10000,
+		EnableSpannerSearchEmbeddings:          false,
+		UseNewIngestionHistorySchema:           false,
+		UseSpannerKeyValueStore:                false,
+		ContainedInPlaceAncestorFirstTypes:     []string{"Place"},
+		ContainedInPlaceEntityScanMinVariables: 50,
 	}
 }
 
@@ -121,6 +124,9 @@ func (f *Flags) validateFlagValues() error {
 		if strings.TrimSpace(placeType) == "" {
 			return fmt.Errorf("ContainedInPlaceAncestorFirstTypes must not contain empty values")
 		}
+	}
+	if f.ContainedInPlaceEntityScanMinVariables < 0 {
+		return fmt.Errorf("ContainedInPlaceEntityScanMinVariables must be non-negative")
 	}
 	return nil
 }

--- a/internal/featureflags/featureflags_test.go
+++ b/internal/featureflags/featureflags_test.go
@@ -44,6 +44,12 @@ func TestDefaultSDMXRemotePlaceExpansionLimit(t *testing.T) {
 	}
 }
 
+func TestDefaultContainedInPlaceAncestorFirstTypes(t *testing.T) {
+	if diff := cmp.Diff([]string{"Place"}, setDefaultValues().ContainedInPlaceAncestorFirstTypes); diff != "" {
+		t.Fatalf("ContainedInPlaceAncestorFirstTypes mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestNewFlags(t *testing.T) {
 	testCases := []struct {
 		name        string
@@ -84,6 +90,39 @@ flags:
 				f.UseMultiEntitySchema = true
 			}),
 			wantErr: false,
+		},
+		{
+			name: "contained in place ancestor first types override",
+			fileContent: `
+flags:
+  ContainedInPlaceAncestorFirstTypes:
+    - County
+`,
+			want: expectedFlags(func(f *Flags) {
+				f.ContainedInPlaceAncestorFirstTypes = []string{"County"}
+			}),
+			wantErr: false,
+		},
+		{
+			name: "contained in place ancestor first types disabled",
+			fileContent: `
+flags:
+  ContainedInPlaceAncestorFirstTypes: []
+`,
+			want: expectedFlags(func(f *Flags) {
+				f.ContainedInPlaceAncestorFirstTypes = []string{}
+			}),
+			wantErr: false,
+		},
+		{
+			name: "validation error - empty contained in place ancestor first type",
+			fileContent: `
+flags:
+  ContainedInPlaceAncestorFirstTypes:
+    - " "
+`,
+			want:    nil,
+			wantErr: true,
 		},
 		{
 			name: "remote SDMX place expansion limit",

--- a/internal/featureflags/featureflags_test.go
+++ b/internal/featureflags/featureflags_test.go
@@ -50,6 +50,12 @@ func TestDefaultContainedInPlaceAncestorFirstTypes(t *testing.T) {
 	}
 }
 
+func TestDefaultContainedInPlaceEntityScanMinVariables(t *testing.T) {
+	if got, want := setDefaultValues().ContainedInPlaceEntityScanMinVariables, 50; got != want {
+		t.Fatalf("ContainedInPlaceEntityScanMinVariables = %d, want %d", got, want)
+	}
+}
+
 func TestNewFlags(t *testing.T) {
 	testCases := []struct {
 		name        string
@@ -120,6 +126,37 @@ flags:
 flags:
   ContainedInPlaceAncestorFirstTypes:
     - " "
+`,
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "contained in place entity scan threshold override",
+			fileContent: `
+flags:
+  ContainedInPlaceEntityScanMinVariables: 25
+`,
+			want: expectedFlags(func(f *Flags) {
+				f.ContainedInPlaceEntityScanMinVariables = 25
+			}),
+			wantErr: false,
+		},
+		{
+			name: "contained in place entity scan disabled",
+			fileContent: `
+flags:
+  ContainedInPlaceEntityScanMinVariables: 0
+`,
+			want: expectedFlags(func(f *Flags) {
+				f.ContainedInPlaceEntityScanMinVariables = 0
+			}),
+			wantErr: false,
+		},
+		{
+			name: "validation error - negative contained in place entity scan threshold",
+			fileContent: `
+flags:
+  ContainedInPlaceEntityScanMinVariables: -1
 `,
 			want:    nil,
 			wantErr: true,

--- a/internal/server/spanner/client.go
+++ b/internal/server/spanner/client.go
@@ -96,6 +96,7 @@ type spannerDatabaseClient struct {
 
 // MultiEntityQueryConfig controls query-planning behavior for the multi-entity schema.
 type MultiEntityQueryConfig struct {
+	// Child place types whose core contained-in-place observation queries should filter by ancestor before type.
 	ContainedInPlaceAncestorFirstTypes []string
 	// ContainedInPlaceEntityScanMinVariables is the minimum number of unique
 	// requested variables that selects the entity1 range-scan plan for core

--- a/internal/server/spanner/client.go
+++ b/internal/server/spanner/client.go
@@ -94,14 +94,23 @@ type spannerDatabaseClient struct {
 	dbInitialized atomic.Bool
 }
 
+// MultiEntityQueryConfig controls query-planning behavior for the multi-entity schema.
+type MultiEntityQueryConfig struct {
+	ContainedInPlaceAncestorFirstTypes []string
+	// ContainedInPlaceEntityScanMinVariables is the minimum number of unique
+	// requested variables that selects the entity1 range-scan plan for core
+	// contained-in-place queries. Zero disables the optimization.
+	ContainedInPlaceEntityScanMinVariables int
+}
+
 // SpannerClientOptions holds optional configuration settings and feature toggles for SpannerClient.
 type SpannerClientOptions struct {
-	DatabaseOverride                   string
-	UseMultiEntitySchema               bool
-	UseNewIngestionHistorySchema       bool
-	UseSpannerKeyValueStore            bool
-	ContainedInPlaceAncestorFirstTypes []string
-	SpannerEmulatorCompatibility       bool
+	DatabaseOverride             string
+	UseMultiEntitySchema         bool
+	UseNewIngestionHistorySchema bool
+	UseSpannerKeyValueStore      bool
+	MultiEntityQueryConfig       MultiEntityQueryConfig
+	SpannerEmulatorCompatibility bool
 }
 
 // newSpannerDatabaseClient creates a new spannerDatabaseClient.
@@ -200,7 +209,7 @@ func NewSpannerClient(ctx context.Context, spannerConfigYaml string, opts *Spann
 	}
 	tableCfg.spannerEmulatorCompatibility = opts.SpannerEmulatorCompatibility
 
-	return NewSchemaSelectorClient(rawClient, opts.UseMultiEntitySchema, tableCfg, opts.ContainedInPlaceAncestorFirstTypes)
+	return NewSchemaSelectorClient(rawClient, opts.UseMultiEntitySchema, tableCfg, opts.MultiEntityQueryConfig)
 }
 
 // createSpannerClient creates the database name string and initializes the Spanner client.

--- a/internal/server/spanner/client.go
+++ b/internal/server/spanner/client.go
@@ -96,11 +96,12 @@ type spannerDatabaseClient struct {
 
 // SpannerClientOptions holds optional configuration settings and feature toggles for SpannerClient.
 type SpannerClientOptions struct {
-	DatabaseOverride             string
-	UseMultiEntitySchema         bool
-	UseNewIngestionHistorySchema bool
-	UseSpannerKeyValueStore      bool
-	SpannerEmulatorCompatibility bool
+	DatabaseOverride                   string
+	UseMultiEntitySchema               bool
+	UseNewIngestionHistorySchema       bool
+	UseSpannerKeyValueStore            bool
+	ContainedInPlaceAncestorFirstTypes []string
+	SpannerEmulatorCompatibility       bool
 }
 
 // newSpannerDatabaseClient creates a new spannerDatabaseClient.
@@ -199,7 +200,7 @@ func NewSpannerClient(ctx context.Context, spannerConfigYaml string, opts *Spann
 	}
 	tableCfg.spannerEmulatorCompatibility = opts.SpannerEmulatorCompatibility
 
-	return NewSchemaSelectorClient(rawClient, opts.UseMultiEntitySchema, tableCfg)
+	return NewSchemaSelectorClient(rawClient, opts.UseMultiEntitySchema, tableCfg, opts.ContainedInPlaceAncestorFirstTypes)
 }
 
 // createSpannerClient creates the database name string and initializes the Spanner client.

--- a/internal/server/spanner/client_multientity.go
+++ b/internal/server/spanner/client_multientity.go
@@ -23,12 +23,12 @@ type multiEntityClient struct {
 }
 
 // newMultiEntityClient initializes the client from a base SpannerClient with a table configuration.
-func newMultiEntityClient(client SpannerClient, cfg TableConfig) (*multiEntityClient, error) {
+func newMultiEntityClient(client SpannerClient, cfg TableConfig, containedInPlaceAncestorFirstTypes []string) (*multiEntityClient, error) {
 	sc, ok := client.(*spannerDatabaseClient)
 	if !ok {
 		return nil, fmt.Errorf("newMultiEntityClient: expected *spannerDatabaseClient, got %T", client)
 	}
-	queryBuilder, err := NewMultiEntityQueryBuilder(cfg)
+	queryBuilder, err := NewMultiEntityQueryBuilder(cfg, containedInPlaceAncestorFirstTypes...)
 	if err != nil {
 		return nil, fmt.Errorf("newMultiEntityClient: %w", err)
 	}

--- a/internal/server/spanner/client_multientity.go
+++ b/internal/server/spanner/client_multientity.go
@@ -22,13 +22,13 @@ type multiEntityClient struct {
 	queryBuilder *multiEntityQueryBuilder
 }
 
-// newMultiEntityClient initializes the client from a base SpannerClient with a table configuration.
-func newMultiEntityClient(client SpannerClient, cfg TableConfig, containedInPlaceAncestorFirstTypes []string) (*multiEntityClient, error) {
+// newMultiEntityClient initializes the client from a base SpannerClient with table and query configuration.
+func newMultiEntityClient(client SpannerClient, tableConfig TableConfig, queryConfig MultiEntityQueryConfig) (*multiEntityClient, error) {
 	sc, ok := client.(*spannerDatabaseClient)
 	if !ok {
 		return nil, fmt.Errorf("newMultiEntityClient: expected *spannerDatabaseClient, got %T", client)
 	}
-	queryBuilder, err := NewMultiEntityQueryBuilder(cfg, containedInPlaceAncestorFirstTypes...)
+	queryBuilder, err := NewMultiEntityQueryBuilder(tableConfig, queryConfig)
 	if err != nil {
 		return nil, fmt.Errorf("newMultiEntityClient: %w", err)
 	}

--- a/internal/server/spanner/client_selector.go
+++ b/internal/server/spanner/client_selector.go
@@ -183,8 +183,8 @@ func (s *schemaSelectorClient) GetSdmxAvailability(ctx context.Context, req *sdm
 }
 
 // NewSchemaSelectorClient creates a new SpannerClient that dispatches calls to either default or multi-entity client.
-func NewSchemaSelectorClient(baseClient SpannerClient, useMultiEntitySchema bool, cfg TableConfig) (SpannerClient, error) {
-	multiEntityClient, err := newMultiEntityClient(baseClient, cfg)
+func NewSchemaSelectorClient(baseClient SpannerClient, useMultiEntitySchema bool, cfg TableConfig, containedInPlaceAncestorFirstTypes []string) (SpannerClient, error) {
+	multiEntityClient, err := newMultiEntityClient(baseClient, cfg, containedInPlaceAncestorFirstTypes)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/spanner/client_selector.go
+++ b/internal/server/spanner/client_selector.go
@@ -183,8 +183,8 @@ func (s *schemaSelectorClient) GetSdmxAvailability(ctx context.Context, req *sdm
 }
 
 // NewSchemaSelectorClient creates a new SpannerClient that dispatches calls to either default or multi-entity client.
-func NewSchemaSelectorClient(baseClient SpannerClient, useMultiEntitySchema bool, cfg TableConfig, containedInPlaceAncestorFirstTypes []string) (SpannerClient, error) {
-	multiEntityClient, err := newMultiEntityClient(baseClient, cfg, containedInPlaceAncestorFirstTypes)
+func NewSchemaSelectorClient(baseClient SpannerClient, useMultiEntitySchema bool, tableConfig TableConfig, queryConfig MultiEntityQueryConfig) (SpannerClient, error) {
+	multiEntityClient, err := newMultiEntityClient(baseClient, tableConfig, queryConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/spanner/golden/query_builder/get_multientity_obs_contained_in_place_ancestor_first_both.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_obs_contained_in_place_ancestor_first_both.sql
@@ -1,0 +1,43 @@
+		@{SCAN_METHOD=COLUMNAR, EXECUTION_METHOD=BATCH}
+		WITH places AS (
+			SELECT DISTINCT contained.subject_id AS place_id
+			FROM Edge contained
+			JOIN@{FORCE_JOIN_ORDER=TRUE} Edge typed ON typed.subject_id = contained.subject_id
+			WHERE contained.predicate = 'linkedContainedInPlace'
+				AND contained.object_id = 'geoId/10'
+				AND typed.predicate = 'typeOf'
+				AND typed.object_id = 'Place'
+		),
+		series AS (
+			SELECT
+				t.variable_measured,
+				t.entity1,
+				t.extra_entities_id,
+				t.facet_id,
+				t.provenance,
+				t.facet
+			FROM places p
+			JOIN@{JOIN_METHOD=APPLY_JOIN} TimeSeries@{FORCE_INDEX=_BASE_TABLE} t
+				ON t.variable_measured = 'AirPollutant_Cancer_Risk'
+				AND t.entity1 = p.place_id
+		)
+		SELECT
+			t.variable_measured,
+			t.entity1 AS observation_about,
+			t.facet_id,
+			ANY_VALUE(t.provenance) AS provenance,
+			ARRAY_AGG(
+				STRUCT(
+					o.date AS date,
+					o.value AS str_value
+				)
+			) AS dates_and_values,
+			ANY_VALUE(t.facet) AS facets
+		FROM series t
+		JOIN@{JOIN_METHOD=APPLY_JOIN} Observation o
+		USING (variable_measured, entity1, extra_entities_id, facet_id)
+		GROUP BY
+			t.variable_measured,
+			t.entity1,
+			t.extra_entities_id,
+			t.facet_id

--- a/internal/server/spanner/golden/query_builder/get_multientity_obs_contained_in_place_ancestor_first_date.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_obs_contained_in_place_ancestor_first_date.sql
@@ -1,0 +1,38 @@
+		@{SCAN_METHOD=COLUMNAR, EXECUTION_METHOD=BATCH}
+		WITH places AS (
+			SELECT DISTINCT contained.subject_id AS place_id
+			FROM Edge contained
+			JOIN@{FORCE_JOIN_ORDER=TRUE} Edge typed ON typed.subject_id = contained.subject_id
+			WHERE contained.predicate = 'linkedContainedInPlace'
+				AND contained.object_id = 'geoId/10'
+				AND typed.predicate = 'typeOf'
+				AND typed.object_id = 'Place'
+		),
+		series AS (
+			SELECT
+				t.variable_measured,
+				t.entity1,
+				t.extra_entities_id,
+				t.facet_id,
+				t.provenance,
+				t.facet
+			FROM places p
+			JOIN@{JOIN_METHOD=APPLY_JOIN} TimeSeries@{FORCE_INDEX=_BASE_TABLE} t
+				ON t.variable_measured IN ('AirPollutant_Cancer_Risk','Count_Person')
+				AND t.entity1 = p.place_id
+		)
+		SELECT
+			t.variable_measured,
+			t.entity1 AS observation_about,
+			t.facet_id,
+			t.provenance,
+			ARRAY(
+				SELECT AS STRUCT
+					o.date AS date,
+					o.value AS str_value
+			) AS dates_and_values,
+			t.facet AS facets
+		FROM series t
+		JOIN@{JOIN_METHOD=APPLY_JOIN} Observation o
+		USING (variable_measured, entity1, extra_entities_id, facet_id)
+		WHERE o.date = '2015'

--- a/internal/server/spanner/golden/query_builder/get_multientity_obs_contained_in_place_ancestor_first_latest.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_obs_contained_in_place_ancestor_first_latest.sql
@@ -1,0 +1,53 @@
+		@{SCAN_METHOD=COLUMNAR, EXECUTION_METHOD=BATCH}
+		WITH places AS (
+			SELECT DISTINCT contained.subject_id AS place_id
+			FROM Edge contained
+			JOIN@{FORCE_JOIN_ORDER=TRUE} Edge typed ON typed.subject_id = contained.subject_id
+			WHERE contained.predicate = 'linkedContainedInPlace'
+				AND contained.object_id = 'geoId/10'
+				AND typed.predicate = 'typeOf'
+				AND typed.object_id = 'Place'
+		),
+		series AS (
+			SELECT
+				t.variable_measured,
+				t.entity1,
+				t.extra_entities_id,
+				t.facet_id,
+				t.provenance,
+				t.facet
+			FROM places p
+			JOIN@{JOIN_METHOD=APPLY_JOIN} TimeSeries@{FORCE_INDEX=_BASE_TABLE} t
+				ON t.variable_measured = 'AirPollutant_Cancer_Risk'
+				AND t.entity1 = p.place_id
+		)
+		SELECT
+			t.variable_measured,
+			t.entity1 AS observation_about,
+			t.facet_id,
+			t.provenance,
+			COALESCE(
+				(
+					SELECT ARRAY(
+						SELECT AS STRUCT
+							o.date AS date,
+							o.value AS str_value
+						FROM Observation o
+						WHERE o.variable_measured = t.variable_measured
+							AND o.entity1 = t.entity1
+							AND o.extra_entities_id = t.extra_entities_id
+							AND o.facet_id = t.facet_id
+						ORDER BY o.date DESC
+						LIMIT 1
+					)
+				),
+				ARRAY(
+					SELECT AS STRUCT
+						CAST(NULL AS STRING) AS date,
+						CAST(NULL AS STRING) AS str_value
+					FROM UNNEST([1])
+					WHERE FALSE
+				)
+			) AS dates_and_values,
+			t.facet AS facets
+		FROM series t

--- a/internal/server/spanner/golden/query_builder/get_multientity_obs_contained_in_place_entity_scan_both.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_obs_contained_in_place_entity_scan_both.sql
@@ -1,0 +1,43 @@
+		@{SCAN_METHOD=COLUMNAR, EXECUTION_METHOD=BATCH}
+		WITH places AS (
+			SELECT DISTINCT contained.subject_id AS place_id
+			FROM Edge typed
+			JOIN@{FORCE_JOIN_ORDER=TRUE} Edge contained ON contained.subject_id = typed.subject_id
+			WHERE typed.predicate = 'typeOf'
+				AND typed.object_id = 'County'
+				AND contained.predicate = 'linkedContainedInPlace'
+				AND contained.object_id = 'geoId/10'
+		),
+		series AS (
+			SELECT
+				t.variable_measured,
+				t.entity1,
+				t.extra_entities_id,
+				t.facet_id,
+				t.provenance,
+				t.facet
+			FROM places p
+			JOIN@{JOIN_METHOD=APPLY_JOIN} TimeSeries@{FORCE_INDEX=TimeSeriesByEntity1, SEEKABLE_KEY_SIZE=1} t
+				ON t.variable_measured IN ('AirPollutant_Cancer_Risk','Count_Person')
+				AND t.entity1 = p.place_id
+		)
+		SELECT
+			t.variable_measured,
+			t.entity1 AS observation_about,
+			t.facet_id,
+			ANY_VALUE(t.provenance) AS provenance,
+			ARRAY_AGG(
+				STRUCT(
+					o.date AS date,
+					o.value AS str_value
+				)
+			) AS dates_and_values,
+			ANY_VALUE(t.facet) AS facets
+		FROM series t
+		JOIN@{JOIN_METHOD=APPLY_JOIN} Observation o
+		USING (variable_measured, entity1, extra_entities_id, facet_id)
+		GROUP BY
+			t.variable_measured,
+			t.entity1,
+			t.extra_entities_id,
+			t.facet_id

--- a/internal/server/spanner/golden/query_builder/get_multientity_obs_contained_in_place_entity_scan_date.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_obs_contained_in_place_entity_scan_date.sql
@@ -1,0 +1,38 @@
+		@{SCAN_METHOD=COLUMNAR, EXECUTION_METHOD=BATCH}
+		WITH places AS (
+			SELECT DISTINCT contained.subject_id AS place_id
+			FROM Edge typed
+			JOIN@{FORCE_JOIN_ORDER=TRUE} Edge contained ON contained.subject_id = typed.subject_id
+			WHERE typed.predicate = 'typeOf'
+				AND typed.object_id = 'County'
+				AND contained.predicate = 'linkedContainedInPlace'
+				AND contained.object_id = 'geoId/10'
+		),
+		series AS (
+			SELECT
+				t.variable_measured,
+				t.entity1,
+				t.extra_entities_id,
+				t.facet_id,
+				t.provenance,
+				t.facet
+			FROM places p
+			JOIN@{JOIN_METHOD=APPLY_JOIN} TimeSeries@{FORCE_INDEX=TimeSeriesByEntity1, SEEKABLE_KEY_SIZE=1} t
+				ON t.variable_measured IN ('AirPollutant_Cancer_Risk','Count_Person')
+				AND t.entity1 = p.place_id
+		)
+		SELECT
+			t.variable_measured,
+			t.entity1 AS observation_about,
+			t.facet_id,
+			t.provenance,
+			ARRAY(
+				SELECT AS STRUCT
+					o.date AS date,
+					o.value AS str_value
+			) AS dates_and_values,
+			t.facet AS facets
+		FROM series t
+		JOIN@{JOIN_METHOD=APPLY_JOIN} Observation o
+		USING (variable_measured, entity1, extra_entities_id, facet_id)
+		WHERE o.date = '2015'

--- a/internal/server/spanner/golden/query_builder/get_multientity_obs_contained_in_place_entity_scan_latest.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_obs_contained_in_place_entity_scan_latest.sql
@@ -1,0 +1,53 @@
+		@{SCAN_METHOD=COLUMNAR, EXECUTION_METHOD=BATCH}
+		WITH places AS (
+			SELECT DISTINCT contained.subject_id AS place_id
+			FROM Edge typed
+			JOIN@{FORCE_JOIN_ORDER=TRUE} Edge contained ON contained.subject_id = typed.subject_id
+			WHERE typed.predicate = 'typeOf'
+				AND typed.object_id = 'County'
+				AND contained.predicate = 'linkedContainedInPlace'
+				AND contained.object_id = 'geoId/10'
+		),
+		series AS (
+			SELECT
+				t.variable_measured,
+				t.entity1,
+				t.extra_entities_id,
+				t.facet_id,
+				t.provenance,
+				t.facet
+			FROM places p
+			JOIN@{JOIN_METHOD=APPLY_JOIN} TimeSeries@{FORCE_INDEX=TimeSeriesByEntity1, SEEKABLE_KEY_SIZE=1} t
+				ON t.variable_measured IN ('AirPollutant_Cancer_Risk','Count_Person')
+				AND t.entity1 = p.place_id
+		)
+		SELECT
+			t.variable_measured,
+			t.entity1 AS observation_about,
+			t.facet_id,
+			t.provenance,
+			COALESCE(
+				(
+					SELECT ARRAY(
+						SELECT AS STRUCT
+							o.date AS date,
+							o.value AS str_value
+						FROM Observation o
+						WHERE o.variable_measured = t.variable_measured
+							AND o.entity1 = t.entity1
+							AND o.extra_entities_id = t.extra_entities_id
+							AND o.facet_id = t.facet_id
+						ORDER BY o.date DESC
+						LIMIT 1
+					)
+				),
+				ARRAY(
+					SELECT AS STRUCT
+						CAST(NULL AS STRING) AS date,
+						CAST(NULL AS STRING) AS str_value
+					FROM UNNEST([1])
+					WHERE FALSE
+				)
+			) AS dates_and_values,
+			t.facet AS facets
+		FROM series t

--- a/internal/server/spanner/golden/query_builder_multientity_test.go
+++ b/internal/server/spanner/golden/query_builder_multientity_test.go
@@ -34,7 +34,7 @@ func TestMultiEntityGetObservationsQuery(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			goldenFile := c.golden + ".sql"
 			runQueryBuilderGoldenTest(t, goldenFile, func(ctx context.Context) (interface{}, error) {
-				builder, err := spanner.NewMultiEntityQueryBuilder(spanner.DefaultTableConfig())
+				builder, err := spanner.NewMultiEntityQueryBuilder(spanner.DefaultTableConfig(), spanner.MultiEntityQueryConfig{})
 				if err != nil {
 					return nil, err
 				}
@@ -52,7 +52,7 @@ func TestMultiEntityGetStatVarsByEntityQuery(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			goldenFile := c.golden + ".sql"
 			runQueryBuilderGoldenTest(t, goldenFile, func(ctx context.Context) (interface{}, error) {
-				builder, err := spanner.NewMultiEntityQueryBuilder(spanner.DefaultTableConfig())
+				builder, err := spanner.NewMultiEntityQueryBuilder(spanner.DefaultTableConfig(), spanner.MultiEntityQueryConfig{})
 				if err != nil {
 					return nil, err
 				}
@@ -70,7 +70,7 @@ func TestMultiEntityCheckGroupPlaceExistenceQuery(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			goldenFile := c.golden + ".sql"
 			runQueryBuilderGoldenTest(t, goldenFile, func(ctx context.Context) (interface{}, error) {
-				builder, err := spanner.NewMultiEntityQueryBuilder(spanner.DefaultTableConfig())
+				builder, err := spanner.NewMultiEntityQueryBuilder(spanner.DefaultTableConfig(), spanner.MultiEntityQueryConfig{})
 				if err != nil {
 					return nil, err
 				}
@@ -88,7 +88,10 @@ func TestMultiEntityGetObservationsContainedInPlaceQuery(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			goldenFile := c.golden + ".sql"
 			runQueryBuilderGoldenTest(t, goldenFile, func(ctx context.Context) (interface{}, error) {
-				builder, err := spanner.NewMultiEntityQueryBuilder(spanner.DefaultTableConfig(), c.ancestorFirstTypes...)
+				builder, err := spanner.NewMultiEntityQueryBuilder(spanner.DefaultTableConfig(), spanner.MultiEntityQueryConfig{
+					ContainedInPlaceAncestorFirstTypes:     c.ancestorFirstTypes,
+					ContainedInPlaceEntityScanMinVariables: c.entityScanMinVars,
+				})
 				if err != nil {
 					return nil, err
 				}
@@ -109,7 +112,7 @@ func TestMultiEntityGetStatVarGroupNodeQuery(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			goldenFile := c.golden + ".sql"
 			runQueryBuilderGoldenTest(t, goldenFile, func(ctx context.Context) (interface{}, error) {
-				builder, err := spanner.NewMultiEntityQueryBuilder(spanner.DefaultTableConfig())
+				builder, err := spanner.NewMultiEntityQueryBuilder(spanner.DefaultTableConfig(), spanner.MultiEntityQueryConfig{})
 				if err != nil {
 					return nil, err
 				}
@@ -127,7 +130,7 @@ func TestMultiEntityGetFilteredSVGChildrenQuery(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			goldenFile := c.golden + ".sql"
 			runQueryBuilderGoldenTest(t, goldenFile, func(ctx context.Context) (interface{}, error) {
-				builder, err := spanner.NewMultiEntityQueryBuilder(spanner.DefaultTableConfig())
+				builder, err := spanner.NewMultiEntityQueryBuilder(spanner.DefaultTableConfig(), spanner.MultiEntityQueryConfig{})
 				if err != nil {
 					return nil, err
 				}
@@ -146,7 +149,7 @@ func TestMultiEntityGetFilteredTopicChildrenQuery(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			goldenFile := c.golden + ".sql"
 			runQueryBuilderGoldenTest(t, goldenFile, func(ctx context.Context) (interface{}, error) {
-				builder, err := spanner.NewMultiEntityQueryBuilder(spanner.DefaultTableConfig())
+				builder, err := spanner.NewMultiEntityQueryBuilder(spanner.DefaultTableConfig(), spanner.MultiEntityQueryConfig{})
 				if err != nil {
 					return nil, err
 				}
@@ -164,7 +167,7 @@ func TestMultiEntityGetSdmxObservationsQuery(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			goldenFile := c.golden + ".sql"
 			runQueryBuilderGoldenTest(t, goldenFile, func(ctx context.Context) (interface{}, error) {
-				builder, err := spanner.NewMultiEntityQueryBuilder(spanner.DefaultTableConfig())
+				builder, err := spanner.NewMultiEntityQueryBuilder(spanner.DefaultTableConfig(), spanner.MultiEntityQueryConfig{})
 				if err != nil {
 					return nil, err
 				}
@@ -180,7 +183,7 @@ func TestMultiEntityGetSdmxObservationsQuery(t *testing.T) {
 }
 
 func TestMultiEntityGetSdmxObservationsQuery_Validation(t *testing.T) {
-	builder, err := spanner.NewMultiEntityQueryBuilder(spanner.DefaultTableConfig())
+	builder, err := spanner.NewMultiEntityQueryBuilder(spanner.DefaultTableConfig(), spanner.MultiEntityQueryConfig{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -311,7 +314,7 @@ func TestMultiEntityGetSdmxObservationsQuery_Validation(t *testing.T) {
 }
 
 func TestMultiEntityGetSdmxObservationsQueryDoesNotUseFacetJSONFallback(t *testing.T) {
-	builder, err := spanner.NewMultiEntityQueryBuilder(spanner.DefaultTableConfig())
+	builder, err := spanner.NewMultiEntityQueryBuilder(spanner.DefaultTableConfig(), spanner.MultiEntityQueryConfig{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -328,7 +331,7 @@ func TestMultiEntityGetSdmxObservationsQueryDoesNotUseFacetJSONFallback(t *testi
 }
 
 func TestMultiEntityGetSdmxObservationsQueryUsesResolvedObservationAboutSlot(t *testing.T) {
-	builder, err := spanner.NewMultiEntityQueryBuilder(spanner.DefaultTableConfig())
+	builder, err := spanner.NewMultiEntityQueryBuilder(spanner.DefaultTableConfig(), spanner.MultiEntityQueryConfig{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -359,9 +362,12 @@ func TestMultiEntityQueryBuildersUseCustomTableConfig(t *testing.T) {
 	cfg := spanner.DefaultTableConfig()
 	cfg.TimeSeriesTable = "CustomTsTable"
 	cfg.ObservationTable = "CustomObsTable"
+	cfg.TimeSeriesByEntity1Index = "CustomEntity1Index"
 	cfg.TimeSeriesByEntity2Index = "CustomEntity2Index"
 	cfg.TimeSeriesByEntity3Index = "CustomEntity3Index"
-	builder, err := spanner.NewMultiEntityQueryBuilder(cfg)
+	builder, err := spanner.NewMultiEntityQueryBuilder(cfg, spanner.MultiEntityQueryConfig{
+		ContainedInPlaceEntityScanMinVariables: 1,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -399,7 +405,7 @@ func TestMultiEntityQueryBuildersUseCustomTableConfig(t *testing.T) {
 	}
 	assertSQLContains(t, containedInStmt.SQL,
 		"CustomObsTable",
-		"CustomTsTable@{FORCE_INDEX=_BASE_TABLE}",
+		"CustomTsTable@{FORCE_INDEX=CustomEntity1Index, SEEKABLE_KEY_SIZE=1}",
 	)
 
 	existenceStmt, err := builder.GetStatVarsByEntityQuery(
@@ -499,7 +505,7 @@ func TestMultiEntityGetSdmxAvailabilityQuery(t *testing.T) {
 		c := c
 		t.Run(c.name, func(t *testing.T) {
 			runQueryBuilderGoldenTest(t, c.golden, func(ctx context.Context) (interface{}, error) {
-				builder, err := spanner.NewMultiEntityQueryBuilder(spanner.DefaultTableConfig())
+				builder, err := spanner.NewMultiEntityQueryBuilder(spanner.DefaultTableConfig(), spanner.MultiEntityQueryConfig{})
 				if err != nil {
 					return nil, err
 				}
@@ -516,7 +522,7 @@ func TestMultiEntityGetSdmxAvailabilityQuery(t *testing.T) {
 
 func TestMultiEntityGetSdmxAvailabilityQueryWithDimensionFilters(t *testing.T) {
 	runQueryBuilderGoldenTest(t, "get_sdmx_availability_filtered_destination_country.sql", func(ctx context.Context) (interface{}, error) {
-		builder, err := spanner.NewMultiEntityQueryBuilder(spanner.DefaultTableConfig())
+		builder, err := spanner.NewMultiEntityQueryBuilder(spanner.DefaultTableConfig(), spanner.MultiEntityQueryConfig{})
 		if err != nil {
 			return nil, err
 		}
@@ -538,7 +544,7 @@ func TestMultiEntityGetSdmxAvailabilityQueryWithDimensionFilters(t *testing.T) {
 }
 
 func TestMultiEntityGetSdmxAvailabilityQuery_Validation(t *testing.T) {
-	builder, err := spanner.NewMultiEntityQueryBuilder(spanner.DefaultTableConfig())
+	builder, err := spanner.NewMultiEntityQueryBuilder(spanner.DefaultTableConfig(), spanner.MultiEntityQueryConfig{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/server/spanner/golden/query_builder_multientity_test.go
+++ b/internal/server/spanner/golden/query_builder_multientity_test.go
@@ -88,7 +88,7 @@ func TestMultiEntityGetObservationsContainedInPlaceQuery(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			goldenFile := c.golden + ".sql"
 			runQueryBuilderGoldenTest(t, goldenFile, func(ctx context.Context) (interface{}, error) {
-				builder, err := spanner.NewMultiEntityQueryBuilder(spanner.DefaultTableConfig())
+				builder, err := spanner.NewMultiEntityQueryBuilder(spanner.DefaultTableConfig(), c.ancestorFirstTypes...)
 				if err != nil {
 					return nil, err
 				}

--- a/internal/server/spanner/golden/query_multientity_cases_test.go
+++ b/internal/server/spanner/golden/query_multientity_cases_test.go
@@ -131,6 +131,7 @@ var multiEntityObservationsContainedInPlaceTestCases = []struct {
 	ancestor           string
 	childPlaceType     string
 	ancestorFirstTypes []string
+	entityScanMinVars  int
 	date               string
 	golden             string
 }{
@@ -187,6 +188,33 @@ var multiEntityObservationsContainedInPlaceTestCases = []struct {
 		ancestorFirstTypes: []string{"Place"},
 		date:               "2015",
 		golden:             "get_multientity_obs_contained_in_place_ancestor_first_date",
+	},
+	{
+		name:              "contained in place entity scan with variables",
+		variables:         []string{"AirPollutant_Cancer_Risk", "Count_Person"},
+		ancestor:          "geoId/10",
+		childPlaceType:    "County",
+		entityScanMinVars: 2,
+		date:              "",
+		golden:            "get_multientity_obs_contained_in_place_entity_scan_both",
+	},
+	{
+		name:              "contained in place entity scan latest date with variables",
+		variables:         []string{"AirPollutant_Cancer_Risk", "Count_Person"},
+		ancestor:          "geoId/10",
+		childPlaceType:    "County",
+		entityScanMinVars: 2,
+		date:              "latest",
+		golden:            "get_multientity_obs_contained_in_place_entity_scan_latest",
+	},
+	{
+		name:              "contained in place entity scan specific date with variables",
+		variables:         []string{"AirPollutant_Cancer_Risk", "Count_Person"},
+		ancestor:          "geoId/10",
+		childPlaceType:    "County",
+		entityScanMinVars: 2,
+		date:              "2015",
+		golden:            "get_multientity_obs_contained_in_place_entity_scan_date",
 	},
 }
 

--- a/internal/server/spanner/golden/query_multientity_cases_test.go
+++ b/internal/server/spanner/golden/query_multientity_cases_test.go
@@ -126,36 +126,67 @@ var multiEntityCheckGroupPlaceExistenceTestCases = []struct {
 }
 
 var multiEntityObservationsContainedInPlaceTestCases = []struct {
-	name           string
-	variables      []string
-	ancestor       string
-	childPlaceType string
-	date           string
-	golden         string
+	name               string
+	variables          []string
+	ancestor           string
+	childPlaceType     string
+	ancestorFirstTypes []string
+	date               string
+	golden             string
 }{
 	{
-		name:           "contained in place with variables",
-		variables:      []string{"AirPollutant_Cancer_Risk"},
-		ancestor:       "geoId/10",
-		childPlaceType: "County",
-		date:           "",
-		golden:         "get_multientity_obs_contained_in_place_both",
+		name:               "contained in place with variables",
+		variables:          []string{"AirPollutant_Cancer_Risk"},
+		ancestor:           "geoId/10",
+		childPlaceType:     "County",
+		ancestorFirstTypes: []string{"Place"},
+		date:               "",
+		golden:             "get_multientity_obs_contained_in_place_both",
 	},
 	{
-		name:           "contained in place latest date with variables",
-		variables:      []string{"AirPollutant_Cancer_Risk"},
-		ancestor:       "geoId/10",
-		childPlaceType: "County",
-		date:           "latest",
-		golden:         "get_multientity_obs_contained_in_place_latest",
+		name:               "contained in place latest date with variables",
+		variables:          []string{"AirPollutant_Cancer_Risk"},
+		ancestor:           "geoId/10",
+		childPlaceType:     "County",
+		ancestorFirstTypes: []string{"Place"},
+		date:               "latest",
+		golden:             "get_multientity_obs_contained_in_place_latest",
 	},
 	{
-		name:           "contained in place specific date with variables",
-		variables:      []string{"AirPollutant_Cancer_Risk", "Count_Person"},
-		ancestor:       "geoId/10",
-		childPlaceType: "County",
-		date:           "2015",
-		golden:         "get_multientity_obs_contained_in_place_date",
+		name:               "contained in place specific date with variables",
+		variables:          []string{"AirPollutant_Cancer_Risk", "Count_Person"},
+		ancestor:           "geoId/10",
+		childPlaceType:     "County",
+		ancestorFirstTypes: []string{"Place"},
+		date:               "2015",
+		golden:             "get_multientity_obs_contained_in_place_date",
+	},
+	{
+		name:               "contained in place ancestor first with variables",
+		variables:          []string{"AirPollutant_Cancer_Risk"},
+		ancestor:           "geoId/10",
+		childPlaceType:     "Place",
+		ancestorFirstTypes: []string{"Place"},
+		date:               "",
+		golden:             "get_multientity_obs_contained_in_place_ancestor_first_both",
+	},
+	{
+		name:               "contained in place ancestor first latest date with variables",
+		variables:          []string{"AirPollutant_Cancer_Risk"},
+		ancestor:           "geoId/10",
+		childPlaceType:     "Place",
+		ancestorFirstTypes: []string{"Place"},
+		date:               "latest",
+		golden:             "get_multientity_obs_contained_in_place_ancestor_first_latest",
+	},
+	{
+		name:               "contained in place ancestor first specific date with variables",
+		variables:          []string{"AirPollutant_Cancer_Risk", "Count_Person"},
+		ancestor:           "geoId/10",
+		childPlaceType:     "Place",
+		ancestorFirstTypes: []string{"Place"},
+		date:               "2015",
+		golden:             "get_multientity_obs_contained_in_place_ancestor_first_date",
 	},
 }
 

--- a/internal/server/spanner/query_builder_multientity.go
+++ b/internal/server/spanner/query_builder_multientity.go
@@ -32,17 +32,22 @@ import (
 )
 
 type multiEntityQueryBuilder struct {
-	statements  *MultiEntityStatements
-	tableConfig TableConfig
+	statements                         *MultiEntityStatements
+	tableConfig                        TableConfig
+	containedInPlaceAncestorFirstTypes []string
 }
 
 // NewMultiEntityQueryBuilder builds a query builder using table-config-specific SQL templates.
-func NewMultiEntityQueryBuilder(cfg TableConfig) (*multiEntityQueryBuilder, error) {
+func NewMultiEntityQueryBuilder(cfg TableConfig, containedInPlaceAncestorFirstTypes ...string) (*multiEntityQueryBuilder, error) {
 	stmts, err := NewMultiEntityStatements(cfg)
 	if err != nil {
 		return nil, err
 	}
-	return &multiEntityQueryBuilder{statements: stmts, tableConfig: cfg}, nil
+	return &multiEntityQueryBuilder{
+		statements:                         stmts,
+		tableConfig:                        cfg,
+		containedInPlaceAncestorFirstTypes: slices.Clone(containedInPlaceAncestorFirstTypes),
+	}, nil
 }
 
 // GetObservationsQuery builds the observation lookup query with optional date filter.
@@ -51,11 +56,13 @@ func (b *multiEntityQueryBuilder) GetObservationsQuery(variables []string, entit
 	if len(entities) == 0 {
 		return nil, fmt.Errorf("GetObservationsQuery: entities must be specified")
 	}
+	uniqueVariables := sortedUniqueStrings(variables)
+	uniqueEntities := sortedUniqueStrings(entities)
 
 	var sql string
 	params := map[string]interface{}{}
 
-	if len(variables) > 0 {
+	if len(uniqueVariables) > 0 {
 		switch strings.ToUpper(date) {
 		case "":
 			sql = stmts.getObsBoth
@@ -65,8 +72,8 @@ func (b *multiEntityQueryBuilder) GetObservationsQuery(variables []string, entit
 			sql = stmts.getObsBothWithDate
 			params["date"] = date
 		}
-		params["variables"] = variables
-		params["entities"] = entities
+		params["variables"] = uniqueVariables
+		params["entities"] = uniqueEntities
 	} else {
 		switch strings.ToUpper(date) {
 		case "":
@@ -77,7 +84,7 @@ func (b *multiEntityQueryBuilder) GetObservationsQuery(variables []string, entit
 			sql = stmts.getObsEntitiesOnlyWithDate
 			params["date"] = date
 		}
-		params["entities"] = entities
+		params["entities"] = uniqueEntities
 	}
 
 	return &spanner.Statement{
@@ -92,21 +99,23 @@ func (b *multiEntityQueryBuilder) GetStatVarsByEntityQuery(variables []string, e
 	if len(variables) == 0 && len(entities) == 0 {
 		return nil, fmt.Errorf("GetStatVarsByEntityQuery: must be called with at least one variable or entity")
 	}
+	uniqueVariables := sortedUniqueStrings(variables)
+	uniqueEntities := sortedUniqueStrings(entities)
 
 	var sql string
 	params := map[string]interface{}{}
 
 	switch {
-	case len(variables) > 0 && len(entities) > 0:
+	case len(uniqueVariables) > 0 && len(uniqueEntities) > 0:
 		sql = stmts.getStatVarsByEntityBoth
-		params["variables"] = variables
-		params["entities"] = entities
-	case len(variables) > 0:
+		params["variables"] = uniqueVariables
+		params["entities"] = uniqueEntities
+	case len(uniqueVariables) > 0:
 		sql = stmts.getStatVarsByEntityVarsOnly
-		params["variables"] = variables
+		params["variables"] = uniqueVariables
 	default:
 		sql = stmts.getStatVarsByEntityEntitiesOnly
-		params["entities"] = entities
+		params["entities"] = uniqueEntities
 	}
 
 	return &spanner.Statement{
@@ -137,21 +146,27 @@ func (b *multiEntityQueryBuilder) GetObservationsContainedInPlaceQuery(variables
 	if containedInPlace == nil {
 		return nil, fmt.Errorf("GetObservationsContainedInPlaceQuery: containedInPlace must be specified")
 	}
+	uniqueVariables := sortedUniqueStrings(variables)
 
 	params := map[string]interface{}{
 		"ancestor":       containedInPlace.Ancestor,
 		"childPlaceType": containedInPlace.ChildPlaceType,
-		"variables":      variables,
+		"variables":      uniqueVariables,
+	}
+
+	containedInPlaceStatements := stmts.getObsByContainedInPlaceTypeFirst
+	if slices.Contains(b.containedInPlaceAncestorFirstTypes, containedInPlace.ChildPlaceType) {
+		containedInPlaceStatements = stmts.getObsByContainedInPlaceAncestorFirst
 	}
 
 	var sql string
 	switch strings.ToUpper(date) {
 	case "":
-		sql = stmts.getObsByContainedInPlaceBoth
+		sql = containedInPlaceStatements.all
 	case shared.LATEST:
-		sql = stmts.getObsByContainedInPlaceBothLatest
+		sql = containedInPlaceStatements.latest
 	default:
-		sql = stmts.getObsByContainedInPlaceBothWithDate
+		sql = containedInPlaceStatements.withDate
 		params["date"] = date
 	}
 
@@ -492,6 +507,7 @@ func (b *multiEntityQueryBuilder) getSdmxContainedInPlaceObservationsQuery(
 	params := maps.Clone(compiled.params)
 	containedRule, _ := datacommons.DataPropertyRule(datacommons.PropertyContainedInPlace)
 	typeRule, _ := datacommons.DataPropertyRule(datacommons.PropertyTypeOf)
+	// TODO: Apply ContainedInPlaceAncestorFirstTypes to SDMX containment CTEs.
 	for i := range resolved {
 		key := resolved[i].relation
 		cteName, ok := relationToCTE[key]

--- a/internal/server/spanner/query_builder_multientity.go
+++ b/internal/server/spanner/query_builder_multientity.go
@@ -32,21 +32,31 @@ import (
 )
 
 type multiEntityQueryBuilder struct {
-	statements                         *MultiEntityStatements
-	tableConfig                        TableConfig
-	containedInPlaceAncestorFirstTypes []string
+	statements  *MultiEntityStatements
+	tableConfig TableConfig
+	queryConfig MultiEntityQueryConfig
 }
 
-// NewMultiEntityQueryBuilder builds a query builder using table-config-specific SQL templates.
-func NewMultiEntityQueryBuilder(cfg TableConfig, containedInPlaceAncestorFirstTypes ...string) (*multiEntityQueryBuilder, error) {
-	stmts, err := NewMultiEntityStatements(cfg)
+// NewMultiEntityQueryBuilder builds a query builder using table and query configuration.
+func NewMultiEntityQueryBuilder(tableConfig TableConfig, queryConfig MultiEntityQueryConfig) (*multiEntityQueryBuilder, error) {
+	if queryConfig.ContainedInPlaceEntityScanMinVariables < 0 {
+		return nil, fmt.Errorf("NewMultiEntityQueryBuilder: ContainedInPlaceEntityScanMinVariables must be non-negative")
+	}
+	for _, placeType := range queryConfig.ContainedInPlaceAncestorFirstTypes {
+		if strings.TrimSpace(placeType) == "" {
+			return nil, fmt.Errorf("NewMultiEntityQueryBuilder: ContainedInPlaceAncestorFirstTypes must not contain empty values")
+		}
+	}
+	queryConfig.ContainedInPlaceAncestorFirstTypes = slices.Clone(queryConfig.ContainedInPlaceAncestorFirstTypes)
+
+	stmts, err := NewMultiEntityStatements(tableConfig)
 	if err != nil {
 		return nil, err
 	}
 	return &multiEntityQueryBuilder{
-		statements:                         stmts,
-		tableConfig:                        cfg,
-		containedInPlaceAncestorFirstTypes: slices.Clone(containedInPlaceAncestorFirstTypes),
+		statements:  stmts,
+		tableConfig: tableConfig,
+		queryConfig: queryConfig,
 	}, nil
 }
 
@@ -155,18 +165,29 @@ func (b *multiEntityQueryBuilder) GetObservationsContainedInPlaceQuery(variables
 	}
 
 	containedInPlaceStatements := stmts.getObsByContainedInPlaceTypeFirst
-	if slices.Contains(b.containedInPlaceAncestorFirstTypes, containedInPlace.ChildPlaceType) {
+	if slices.Contains(b.queryConfig.ContainedInPlaceAncestorFirstTypes, containedInPlace.ChildPlaceType) {
 		containedInPlaceStatements = stmts.getObsByContainedInPlaceAncestorFirst
+	}
+
+	selectedStatements := containedInPlaceStatements.variableSeek
+	minVariables := b.queryConfig.ContainedInPlaceEntityScanMinVariables
+	if minVariables > 0 && len(uniqueVariables) >= minVariables {
+		// The base-table plan performs one sparse seek per place-variable pair.
+		// For broad variable lists, scanning each entity1 index range once and
+		// applying variable_measured as a residual filter can be cheaper. This
+		// threshold is a heuristic because the builder does not know how many
+		// TimeSeries rows belong to each selected place.
+		selectedStatements = containedInPlaceStatements.entityScan
 	}
 
 	var sql string
 	switch strings.ToUpper(date) {
 	case "":
-		sql = containedInPlaceStatements.all
+		sql = selectedStatements.all
 	case shared.LATEST:
-		sql = containedInPlaceStatements.latest
+		sql = selectedStatements.latest
 	default:
-		sql = containedInPlaceStatements.withDate
+		sql = selectedStatements.withDate
 		params["date"] = date
 	}
 

--- a/internal/server/spanner/query_multientity_test.go
+++ b/internal/server/spanner/query_multientity_test.go
@@ -345,7 +345,7 @@ func TestMultiEntityGetObservationsContainedInPlaceInvalidArgsReturnEmpty(t *tes
 }
 
 func TestMultiEntityCoreQueryBuildersDeduplicateParameters(t *testing.T) {
-	queryBuilder, err := NewMultiEntityQueryBuilder(DefaultTableConfig())
+	queryBuilder, err := NewMultiEntityQueryBuilder(DefaultTableConfig(), MultiEntityQueryConfig{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -382,6 +382,171 @@ func TestMultiEntityCoreQueryBuildersDeduplicateParameters(t *testing.T) {
 		if diff := cmp.Diff(wantEntities, statements[name].Params["entities"]); diff != "" {
 			t.Errorf("%s entities mismatch (-want +got):\n%s", name, diff)
 		}
+	}
+}
+
+func TestMultiEntityContainedInPlaceSelectsAccessPathByUniqueVariableCount(t *testing.T) {
+	const (
+		variableSeekHint = "FORCE_INDEX=_BASE_TABLE"
+		entityScanHint   = "FORCE_INDEX=TimeSeriesByEntity1, SEEKABLE_KEY_SIZE=1"
+	)
+
+	for _, tc := range []struct {
+		name                 string
+		variables            []string
+		date                 string
+		queryConfig          MultiEntityQueryConfig
+		childPlaceType       string
+		wantEntityScan       bool
+		wantAncestorFirstCTE bool
+	}{
+		{
+			name:           "disabled",
+			variables:      []string{"var1", "var2", "var3"},
+			queryConfig:    MultiEntityQueryConfig{},
+			childPlaceType: "County",
+		},
+		{
+			name:      "below threshold",
+			variables: []string{"var1", "var2"},
+			queryConfig: MultiEntityQueryConfig{
+				ContainedInPlaceEntityScanMinVariables: 3,
+			},
+			childPlaceType: "County",
+		},
+		{
+			name:      "duplicates do not reach threshold",
+			variables: []string{"var1", "var2", "var2"},
+			queryConfig: MultiEntityQueryConfig{
+				ContainedInPlaceEntityScanMinVariables: 3,
+			},
+			childPlaceType: "County",
+		},
+		{
+			name:      "all dates at threshold",
+			variables: []string{"var1", "var2", "var3"},
+			queryConfig: MultiEntityQueryConfig{
+				ContainedInPlaceEntityScanMinVariables: 3,
+			},
+			childPlaceType: "County",
+			wantEntityScan: true,
+		},
+		{
+			name:      "latest at threshold",
+			variables: []string{"var1", "var2", "var3"},
+			date:      "latest",
+			queryConfig: MultiEntityQueryConfig{
+				ContainedInPlaceEntityScanMinVariables: 3,
+			},
+			childPlaceType: "County",
+			wantEntityScan: true,
+		},
+		{
+			name:      "exact date at threshold",
+			variables: []string{"var1", "var2", "var3"},
+			date:      "2020",
+			queryConfig: MultiEntityQueryConfig{
+				ContainedInPlaceEntityScanMinVariables: 3,
+			},
+			childPlaceType: "County",
+			wantEntityScan: true,
+		},
+		{
+			name:      "ancestor first at threshold",
+			variables: []string{"var1", "var2", "var3"},
+			queryConfig: MultiEntityQueryConfig{
+				ContainedInPlaceAncestorFirstTypes:     []string{"Place"},
+				ContainedInPlaceEntityScanMinVariables: 3,
+			},
+			childPlaceType:       "Place",
+			wantEntityScan:       true,
+			wantAncestorFirstCTE: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			queryBuilder, err := NewMultiEntityQueryBuilder(DefaultTableConfig(), tc.queryConfig)
+			if err != nil {
+				t.Fatal(err)
+			}
+			stmt, err := queryBuilder.GetObservationsContainedInPlaceQuery(
+				tc.variables,
+				&v2.ContainedInPlace{Ancestor: "geoId/06", ChildPlaceType: tc.childPlaceType},
+				tc.date,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if got := strings.Contains(stmt.SQL, entityScanHint); got != tc.wantEntityScan {
+				t.Errorf("entity scan hint present = %t, want %t\nSQL:\n%s", got, tc.wantEntityScan, stmt.SQL)
+			}
+			if got := strings.Contains(stmt.SQL, variableSeekHint); got == tc.wantEntityScan {
+				t.Errorf("variable seek hint present = %t, want %t\nSQL:\n%s", got, !tc.wantEntityScan, stmt.SQL)
+			}
+			ancestorFirstCTE := "FROM Edge contained\n\t\t\tJOIN@{FORCE_JOIN_ORDER=TRUE} Edge typed"
+			if got := strings.Contains(stmt.SQL, ancestorFirstCTE); got != tc.wantAncestorFirstCTE {
+				t.Errorf("ancestor-first CTE present = %t, want %t\nSQL:\n%s", got, tc.wantAncestorFirstCTE, stmt.SQL)
+			}
+		})
+	}
+}
+
+func TestMultiEntityEntityScanThresholdDoesNotAffectDirectObservations(t *testing.T) {
+	queryBuilder, err := NewMultiEntityQueryBuilder(DefaultTableConfig(), MultiEntityQueryConfig{
+		ContainedInPlaceEntityScanMinVariables: 1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	stmt, err := queryBuilder.GetObservationsQuery([]string{"var1"}, []string{"geoId/06"}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(stmt.SQL, "SEEKABLE_KEY_SIZE") {
+		t.Errorf("direct observation SQL unexpectedly contains contained-in-place access hint:\n%s", stmt.SQL)
+	}
+}
+
+func TestNewMultiEntityQueryBuilderValidatesAndClonesQueryConfig(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		queryConfig MultiEntityQueryConfig
+	}{
+		{
+			name: "negative entity scan threshold",
+			queryConfig: MultiEntityQueryConfig{
+				ContainedInPlaceEntityScanMinVariables: -1,
+			},
+		},
+		{
+			name: "empty ancestor first type",
+			queryConfig: MultiEntityQueryConfig{
+				ContainedInPlaceAncestorFirstTypes: []string{" "},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := NewMultiEntityQueryBuilder(DefaultTableConfig(), tc.queryConfig); err == nil {
+				t.Fatal("NewMultiEntityQueryBuilder() error = nil, want error")
+			}
+		})
+	}
+
+	ancestorFirstTypes := []string{"Place"}
+	queryConfig := MultiEntityQueryConfig{
+		ContainedInPlaceAncestorFirstTypes:     ancestorFirstTypes,
+		ContainedInPlaceEntityScanMinVariables: 50,
+	}
+	client, err := newMultiEntityClient(&spannerDatabaseClient{}, DefaultTableConfig(), queryConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ancestorFirstTypes[0] = "County"
+	if diff := cmp.Diff(queryConfig.ContainedInPlaceEntityScanMinVariables, client.queryBuilder.queryConfig.ContainedInPlaceEntityScanMinVariables); diff != "" {
+		t.Errorf("entity scan threshold mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff([]string{"Place"}, client.queryBuilder.queryConfig.ContainedInPlaceAncestorFirstTypes); diff != "" {
+		t.Errorf("ancestor-first types were not cloned (-want +got):\n%s", diff)
 	}
 }
 
@@ -538,7 +703,7 @@ func TestMultiEntityGetSdmxObservationsRejectsInvalidVariableMeasured(t *testing
 }
 
 func TestPrepareSdmxObservationsQuery(t *testing.T) {
-	queryBuilder, err := NewMultiEntityQueryBuilder(DefaultTableConfig())
+	queryBuilder, err := NewMultiEntityQueryBuilder(DefaultTableConfig(), MultiEntityQueryConfig{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -631,7 +796,7 @@ func TestPrepareSdmxObservationsQuery(t *testing.T) {
 }
 
 func TestPrepareSdmxObservationsQueryWithRemoteContainedInPlace(t *testing.T) {
-	queryBuilder, err := NewMultiEntityQueryBuilder(DefaultTableConfig())
+	queryBuilder, err := NewMultiEntityQueryBuilder(DefaultTableConfig(), MultiEntityQueryConfig{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -712,7 +877,7 @@ func TestCompileSdmxConstraintsCanonicalizesObservationPropertyNames(t *testing.
 }
 
 func TestGetSdmxObservationsQueryCanonicalizesContainedInPlaceObservationPropertyNames(t *testing.T) {
-	queryBuilder, err := NewMultiEntityQueryBuilder(DefaultTableConfig())
+	queryBuilder, err := NewMultiEntityQueryBuilder(DefaultTableConfig(), MultiEntityQueryConfig{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -750,7 +915,7 @@ func TestGetSdmxObservationsQueryCanonicalizesContainedInPlaceObservationPropert
 func TestGetSdmxObservationsQueryUsesEmulatorCompatibleHints(t *testing.T) {
 	cfg := DefaultTableConfig()
 	cfg.spannerEmulatorCompatibility = true
-	queryBuilder, err := NewMultiEntityQueryBuilder(cfg)
+	queryBuilder, err := NewMultiEntityQueryBuilder(cfg, MultiEntityQueryConfig{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -776,7 +941,7 @@ func TestGetSdmxObservationsQueryUsesEmulatorCompatibleHints(t *testing.T) {
 }
 
 func TestPrepareSdmxObservationsQueryWithContainedInPlace(t *testing.T) {
-	queryBuilder, err := NewMultiEntityQueryBuilder(DefaultTableConfig())
+	queryBuilder, err := NewMultiEntityQueryBuilder(DefaultTableConfig(), MultiEntityQueryConfig{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -823,7 +988,7 @@ func TestPrepareSdmxObservationsQueryWithContainedInPlace(t *testing.T) {
 }
 
 func TestPrepareSdmxObservationsQueryRejectsPropertyConstraintOutsideObservationProperties(t *testing.T) {
-	queryBuilder, err := NewMultiEntityQueryBuilder(DefaultTableConfig())
+	queryBuilder, err := NewMultiEntityQueryBuilder(DefaultTableConfig(), MultiEntityQueryConfig{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -846,7 +1011,7 @@ func TestPrepareSdmxObservationsQueryRejectsPropertyConstraintOutsideObservation
 }
 
 func TestPrepareSdmxAvailabilityQuery(t *testing.T) {
-	queryBuilder, err := NewMultiEntityQueryBuilder(DefaultTableConfig())
+	queryBuilder, err := NewMultiEntityQueryBuilder(DefaultTableConfig(), MultiEntityQueryConfig{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -919,7 +1084,7 @@ func TestPrepareSdmxAvailabilityQuery(t *testing.T) {
 }
 
 func TestPrepareSdmxAvailabilityQueryValidation(t *testing.T) {
-	queryBuilder, err := NewMultiEntityQueryBuilder(DefaultTableConfig())
+	queryBuilder, err := NewMultiEntityQueryBuilder(DefaultTableConfig(), MultiEntityQueryConfig{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/server/spanner/query_multientity_test.go
+++ b/internal/server/spanner/query_multientity_test.go
@@ -344,6 +344,47 @@ func TestMultiEntityGetObservationsContainedInPlaceInvalidArgsReturnEmpty(t *tes
 	}
 }
 
+func TestMultiEntityCoreQueryBuildersDeduplicateParameters(t *testing.T) {
+	queryBuilder, err := NewMultiEntityQueryBuilder(DefaultTableConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	variables := []string{"var2", "var1", "var2"}
+	entities := []string{"geoId/10", "geoId/06", "geoId/10"}
+	statements := map[string]*cloudspanner.Statement{}
+	statements["observations"], err = queryBuilder.GetObservationsQuery(variables, entities, "")
+	if err != nil {
+		t.Fatalf("GetObservationsQuery() error = %v", err)
+	}
+	statements["contained in place"], err = queryBuilder.GetObservationsContainedInPlaceQuery(
+		variables,
+		&v2.ContainedInPlace{Ancestor: "geoId/06", ChildPlaceType: "County"},
+		"",
+	)
+	if err != nil {
+		t.Fatalf("GetObservationsContainedInPlaceQuery() error = %v", err)
+	}
+	statements["variable existence"], err = queryBuilder.GetStatVarsByEntityQuery(variables, entities)
+	if err != nil {
+		t.Fatalf("GetStatVarsByEntityQuery() error = %v", err)
+	}
+
+	wantVariables := []string{"var1", "var2"}
+	for name, stmt := range statements {
+		if diff := cmp.Diff(wantVariables, stmt.Params["variables"]); diff != "" {
+			t.Errorf("%s variables mismatch (-want +got):\n%s", name, diff)
+		}
+	}
+
+	wantEntities := []string{"geoId/06", "geoId/10"}
+	for _, name := range []string{"observations", "variable existence"} {
+		if diff := cmp.Diff(wantEntities, statements[name].Params["entities"]); diff != "" {
+			t.Errorf("%s entities mismatch (-want +got):\n%s", name, diff)
+		}
+	}
+}
+
 func TestValidateObservationsRequiresProvenance(t *testing.T) {
 	for _, tc := range []struct {
 		name       string

--- a/internal/server/spanner/statements_multientity.go
+++ b/internal/server/spanner/statements_multientity.go
@@ -27,8 +27,8 @@ type MultiEntityStatements struct {
 	getObsEntitiesOnly                             string
 	getObsEntitiesOnlyWithDate                     string
 	getObsEntitiesOnlyLatest                       string
-	getObsByContainedInPlaceTypeFirst              containedInPlaceStatements
-	getObsByContainedInPlaceAncestorFirst          containedInPlaceStatements
+	getObsByContainedInPlaceTypeFirst              containedInPlaceAccessPathStatements
+	getObsByContainedInPlaceAncestorFirst          containedInPlaceAccessPathStatements
 	getSdmxObs                                     string
 	getSdmxAvailability                            string
 	getSdmxContainedInPlace                        string
@@ -61,13 +61,18 @@ type containedInPlaceStatements struct {
 	latest   string
 }
 
+type containedInPlaceAccessPathStatements struct {
+	variableSeek containedInPlaceStatements
+	entityScan   containedInPlaceStatements
+}
+
 // NewMultiEntityStatements builds multi-entity SQL templates from table configuration.
 func NewMultiEntityStatements(cfg TableConfig) (*MultiEntityStatements, error) {
 	if err := validateMultiEntityTableConfig(cfg); err != nil {
 		return nil, err
 	}
-	typeFirstContainedInPlace := newContainedInPlaceStatements(cfg, typeFirstPlacesCTE)
-	ancestorFirstContainedInPlace := newContainedInPlaceStatements(cfg, ancestorFirstPlacesCTE)
+	typeFirstContainedInPlace := newContainedInPlaceAccessPathStatements(cfg, typeFirstPlacesCTE)
+	ancestorFirstContainedInPlace := newContainedInPlaceAccessPathStatements(cfg, ancestorFirstPlacesCTE)
 
 	return &MultiEntityStatements{
 		// Retrieve observations where both variables and entities are present (full series)
@@ -646,7 +651,25 @@ const ancestorFirstPlacesCTE = `places AS (
 				AND typed.object_id = @childPlaceType
 		)`
 
-func newContainedInPlaceStatements(cfg TableConfig, placesCTE string) containedInPlaceStatements {
+func newContainedInPlaceAccessPathStatements(cfg TableConfig, placesCTE string) containedInPlaceAccessPathStatements {
+	return containedInPlaceAccessPathStatements{
+		variableSeek: newContainedInPlaceStatements(
+			cfg,
+			placesCTE,
+			fmt.Sprintf("%s@{FORCE_INDEX=_BASE_TABLE}", cfg.TimeSeriesTable),
+		),
+		// Limit the seekable index prefix to entity1 so variable_measured is
+		// evaluated as a residual filter instead of producing one sparse range
+		// lookup for every place-variable pair.
+		entityScan: newContainedInPlaceStatements(
+			cfg,
+			placesCTE,
+			fmt.Sprintf("%s@{FORCE_INDEX=%s, SEEKABLE_KEY_SIZE=1}", cfg.TimeSeriesTable, cfg.TimeSeriesByEntity1Index),
+		),
+	}
+}
+
+func newContainedInPlaceStatements(cfg TableConfig, placesCTE, timeSeriesSource string) containedInPlaceStatements {
 	return containedInPlaceStatements{
 		// Join all dates before aggregation to optimize total result throughput.
 		all: fmt.Sprintf(`		@{SCAN_METHOD=COLUMNAR, EXECUTION_METHOD=BATCH}
@@ -660,7 +683,7 @@ func newContainedInPlaceStatements(cfg TableConfig, placesCTE string) containedI
 				t.provenance,
 				t.facet
 			FROM places p
-			JOIN@{JOIN_METHOD=APPLY_JOIN} %[2]s@{FORCE_INDEX=_BASE_TABLE} t
+			JOIN@{JOIN_METHOD=APPLY_JOIN} %[2]s t
 				ON t.variable_measured IN UNNEST(@variables)
 				AND t.entity1 = p.place_id
 		)
@@ -683,7 +706,7 @@ func newContainedInPlaceStatements(cfg TableConfig, placesCTE string) containedI
 			t.variable_measured,
 			t.entity1,
 			t.extra_entities_id,
-			t.facet_id`, cfg.ObservationTable, cfg.TimeSeriesTable, placesCTE),
+			t.facet_id`, cfg.ObservationTable, timeSeriesSource, placesCTE),
 
 		// Join to Observation so TimeSeries without the requested date are
 		// discarded in Spanner.
@@ -698,7 +721,7 @@ func newContainedInPlaceStatements(cfg TableConfig, placesCTE string) containedI
 				t.provenance,
 				t.facet
 			FROM places p
-			JOIN@{JOIN_METHOD=APPLY_JOIN} %[2]s@{FORCE_INDEX=_BASE_TABLE} t
+			JOIN@{JOIN_METHOD=APPLY_JOIN} %[2]s t
 				ON t.variable_measured IN UNNEST(@variables)
 				AND t.entity1 = p.place_id
 		)
@@ -716,7 +739,7 @@ func newContainedInPlaceStatements(cfg TableConfig, placesCTE string) containedI
 		FROM series t
 		JOIN@{JOIN_METHOD=APPLY_JOIN} %[1]s o
 		USING (variable_measured, entity1, extra_entities_id, facet_id)
-		WHERE o.date = @date`, cfg.ObservationTable, cfg.TimeSeriesTable, placesCTE),
+		WHERE o.date = @date`, cfg.ObservationTable, timeSeriesSource, placesCTE),
 
 		// Use a correlated full-key lookup so the date-descending child scan can
 		// stop after one row.
@@ -731,7 +754,7 @@ func newContainedInPlaceStatements(cfg TableConfig, placesCTE string) containedI
 				t.provenance,
 				t.facet
 			FROM places p
-			JOIN@{JOIN_METHOD=APPLY_JOIN} %[2]s@{FORCE_INDEX=_BASE_TABLE} t
+			JOIN@{JOIN_METHOD=APPLY_JOIN} %[2]s t
 				ON t.variable_measured IN UNNEST(@variables)
 				AND t.entity1 = p.place_id
 		)
@@ -764,7 +787,7 @@ func newContainedInPlaceStatements(cfg TableConfig, placesCTE string) containedI
 				)
 			) AS dates_and_values,
 			t.facet AS facets
-		FROM series t`, cfg.ObservationTable, cfg.TimeSeriesTable, placesCTE),
+		FROM series t`, cfg.ObservationTable, timeSeriesSource, placesCTE),
 	}
 }
 

--- a/internal/server/spanner/statements_multientity.go
+++ b/internal/server/spanner/statements_multientity.go
@@ -27,9 +27,8 @@ type MultiEntityStatements struct {
 	getObsEntitiesOnly                             string
 	getObsEntitiesOnlyWithDate                     string
 	getObsEntitiesOnlyLatest                       string
-	getObsByContainedInPlaceBoth                   string
-	getObsByContainedInPlaceBothWithDate           string
-	getObsByContainedInPlaceBothLatest             string
+	getObsByContainedInPlaceTypeFirst              containedInPlaceStatements
+	getObsByContainedInPlaceAncestorFirst          containedInPlaceStatements
 	getSdmxObs                                     string
 	getSdmxAvailability                            string
 	getSdmxContainedInPlace                        string
@@ -56,11 +55,19 @@ type MultiEntityStatements struct {
 	filterEntity3Exists                            string
 }
 
+type containedInPlaceStatements struct {
+	all      string
+	withDate string
+	latest   string
+}
+
 // NewMultiEntityStatements builds multi-entity SQL templates from table configuration.
 func NewMultiEntityStatements(cfg TableConfig) (*MultiEntityStatements, error) {
 	if err := validateMultiEntityTableConfig(cfg); err != nil {
 		return nil, err
 	}
+	typeFirstContainedInPlace := newContainedInPlaceStatements(cfg, typeFirstPlacesCTE)
+	ancestorFirstContainedInPlace := newContainedInPlaceStatements(cfg, ancestorFirstPlacesCTE)
 
 	return &MultiEntityStatements{
 		// Retrieve observations where both variables and entities are present (full series)
@@ -231,151 +238,8 @@ func NewMultiEntityStatements(cfg TableConfig) (*MultiEntityStatements, error) {
 		FROM %[2]s t
 		WHERE t.entity1 IN UNNEST(@entities)`, cfg.ObservationTable, cfg.TimeSeriesTable),
 
-		// The containment queries below force typeOf edges as the left input so
-		// Spanner filters by place type before containment. A broad containment
-		// lookup can return every place under an ancestor and usually produces a
-		// larger intermediate result than the typeOf lookup.
-		// Join all dates before aggregation to optimize total result throughput.
-		getObsByContainedInPlaceBoth: fmt.Sprintf(`		@{SCAN_METHOD=COLUMNAR, EXECUTION_METHOD=BATCH}
-		WITH places AS (
-			SELECT DISTINCT contained.subject_id AS place_id
-			FROM Edge typed
-			JOIN@{FORCE_JOIN_ORDER=TRUE} Edge contained ON contained.subject_id = typed.subject_id
-			WHERE typed.predicate = 'typeOf'
-				AND typed.object_id = @childPlaceType
-				AND contained.predicate = 'linkedContainedInPlace'
-				AND contained.object_id = @ancestor
-		),
-		series AS (
-			SELECT
-				t.variable_measured,
-				t.entity1,
-				t.extra_entities_id,
-				t.facet_id,
-				t.provenance,
-				t.facet
-			FROM places p
-			JOIN@{JOIN_METHOD=APPLY_JOIN} %[2]s@{FORCE_INDEX=_BASE_TABLE} t
-				ON t.variable_measured IN UNNEST(@variables)
-				AND t.entity1 = p.place_id
-		)
-		SELECT
-			t.variable_measured,
-			t.entity1 AS observation_about,
-			t.facet_id,
-			ANY_VALUE(t.provenance) AS provenance,
-			ARRAY_AGG(
-				STRUCT(
-					o.date AS date,
-					o.value AS str_value
-				)
-			) AS dates_and_values,
-			ANY_VALUE(t.facet) AS facets
-		FROM series t
-		JOIN@{JOIN_METHOD=APPLY_JOIN} %[1]s o
-		USING (variable_measured, entity1, extra_entities_id, facet_id)
-		GROUP BY
-			t.variable_measured,
-			t.entity1,
-			t.extra_entities_id,
-			t.facet_id`, cfg.ObservationTable, cfg.TimeSeriesTable),
-
-		// Join the exact-date query to Observation so TimeSeries without the
-		// requested date are discarded in Spanner.
-		getObsByContainedInPlaceBothWithDate: fmt.Sprintf(`		@{SCAN_METHOD=COLUMNAR, EXECUTION_METHOD=BATCH}
-		WITH places AS (
-			SELECT DISTINCT contained.subject_id AS place_id
-			FROM Edge typed
-			JOIN@{FORCE_JOIN_ORDER=TRUE} Edge contained ON contained.subject_id = typed.subject_id
-			WHERE typed.predicate = 'typeOf'
-				AND typed.object_id = @childPlaceType
-				AND contained.predicate = 'linkedContainedInPlace'
-				AND contained.object_id = @ancestor
-		),
-		series AS (
-			SELECT
-				t.variable_measured,
-				t.entity1,
-				t.extra_entities_id,
-				t.facet_id,
-				t.provenance,
-				t.facet
-			FROM places p
-			JOIN@{JOIN_METHOD=APPLY_JOIN} %[2]s@{FORCE_INDEX=_BASE_TABLE} t
-				ON t.variable_measured IN UNNEST(@variables)
-				AND t.entity1 = p.place_id
-		)
-		SELECT
-			t.variable_measured,
-			t.entity1 AS observation_about,
-			t.facet_id,
-			t.provenance,
-			ARRAY(
-				SELECT AS STRUCT
-					o.date AS date,
-					o.value AS str_value
-			) AS dates_and_values,
-			t.facet AS facets
-		FROM series t
-		JOIN@{JOIN_METHOD=APPLY_JOIN} %[1]s o
-		USING (variable_measured, entity1, extra_entities_id, facet_id)
-		WHERE o.date = @date`, cfg.ObservationTable, cfg.TimeSeriesTable),
-
-		// Retrieve the latest observation with a correlated full-key lookup so the
-		// date-descending child scan can stop after one row.
-		getObsByContainedInPlaceBothLatest: fmt.Sprintf(`		@{SCAN_METHOD=COLUMNAR, EXECUTION_METHOD=BATCH}
-		WITH places AS (
-			SELECT DISTINCT contained.subject_id AS place_id
-			FROM Edge typed
-			JOIN@{FORCE_JOIN_ORDER=TRUE} Edge contained ON contained.subject_id = typed.subject_id
-			WHERE typed.predicate = 'typeOf'
-				AND typed.object_id = @childPlaceType
-				AND contained.predicate = 'linkedContainedInPlace'
-				AND contained.object_id = @ancestor
-		),
-		series AS (
-			SELECT
-				t.variable_measured,
-				t.entity1,
-				t.extra_entities_id,
-				t.facet_id,
-				t.provenance,
-				t.facet
-			FROM places p
-			JOIN@{JOIN_METHOD=APPLY_JOIN} %[2]s@{FORCE_INDEX=_BASE_TABLE} t
-				ON t.variable_measured IN UNNEST(@variables)
-				AND t.entity1 = p.place_id
-		)
-		SELECT
-			t.variable_measured,
-			t.entity1 AS observation_about,
-			t.facet_id,
-			t.provenance,
-			COALESCE(
-				(
-					SELECT ARRAY(
-						SELECT AS STRUCT
-							o.date AS date,
-							o.value AS str_value
-						FROM %[1]s o
-						WHERE o.variable_measured = t.variable_measured
-							AND o.entity1 = t.entity1
-							AND o.extra_entities_id = t.extra_entities_id
-							AND o.facet_id = t.facet_id
-						ORDER BY o.date DESC
-						LIMIT 1
-					)
-				),
-				ARRAY(
-					SELECT AS STRUCT
-						CAST(NULL AS STRING) AS date,
-						CAST(NULL AS STRING) AS str_value
-					FROM UNNEST([1])
-					WHERE FALSE
-				)
-			) AS dates_and_values,
-			t.facet AS facets
-		FROM series t`, cfg.ObservationTable, cfg.TimeSeriesTable),
+		getObsByContainedInPlaceTypeFirst:     typeFirstContainedInPlace,
+		getObsByContainedInPlaceAncestorFirst: ancestorFirstContainedInPlace,
 		getSdmxObs: fmt.Sprintf("\t\tSELECT \n"+`			t.variable_measured,
 			t.entity1 AS observation_about,
 			t.facet_id,
@@ -760,6 +624,148 @@ func NewMultiEntityStatements(cfg TableConfig) (*MultiEntityStatements, error) {
 
 		filterEntity3Exists: "WHERE t.entity3 IS NOT NULL\n\t\t\t\t\t\tAND t.entity2 IS NOT NULL",
 	}, nil
+}
+
+const typeFirstPlacesCTE = `places AS (
+			SELECT DISTINCT contained.subject_id AS place_id
+			FROM Edge typed
+			JOIN@{FORCE_JOIN_ORDER=TRUE} Edge contained ON contained.subject_id = typed.subject_id
+			WHERE typed.predicate = 'typeOf'
+				AND typed.object_id = @childPlaceType
+				AND contained.predicate = 'linkedContainedInPlace'
+				AND contained.object_id = @ancestor
+		)`
+
+const ancestorFirstPlacesCTE = `places AS (
+			SELECT DISTINCT contained.subject_id AS place_id
+			FROM Edge contained
+			JOIN@{FORCE_JOIN_ORDER=TRUE} Edge typed ON typed.subject_id = contained.subject_id
+			WHERE contained.predicate = 'linkedContainedInPlace'
+				AND contained.object_id = @ancestor
+				AND typed.predicate = 'typeOf'
+				AND typed.object_id = @childPlaceType
+		)`
+
+func newContainedInPlaceStatements(cfg TableConfig, placesCTE string) containedInPlaceStatements {
+	return containedInPlaceStatements{
+		// Join all dates before aggregation to optimize total result throughput.
+		all: fmt.Sprintf(`		@{SCAN_METHOD=COLUMNAR, EXECUTION_METHOD=BATCH}
+		WITH %[3]s,
+		series AS (
+			SELECT
+				t.variable_measured,
+				t.entity1,
+				t.extra_entities_id,
+				t.facet_id,
+				t.provenance,
+				t.facet
+			FROM places p
+			JOIN@{JOIN_METHOD=APPLY_JOIN} %[2]s@{FORCE_INDEX=_BASE_TABLE} t
+				ON t.variable_measured IN UNNEST(@variables)
+				AND t.entity1 = p.place_id
+		)
+		SELECT
+			t.variable_measured,
+			t.entity1 AS observation_about,
+			t.facet_id,
+			ANY_VALUE(t.provenance) AS provenance,
+			ARRAY_AGG(
+				STRUCT(
+					o.date AS date,
+					o.value AS str_value
+				)
+			) AS dates_and_values,
+			ANY_VALUE(t.facet) AS facets
+		FROM series t
+		JOIN@{JOIN_METHOD=APPLY_JOIN} %[1]s o
+		USING (variable_measured, entity1, extra_entities_id, facet_id)
+		GROUP BY
+			t.variable_measured,
+			t.entity1,
+			t.extra_entities_id,
+			t.facet_id`, cfg.ObservationTable, cfg.TimeSeriesTable, placesCTE),
+
+		// Join to Observation so TimeSeries without the requested date are
+		// discarded in Spanner.
+		withDate: fmt.Sprintf(`		@{SCAN_METHOD=COLUMNAR, EXECUTION_METHOD=BATCH}
+		WITH %[3]s,
+		series AS (
+			SELECT
+				t.variable_measured,
+				t.entity1,
+				t.extra_entities_id,
+				t.facet_id,
+				t.provenance,
+				t.facet
+			FROM places p
+			JOIN@{JOIN_METHOD=APPLY_JOIN} %[2]s@{FORCE_INDEX=_BASE_TABLE} t
+				ON t.variable_measured IN UNNEST(@variables)
+				AND t.entity1 = p.place_id
+		)
+		SELECT
+			t.variable_measured,
+			t.entity1 AS observation_about,
+			t.facet_id,
+			t.provenance,
+			ARRAY(
+				SELECT AS STRUCT
+					o.date AS date,
+					o.value AS str_value
+			) AS dates_and_values,
+			t.facet AS facets
+		FROM series t
+		JOIN@{JOIN_METHOD=APPLY_JOIN} %[1]s o
+		USING (variable_measured, entity1, extra_entities_id, facet_id)
+		WHERE o.date = @date`, cfg.ObservationTable, cfg.TimeSeriesTable, placesCTE),
+
+		// Use a correlated full-key lookup so the date-descending child scan can
+		// stop after one row.
+		latest: fmt.Sprintf(`		@{SCAN_METHOD=COLUMNAR, EXECUTION_METHOD=BATCH}
+		WITH %[3]s,
+		series AS (
+			SELECT
+				t.variable_measured,
+				t.entity1,
+				t.extra_entities_id,
+				t.facet_id,
+				t.provenance,
+				t.facet
+			FROM places p
+			JOIN@{JOIN_METHOD=APPLY_JOIN} %[2]s@{FORCE_INDEX=_BASE_TABLE} t
+				ON t.variable_measured IN UNNEST(@variables)
+				AND t.entity1 = p.place_id
+		)
+		SELECT
+			t.variable_measured,
+			t.entity1 AS observation_about,
+			t.facet_id,
+			t.provenance,
+			COALESCE(
+				(
+					SELECT ARRAY(
+						SELECT AS STRUCT
+							o.date AS date,
+							o.value AS str_value
+						FROM %[1]s o
+						WHERE o.variable_measured = t.variable_measured
+							AND o.entity1 = t.entity1
+							AND o.extra_entities_id = t.extra_entities_id
+							AND o.facet_id = t.facet_id
+						ORDER BY o.date DESC
+						LIMIT 1
+					)
+				),
+				ARRAY(
+					SELECT AS STRUCT
+						CAST(NULL AS STRING) AS date,
+						CAST(NULL AS STRING) AS str_value
+					FROM UNNEST([1])
+					WHERE FALSE
+				)
+			) AS dates_and_values,
+			t.facet AS facets
+		FROM series t`, cfg.ObservationTable, cfg.TimeSeriesTable, placesCTE),
+	}
 }
 
 func validateMultiEntityTableConfig(cfg TableConfig) error {

--- a/test/setup.go
+++ b/test/setup.go
@@ -461,7 +461,7 @@ func newSpannerClient(ctx context.Context, spannerGraphInfoYamlPath string) span
 // NewSchemaSelectorSpannerClient creates a new test schema selector spanner client.
 func NewSchemaSelectorSpannerClient(t *testing.T) spanner.SpannerClient {
 	baseClient := NewNormalizedSpannerClient(t)
-	selectorClient, err := spanner.NewSchemaSelectorClient(baseClient, false, spanner.DefaultTableConfig(), nil)
+	selectorClient, err := spanner.NewSchemaSelectorClient(baseClient, false, spanner.DefaultTableConfig(), spanner.MultiEntityQueryConfig{})
 	if err != nil {
 		t.Fatalf("Failed to create SchemaSelectorClient: %v", err)
 	}

--- a/test/setup.go
+++ b/test/setup.go
@@ -461,7 +461,7 @@ func newSpannerClient(ctx context.Context, spannerGraphInfoYamlPath string) span
 // NewSchemaSelectorSpannerClient creates a new test schema selector spanner client.
 func NewSchemaSelectorSpannerClient(t *testing.T) spanner.SpannerClient {
 	baseClient := NewNormalizedSpannerClient(t)
-	selectorClient, err := spanner.NewSchemaSelectorClient(baseClient, false, spanner.DefaultTableConfig())
+	selectorClient, err := spanner.NewSchemaSelectorClient(baseClient, false, spanner.DefaultTableConfig(), nil)
 	if err != nil {
 		t.Fatalf("Failed to create SchemaSelectorClient: %v", err)
 	}


### PR DESCRIPTION
  ## Summary

  - Deduplicate observation query variables and entities before constructing Spanner parameters.
  - Add configurable ancestor-first traversal for selected child place types.
  - Use TimeSeriesByEntity1 with SEEKABLE_KEY_SIZE=1 when contained-in-place requests exceed a configurable unique-variable threshold.
  - Apply the optimized path to all-date, latest-date, and exact-date queries.

  ## Motivation

  A representative request with 3,313 places and 266 unique variables generated 881,258 sparse TimeSeries seeks. The optimized entity-range plan reduced Spanner latency from 55.35s to 5.28s and CPU from 1,028.3s
  to 3.98s while returning the same results.

  The threshold defaults to 50 unique variables and can be set to 0 to disable the optimization.

  ## Impact

  This affects V2 and V3 Observation requests using contained-in-place expressions when routed to the multi-entity Spanner schema. Direct entity observation and SDMX queries are unchanged. There are no request or
  response contract changes.

  ## Testing

  - Added unit coverage for threshold selection, deduplication, configuration validation, and unaffected direct queries.
  - Added SQL goldens for ancestor-first and entity-range all/latest/exact-date queries.
  - Verified affected packages and golangci-lint.