### PR TITLE
Disable EnableSpannerSearchEmbeddings in autopush feature flags

### DIFF
--- a/deploy/featureflags/autopush.yaml
+++ b/deploy/featureflags/autopush.yaml
@@ -6,7 +6,7 @@ flags:
   WriteUsageLogs: 1.0
   UseSpannerGraph: true
   SpannerGraphDatabase: projects/datcom-store/instances/dc-graph-prod/databases/dc_graph
-  EnableSpannerSearchEmbeddings: true
+  EnableSpannerSearchEmbeddings: false
   UseMultiEntitySchema: true
   EnableSDMXDataApi: true
   UseSpannerKeyValueStore: true

--- a/deploy/featureflags/autopush_website.yaml
+++ b/deploy/featureflags/autopush_website.yaml
@@ -7,7 +7,7 @@ flags:
   WriteUsageLogs: 1.0
   UseSpannerGraph: true
   SpannerGraphDatabase: projects/datcom-store/instances/dc-graph-prod/databases/dc_graph
-  EnableSpannerSearchEmbeddings: true
+  EnableSpannerSearchEmbeddings: false
   UseMultiEntitySchema: true
   EnableSDMXDataApi: true
   UseSpannerKeyValueStore: true


### PR DESCRIPTION
We're seeing an issue in Autopush environment where searching the explore page for a query like "Jobs in Texas" is redirecting to the place page. This doesn't happen in prod/staging. We traced the issue to potentially the behaviour of code behind the flag `EnableSpannerSearchEmbeddings`. So I'm disabling it for now on autopush.

