### PR TITLE
 Fix Spanner validation for SDMX time-period queries

### DIFF
--- a/internal/server/spanner/golden/emulator/sdmx_test.go
+++ b/internal/server/spanner/golden/emulator/sdmx_test.go
@@ -73,26 +73,6 @@ func TestSDMXData(t *testing.T) {
 			golden: "data_fallback_observation_about.csv",
 		},
 		{
-			name:   "explicit time period list",
-			query:  "c[variableMeasured]=Count_TimeSeries&c[observationAbout]=country%2FUSA&c[TIME_PERIOD]=2020,2022,2023",
-			golden: "data_time_period_date_list.csv",
-		},
-		{
-			name:   "single time period omits unmatched series",
-			query:  "c[variableMeasured]=Count_TimeSeries&c[observationAbout]=country%2FUSA&c[TIME_PERIOD]=2020",
-			golden: "data_time_period_single_date.csv",
-		},
-		{
-			name:   "latest time period per series",
-			query:  "c[variableMeasured]=Count_TimeSeries&c[observationAbout]=country%2FUSA&c[TIME_PERIOD]=LATEST",
-			golden: "data_time_period_latest.csv",
-		},
-		{
-			name:   "contained observation about with latest time period",
-			query:  "c[variableMeasured]=Count_TimeSeries&c[observationAbout.containedInPlace+]=northamerica&c[observationAbout.typeOf]=Country&c[TIME_PERIOD]=latest",
-			golden: "data_time_period_latest.csv",
-		},
-		{
 			name:   "three observation properties",
 			query:  "c[variableMeasured]=Count_MigrationByTransportMode&c[destinationCountry]=country%2FCAN&c[sourceCountry]=country%2FUSA&c[transportMode]=Air&c[unit]=Count&c[measurementMethod]=Census&c[observationPeriod]=P1Y&c[provenance]=dc%2Fbase%2FHumanReadableStatVars",
 			golden: "data_three_entities.csv",
@@ -165,6 +145,78 @@ func TestSDMXData(t *testing.T) {
 			}
 			compareEmulatorCSVGolden(t, testCase.golden, string(response.Body))
 		})
+	}
+}
+
+func TestSDMXDataTimePeriods(t *testing.T) {
+	sdmxService := newSDMXService(requireSuite(t).spannerClient)
+	paths := []struct {
+		name     string
+		selector string
+	}{
+		{
+			name:     "direct",
+			selector: "c[observationAbout]=country%2FUSA",
+		},
+		{
+			name:     "contained",
+			selector: "c[observationAbout.containedInPlace+]=northamerica&c[observationAbout.typeOf]=Country",
+		},
+	}
+	timeSelections := []struct {
+		name   string
+		filter string
+		golden string
+	}{
+		{
+			name:   "all",
+			golden: "data_time_period_all.csv",
+		},
+		{
+			name:   "latest",
+			filter: "LATEST",
+			golden: "data_time_period_latest.csv",
+		},
+		{
+			name:   "one_date",
+			filter: "2020",
+			golden: "data_time_period_single_date.csv",
+		},
+		{
+			name:   "two_dates",
+			filter: "2020,2022",
+			golden: "data_time_period_two_dates.csv",
+		},
+		{
+			name:   "ten_dates",
+			filter: "2010,2011,2012,2013,2014,2015,2016,2020,2022,2023",
+			golden: "data_time_period_date_list.csv",
+		},
+		{
+			name:   "eleven_dates",
+			filter: "2010,2011,2012,2013,2014,2015,2016,2017,2020,2022,2023",
+			golden: "data_time_period_date_list.csv",
+		},
+	}
+
+	for _, path := range paths {
+		for _, selection := range timeSelections {
+			t.Run(path.name+"/"+selection.name, func(t *testing.T) {
+				t.Parallel()
+				query := "c[variableMeasured]=Count_TimeSeries&" + path.selector
+				if selection.filter != "" {
+					query += "&c[TIME_PERIOD]=" + selection.filter
+				}
+				response, err := sdmxService.Data(context.Background(), emulatorDataRequest(query))
+				if err != nil {
+					t.Fatalf("Data() error = %v", err)
+				}
+				if response.ContentType != sdmxformat.CSVContentType {
+					t.Fatalf("Data() content type = %q, want %q", response.ContentType, sdmxformat.CSVContentType)
+				}
+				compareEmulatorCSVGolden(t, selection.golden, string(response.Body))
+			})
+		}
 	}
 }
 
