### PR TITLE
[featureflags] Enable UseSpannerKeyValueStore in DCP and local configs

### DIFF
--- a/deploy/featureflags/dcp.yaml
+++ b/deploy/featureflags/dcp.yaml
@@ -7,4 +7,4 @@ flags:
   EnableEmbeddingsResolver: false
   EnableSpannerSearchEmbeddings: true
   UseNewIngestionHistorySchema: false
-  UseSpannerKeyValueStore: false
+  UseSpannerKeyValueStore: true

--- a/deploy/featureflags/local.yaml
+++ b/deploy/featureflags/local.yaml
@@ -1,2 +1,4 @@
 flags:
   EnableSDMXDataApi: true
+  UseSpannerGraph: true
+  UseSpannerKeyValueStore: true


### PR DESCRIPTION
This PR enables the `UseSpannerKeyValueStore` feature flag in the DCP default configuration (`deploy/featureflags/dcp.yaml`) and local configuration (`deploy/featureflags/local.yaml`).