### PR TITLE
Use prod spanner db on autopush

### DIFF
--- a/deploy/featureflags/autopush.yaml
+++ b/deploy/featureflags/autopush.yaml
@@ -5,8 +5,9 @@ flags:
   V3MirrorFraction: 1.0
   WriteUsageLogs: 1.0
   UseSpannerGraph: true
-  SpannerGraphDatabase: projects/datcom-store/instances/dc-graph-staging/databases/dc_graph
+  SpannerGraphDatabase: projects/datcom-store/instances/dc-graph-prod/databases/dc_graph
   EnableSpannerSearchEmbeddings: true
   UseMultiEntitySchema: true
   EnableSDMXDataApi: true
   UseSpannerKeyValueStore: true
+  V2DivertFraction: 1.0

--- a/deploy/featureflags/autopush_website.yaml
+++ b/deploy/featureflags/autopush_website.yaml
@@ -6,7 +6,7 @@ flags:
   V3MirrorFraction: 1.0
   WriteUsageLogs: 1.0
   UseSpannerGraph: true
-  SpannerGraphDatabase: projects/datcom-store/instances/dc-graph-staging/databases/dc_graph
+  SpannerGraphDatabase: projects/datcom-store/instances/dc-graph-prod/databases/dc_graph
   EnableSpannerSearchEmbeddings: true
   UseMultiEntitySchema: true
   EnableSDMXDataApi: true


### PR DESCRIPTION
Also enables 100% diversion to spanner on standalone autopush mixer

(Note autopush website will have separate diversion setup)