@@ -422,24 +474,6 @@ func TestSDMXAvailability(t *testing.T) {
 			golden:    "availability_variable_measured.json",
 		},
 		{
-			name:      "single time period",
-			component: "measurementMethod",
-			query:     "c[variableMeasured]=Count_TimeSeries&c[TIME_PERIOD]=2020",
-			golden:    "availability_time_period_single_date.json",
-		},
-		{
-			name:      "time period list",
-			component: "measurementMethod",
-			query:     "c[variableMeasured]=Count_TimeSeries&c[TIME_PERIOD]=2020,2023",
-			golden:    "availability_time_period_date_list.json",
-		},
-		{
-			name:      "time period list with series constraint",
-			component: "measurementMethod",
-			query:     "c[variableMeasured]=Count_TimeSeries&c[unit]=Count&c[TIME_PERIOD]=2020,2023",
-			golden:    "availability_time_period_date_list.json",
-		},
-		{
 			name:      "unmatched time period",
 			component: "measurementMethod",
 			query:     "c[variableMeasured]=Count_TimeSeries&c[TIME_PERIOD]=1999",
@@ -464,6 +498,85 @@ func TestSDMXAvailability(t *testing.T) {
 			}
 			compareEmulatorJSONGolden(t, testCase.golden, string(response.Body))
 		})
+	}
+}
+
+func TestSDMXAvailabilityTimePeriods(t *testing.T) {
+	sdmxService := newSDMXService(requireSuite(t).spannerClient)
+	paths := []struct {
+		name       string
+		constraint string
+	}{
+		{name: "broad"},
+		{
+			name:       "filtered",
+			constraint: "&c[unit]=Count",
+		},
+	}
+	timeSelections := []struct {
+		name     string
+		filter   string
+		golden   string
+		wantCode codes.Code
+	}{
+		{
+			name:   "all",
+			golden: "availability_time_period_date_list.json",
+		},
+		{
+			name:     "latest",
+			filter:   "LATEST",
+			wantCode: codes.InvalidArgument,
+		},
+		{
+			name:   "one_date",
+			filter: "2020",
+			golden: "availability_time_period_single_date.json",
+		},
+		{
+			name:   "two_dates",
+			filter: "2020,2023",
+			golden: "availability_time_period_date_list.json",
+		},
+		{
+			name:   "ten_dates",
+			filter: "2010,2011,2012,2013,2014,2015,2016,2017,2020,2023",
+			golden: "availability_time_period_date_list.json",
+		},
+		{
+			name:   "eleven_dates",
+			filter: "2010,2011,2012,2013,2014,2015,2016,2017,2018,2020,2023",
+			golden: "availability_time_period_date_list.json",
+		},
+	}
+
+	for _, path := range paths {
+		for _, selection := range timeSelections {
+			t.Run(path.name+"/"+selection.name, func(t *testing.T) {
+				t.Parallel()
+				query := "c[variableMeasured]=Count_TimeSeries" + path.constraint
+				if selection.filter != "" {
+					query += "&c[TIME_PERIOD]=" + selection.filter
+				}
+				response, err := sdmxService.Availability(
+					context.Background(),
+					emulatorAvailabilityRequest("measurementMethod", query),
+				)
+				if status.Code(err) != selection.wantCode {
+					t.Fatalf("Availability() code = %v, want %v; err = %v", status.Code(err), selection.wantCode, err)
+				}
+				if selection.wantCode != codes.OK {
+					if !strings.Contains(status.Convert(err).Message(), "LATEST is not valid for availability") {
+						t.Fatalf("Availability() message = %q, want LATEST validation error", status.Convert(err).Message())
+					}
+					return
+				}
+				if response.ContentType != sdmxformat.StructureJSONType {
+					t.Fatalf("Availability() content type = %q, want %q", response.ContentType, sdmxformat.StructureJSONType)
+				}
+				compareEmulatorJSONGolden(t, selection.golden, string(response.Body))
+			})
+		}
 	}
 }
 

