### PR TITLE
Prevent observation OOM when variables are not specified

### DIFF
--- a/internal/server/spanner/datasource.go
+++ b/internal/server/spanner/datasource.go
@@ -175,21 +175,24 @@ func (sds *SpannerDataSource) Observation(ctx context.Context, req *pbv2.Observa
 		return nil, fmt.Errorf("variable must be specified for entity.expression")
 	}
 
-	var observations []*Observation
-	var err error
-
 	qo := selectFieldsToQueryOptions(req.Select)
 
-	// Check if this is an existence-only request:
-	// 1. Only 'variable' and 'entity' are requested (no date, value, or facet).
-	// 2. A simple list of entities is provided (no complex entity expression).
-	isExistenceRequest := !qo.date && !qo.value && !qo.facet && len(entities) > 0 && entityExpr == ""
+	// A request without date/value is existence-only unless facets were
+	// requested for explicitly specified variables.
+	isExistenceRequest := entityExpr == "" &&
+		!qo.date &&
+		!qo.value &&
+		(!qo.facet || len(variables) == 0)
 
-	if isExistenceRequest {
+	switch {
+	case isExistenceRequest:
 		return sds.handleExistenceRequest(ctx, req, variables, entities)
+	case len(variables) == 0:
+		// Match legacy behavior: observation fields without variables return no data.
+		return &pbv2.ObservationResponse{}, nil
 	}
 
-	observations, err = sds.fetchObservations(ctx, req)
+	observations, err := sds.fetchObservations(ctx, req)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/spanner/golden/datasource_test.go
+++ b/internal/server/spanner/golden/datasource_test.go
@@ -51,6 +51,7 @@ type mockSpannerClient struct {
 	checkVariableSourceExistenceErr    error
 	filterNodesByTypeRes               map[string][]string
 	getObservationsRes                 []*spanner.Observation
+	getObservationsCalls               int
 	getObservationsContainedInPlaceRes []*spanner.Observation
 }
 
@@ -66,6 +67,7 @@ func (m *mockSpannerClient) GetNodeEdgesByID(ctx context.Context, ids []string, 
 	return m.getNodeEdgesRes, nil
 }
 func (m *mockSpannerClient) GetObservations(ctx context.Context, variables []string, entities []string, date string) ([]*spanner.Observation, error) {
+	m.getObservationsCalls++
 	return m.getObservationsRes, nil
 }
 func (m *mockSpannerClient) CheckVariableExistence(ctx context.Context, variables []string, entities []string) ([][]string, error) {
@@ -501,6 +503,20 @@ func TestSpannerObservation(t *testing.T) {
 			goldenFile: "observation_existence_no_vars.json",
 		},
 		{
+			desc: "No variables requested with facet (returns all vars for entity)",
+			req: &pbv2.ObservationRequest{
+				Entity: &pbv2.DcidOrExpression{
+					Dcids: []string{"geoId/06"},
+				},
+				Select: []string{"variable", "entity", "facet"},
+			},
+			mockRes: [][]string{
+				{"Count_Person", "geoId/06"},
+				{"Median_Income_Person", "geoId/06"},
+			},
+			goldenFile: "observation_existence_no_vars.json",
+		},
+		{
 			desc: "Single entity existence check",
 			req: &pbv2.ObservationRequest{
 				Variable: &pbv2.DcidOrExpression{
@@ -604,6 +620,26 @@ func TestSpannerObservation(t *testing.T) {
 		if diff := cmp.Diff(got, &want, cmpOpts); diff != "" {
 			t.Errorf("%s: %v payload mismatch:\n%v", c.desc, c.goldenFile, diff)
 		}
+	}
+}
+
+func TestSpannerObservationNoVariablesDoesNotFetchValues(t *testing.T) {
+	t.Parallel()
+
+	client := &mockSpannerClient{}
+	ds := spanner.NewSpannerDataSource(client, nil)
+	got, err := ds.Observation(context.Background(), &pbv2.ObservationRequest{
+		Entity: &pbv2.DcidOrExpression{Dcids: []string{"geoId/06"}},
+		Select: []string{"variable", "entity", "date", "value"},
+	})
+	if err != nil {
+		t.Fatalf("Observation() returned error: %v", err)
+	}
+	if client.getObservationsCalls != 0 {
+		t.Fatalf("GetObservations() called %d times, want 0", client.getObservationsCalls)
+	}
+	if diff := cmp.Diff(&pbv2.ObservationResponse{}, got, protocmp.Transform()); diff != "" {
+		t.Errorf("Observation() response mismatch (-want +got):\n%s", diff)
 	}
 }
 


### PR DESCRIPTION
  ## Summary

  Prevent Spanner observation requests with an empty variable list from fetching complete observation histories for every variable associated with an entity.

  The multi-entity query previously interpreted an empty variable list as all variables. When date or value fields were selected, this produced an unbounded observation query and could cause Mixer to run out of memory.

  This change matches the legacy Bigtable behavior:

  - Requests without date or value fields use the variable-existence path.
  - Facet-only requests without variables return the variables available for the entity.
  - Date or value requests without variables return an empty response without calling `GetObservations`.
  - Requests with explicit variables continue using the existing observation and facet paths.

  ## Testing

  - `go test ./internal/server/spanner/... -count=1`
  - `./run_test.sh -l`
  - `git diff --check`