### PR TITLE
Use prod db on staging and staging db on dev

### DIFF
--- a/deploy/featureflags/dev.yaml
+++ b/deploy/featureflags/dev.yaml
@@ -5,7 +5,7 @@ flags:
   V3MirrorFraction: 1.0
   WriteUsageLogs: 1.0
   UseSpannerGraph: true
-  SpannerGraphDatabase: projects/datcom-store/instances/dc-graph-prod/databases/dc_graph
+  SpannerGraphDatabase: projects/datcom-store/instances/dc-graph-staging/databases/dc_graph
   EnableSpannerSearchEmbeddings: true
   UseMultiEntitySchema: true  
   V2DivertFraction: 1.0

--- a/deploy/featureflags/dev_website.yaml
+++ b/deploy/featureflags/dev_website.yaml
@@ -6,7 +6,7 @@ flags:
   V3MirrorFraction: 1.0
   WriteUsageLogs: 1.0
   UseSpannerGraph: true
-  SpannerGraphDatabase: projects/datcom-store/instances/dc-graph-prod/databases/dc_graph
+  SpannerGraphDatabase: projects/datcom-store/instances/dc-graph-staging/databases/dc_graph
   EnableSpannerSearchEmbeddings: true
   UseMultiEntitySchema: true
   V2DivertFraction: 1.0

--- a/deploy/featureflags/staging.yaml
+++ b/deploy/featureflags/staging.yaml
@@ -5,7 +5,7 @@ flags:
   V3MirrorFraction: 1.0
   WriteUsageLogs: 1.0
   UseSpannerGraph: true
-  SpannerGraphDatabase: projects/datcom-store/instances/dc-graph-staging/databases/dc_graph
+  SpannerGraphDatabase: projects/datcom-store/instances/dc-graph-prod/databases/dc_graph
   EnableSpannerSearchEmbeddings: false
   UseMultiEntitySchema: true
   UseSpannerKeyValueStore: true

--- a/deploy/featureflags/staging_website.yaml
+++ b/deploy/featureflags/staging_website.yaml
@@ -6,7 +6,7 @@ flags:
   V3MirrorFraction: 1.0
   WriteUsageLogs: 1.0
   UseSpannerGraph: true
-  SpannerGraphDatabase: projects/datcom-store/instances/dc-graph-staging/databases/dc_graph
+  SpannerGraphDatabase: projects/datcom-store/instances/dc-graph-prod/databases/dc_graph
   EnableSpannerSearchEmbeddings: false
   UseMultiEntitySchema: true
   UseSpannerKeyValueStore: true


### PR DESCRIPTION
Swap staging env to use prod db to unblock diverting autopush to spanner

Swap dev env to use staging db to allow testing on multi-entity data