--- a/internal/server/spanner/golden/emulator/testdata/sdmx/data_time_period_all.csv
+++ b/internal/server/spanner/golden/emulator/testdata/sdmx/data_time_period_all.csv
@@ -1,0 +1,5 @@
+STRUCTURE,STRUCTURE_ID,ACTION,variableMeasured,observationAbout,unit,measurementMethod,observationPeriod,provenance,TIME_PERIOD,OBS_VALUE,scalingFactor,facetId
+dataflow,DC:DF_OBS(1.0.0),I,Count_TimeSeries,country/USA,Count,Census,P1Y,dc/base/HumanReadableStatVars,2020,10,,facet-a
+dataflow,DC:DF_OBS(1.0.0),I,Count_TimeSeries,country/USA,Count,Census,P1Y,dc/base/HumanReadableStatVars,2022,12,,facet-a
+dataflow,DC:DF_OBS(1.0.0),I,Count_TimeSeries,country/USA,Count,Survey,P1Y,dc/base/HumanReadableStatVars,2021,20,,facet-b
+dataflow,DC:DF_OBS(1.0.0),I,Count_TimeSeries,country/USA,Count,Survey,P1Y,dc/base/HumanReadableStatVars,2023,23,,facet-b

--- a/internal/server/spanner/golden/emulator/testdata/sdmx/data_time_period_two_dates.csv
+++ b/internal/server/spanner/golden/emulator/testdata/sdmx/data_time_period_two_dates.csv
@@ -1,0 +1,3 @@
+STRUCTURE,STRUCTURE_ID,ACTION,variableMeasured,observationAbout,unit,measurementMethod,observationPeriod,provenance,TIME_PERIOD,OBS_VALUE,scalingFactor,facetId
+dataflow,DC:DF_OBS(1.0.0),I,Count_TimeSeries,country/USA,Count,Census,P1Y,dc/base/HumanReadableStatVars,2020,10,,facet-a
+dataflow,DC:DF_OBS(1.0.0),I,Count_TimeSeries,country/USA,Count,Census,P1Y,dc/base/HumanReadableStatVars,2022,12,,facet-a

--- a/internal/server/spanner/golden/query_builder/get_sdmx_obs_contained_entity1.sql
+++ b/internal/server/spanner/golden/query_builder/get_sdmx_obs_contained_entity1.sql
@@ -27,7 +27,10 @@
 			t.entity1 AS observation_about,
 			t.facet_id,
 			ANY_VALUE(t.provenance) AS provenance,
-			ARRAY_AGG(STRUCT(o.date AS date, o.value AS str_value)) AS dates_and_values,
+			COALESCE(
+				ARRAY_AGG(STRUCT(o.date AS date, o.value AS str_value)),
+				ARRAY(SELECT AS STRUCT CAST(NULL AS STRING) AS date, CAST(NULL AS STRING) AS str_value FROM UNNEST([1]) WHERE FALSE)
+			) AS dates_and_values,
 			ANY_VALUE(t.facet) AS facets,
 			ANY_VALUE(t.entities) AS entities
 		FROM series t

--- a/internal/server/spanner/golden/query_builder/get_sdmx_obs_contained_entity1_explicit_time_periods.sql
+++ b/internal/server/spanner/golden/query_builder/get_sdmx_obs_contained_entity1_explicit_time_periods.sql
@@ -27,7 +27,10 @@
 			t.entity1 AS observation_about,
 			t.facet_id,
 			ANY_VALUE(t.provenance) AS provenance,
-			ARRAY_AGG(STRUCT(o.date AS date, o.value AS str_value) ORDER BY o.date) AS dates_and_values,
+			COALESCE(
+				ARRAY_AGG(STRUCT(o.date AS date, o.value AS str_value) ORDER BY o.date),
+				ARRAY(SELECT AS STRUCT CAST(NULL AS STRING) AS date, CAST(NULL AS STRING) AS str_value FROM UNNEST([1]) WHERE FALSE)
+			) AS dates_and_values,
 			ANY_VALUE(t.facet) AS facets,
 			ANY_VALUE(t.entities) AS entities
 		FROM series t

