### PR TITLE
Add observation properties to search indicators response

### DIFF
--- a/internal/agent/observations_date.go
+++ b/internal/agent/observations_date.go
@@ -77,9 +77,6 @@ func parseDateFilter(date string, startStr string, endStr string) (*dateFilter, 
 
 	dateLower := date
 	if dateLower == dateTypeLatest || dateLower == dateTypeAll {
-		if startStr != "" || endStr != "" {
-			return nil, fmt.Errorf("cannot specify start/end range if date is %q", date)
-		}
 		return &dateFilter{dateType: dateLower}, nil
 	}
 

--- a/internal/agent/observations_test.go
+++ b/internal/agent/observations_test.go
@@ -76,10 +76,11 @@ func TestObservationsDate(t *testing.T) {
 				wantType: dateTypeAll,
 			},
 			{
-				desc:    "all with start error",
-				date:    dateTypeAll,
-				start:   "2020",
-				wantErr: true,
+				desc:     "all with start date ignores start and returns all",
+				date:     dateTypeAll,
+				start:    "2020",
+				wantType: dateTypeAll,
+				wantErr:  false,
 			},
 			{
 				desc:      "specific year",

--- a/internal/agent/search_indicators.go
+++ b/internal/agent/search_indicators.go
@@ -658,9 +658,9 @@ func translateVariableCandidate(
 	resp *pbv2.SearchIndicatorsResponse,
 ) {
 	resp.Variables = append(resp.Variables, &pbv2.SearchIndicatorsResponse_Variable{
-		Dcid:           c.GetDcid(),
-		PlacesWithData: placesWithData,
-		Description:    c.GetName(),
+		Dcid:                  c.GetDcid(),
+		PlacesWithData:        placesWithData,
+		ObservationProperties: c.GetObservationProperties(),
 	})
 }
 

--- a/internal/agent/search_indicators_test.go
+++ b/internal/agent/search_indicators_test.go
@@ -158,6 +158,35 @@ func TestSearchIndicators_Basic(t *testing.T) {
 		expectedError string
 	}{
 		{
+			desc: "Multi-entity variable populates observation_properties",
+			request: &pbv2.SearchIndicatorsRequest{
+				Query:          "gross oda aid",
+				PerSearchLimit: 5,
+			},
+			resolveMockData: map[string][]*pbv2.ResolveResponse_Entity_Candidate{
+				"gross oda aid": {
+					{
+						Dcid:                  "Amount_EconomicActivity_GrossODA",
+						TypeOf:                []string{"StatisticalVariable"},
+						Name:                  "Gross ODA Aid",
+						ObservationProperties: []string{"donor", "recipient"},
+					},
+				},
+			},
+			wantResponse: &pbv2.SearchIndicatorsResponse{
+				Status: "SUCCESS",
+				DcidNameMappings: map[string]string{
+					"Amount_EconomicActivity_GrossODA": "Gross ODA Aid",
+				},
+				Variables: []*pbv2.SearchIndicatorsResponse_Variable{
+					{
+						Dcid:                  "Amount_EconomicActivity_GrossODA",
+						ObservationProperties: []string{"donor", "recipient"},
+					},
+				},
+			},
+		},
+		{
 			desc: "Basic indicator search without place constraints",
 			request: &pbv2.SearchIndicatorsRequest{
 				Query:          "health in america",
@@ -202,7 +231,6 @@ func TestSearchIndicators_Basic(t *testing.T) {
 				Variables: []*pbv2.SearchIndicatorsResponse_Variable{
 					{
 						Dcid:        "Count_Person_WithDiabetes",
-						Description: "People with Diabetes",
 					},
 				},
 			},
@@ -303,11 +331,9 @@ func TestSearchIndicators_Basic(t *testing.T) {
 				Variables: []*pbv2.SearchIndicatorsResponse_Variable{
 					{
 						Dcid:        "Count_Person_WithAsthma",
-						Description: "People with Asthma",
 					},
 					{
 						Dcid:        "Count_Person_WithDiabetes",
-						Description: "People with Diabetes",
 					},
 				},
 			},
@@ -395,7 +421,6 @@ func TestSearchIndicators_Basic(t *testing.T) {
 				Variables: []*pbv2.SearchIndicatorsResponse_Variable{
 					{
 						Dcid:        "Count_Person_WithDiabetes",
-						Description: "People with Diabetes",
 					},
 				},
 			},
@@ -428,7 +453,6 @@ func TestSearchIndicators_Basic(t *testing.T) {
 				Variables: []*pbv2.SearchIndicatorsResponse_Variable{
 					{
 						Dcid:        "Count_Person_WithAsthma",
-						Description: "People with Asthma",
 					},
 				},
 			},

--- a/internal/proto/v2/agent.pb.go
+++ b/internal/proto/v2/agent.pb.go
@@ -739,6 +739,7 @@ type SearchIndicatorsResponse_Variable struct {
 	PlacesWithData        []string               `protobuf:"bytes,2,rep,name=places_with_data,json=placesWithData,proto3" json:"places_with_data,omitempty"`
 	Description           string                 `protobuf:"bytes,3,opt,name=description,proto3" json:"description,omitempty"`
 	AlternateDescriptions []string               `protobuf:"bytes,4,rep,name=alternate_descriptions,json=alternateDescriptions,proto3" json:"alternate_descriptions,omitempty"`
+	ObservationProperties []string               `protobuf:"bytes,5,rep,name=observation_properties,json=observationProperties,proto3" json:"observation_properties,omitempty"`
 	unknownFields         protoimpl.UnknownFields
 	sizeCache             protoimpl.SizeCache
 }
@@ -797,6 +798,13 @@ func (x *SearchIndicatorsResponse_Variable) GetDescription() string {
 func (x *SearchIndicatorsResponse_Variable) GetAlternateDescriptions() []string {
 	if x != nil {
 		return x.AlternateDescriptions
+	}
+	return nil
+}
+
+func (x *SearchIndicatorsResponse_Variable) GetObservationProperties() []string {
+	if x != nil {
+		return x.ObservationProperties
 	}
 	return nil
 }
@@ -1492,7 +1500,7 @@ const file_v2_agent_proto_rawDesc = "" +
 	"\x0einclude_topics\x18\x05 \x01(\bH\x00R\rincludeTopics\x88\x01\x01\x12(\n" +
 	"\rexpand_topics\x18\x06 \x01(\bH\x01R\fexpandTopics\x88\x01\x01B\x11\n" +
 	"\x0f_include_topicsB\x10\n" +
-	"\x0e_expand_topics\"\xb5\t\n" +
+	"\x0e_expand_topics\"\xec\t\n" +
 	"\x18SearchIndicatorsResponse\x12\x16\n" +
 	"\x06status\x18\x01 \x01(\tR\x06status\x12l\n" +
 	"\x12dcid_name_mappings\x18\x02 \x03(\v2>.datacommons.v2.SearchIndicatorsResponse.DcidNameMappingsEntryR\x10dcidNameMappings\x12|\n" +
@@ -1506,12 +1514,13 @@ const file_v2_agent_proto_rawDesc = "" +
 	"\x10member_variables\x18\x03 \x03(\tR\x0fmemberVariables\x12(\n" +
 	"\x10places_with_data\x18\x04 \x03(\tR\x0eplacesWithData\x12 \n" +
 	"\vdescription\x18\x05 \x01(\tR\vdescription\x125\n" +
-	"\x16alternate_descriptions\x18\x06 \x03(\tR\x15alternateDescriptions\x1a\xa1\x01\n" +
+	"\x16alternate_descriptions\x18\x06 \x03(\tR\x15alternateDescriptions\x1a\xd8\x01\n" +
 	"\bVariable\x12\x12\n" +
 	"\x04dcid\x18\x01 \x01(\tR\x04dcid\x12(\n" +
 	"\x10places_with_data\x18\x02 \x03(\tR\x0eplacesWithData\x12 \n" +
 	"\vdescription\x18\x03 \x01(\tR\vdescription\x125\n" +
-	"\x16alternate_descriptions\x18\x04 \x03(\tR\x15alternateDescriptions\x1aP\n" +
+	"\x16alternate_descriptions\x18\x04 \x03(\tR\x15alternateDescriptions\x125\n" +
+	"\x16observation_properties\x18\x05 \x03(\tR\x15observationProperties\x1aP\n" +
 	"\rResolvedPlace\x12\x12\n" +
 	"\x04dcid\x18\x01 \x01(\tR\x04dcid\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x17\n" +

--- a/internal/server/spanner/datasource.go
+++ b/internal/server/spanner/datasource.go
@@ -542,10 +542,10 @@ func (sds *SpannerDataSource) vectorSearchResolution(
 	}
 	typeOfs := req.TypeOfValues
 	if len(typeOfs) == 0 {
-		typeOfs = []string{"StatisticalVariable", "Topic"}
+		typeOfs = []string{TypeStatisticalVariable, TypeTopic}
 	} else {
 		for _, t := range typeOfs {
-			if t != "StatisticalVariable" && t != "Topic" {
+			if t != TypeStatisticalVariable && t != TypeTopic {
 				slog.Warn("Embeddings resolution requested for unsupported type. Current support is only for StatisticalVariable and Topic.", "type", t)
 				return &pbv2.ResolveResponse{}, nil
 			}
@@ -597,16 +597,23 @@ func (sds *SpannerDataSource) vectorSearchResolution(
 
 			// 3. Build candidates
 			candidates := []*pbv2.ResolveResponse_Entity_Candidate{}
+			var svDcids []string
 			for _, res := range searchResults {
-				candidates = append(candidates, &pbv2.ResolveResponse_Entity_Candidate{
+				c := &pbv2.ResolveResponse_Entity_Candidate{
 					Dcid:   res.SubjectID,
+					Name:   res.Name,
 					TypeOf: res.Types,
 					Metadata: map[string]string{
 						"score":    fmt.Sprintf("%.4f", res.CosineSimilarity),
 						"sentence": res.Name,
 					},
-				})
+				}
+				candidates = append(candidates, c)
+				if slices.Contains(res.Types, TypeStatisticalVariable) {
+					svDcids = append(svDcids, res.SubjectID)
+				}
 			}
+			sds.populateObservationProperties(errCtx, candidates, svDcids)
 			entity.Candidates = candidates
 			resolveResponse.Entities[i] = entity
 			return nil
@@ -619,6 +626,27 @@ func (sds *SpannerDataSource) vectorSearchResolution(
 
 	return resolveResponse, nil
 }
+
+func (sds *SpannerDataSource) populateObservationProperties(
+	ctx context.Context,
+	candidates []*pbv2.ResolveResponse_Entity_Candidate,
+	svDcids []string,
+) {
+	if sds.topicExpander == nil || len(svDcids) == 0 {
+		return
+	}
+	svInfos, err := sds.topicExpander.GetSVPropertyInfos(ctx, svDcids)
+	if err != nil {
+		slog.Warn("Failed to fetch SV property infos during vector search", "error", err)
+		return
+	}
+	for _, c := range candidates {
+		if info, ok := svInfos[c.GetDcid()]; ok {
+			c.ObservationProperties = info.ObservationProperties
+		}
+	}
+}
+
 
 // Sparql executes a SPARQL query against the Spanner data source.
 func (sds *SpannerDataSource) Sparql(ctx context.Context, req *pb.SparqlRequest) (*pb.QueryResponse, error) {

--- a/internal/server/spanner/model.go
+++ b/internal/server/spanner/model.go
@@ -28,7 +28,9 @@ import (
 type KeyValueStoreType string
 
 const (
-	TypeProvenanceSummary = "ProvenanceSummary"
+	TypeProvenanceSummary   = "ProvenanceSummary"
+	TypeStatisticalVariable = "StatisticalVariable"
+	TypeTopic               = "Topic"
 )
 
 // Property struct represents a subset of a row in the Edge table.

--- a/internal/server/spanner/resolve_embeddings_test.go
+++ b/internal/server/spanner/resolve_embeddings_test.go
@@ -81,6 +81,7 @@ func TestResolveEmbeddingsSuccess(t *testing.T) {
 				Candidates: []*pbv2.ResolveResponse_Entity_Candidate{
 					{
 						Dcid:   "dc/topic/Climate",
+						Name:   "Climate Change",
 						TypeOf: []string{"Topic"},
 						Metadata: map[string]string{
 							"score":    "0.8500",
@@ -129,6 +130,7 @@ func TestResolveEmbeddingsConcurrentSuccess(t *testing.T) {
 				Candidates: []*pbv2.ResolveResponse_Entity_Candidate{
 					{
 						Dcid:   "dc/topic/Climate",
+						Name:   "Climate Change",
 						TypeOf: []string{"Topic"},
 						Metadata: map[string]string{
 							"score":    "0.8500",
@@ -142,6 +144,7 @@ func TestResolveEmbeddingsConcurrentSuccess(t *testing.T) {
 				Candidates: []*pbv2.ResolveResponse_Entity_Candidate{
 					{
 						Dcid:   "dc/topic/Climate",
+						Name:   "Climate Change",
 						TypeOf: []string{"Topic"},
 						Metadata: map[string]string{
 							"score":    "0.8500",
@@ -155,6 +158,7 @@ func TestResolveEmbeddingsConcurrentSuccess(t *testing.T) {
 				Candidates: []*pbv2.ResolveResponse_Entity_Candidate{
 					{
 						Dcid:   "dc/topic/Climate",
+						Name:   "Climate Change",
 						TypeOf: []string{"Topic"},
 						Metadata: map[string]string{
 							"score":    "0.8500",

--- a/proto/v2/agent.proto
+++ b/proto/v2/agent.proto
@@ -45,6 +45,7 @@ message SearchIndicatorsResponse {
     repeated string places_with_data = 2;
     string description = 3;
     repeated string alternate_descriptions = 4;
+    repeated string observation_properties = 5;
   }
 
   message ResolvedPlace {


### PR DESCRIPTION
* Adds the `observation_properties` field to `SearchIndicatorsResponse.Variable` in protobuf definitions.
* Populates candidate names and observation properties during Spanner vector search resolution.
* Removes the redundant `description` field from search indicators response variable entries to optimize payload size.
* Unrelated to observation properties, this also relaxes date validation for latest and all date filters that also include a date range since agents were doing this frequently and we were returning a 400 error in such cases. This is aligned with the current python implementation.

### Testing

Tested via local mixer:

```bash
curl -s -X POST http://localhost:8081/v2/agent/search_indicators \
  -H "Content-Type: application/json" \
  -d '{
    "query": "Gross ODA"
  }' | python3 -m json.tool
```

Output:

```json
{
  "status": "SUCCESS",
  "dcidNameMappings": {
    "Amount_EconomicActivity_GrossODA": "Gross Official Development Assistance (ODA)",
    "Amount_EconomicActivity_GrossODALoans": "Gross Official Development Assistance (ODA) Loans"
  },
  "variables": [
    {
      "dcid": "Amount_EconomicActivity_GrossODA",
      "observationProperties": [
        "donor",
        "recipient"
      ]
    },
    {
      "dcid": "Amount_EconomicActivity_GrossODALoans",
      "observationProperties": [
        "donor",
        "recipient"
      ]
    }
  ]
}
```