--- a/internal/server/spanner/golden/query_builder/get_sdmx_obs_contained_entity1_multiple_sets.sql
+++ b/internal/server/spanner/golden/query_builder/get_sdmx_obs_contained_entity1_multiple_sets.sql
@@ -49,7 +49,10 @@
 			t.entity1 AS observation_about,
 			t.facet_id,
 			ANY_VALUE(t.provenance) AS provenance,
-			ARRAY_AGG(STRUCT(o.date AS date, o.value AS str_value)) AS dates_and_values,
+			COALESCE(
+				ARRAY_AGG(STRUCT(o.date AS date, o.value AS str_value)),
+				ARRAY(SELECT AS STRUCT CAST(NULL AS STRING) AS date, CAST(NULL AS STRING) AS str_value FROM UNNEST([1]) WHERE FALSE)
+			) AS dates_and_values,
 			ANY_VALUE(t.facet) AS facets,
 			ANY_VALUE(t.entities) AS entities
 		FROM series t

--- a/internal/server/spanner/golden/query_builder/get_sdmx_obs_contained_entity2.sql
+++ b/internal/server/spanner/golden/query_builder/get_sdmx_obs_contained_entity2.sql
@@ -28,7 +28,10 @@
 			t.entity1 AS observation_about,
 			t.facet_id,
 			ANY_VALUE(t.provenance) AS provenance,
-			ARRAY_AGG(STRUCT(o.date AS date, o.value AS str_value)) AS dates_and_values,
+			COALESCE(
+				ARRAY_AGG(STRUCT(o.date AS date, o.value AS str_value)),
+				ARRAY(SELECT AS STRUCT CAST(NULL AS STRING) AS date, CAST(NULL AS STRING) AS str_value FROM UNNEST([1]) WHERE FALSE)
+			) AS dates_and_values,
 			ANY_VALUE(t.facet) AS facets,
 			ANY_VALUE(t.entities) AS entities
 		FROM series t

--- a/internal/server/spanner/golden/query_builder/get_sdmx_obs_contained_entity3.sql
+++ b/internal/server/spanner/golden/query_builder/get_sdmx_obs_contained_entity3.sql
@@ -29,7 +29,10 @@
 			t.entity1 AS observation_about,
 			t.facet_id,
 			ANY_VALUE(t.provenance) AS provenance,
-			ARRAY_AGG(STRUCT(o.date AS date, o.value AS str_value)) AS dates_and_values,
+			COALESCE(
+				ARRAY_AGG(STRUCT(o.date AS date, o.value AS str_value)),
+				ARRAY(SELECT AS STRUCT CAST(NULL AS STRING) AS date, CAST(NULL AS STRING) AS str_value FROM UNNEST([1]) WHERE FALSE)
+			) AS dates_and_values,
 			ANY_VALUE(t.facet) AS facets,
 			ANY_VALUE(t.entities) AS entities
 		FROM series t

--- a/internal/server/spanner/golden/query_builder/get_sdmx_obs_contained_entity3_before_entity2.sql
+++ b/internal/server/spanner/golden/query_builder/get_sdmx_obs_contained_entity3_before_entity2.sql
@@ -30,7 +30,10 @@
 			t.entity1 AS observation_about,
 			t.facet_id,
 			ANY_VALUE(t.provenance) AS provenance,
-			ARRAY_AGG(STRUCT(o.date AS date, o.value AS str_value)) AS dates_and_values,
+			COALESCE(
+				ARRAY_AGG(STRUCT(o.date AS date, o.value AS str_value)),
+				ARRAY(SELECT AS STRUCT CAST(NULL AS STRING) AS date, CAST(NULL AS STRING) AS str_value FROM UNNEST([1]) WHERE FALSE)
+			) AS dates_and_values,
 			ANY_VALUE(t.facet) AS facets,
 			ANY_VALUE(t.entities) AS entities
 		FROM series t

--- a/internal/server/spanner/golden/query_builder/get_sdmx_obs_contained_entity3_before_entity2_remote.sql
+++ b/internal/server/spanner/golden/query_builder/get_sdmx_obs_contained_entity3_before_entity2_remote.sql
@@ -33,7 +33,10 @@
 			t.entity1 AS observation_about,
 			t.facet_id,
 			ANY_VALUE(t.provenance) AS provenance,
-			ARRAY_AGG(STRUCT(o.date AS date, o.value AS str_value)) AS dates_and_values,
+			COALESCE(
+				ARRAY_AGG(STRUCT(o.date AS date, o.value AS str_value)),
+				ARRAY(SELECT AS STRUCT CAST(NULL AS STRING) AS date, CAST(NULL AS STRING) AS str_value FROM UNNEST([1]) WHERE FALSE)
+			) AS dates_and_values,
 			ANY_VALUE(t.facet) AS facets,
 			ANY_VALUE(t.entities) AS entities
 		FROM series t

--- a/internal/server/spanner/golden/query_builder/get_sdmx_obs_explicit_time_periods.sql
+++ b/internal/server/spanner/golden/query_builder/get_sdmx_obs_explicit_time_periods.sql
@@ -16,7 +16,10 @@
 			t.entity1 AS observation_about,
 			t.facet_id,
 			ANY_VALUE(t.provenance) AS provenance,
-			ARRAY_AGG(STRUCT(o.date AS date, o.value AS str_value) ORDER BY o.date) AS dates_and_values,
+			COALESCE(
+				ARRAY_AGG(STRUCT(o.date AS date, o.value AS str_value) ORDER BY o.date),
+				ARRAY(SELECT AS STRUCT CAST(NULL AS STRING) AS date, CAST(NULL AS STRING) AS str_value FROM UNNEST([1]) WHERE FALSE)
+			) AS dates_and_values,
 			ANY_VALUE(t.facet) AS facets,
 			ANY_VALUE(t.entities) AS entities
 		FROM series t

--- a/internal/server/spanner/golden/query_builder_multientity_test.go
+++ b/internal/server/spanner/golden/query_builder_multientity_test.go
@@ -16,9 +16,11 @@ package golden
 
 import (
 	"context"
+	"strconv"
 	"strings"
 	"testing"
 
+	cloudSpanner "cloud.google.com/go/spanner"
 	sdmxpb "github.com/datacommonsorg/mixer/internal/proto/sdmx"
 	"github.com/datacommonsorg/mixer/internal/server/spanner"
 	v2 "github.com/datacommonsorg/mixer/internal/server/v2"
@@ -378,6 +380,157 @@ func TestMultiEntityGetSdmxObservationsQueryTimePlans(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestMultiEntityGetSdmxObservationsQueryDateArraysAreNonNull(t *testing.T) {
+	builder, err := spanner.NewMultiEntityQueryBuilder(spanner.DefaultTableConfig(), spanner.MultiEntityQueryConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	timeSelections := []struct {
+		name   string
+		values []string
+	}{
+		{name: "all"},
+		{name: "explicit", values: []string{"2020", "2022"}},
+		{name: "latest", values: []string{"LATEST"}},
+	}
+	for _, contained := range []bool{false, true} {
+		pathName := "direct"
+		if contained {
+			pathName = "contained"
+		}
+		for _, selection := range timeSelections {
+			t.Run(pathName+"/"+selection.name, func(t *testing.T) {
+				constraints := map[string]*sdmxpb.SdmxComponentConstraint{
+					"variableMeasured": sdmxComponentConstraint("var1"),
+				}
+				observationPropertyToEntitySlot := map[string]string{}
+				if contained {
+					constraints["observationAbout"] = sdmxContainedInPlaceConstraint("northamerica", "Country")
+					observationPropertyToEntitySlot["observationAbout"] = "entity1"
+				} else {
+					constraints["observationAbout"] = sdmxComponentConstraint("country/USA")
+					observationPropertyToEntitySlot["observationAbout"] = "entity1"
+				}
+				if len(selection.values) > 0 {
+					constraints["TIME_PERIOD"] = sdmxComponentConstraint(selection.values...)
+				}
+
+				statement, err := builder.GetSdmxObservationsQuery(constraints, observationPropertyToEntitySlot, nil)
+				if err != nil {
+					t.Fatalf("GetSdmxObservationsQuery() error = %v", err)
+				}
+				for _, substring := range []string{
+					"COALESCE(",
+					"ARRAY(SELECT AS STRUCT CAST(NULL AS STRING) AS date, CAST(NULL AS STRING) AS str_value FROM UNNEST([1]) WHERE FALSE)",
+				} {
+					if !strings.Contains(statement.SQL, substring) {
+						t.Errorf("GetSdmxObservationsQuery() SQL missing %q:\n%s", substring, statement.SQL)
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestMultiEntitySdmxTimePeriodUnrollPlans(t *testing.T) {
+	builder, err := spanner.NewMultiEntityQueryBuilder(spanner.DefaultTableConfig(), spanner.MultiEntityQueryConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	paths := []struct {
+		name  string
+		build func([]string) (*cloudSpanner.Statement, error)
+	}{
+		{
+			name: "data/direct",
+			build: func(dates []string) (*cloudSpanner.Statement, error) {
+				return builder.GetSdmxObservationsQuery(
+					map[string]*sdmxpb.SdmxComponentConstraint{
+						"variableMeasured": sdmxComponentConstraint("Count_TimeSeries"),
+						"observationAbout": sdmxComponentConstraint("country/USA"),
+						"TIME_PERIOD":      sdmxComponentConstraint(dates...),
+					},
+					map[string]string{"observationAbout": "entity1"},
+					nil,
+				)
+			},
+		},
+		{
+			name: "data/contained",
+			build: func(dates []string) (*cloudSpanner.Statement, error) {
+				return builder.GetSdmxObservationsQuery(
+					map[string]*sdmxpb.SdmxComponentConstraint{
+						"variableMeasured": sdmxComponentConstraint("Count_TimeSeries"),
+						"observationAbout": sdmxContainedInPlaceConstraint("northamerica", "Country"),
+						"TIME_PERIOD":      sdmxComponentConstraint(dates...),
+					},
+					map[string]string{"observationAbout": "entity1"},
+					nil,
+				)
+			},
+		},
+		{
+			name: "availability/broad",
+			build: func(dates []string) (*cloudSpanner.Statement, error) {
+				return builder.GetSdmxAvailabilityQuery(&sdmxpb.SdmxAvailabilityQuery{
+					ComponentId: "measurementMethod",
+					Constraints: map[string]*sdmxpb.SdmxComponentConstraint{
+						"variableMeasured": sdmxComponentConstraint("Count_TimeSeries"),
+						"TIME_PERIOD":      sdmxComponentConstraint(dates...),
+					},
+				}, nil)
+			},
+		},
+		{
+			name: "availability/filtered",
+			build: func(dates []string) (*cloudSpanner.Statement, error) {
+				return builder.GetSdmxAvailabilityQuery(&sdmxpb.SdmxAvailabilityQuery{
+					ComponentId: "measurementMethod",
+					Constraints: map[string]*sdmxpb.SdmxComponentConstraint{
+						"variableMeasured": sdmxComponentConstraint("Count_TimeSeries"),
+						"TIME_PERIOD":      sdmxComponentConstraint(dates...),
+						"unit":             sdmxComponentConstraint("Count"),
+					},
+				}, nil)
+			},
+		},
+	}
+	allDates := []string{"2000", "2001", "2002", "2003", "2004", "2005", "2006", "2007", "2008", "2009", "2010"}
+	for _, path := range paths {
+		for _, count := range []int{1, 2, 10, 11} {
+			t.Run(path.name+"/"+strconv.Itoa(count), func(t *testing.T) {
+				statement, err := path.build(allDates[:count])
+				if err != nil {
+					t.Fatalf("build SDMX statement error = %v", err)
+				}
+				spanner.UnrollParameters(statement)
+
+				switch count {
+				case 1:
+					if !strings.Contains(statement.SQL, "o.date = @time_periods_0") {
+						t.Errorf("unrolled SQL missing single-date equality:\n%s", statement.SQL)
+					}
+				case 2, 10:
+					dateParams := make([]string, count)
+					for i := range count {
+						dateParams[i] = "@time_periods_" + strconv.Itoa(i)
+					}
+					want := "o.date IN (" + strings.Join(dateParams, ",") + ")"
+					if !strings.Contains(statement.SQL, want) {
+						t.Errorf("unrolled SQL missing explicit date list:\n%s", statement.SQL)
+					}
+				case 11:
+					if !strings.Contains(statement.SQL, "o.date IN UNNEST(@time_periods)") {
+						t.Errorf("SQL unexpectedly unrolled 11 dates:\n%s", statement.SQL)
+					}
+				}
+			})
+		}
 	}
 }
 

--- a/internal/server/spanner/statements_multientity.go
+++ b/internal/server/spanner/statements_multientity.go
@@ -303,7 +303,10 @@ func NewMultiEntityStatements(cfg TableConfig) (*MultiEntityStatements, error) {
 			t.entity1 AS observation_about,
 			t.facet_id,
 			ANY_VALUE(t.provenance) AS provenance,
-			ARRAY_AGG(STRUCT(o.date AS date, o.value AS str_value) ORDER BY o.date) AS dates_and_values,
+			COALESCE(
+				ARRAY_AGG(STRUCT(o.date AS date, o.value AS str_value) ORDER BY o.date),
+				ARRAY(SELECT AS STRUCT CAST(NULL AS STRING) AS date, CAST(NULL AS STRING) AS str_value FROM UNNEST([1]) WHERE FALSE)
+			) AS dates_and_values,
 			ANY_VALUE(t.facet) AS facets,
 			ANY_VALUE(t.entities) AS entities
 		FROM series t
@@ -410,7 +413,10 @@ func NewMultiEntityStatements(cfg TableConfig) (*MultiEntityStatements, error) {
 			t.entity1 AS observation_about,
 			t.facet_id,
 			ANY_VALUE(t.provenance) AS provenance,
-			ARRAY_AGG(STRUCT(o.date AS date, o.value AS str_value)) AS dates_and_values,
+			COALESCE(
+				ARRAY_AGG(STRUCT(o.date AS date, o.value AS str_value)),
+				ARRAY(SELECT AS STRUCT CAST(NULL AS STRING) AS date, CAST(NULL AS STRING) AS str_value FROM UNNEST([1]) WHERE FALSE)
+			) AS dates_and_values,
 			ANY_VALUE(t.facet) AS facets,
 			ANY_VALUE(t.entities) AS entities
 		FROM series t
@@ -429,7 +435,10 @@ func NewMultiEntityStatements(cfg TableConfig) (*MultiEntityStatements, error) {
 			t.entity1 AS observation_about,
 			t.facet_id,
 			ANY_VALUE(t.provenance) AS provenance,
-			ARRAY_AGG(STRUCT(o.date AS date, o.value AS str_value) ORDER BY o.date) AS dates_and_values,
+			COALESCE(
+				ARRAY_AGG(STRUCT(o.date AS date, o.value AS str_value) ORDER BY o.date),
+				ARRAY(SELECT AS STRUCT CAST(NULL AS STRING) AS date, CAST(NULL AS STRING) AS str_value FROM UNNEST([1]) WHERE FALSE)
+			) AS dates_and_values,
 			ANY_VALUE(t.facet) AS facets,
 			ANY_VALUE(t.entities) AS entities
 		FROM series t


### PR DESCRIPTION
 ## Summary

  - Make SDMX `dates_and_values` arrays statically non-null using a typed `COALESCE` fallback.
  - Preserve the existing inner-join behavior: series without matching observations remain excluded.
  - Add emulator coverage for direct and contained data queries across all, latest, 1, 2, 10, and 11 dates.
  - Add equivalent coverage for broad and filtered availability queries.
  - Verify the SDMX query shapes at each parameter-unroll boundary.

  ## Why

  Production Spanner rejects the `ARRAY_AGG<STRUCT>` expression because it considers the resulting array potentially nullable, even though the join and grouping logically guarantee rows. The typed fallback
  satisfies Spanner’s static nullability analysis without changing query results or join plans.

  The emulator does not reproduce this production validation, so query-shape tests explicitly ensure the non-null guard remains present.

  ## Tests

  - `go test ./internal/server/spanner/...`
  - `./scripts/run_spanner_emulator_tests.sh`
  - `./run_test.sh -f`