### PR TITLE
Support containedInPlace+ expansion in SDMX availability queries

### DIFF
--- a/internal/server/dispatcher/relation_expression_processor.go
+++ b/internal/server/dispatcher/relation_expression_processor.go
@@ -61,8 +61,8 @@ func NewRelationExpressionProcessor(
 // TODO: Mark local-only responses caused by remote expansion failures as
 // non-cacheable so transient failures are not cached by Redis.
 func (p *RelationExpressionProcessor) PreProcess(rc *RequestContext) (Outcome, error) {
-	if rc.Type == TypeSdmxData {
-		return p.preProcessSdmxData(rc)
+	if rc.Type == TypeSdmxData || rc.Type == TypeSdmxAvailability {
+		return p.preProcessSdmx(rc)
 	}
 
 	// Only process observation requests.
@@ -105,19 +105,23 @@ func (p *RelationExpressionProcessor) PreProcess(rc *RequestContext) (Outcome, e
 	return Continue, nil
 }
 
-// TODO: Break this orchestration into reusable helpers when remote containment
-// expansion is added to SDMX Availability.
-func (p *RelationExpressionProcessor) preProcessSdmxData(rc *RequestContext) (Outcome, error) {
+func (p *RelationExpressionProcessor) preProcessSdmx(rc *RequestContext) (Outcome, error) {
 	if p.source == nil {
 		return Continue, nil
 	}
-	req, ok := rc.CurrentRequest.(*sdmx.SdmxDataQuery)
-	if !ok {
-		slog.Error("RelationExpressionProcessor: failed to cast request to SdmxDataQuery", "type", rc.Type)
-		return Continue, fmt.Errorf("failed to cast request to SdmxDataQuery")
+
+	var constraints map[string]*sdmx.SdmxComponentConstraint
+	switch req := rc.CurrentRequest.(type) {
+	case *sdmx.SdmxDataQuery:
+		constraints = req.GetConstraints()
+	case *sdmx.SdmxAvailabilityQuery:
+		constraints = req.GetConstraints()
+	default:
+		slog.Error("RelationExpressionProcessor: failed to cast SDMX request", "type", rc.Type)
+		return Continue, fmt.Errorf("failed to cast SDMX request")
 	}
 
-	componentToContainedInPlace, err := datacommons.ContainedInPlaceConstraints(req.GetConstraints())
+	componentToContainedInPlace, err := datacommons.ContainedInPlaceConstraints(constraints)
 	if err != nil {
 		return Continue, err
 	}

--- a/internal/server/dispatcher/relation_expression_processor_test.go
+++ b/internal/server/dispatcher/relation_expression_processor_test.go
@@ -243,6 +243,21 @@ func sdmxDataQueryWithContainedInPlace(
 	return &sdmxpb.SdmxDataQuery{Constraints: constraints}
 }
 
+func sdmxAvailabilityQueryWithContainedInPlace(
+	componentToContainedInPlace map[string]*sdmxpb.SdmxComponentConstraint,
+) *sdmxpb.SdmxAvailabilityQuery {
+	constraints := map[string]*sdmxpb.SdmxComponentConstraint{
+		datacommons.ComponentVariableMeasured: sdmxComponentConstraint("Count_Person"),
+	}
+	for component, constraint := range componentToContainedInPlace {
+		constraints[component] = constraint
+	}
+	return &sdmxpb.SdmxAvailabilityQuery{
+		ComponentId: datacommons.ComponentUnit,
+		Constraints: constraints,
+	}
+}
+
 func sdmxNodeResponse(subject string, dcids []string, nextToken string) *pbv2.NodeResponse {
 	nodes := make([]*pb.EntityInfo, 0, len(dcids))
 	for _, dcid := range dcids {
@@ -308,6 +323,38 @@ func TestRelationExpressionProcessorPreProcessSdmxDataDeduplicatesRelationsAndPa
 	got := SdmxContainedInPlaceToRemoteDCIDsFromContext(rc.Context)
 	if !slices.Equal(got[relation], want[relation]) || len(got) != len(want) {
 		t.Fatalf("remote expansions = %v, want %v", got, want)
+	}
+}
+
+func TestRelationExpressionProcessorPreProcessSdmxAvailability(t *testing.T) {
+	relation := datacommons.ContainedInPlaceConstraint{Ancestor: "northamerica", ChildPlaceType: "Country"}
+	remoteSource := &mockSource{
+		nodeFunc: func(_ context.Context, req *pbv2.NodeRequest, _ int) (*pbv2.NodeResponse, error) {
+			if got, want := req.GetProperty(), "<-containedInPlace+{typeOf:Country}"; got != want {
+				return nil, fmt.Errorf("Node() property = %q, want %q", got, want)
+			}
+			return sdmxNodeResponse(relation.Ancestor, []string{"country/USA", "country/CAN"}, ""), nil
+		},
+	}
+	processor := NewRelationExpressionProcessor(remoteSource, 10)
+	rc := &RequestContext{
+		Context: context.Background(),
+		Type:    TypeSdmxAvailability,
+		CurrentRequest: sdmxAvailabilityQueryWithContainedInPlace(map[string]*sdmxpb.SdmxComponentConstraint{
+			"sourceCountry": sdmxContainedInPlaceComponentConstraint(relation.Ancestor, relation.ChildPlaceType),
+		}),
+	}
+
+	outcome, err := processor.PreProcess(rc)
+	if err != nil {
+		t.Fatalf("PreProcess() error = %v", err)
+	}
+	if outcome != Continue {
+		t.Fatalf("PreProcess() outcome = %v, want %v", outcome, Continue)
+	}
+	got := SdmxContainedInPlaceToRemoteDCIDsFromContext(rc.Context)
+	if want := []string{"country/CAN", "country/USA"}; !slices.Equal(got[relation], want) {
+		t.Fatalf("remote expansion = %v, want %v", got[relation], want)
 	}
 }
 

--- a/internal/server/sdmx/datacommons/constraints.go
+++ b/internal/server/sdmx/datacommons/constraints.go
@@ -51,7 +51,7 @@ type constraintConfig struct {
 	propertyRules map[string]PropertyRule
 }
 
-var dataConstraintConfig = constraintConfig{
+var supportedConstraintConfig = constraintConfig{
 	propertyRules: map[string]PropertyRule{
 		PropertyContainedInPlace: {
 			Scope:          ComponentScopeObservationProperty,
@@ -65,8 +65,6 @@ var dataConstraintConfig = constraintConfig{
 		},
 	},
 }
-
-var availabilityConstraintConfig = constraintConfig{propertyRules: map[string]PropertyRule{}}
 
 type ContainedInPlaceConstraint struct {
 	Ancestor       string
@@ -86,10 +84,10 @@ type TimePeriodSelection struct {
 	Dates []string
 }
 
-// DataPropertyRule returns the rule used to validate and compile an SDMX data
+// PropertyRuleForID returns the rule used to validate and compile an SDMX
 // property constraint.
-func DataPropertyRule(propertyID string) (PropertyRule, bool) {
-	rule, ok := dataConstraintConfig.propertyRules[propertyID]
+func PropertyRuleForID(propertyID string) (PropertyRule, bool) {
+	rule, ok := supportedConstraintConfig.propertyRules[propertyID]
 	return rule, ok
 }
 
@@ -99,7 +97,16 @@ func ValidateDataConstraints(constraints map[string]*sdmxpb.SdmxComponentConstra
 	if err := validateComponentPredicates(constraints); err != nil {
 		return err
 	}
+	if err := validatePropertyConstraints(constraints); err != nil {
+		return err
+	}
+	if _, err := ClassifyTimePeriod(constraints); err != nil {
+		return err
+	}
+	return validateRequiredVariableMeasured(constraints)
+}
 
+func validatePropertyConstraints(constraints map[string]*sdmxpb.SdmxComponentConstraint) error {
 	for _, componentID := range slices.Sorted(maps.Keys(constraints)) {
 		constraint := constraints[componentID]
 		properties := constraint.GetPropertyConstraints()
@@ -117,7 +124,7 @@ func ValidateDataConstraints(constraints map[string]*sdmxpb.SdmxComponentConstra
 
 		for _, propertyID := range slices.Sorted(maps.Keys(properties)) {
 			propertyConstraint := properties[propertyID]
-			rule, ok := DataPropertyRule(propertyID)
+			rule, ok := PropertyRuleForID(propertyID)
 			if !ok {
 				return status.Errorf(codes.Unimplemented, "SDMX property constraint %q is not implemented yet", propertyID)
 			}
@@ -132,10 +139,7 @@ func ValidateDataConstraints(constraints map[string]*sdmxpb.SdmxComponentConstra
 			return status.Errorf(codes.InvalidArgument, "SDMX property filters on component %q require containedInPlace+ and typeOf", componentID)
 		}
 	}
-	if _, err := ClassifyTimePeriod(constraints); err != nil {
-		return err
-	}
-	return validateRequiredVariableMeasured(constraints)
+	return nil
 }
 
 // ClassifyTimePeriod returns the request's time selection mode.
@@ -179,16 +183,8 @@ func ValidateAvailabilityConstraints(constraints map[string]*sdmxpb.SdmxComponen
 	if err := validateComponentPredicates(constraints); err != nil {
 		return err
 	}
-	for _, componentID := range slices.Sorted(maps.Keys(constraints)) {
-		for _, propertyID := range slices.Sorted(maps.Keys(constraints[componentID].GetPropertyConstraints())) {
-			rule, ok := availabilityConstraintConfig.propertyRules[propertyID]
-			if !ok {
-				return status.Error(codes.Unimplemented, "SDMX property constraints are not implemented for availability yet")
-			}
-			if err := validatePropertyConstraint(componentID, propertyID, constraints[componentID].GetPropertyConstraints()[propertyID], rule); err != nil {
-				return err
-			}
-		}
+	if err := validatePropertyConstraints(constraints); err != nil {
+		return err
 	}
 	timeSelection, err := ClassifyTimePeriod(constraints)
 	if err != nil {
@@ -203,7 +199,7 @@ func ValidateAvailabilityConstraints(constraints map[string]*sdmxpb.SdmxComponen
 // ContainedInPlaceConstraints returns the validated containment pair for each
 // constrained component.
 func ContainedInPlaceConstraints(constraints map[string]*sdmxpb.SdmxComponentConstraint) (map[string]ContainedInPlaceConstraint, error) {
-	if err := ValidateDataConstraints(constraints); err != nil {
+	if err := validatePropertyConstraints(constraints); err != nil {
 		return nil, err
 	}
 	result := map[string]ContainedInPlaceConstraint{}

--- a/internal/server/sdmx/datacommons/constraints_test.go
+++ b/internal/server/sdmx/datacommons/constraints_test.go
@@ -224,12 +224,22 @@ func TestContainedInPlaceConstraints(t *testing.T) {
 	}
 }
 
-func TestValidateAvailabilityConstraintsRejectsProperties(t *testing.T) {
-	err := ValidateAvailabilityConstraints(map[string]*sdmxpb.SdmxComponentConstraint{
-		"observationAbout": testContainedInPlaceConstraint("country/USA", "County"),
-	})
-	if status.Code(err) != codes.Unimplemented {
-		t.Fatalf("ValidateAvailabilityConstraints() code = %v, want %v; err = %v", status.Code(err), codes.Unimplemented, err)
+func TestValidateAvailabilityConstraintsPropertyConstraints(t *testing.T) {
+	constraints := map[string]*sdmxpb.SdmxComponentConstraint{
+		ComponentVariableMeasured: {Predicates: []*sdmxpb.SdmxPredicate{{Value: "Count_Person"}}},
+		ComponentObservationAbout: testContainedInPlaceConstraint("country/USA", "County"),
+	}
+	if err := ValidateAvailabilityConstraints(constraints); err != nil {
+		t.Fatalf("ValidateAvailabilityConstraints() error = %v, want nil", err)
+	}
+
+	constraints[ComponentObservationAbout] = &sdmxpb.SdmxComponentConstraint{
+		PropertyConstraints: map[string]*sdmxpb.SdmxPropertyConstraint{
+			PropertyTypeOf: {Predicates: []*sdmxpb.SdmxPredicate{{Value: "County"}}},
+		},
+	}
+	if err := ValidateAvailabilityConstraints(constraints); status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("ValidateAvailabilityConstraints() code = %v, want %v; err = %v", status.Code(err), codes.InvalidArgument, err)
 	}
 }
 

--- a/internal/server/sdmx/rest/v2/availability_test.go
+++ b/internal/server/sdmx/rest/v2/availability_test.go
@@ -140,6 +140,27 @@ func TestParseAvailabilityRequest_Constraints(t *testing.T) {
 	}
 }
 
+func TestParseAvailabilityRequest_PropertyConstraints(t *testing.T) {
+	for _, query := range []string{
+		"c[variableMeasured]=Count_Migration&c[sourceCountry.containedInPlace+]=country%2FUSA&c[sourceCountry.typeOf]=State",
+		"c%5BvariableMeasured%5D=Count_Migration&c%5BsourceCountry.containedInPlace%2B%5D=country%2FUSA&c%5BsourceCountry.typeOf%5D=State",
+	} {
+		got, err := ParseAvailabilityRequest(availabilityTail("destinationCountry"), availabilityURI("destinationCountry", query))
+		if err != nil {
+			t.Fatalf("ParseAvailabilityRequest() error = %v", err)
+		}
+		constraint := got.Constraints["sourceCountry"]
+		containedIn := constraint.GetPropertyConstraints()["containedInPlace"]
+		if !containedIn.GetTransitive() || containedIn.GetPredicates()[0].GetValue() != "country/USA" {
+			t.Fatalf("containedInPlace constraint = %v", containedIn)
+		}
+		typeOf := constraint.GetPropertyConstraints()["typeOf"]
+		if typeOf.GetTransitive() || typeOf.GetPredicates()[0].GetValue() != "State" {
+			t.Fatalf("typeOf constraint = %v", typeOf)
+		}
+	}
+}
+
 func TestParseAvailabilityRequest_Errors(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -248,11 +269,6 @@ func TestParseAvailabilityRequest_Errors(t *testing.T) {
 		{
 			name:        "operator unsupported",
 			originalURI: availabilityURI("observationAbout", "c[variableMeasured]=ge:2020"),
-			wantCode:    codes.Unimplemented,
-		},
-		{
-			name:        "property constraint unsupported",
-			originalURI: availabilityURI("observationAbout", "c[variableMeasured]=Count_Person&c[observationAbout.containedInPlace+]=country%2FUSA&c[observationAbout.typeOf]=County"),
 			wantCode:    codes.Unimplemented,
 		},
 		{

--- a/internal/server/sdmx/service/service_test.go
+++ b/internal/server/sdmx/service/service_test.go
@@ -704,6 +704,41 @@ func TestAvailabilitySuccess(t *testing.T) {
 	}
 }
 
+func TestAvailabilityPreservesPropertyConstraints(t *testing.T) {
+	ds := &sdmxDataSource{
+		availabilityResult: &sdmxpb.SdmxAvailabilityResult{Values: []string{"country/CAN"}},
+	}
+	svc := newSdmxTestService(ds)
+
+	_, err := svc.Availability(context.Background(), sdmxAvailabilityRequest(
+		"destinationCountry",
+		"c[variableMeasured]=Count_Migration&c[sourceCountry.containedInPlace+]=country%2FUSA&c[sourceCountry.typeOf]=State",
+	))
+	if err != nil {
+		t.Fatalf("Availability() error = %v", err)
+	}
+	wantQuery := &sdmxpb.SdmxAvailabilityQuery{
+		ComponentId: "destinationCountry",
+		Constraints: map[string]*sdmxpb.SdmxComponentConstraint{
+			"variableMeasured": sdmxComponentConstraint("Count_Migration"),
+			"sourceCountry": {
+				PropertyConstraints: map[string]*sdmxpb.SdmxPropertyConstraint{
+					datacommons.PropertyContainedInPlace: {
+						Predicates: []*sdmxpb.SdmxPredicate{{Value: "country/USA"}},
+						Transitive: true,
+					},
+					datacommons.PropertyTypeOf: {
+						Predicates: []*sdmxpb.SdmxPredicate{{Value: "State"}},
+					},
+				},
+			},
+		},
+	}
+	if diff := cmp.Diff(wantQuery, ds.gotAvailability, protocmp.Transform()); diff != "" {
+		t.Fatalf("dispatcher query mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestAvailabilitySelectsOtherDimension(t *testing.T) {
 	ds := &sdmxDataSource{
 		availabilityResult: &sdmxpb.SdmxAvailabilityResult{Values: []string{"Person"}},

--- a/internal/server/spanner/golden/emulator/sdmx_test.go
+++ b/internal/server/spanner/golden/emulator/sdmx_test.go
@@ -54,6 +54,9 @@ func (s *sdmxRemoteDataSource) Node(ctx context.Context, req *pbv2.NodeRequest, 
 func (s *sdmxRemoteDataSource) SdmxData(context.Context, *sdmxpb.SdmxDataQuery) (*sdmxpb.SdmxDataResult, error) {
 	return &sdmxpb.SdmxDataResult{}, nil
 }
+func (s *sdmxRemoteDataSource) SdmxAvailability(context.Context, *sdmxpb.SdmxAvailabilityQuery) (*sdmxpb.SdmxAvailabilityResult, error) {
+	return &sdmxpb.SdmxAvailabilityResult{}, nil
+}
 
 func TestSDMXData(t *testing.T) {
 	sdmxService := newSDMXService(requireSuite(t).spannerClient)
@@ -480,6 +483,24 @@ func TestSDMXAvailability(t *testing.T) {
 			golden:    "availability_empty.json",
 		},
 		{
+			name:      "contained observation about",
+			component: "observationAbout",
+			query:     "c[variableMeasured]=Count_TimeSeries&c[observationAbout.containedInPlace+]=northamerica&c[observationAbout.typeOf]=Country",
+			golden:    "availability_fallback_observation_about.json",
+		},
+		{
+			name:      "contained observation about with time period",
+			component: "measurementMethod",
+			query:     "c[variableMeasured]=Count_TimeSeries&c[observationAbout.containedInPlace+]=northamerica&c[observationAbout.typeOf]=Country&c[TIME_PERIOD]=2020",
+			golden:    "availability_time_period_single_date.json",
+		},
+		{
+			name:      "empty containment result",
+			component: "destinationCountry",
+			query:     "c[variableMeasured]=Count_Migration&c[sourceCountry.containedInPlace+]=oceania&c[sourceCountry.typeOf]=Country",
+			golden:    "availability_empty.json",
+		},
+		{
 			name:      "empty result",
 			component: "sourceCountry",
 			query:     "c[variableMeasured]=Count_Migration&c[destinationCountry]=country%2FZZZ",
@@ -578,6 +599,39 @@ func TestSDMXAvailabilityTimePeriods(t *testing.T) {
 			})
 		}
 	}
+}
+
+func TestSDMXAvailabilityUsesRemoteContainedInPlaceWithLocalObservations(t *testing.T) {
+	relation := datacommons.ContainedInPlaceConstraint{Ancestor: "Earth", ChildPlaceType: "Country"}
+	expansions := map[datacommons.ContainedInPlaceConstraint][]string{
+		relation: {"country/USA"},
+	}
+	var calls int
+	remoteSource := &sdmxRemoteDataSource{
+		nodeFunc: func(_ context.Context, req *pbv2.NodeRequest, _ int) (*pbv2.NodeResponse, error) {
+			got, err := matchSdmxRemoteExpansion(req, expansions)
+			if err != nil {
+				return nil, err
+			}
+			calls++
+			return sdmxRemoteNodeResponse(got, expansions[got]), nil
+		},
+	}
+	sdmxService := newSDMXServiceWithRemote(requireSuite(t).spannerClient, remoteSource)
+	response, err := sdmxService.Availability(context.Background(), emulatorAvailabilityRequest(
+		"observationAbout",
+		"c[variableMeasured]=Count_TimeSeries&c[observationAbout.containedInPlace+]=Earth&c[observationAbout.typeOf]=Country",
+	))
+	if err != nil {
+		t.Fatalf("Availability() error = %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("Node() calls = %d, want 1", calls)
+	}
+	if response.ContentType != sdmxformat.StructureJSONType {
+		t.Fatalf("Availability() content type = %q, want %q", response.ContentType, sdmxformat.StructureJSONType)
+	}
+	compareEmulatorJSONGolden(t, "availability_fallback_observation_about.json", string(response.Body))
 }
 
 func TestSDMXRejectsIncompatibleStatVariableShapes(t *testing.T) {

--- a/internal/server/spanner/golden/emulator/sdmx_test.go
+++ b/internal/server/spanner/golden/emulator/sdmx_test.go
@@ -483,24 +483,6 @@ func TestSDMXAvailability(t *testing.T) {
 			golden:    "availability_empty.json",
 		},
 		{
-			name:      "contained observation about",
-			component: "observationAbout",
-			query:     "c[variableMeasured]=Count_TimeSeries&c[observationAbout.containedInPlace+]=northamerica&c[observationAbout.typeOf]=Country",
-			golden:    "availability_fallback_observation_about.json",
-		},
-		{
-			name:      "contained observation about with time period",
-			component: "measurementMethod",
-			query:     "c[variableMeasured]=Count_TimeSeries&c[observationAbout.containedInPlace+]=northamerica&c[observationAbout.typeOf]=Country&c[TIME_PERIOD]=2020",
-			golden:    "availability_time_period_single_date.json",
-		},
-		{
-			name:      "empty containment result",
-			component: "destinationCountry",
-			query:     "c[variableMeasured]=Count_Migration&c[sourceCountry.containedInPlace+]=oceania&c[sourceCountry.typeOf]=Country",
-			golden:    "availability_empty.json",
-		},
-		{
 			name:      "empty result",
 			component: "sourceCountry",
 			query:     "c[variableMeasured]=Count_Migration&c[destinationCountry]=country%2FZZZ",
@@ -511,6 +493,54 @@ func TestSDMXAvailability(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 			response, err := sdmxService.Availability(context.Background(), emulatorAvailabilityRequest(testCase.component, testCase.query))
+			if err != nil {
+				t.Fatalf("Availability() error = %v", err)
+			}
+			if response.ContentType != sdmxformat.StructureJSONType {
+				t.Fatalf("Availability() content type = %q, want %q", response.ContentType, sdmxformat.StructureJSONType)
+			}
+			compareEmulatorJSONGolden(t, testCase.golden, string(response.Body))
+		})
+	}
+}
+
+func TestSDMXAvailabilityContainedInPlace(t *testing.T) {
+	sdmxService := newSDMXService(requireSuite(t).spannerClient)
+	baseQuery := "c[variableMeasured]=Count_Migration,Count_Refugee&" +
+		"c[sourceCountry.containedInPlace+]=northamerica&c[sourceCountry.typeOf]=Country"
+	tests := []struct {
+		name      string
+		component string
+		query     string
+		golden    string
+	}{
+		{
+			name:      "nonempty entity2",
+			component: "destinationCountry",
+			query:     baseQuery,
+			golden:    "availability_contained_source_country.json",
+		},
+		{
+			name:      "nonempty entity2 with time periods",
+			component: "destinationCountry",
+			query:     baseQuery + "&c[TIME_PERIOD]=2023,2024",
+			golden:    "availability_contained_source_country_with_time_periods.json",
+		},
+		{
+			name:      "empty entity2",
+			component: "destinationCountry",
+			query:     "c[variableMeasured]=Count_Migration&c[sourceCountry.containedInPlace+]=oceania&c[sourceCountry.typeOf]=Country",
+			golden:    "availability_contained_empty.json",
+		},
+	}
+	for _, testCase := range tests {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			response, err := sdmxService.Availability(
+				context.Background(),
+				emulatorAvailabilityRequest(testCase.component, testCase.query),
+			)
 			if err != nil {
 				t.Fatalf("Availability() error = %v", err)
 			}
@@ -619,8 +649,8 @@ func TestSDMXAvailabilityUsesRemoteContainedInPlaceWithLocalObservations(t *test
 	}
 	sdmxService := newSDMXServiceWithRemote(requireSuite(t).spannerClient, remoteSource)
 	response, err := sdmxService.Availability(context.Background(), emulatorAvailabilityRequest(
-		"observationAbout",
-		"c[variableMeasured]=Count_TimeSeries&c[observationAbout.containedInPlace+]=Earth&c[observationAbout.typeOf]=Country",
+		"destinationCountry",
+		"c[variableMeasured]=Count_Migration,Count_Refugee&c[sourceCountry.containedInPlace+]=Earth&c[sourceCountry.typeOf]=Country",
 	))
 	if err != nil {
 		t.Fatalf("Availability() error = %v", err)
@@ -631,7 +661,7 @@ func TestSDMXAvailabilityUsesRemoteContainedInPlaceWithLocalObservations(t *test
 	if response.ContentType != sdmxformat.StructureJSONType {
 		t.Fatalf("Availability() content type = %q, want %q", response.ContentType, sdmxformat.StructureJSONType)
 	}
-	compareEmulatorJSONGolden(t, "availability_fallback_observation_about.json", string(response.Body))
+	compareEmulatorJSONGolden(t, "availability_remote_contained_source_country.json", string(response.Body))
 }
 
 func TestSDMXRejectsIncompatibleStatVariableShapes(t *testing.T) {

--- a/internal/server/spanner/golden/emulator/testdata/sdmx/availability_contained_empty.json
+++ b/internal/server/spanner/golden/emulator/testdata/sdmx/availability_contained_empty.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json.sdmx.org/2.0.0/sdmx-json-structure-schema.json",
+  "data": {
+    "dataConstraints": [
+      {
+        "agencyID": "DC",
+        "id": "DF_OBS_AVAILABILITY",
+        "name": "Available DF_OBS data",
+        "role": "Actual",
+        "version": "1.0.0"
+      }
+    ]
+  }
+}

--- a/internal/server/spanner/golden/emulator/testdata/sdmx/availability_contained_source_country.json
+++ b/internal/server/spanner/golden/emulator/testdata/sdmx/availability_contained_source_country.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json.sdmx.org/2.0.0/sdmx-json-structure-schema.json",
+  "data": {
+    "dataConstraints": [
+      {
+        "agencyID": "DC",
+        "cubeRegions": [
+          {
+            "include": true,
+            "keyValues": [
+              {
+                "id": "destinationCountry",
+                "include": true,
+                "values": [
+                  "country/CAN"
+                ]
+              }
+            ]
+          }
+        ],
+        "id": "DF_OBS_AVAILABILITY",
+        "name": "Available DF_OBS data",
+        "role": "Actual",
+        "version": "1.0.0"
+      }
+    ]
+  }
+}

--- a/internal/server/spanner/golden/emulator/testdata/sdmx/availability_contained_source_country_with_time_periods.json
+++ b/internal/server/spanner/golden/emulator/testdata/sdmx/availability_contained_source_country_with_time_periods.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json.sdmx.org/2.0.0/sdmx-json-structure-schema.json",
+  "data": {
+    "dataConstraints": [
+      {
+        "agencyID": "DC",
+        "cubeRegions": [
+          {
+            "include": true,
+            "keyValues": [
+              {
+                "id": "destinationCountry",
+                "include": true,
+                "values": [
+                  "country/CAN"
+                ]
+              }
+            ]
+          }
+        ],
+        "id": "DF_OBS_AVAILABILITY",
+        "name": "Available DF_OBS data",
+        "role": "Actual",
+        "version": "1.0.0"
+      }
+    ]
+  }
+}

--- a/internal/server/spanner/golden/emulator/testdata/sdmx/availability_remote_contained_source_country.json
+++ b/internal/server/spanner/golden/emulator/testdata/sdmx/availability_remote_contained_source_country.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json.sdmx.org/2.0.0/sdmx-json-structure-schema.json",
+  "data": {
+    "dataConstraints": [
+      {
+        "agencyID": "DC",
+        "cubeRegions": [
+          {
+            "include": true,
+            "keyValues": [
+              {
+                "id": "destinationCountry",
+                "include": true,
+                "values": [
+                  "country/CAN"
+                ]
+              }
+            ]
+          }
+        ],
+        "id": "DF_OBS_AVAILABILITY",
+        "name": "Available DF_OBS data",
+        "role": "Actual",
+        "version": "1.0.0"
+      }
+    ]
+  }
+}

--- a/internal/server/spanner/golden/query_builder/get_sdmx_availability_contained_entity1.sql
+++ b/internal/server/spanner/golden/query_builder/get_sdmx_availability_contained_entity1.sql
@@ -1,0 +1,23 @@
+		@{SCAN_METHOD=COLUMNAR, EXECUTION_METHOD=BATCH}
+		WITH contained_places_0 AS (
+			SELECT DISTINCT contained.subject_id AS place_id
+			FROM Edge typed
+			JOIN@{FORCE_JOIN_ORDER=TRUE} Edge contained ON contained.subject_id = typed.subject_id
+			WHERE contained.predicate = 'linkedContainedInPlace'
+				AND contained.object_id = 'country/USA'
+				AND typed.predicate = 'typeOf'
+				AND typed.object_id = 'County'
+		),
+			series AS (
+			SELECT
+				t.entity1 AS value
+			FROM contained_places_0 anchor
+			JOIN@{JOIN_METHOD=APPLY_JOIN} TimeSeries@{FORCE_INDEX=_BASE_TABLE} t
+				ON t.entity1 = anchor.place_id
+				AND t.variable_measured = 'var1'
+		)
+			SELECT DISTINCT t.value AS value
+			FROM series t
+			WHERE t.value IS NOT NULL
+				AND t.value != ''
+			ORDER BY value

--- a/internal/server/spanner/golden/query_builder/get_sdmx_availability_contained_entity1_explicit_time_periods.sql
+++ b/internal/server/spanner/golden/query_builder/get_sdmx_availability_contained_entity1_explicit_time_periods.sql
@@ -1,0 +1,30 @@
+		@{SCAN_METHOD=COLUMNAR, EXECUTION_METHOD=BATCH}
+		WITH contained_places_0 AS (
+			SELECT DISTINCT contained.subject_id AS place_id
+			FROM Edge typed
+			JOIN@{FORCE_JOIN_ORDER=TRUE} Edge contained ON contained.subject_id = typed.subject_id
+			WHERE contained.predicate = 'linkedContainedInPlace'
+				AND contained.object_id = 'country/USA'
+				AND typed.predicate = 'typeOf'
+				AND typed.object_id = 'County'
+		),
+			series AS (
+			SELECT
+				t.variable_measured,
+				t.entity1,
+				t.extra_entities_id,
+				t.facet_id,
+				t.entity1 AS value
+			FROM contained_places_0 anchor
+			JOIN@{JOIN_METHOD=APPLY_JOIN} TimeSeries@{FORCE_INDEX=_BASE_TABLE} t
+				ON t.entity1 = anchor.place_id
+				AND t.variable_measured = 'var1'
+		)
+			SELECT DISTINCT t.value AS value
+			FROM series t
+			JOIN Observation o
+			USING (variable_measured, entity1, extra_entities_id, facet_id)
+			WHERE o.date IN ('2020','2022')
+				AND t.value IS NOT NULL
+				AND t.value != ''
+			ORDER BY value

--- a/internal/server/spanner/golden/query_builder/get_sdmx_availability_contained_entity2_remote.sql
+++ b/internal/server/spanner/golden/query_builder/get_sdmx_availability_contained_entity2_remote.sql
@@ -1,0 +1,27 @@
+		@{SCAN_METHOD=COLUMNAR, EXECUTION_METHOD=BATCH}
+		WITH contained_places_0 AS (
+			SELECT DISTINCT contained.subject_id AS place_id
+			FROM Edge typed
+			JOIN@{FORCE_JOIN_ORDER=TRUE} Edge contained ON contained.subject_id = typed.subject_id
+			WHERE contained.predicate = 'linkedContainedInPlace'
+				AND contained.object_id = 'Earth'
+				AND typed.predicate = 'typeOf'
+				AND typed.object_id = 'Country'
+			UNION DISTINCT
+			SELECT place_id
+			FROM UNNEST(['country/USA']) AS place_id
+		),
+			series AS (
+			SELECT
+				t.entity1 AS value
+			FROM contained_places_0 anchor
+			JOIN@{JOIN_METHOD=APPLY_JOIN} TimeSeries@{FORCE_INDEX=TimeSeriesByEntity2} t
+				ON t.entity2 = anchor.place_id
+				AND t.variable_measured = 'var1'
+			WHERE t.entity2 IS NOT NULL
+		)
+			SELECT DISTINCT t.value AS value
+			FROM series t
+			WHERE t.value IS NOT NULL
+				AND t.value != ''
+			ORDER BY value

--- a/internal/server/spanner/golden/query_builder_multientity_test.go
+++ b/internal/server/spanner/golden/query_builder_multientity_test.go
@@ -916,7 +916,7 @@ func TestMultiEntityGetSdmxAvailabilityQueryContainedInPlace(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			runQueryBuilderGoldenTest(t, tc.golden, func(ctx context.Context) (interface{}, error) {
-				builder, err := spanner.NewMultiEntityQueryBuilder(spanner.DefaultTableConfig(), spanner.MultiEntityQueryConfig{})
+				builder, err := spanner.NewMultiEntityQueryBuilder(spanner.DefaultTableConfig(), spanner.QueryConfig{})
 				if err != nil {
 					return nil, err
 				}

--- a/internal/server/spanner/golden/query_builder_multientity_test.go
+++ b/internal/server/spanner/golden/query_builder_multientity_test.go
@@ -483,7 +483,7 @@ func TestMultiEntitySdmxTimePeriodUnrollPlans(t *testing.T) {
 						"variableMeasured": sdmxComponentConstraint("Count_TimeSeries"),
 						"TIME_PERIOD":      sdmxComponentConstraint(dates...),
 					},
-				}, nil)
+				}, nil, nil)
 			},
 		},
 		{
@@ -496,7 +496,7 @@ func TestMultiEntitySdmxTimePeriodUnrollPlans(t *testing.T) {
 						"TIME_PERIOD":      sdmxComponentConstraint(dates...),
 						"unit":             sdmxComponentConstraint("Count"),
 					},
-				}, nil)
+				}, nil, nil)
 			},
 		},
 	}
@@ -656,7 +656,7 @@ func TestMultiEntityQueryBuildersUseCustomTableConfig(t *testing.T) {
 		},
 	}, map[string]string{
 		"observationAbout": "entity1",
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("GetSdmxAvailabilityQuery() returned error: %v", err)
 	}
@@ -735,7 +735,7 @@ func TestMultiEntityGetSdmxAvailabilityQuery(t *testing.T) {
 					Constraints: map[string]*sdmxpb.SdmxComponentConstraint{
 						"variableMeasured": sdmxComponentConstraint("Count_Person", "Count_Household"),
 					},
-				}, c.observationPropertyToEntitySlot)
+				}, c.observationPropertyToEntitySlot, nil)
 			})
 		})
 	}
@@ -760,7 +760,7 @@ func TestMultiEntityGetSdmxAvailabilityQueryWithDimensionFilters(t *testing.T) {
 			},
 		}, map[string]string{
 			"destinationCountry": "entity1", "sourceCountry": "entity2",
-		})
+		}, nil)
 	})
 }
 
@@ -776,7 +776,7 @@ func TestMultiEntityGetSdmxAvailabilityQueryWithTimePeriods(t *testing.T) {
 				"variableMeasured": sdmxComponentConstraint("Count_TimeSeries"),
 				"TIME_PERIOD":      sdmxComponentConstraint("2023", "2020", "2020"),
 			},
-		}, nil)
+		}, nil, nil)
 	})
 }
 
@@ -793,7 +793,7 @@ func TestMultiEntityGetSdmxAvailabilityQueryWithTimePeriodsAndSeriesFilter(t *te
 				"TIME_PERIOD":      sdmxComponentConstraint("2023", "2020"),
 				"unit":             sdmxComponentConstraint("Count"),
 			},
-		}, nil)
+		}, nil, nil)
 	})
 }
 
@@ -808,7 +808,7 @@ func TestMultiEntityGetSdmxAvailabilityQueryTimePlan(t *testing.T) {
 			"variableMeasured": sdmxComponentConstraint("Count_TimeSeries"),
 			"TIME_PERIOD":      sdmxComponentConstraint("2020", "2023"),
 		},
-	}, nil)
+	}, nil, nil)
 	if err != nil {
 		t.Fatalf("GetSdmxAvailabilityQuery() error = %v", err)
 	}
@@ -842,7 +842,7 @@ func TestMultiEntityGetSdmxAvailabilityQueryFilteredTimePlan(t *testing.T) {
 			"TIME_PERIOD":      sdmxComponentConstraint("2020", "2023"),
 			"unit":             sdmxComponentConstraint("Count"),
 		},
-	}, nil)
+	}, nil, nil)
 	if err != nil {
 		t.Fatalf("GetSdmxAvailabilityQuery() error = %v", err)
 	}
@@ -859,6 +859,71 @@ func TestMultiEntityGetSdmxAvailabilityQueryFilteredTimePlan(t *testing.T) {
 		if strings.Contains(statement.SQL, substring) {
 			t.Errorf("GetSdmxAvailabilityQuery() SQL unexpectedly contains %q:\n%s", substring, statement.SQL)
 		}
+	}
+}
+
+func TestMultiEntityGetSdmxAvailabilityQueryContainedInPlace(t *testing.T) {
+	builder, err := spanner.NewMultiEntityQueryBuilder(spanner.DefaultTableConfig(), spanner.MultiEntityQueryConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		name        string
+		timePeriods []string
+		contains    []string
+		excludes    []string
+	}{
+		{
+			name: "all dates",
+			contains: []string{
+				"WITH contained_places_0 AS",
+				"t.entity1 AS value",
+				"SELECT DISTINCT t.value AS value",
+			},
+			excludes: []string{"JOIN Observation o", "@time_periods"},
+		},
+		{
+			name:        "explicit dates use automatic observation join",
+			timePeriods: []string{"2022", "2020"},
+			contains: []string{
+				"t.variable_measured",
+				"JOIN Observation o",
+				"WHERE o.date IN UNNEST(@time_periods)",
+			},
+			excludes: []string{"JOIN@{JOIN_METHOD=MERGE_JOIN} Observation", "MERGE_JOIN"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			constraints := map[string]*sdmxpb.SdmxComponentConstraint{
+				"variableMeasured": sdmxComponentConstraint("var1"),
+				"observationAbout": sdmxContainedInPlaceConstraint("country/USA", "County"),
+			}
+			if len(tc.timePeriods) > 0 {
+				constraints["TIME_PERIOD"] = sdmxComponentConstraint(tc.timePeriods...)
+			}
+			statement, err := builder.GetSdmxAvailabilityQuery(
+				&sdmxpb.SdmxAvailabilityQuery{
+					ComponentId: "observationAbout",
+					Constraints: constraints,
+				},
+				map[string]string{"observationAbout": "entity1"},
+				nil,
+			)
+			if err != nil {
+				t.Fatalf("GetSdmxAvailabilityQuery() error = %v", err)
+			}
+			for _, substring := range tc.contains {
+				if !strings.Contains(statement.SQL, substring) {
+					t.Errorf("GetSdmxAvailabilityQuery() SQL missing %q:\n%s", substring, statement.SQL)
+				}
+			}
+			for _, substring := range tc.excludes {
+				if strings.Contains(statement.SQL, substring) {
+					t.Errorf("GetSdmxAvailabilityQuery() SQL unexpectedly contains %q:\n%s", substring, statement.SQL)
+				}
+			}
+		})
 	}
 }
 
@@ -967,7 +1032,7 @@ func TestMultiEntityGetSdmxAvailabilityQuery_Validation(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := builder.GetSdmxAvailabilityQuery(tc.req, tc.observationPropertyToEntitySlot)
+			_, err := builder.GetSdmxAvailabilityQuery(tc.req, tc.observationPropertyToEntitySlot, nil)
 			if status.Code(err) != codes.InvalidArgument {
 				t.Fatalf("GetSdmxAvailabilityQuery() code = %v, want %v; err = %v", status.Code(err), codes.InvalidArgument, err)
 			}

--- a/internal/server/spanner/golden/query_builder_multientity_test.go
+++ b/internal/server/spanner/golden/query_builder_multientity_test.go
@@ -22,6 +22,7 @@ import (
 
 	cloudSpanner "cloud.google.com/go/spanner"
 	sdmxpb "github.com/datacommonsorg/mixer/internal/proto/sdmx"
+	"github.com/datacommonsorg/mixer/internal/server/sdmx/datacommons"
 	"github.com/datacommonsorg/mixer/internal/server/spanner"
 	v2 "github.com/datacommonsorg/mixer/internal/server/v2"
 	"google.golang.org/grpc/codes"
@@ -863,66 +864,71 @@ func TestMultiEntityGetSdmxAvailabilityQueryFilteredTimePlan(t *testing.T) {
 }
 
 func TestMultiEntityGetSdmxAvailabilityQueryContainedInPlace(t *testing.T) {
-	builder, err := spanner.NewMultiEntityQueryBuilder(spanner.DefaultTableConfig(), spanner.MultiEntityQueryConfig{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	t.Parallel()
+	earthCountries := datacommons.ContainedInPlaceConstraint{Ancestor: "Earth", ChildPlaceType: "Country"}
 
 	for _, tc := range []struct {
-		name        string
-		timePeriods []string
-		contains    []string
-		excludes    []string
+		name                            string
+		componentID                     string
+		constraints                     map[string]*sdmxpb.SdmxComponentConstraint
+		observationPropertyToEntitySlot map[string]string
+		containedInPlaceToRemoteDCIDs   map[datacommons.ContainedInPlaceConstraint][]string
+		golden                          string
 	}{
 		{
-			name: "all dates",
-			contains: []string{
-				"WITH contained_places_0 AS",
-				"t.entity1 AS value",
-				"SELECT DISTINCT t.value AS value",
-			},
-			excludes: []string{"JOIN Observation o", "@time_periods"},
-		},
-		{
-			name:        "explicit dates use automatic observation join",
-			timePeriods: []string{"2022", "2020"},
-			contains: []string{
-				"t.variable_measured",
-				"JOIN Observation o",
-				"WHERE o.date IN UNNEST(@time_periods)",
-			},
-			excludes: []string{"JOIN@{JOIN_METHOD=MERGE_JOIN} Observation", "MERGE_JOIN"},
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			constraints := map[string]*sdmxpb.SdmxComponentConstraint{
+			name:        "entity1 all dates",
+			componentID: "observationAbout",
+			constraints: map[string]*sdmxpb.SdmxComponentConstraint{
 				"variableMeasured": sdmxComponentConstraint("var1"),
 				"observationAbout": sdmxContainedInPlaceConstraint("country/USA", "County"),
-			}
-			if len(tc.timePeriods) > 0 {
-				constraints["TIME_PERIOD"] = sdmxComponentConstraint(tc.timePeriods...)
-			}
-			statement, err := builder.GetSdmxAvailabilityQuery(
-				&sdmxpb.SdmxAvailabilityQuery{
-					ComponentId: "observationAbout",
-					Constraints: constraints,
-				},
-				map[string]string{"observationAbout": "entity1"},
-				nil,
-			)
-			if err != nil {
-				t.Fatalf("GetSdmxAvailabilityQuery() error = %v", err)
-			}
-			for _, substring := range tc.contains {
-				if !strings.Contains(statement.SQL, substring) {
-					t.Errorf("GetSdmxAvailabilityQuery() SQL missing %q:\n%s", substring, statement.SQL)
+			},
+			observationPropertyToEntitySlot: map[string]string{"observationAbout": "entity1"},
+			golden:                          "get_sdmx_availability_contained_entity1.sql",
+		},
+		{
+			name:        "entity1 explicit time periods",
+			componentID: "observationAbout",
+			constraints: map[string]*sdmxpb.SdmxComponentConstraint{
+				"variableMeasured": sdmxComponentConstraint("var1"),
+				"observationAbout": sdmxContainedInPlaceConstraint("country/USA", "County"),
+				"TIME_PERIOD":      sdmxComponentConstraint("2022", "2020"),
+			},
+			observationPropertyToEntitySlot: map[string]string{"observationAbout": "entity1"},
+			golden:                          "get_sdmx_availability_contained_entity1_explicit_time_periods.sql",
+		},
+		{
+			name:        "remote entity2",
+			componentID: "destinationCountry",
+			constraints: map[string]*sdmxpb.SdmxComponentConstraint{
+				"variableMeasured": sdmxComponentConstraint("var1"),
+				"sourceCountry":    sdmxContainedInPlaceConstraint(earthCountries.Ancestor, earthCountries.ChildPlaceType),
+			},
+			observationPropertyToEntitySlot: map[string]string{
+				"destinationCountry": "entity1",
+				"sourceCountry":      "entity2",
+			},
+			containedInPlaceToRemoteDCIDs: map[datacommons.ContainedInPlaceConstraint][]string{
+				earthCountries: {"country/USA"},
+			},
+			golden: "get_sdmx_availability_contained_entity2_remote.sql",
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			runQueryBuilderGoldenTest(t, tc.golden, func(ctx context.Context) (interface{}, error) {
+				builder, err := spanner.NewMultiEntityQueryBuilder(spanner.DefaultTableConfig(), spanner.MultiEntityQueryConfig{})
+				if err != nil {
+					return nil, err
 				}
-			}
-			for _, substring := range tc.excludes {
-				if strings.Contains(statement.SQL, substring) {
-					t.Errorf("GetSdmxAvailabilityQuery() SQL unexpectedly contains %q:\n%s", substring, statement.SQL)
-				}
-			}
+				return builder.GetSdmxAvailabilityQuery(
+					&sdmxpb.SdmxAvailabilityQuery{
+						ComponentId: tc.componentID,
+						Constraints: tc.constraints,
+					},
+					tc.observationPropertyToEntitySlot,
+					tc.containedInPlaceToRemoteDCIDs,
+				)
+			})
 		})
 	}
 }

--- a/internal/server/spanner/query_builder_multientity.go
+++ b/internal/server/spanner/query_builder_multientity.go
@@ -601,8 +601,8 @@ func (b *multiEntityQueryBuilder) buildSdmxContainedSeriesPlan(
 	relationToCTE := map[datacommons.ContainedInPlaceConstraint]string{}
 	cteDefinitions := []string{}
 	params := maps.Clone(compiled.params)
-	containedRule, _ := datacommons.DataPropertyRule(datacommons.PropertyContainedInPlace)
-	typeRule, _ := datacommons.DataPropertyRule(datacommons.PropertyTypeOf)
+	containedRule, _ := datacommons.PropertyRuleForID(datacommons.PropertyContainedInPlace)
+	typeRule, _ := datacommons.PropertyRuleForID(datacommons.PropertyTypeOf)
 	// TODO: Apply QueryConfig.ContainedInPlaceAncestorFirstTypes to SDMX containment CTEs.
 	for i := range resolved {
 		key := resolved[i].relation

--- a/internal/server/spanner/query_builder_multientity.go
+++ b/internal/server/spanner/query_builder_multientity.go
@@ -334,6 +334,9 @@ func (b *multiEntityQueryBuilder) GetSdmxObservationsQuery(
 	observationPropertyToEntitySlot map[string]string,
 	containedInPlaceToRemoteDCIDs map[datacommons.ContainedInPlaceConstraint][]string,
 ) (*spanner.Statement, error) {
+	if err := datacommons.ValidateDataConstraints(constraints); err != nil {
+		return nil, status.Errorf(status.Code(err), "GetSdmxObservationsQuery: %s", status.Convert(err).Message())
+	}
 	// TODO: Parse SDMX constraints in prepareSdmxObservationsQuery and pass the
 	// classified time and containment selections into this builder instead of
 	// revalidating the raw constraint map.
@@ -521,6 +524,14 @@ type resolvedSdmxContainedInPlace struct {
 	cteName      string
 }
 
+type sdmxContainedSeriesPlan struct {
+	statementHint   string
+	cteDefinitions  string
+	seriesCTE       string
+	params          map[string]interface{}
+	dateJoinContext sdmxAvailabilityDateJoinContext
+}
+
 func (b *multiEntityQueryBuilder) getSdmxContainedInPlaceObservationsQuery(
 	constraints map[string]datacommons.ContainedInPlaceConstraint,
 	observationPropertyToEntitySlot map[string]string,
@@ -528,6 +539,51 @@ func (b *multiEntityQueryBuilder) getSdmxContainedInPlaceObservationsQuery(
 	containedInPlaceToRemoteDCIDs map[datacommons.ContainedInPlaceConstraint][]string,
 	timeSelection datacommons.TimePeriodSelection,
 ) (*spanner.Statement, error) {
+	projection := strings.Join([]string{
+		"t.variable_measured",
+		"t.entity1",
+		"t.extra_entities_id",
+		"t.facet_id",
+		"t.provenance",
+		"t.facet",
+		"t.entities",
+	}, ",\n\t\t\t\t")
+	plan, err := b.buildSdmxContainedSeriesPlan(
+		constraints,
+		observationPropertyToEntitySlot,
+		compiled,
+		containedInPlaceToRemoteDCIDs,
+		projection,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	queryTemplate := b.statements.getSdmxContainedInPlace
+	switch timeSelection.Mode {
+	case datacommons.TimePeriodExplicit:
+		queryTemplate = b.statements.getSdmxContainedInPlaceWithDates
+		plan.params["time_periods"] = timeSelection.Dates
+	case datacommons.TimePeriodLatest:
+		queryTemplate = b.statements.getSdmxContainedInPlaceLatest
+	}
+	sql := fmt.Sprintf(
+		queryTemplate,
+		plan.statementHint,
+		plan.cteDefinitions,
+		plan.seriesCTE,
+	)
+
+	return &spanner.Statement{SQL: sql, Params: plan.params}, nil
+}
+
+func (b *multiEntityQueryBuilder) buildSdmxContainedSeriesPlan(
+	constraints map[string]datacommons.ContainedInPlaceConstraint,
+	observationPropertyToEntitySlot map[string]string,
+	compiled *compiledSdmxConstraints,
+	containedInPlaceToRemoteDCIDs map[datacommons.ContainedInPlaceConstraint][]string,
+	projection string,
+) (*sdmxContainedSeriesPlan, error) {
 	resolved := make([]resolvedSdmxContainedInPlace, 0, len(constraints))
 	for _, componentID := range slices.Sorted(maps.Keys(constraints)) {
 		relation := constraints[componentID]
@@ -552,8 +608,8 @@ func (b *multiEntityQueryBuilder) getSdmxContainedInPlaceObservationsQuery(
 	relationToCTE := map[datacommons.ContainedInPlaceConstraint]string{}
 	cteDefinitions := []string{}
 	params := maps.Clone(compiled.params)
-	containedRule, _ := datacommons.DataPropertyRule(datacommons.PropertyContainedInPlace)
-	typeRule, _ := datacommons.DataPropertyRule(datacommons.PropertyTypeOf)
+	containedRule, _ := datacommons.PropertyRuleForID(datacommons.PropertyContainedInPlace)
+	typeRule, _ := datacommons.PropertyRuleForID(datacommons.PropertyTypeOf)
 	// TODO: Apply ContainedInPlaceAncestorFirstTypes to SDMX containment CTEs.
 	for i := range resolved {
 		key := resolved[i].relation
@@ -650,25 +706,20 @@ func (b *multiEntityQueryBuilder) getSdmxContainedInPlaceObservationsQuery(
 		anchor.entityColumn,
 		compiled.where,
 		where,
+		projection,
 	)
 
 	statementHint := fmt.Sprintf("@{%s}\n\t\t", strings.Join(statementHints, ", "))
-	queryTemplate := b.statements.getSdmxContainedInPlace
-	switch timeSelection.Mode {
-	case datacommons.TimePeriodExplicit:
-		queryTemplate = b.statements.getSdmxContainedInPlaceWithDates
-		params["time_periods"] = timeSelection.Dates
-	case datacommons.TimePeriodLatest:
-		queryTemplate = b.statements.getSdmxContainedInPlaceLatest
-	}
-	sql := fmt.Sprintf(
-		queryTemplate,
-		statementHint,
-		strings.Join(cteDefinitions, ",\n\t\t"),
-		seriesCTE,
-	)
-
-	return &spanner.Statement{SQL: sql, Params: params}, nil
+	return &sdmxContainedSeriesPlan{
+		statementHint:  statementHint,
+		cteDefinitions: strings.Join(cteDefinitions, ",\n\t\t"),
+		seriesCTE:      seriesCTE,
+		params:         params,
+		dateJoinContext: sdmxAvailabilityDateJoinContext{
+			seriesOrderedByFullKey: false,
+			broadSeriesScan:        false,
+		},
+	}, nil
 }
 
 func sdmxContainmentAnchorPriority(entityColumn string) int {
@@ -703,10 +754,10 @@ type sdmxAvailabilityDateJoinContext struct {
 // order. Direct queries can guarantee that by forcing both base tables. A
 // secondary index, containment anchor, candidate-series CTE, or local/remote
 // union must be treated as unordered until a production query plan proves that
-// it preserves the complete key order. Future containment builders should
-// construct this context after choosing their series access path and default to
-// automatic planning. Do not run a COUNT query to make this choice; if reliable
-// cardinality metadata becomes available, add it to this context instead.
+// it preserves the complete key order. Containment builders construct this
+// context after choosing their series access path and default to automatic
+// planning. Do not run a COUNT query to make this choice; if reliable cardinality
+// metadata becomes available, add it to this context instead.
 func selectSdmxAvailabilityDateJoinPlan(
 	joinContext sdmxAvailabilityDateJoinContext,
 ) sdmxAvailabilityDateJoinPlan {
@@ -731,6 +782,7 @@ func isBroadSdmxAvailabilitySeriesScan(
 func (b *multiEntityQueryBuilder) GetSdmxAvailabilityQuery(
 	req *sdmxpb.SdmxAvailabilityQuery,
 	observationPropertyToEntitySlot map[string]string,
+	containedInPlaceToRemoteDCIDs map[datacommons.ContainedInPlaceConstraint][]string,
 ) (*spanner.Statement, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "SDMX availability request cannot be nil")
@@ -739,6 +791,10 @@ func (b *multiEntityQueryBuilder) GetSdmxAvailabilityQuery(
 		return nil, status.Errorf(status.Code(err), "GetSdmxAvailabilityQuery: %s", status.Convert(err).Message())
 	}
 	timeSelection, err := datacommons.ClassifyTimePeriod(req.GetConstraints())
+	if err != nil {
+		return nil, status.Errorf(status.Code(err), "GetSdmxAvailabilityQuery: %s", status.Convert(err).Message())
+	}
+	containedInPlaceConstraints, err := datacommons.ContainedInPlaceConstraints(req.GetConstraints())
 	if err != nil {
 		return nil, status.Errorf(status.Code(err), "GetSdmxAvailabilityQuery: %s", status.Convert(err).Message())
 	}
@@ -751,6 +807,20 @@ func (b *multiEntityQueryBuilder) GetSdmxAvailabilityQuery(
 	valueExpression, err := sdmxAvailabilityValueExpression(req.GetComponentId(), observationPropertyToEntitySlot)
 	if err != nil {
 		return nil, err
+	}
+	if len(containedInPlaceConstraints) > 0 {
+		statement, err := b.getSdmxContainedInPlaceAvailabilityQuery(
+			containedInPlaceConstraints,
+			observationPropertyToEntitySlot,
+			compiled,
+			containedInPlaceToRemoteDCIDs,
+			timeSelection,
+			valueExpression,
+		)
+		if err != nil {
+			return nil, status.Errorf(status.Code(err), "GetSdmxAvailabilityQuery: %s", status.Convert(err).Message())
+		}
+		return statement, nil
 	}
 
 	queryTemplate := b.statements.getSdmxAvailability
@@ -773,6 +843,54 @@ func (b *multiEntityQueryBuilder) GetSdmxAvailabilityQuery(
 	return &spanner.Statement{
 		SQL:    fmt.Sprintf(queryTemplate, valueExpression, compiled.where),
 		Params: params,
+	}, nil
+}
+
+func (b *multiEntityQueryBuilder) getSdmxContainedInPlaceAvailabilityQuery(
+	constraints map[string]datacommons.ContainedInPlaceConstraint,
+	observationPropertyToEntitySlot map[string]string,
+	compiled *compiledSdmxConstraints,
+	containedInPlaceToRemoteDCIDs map[datacommons.ContainedInPlaceConstraint][]string,
+	timeSelection datacommons.TimePeriodSelection,
+	valueExpression string,
+) (*spanner.Statement, error) {
+	projectionColumns := []string{valueExpression + " AS value"}
+	if timeSelection.Mode == datacommons.TimePeriodExplicit {
+		projectionColumns = append([]string{
+			"t.variable_measured",
+			"t.entity1",
+			"t.extra_entities_id",
+			"t.facet_id",
+		}, projectionColumns...)
+	}
+	plan, err := b.buildSdmxContainedSeriesPlan(
+		constraints,
+		observationPropertyToEntitySlot,
+		compiled,
+		containedInPlaceToRemoteDCIDs,
+		strings.Join(projectionColumns, ",\n\t\t\t\t"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	queryTemplate := b.statements.getSdmxContainedAvailability
+	if timeSelection.Mode == datacommons.TimePeriodExplicit {
+		if joinPlan := selectSdmxAvailabilityDateJoinPlan(plan.dateJoinContext); joinPlan != sdmxAvailabilityDateJoinAutomatic {
+			return nil, status.Error(codes.Internal, "unsupported SDMX containment availability date join plan")
+		}
+		queryTemplate = b.statements.getSdmxContainedAvailabilityWithDates
+		plan.params["time_periods"] = timeSelection.Dates
+	}
+
+	return &spanner.Statement{
+		SQL: fmt.Sprintf(
+			queryTemplate,
+			plan.statementHint,
+			plan.cteDefinitions,
+			plan.seriesCTE,
+		),
+		Params: plan.params,
 	}, nil
 }
 

--- a/internal/server/spanner/query_multientity.go
+++ b/internal/server/spanner/query_multientity.go
@@ -845,13 +845,20 @@ func prepareSdmxAvailabilityQuery(
 	if err != nil {
 		return nil, err
 	}
+	if err := validateSdmxPropertyConstraintScopes(req.GetConstraints(), preparedShape.observationPropertyToEntitySlot); err != nil {
+		return nil, err
+	}
 	if err := validateSdmxAvailabilityConstraintComponents(req.GetConstraints(), preparedShape.shape); err != nil {
 		return nil, err
 	}
 	if err := validateSdmxAvailabilityComponent(req.GetComponentId(), preparedShape.shape); err != nil {
 		return nil, err
 	}
-	return queryBuilder.GetSdmxAvailabilityQuery(req, preparedShape.observationPropertyToEntitySlot)
+	return queryBuilder.GetSdmxAvailabilityQuery(
+		req,
+		preparedShape.observationPropertyToEntitySlot,
+		dispatcher.SdmxContainedInPlaceToRemoteDCIDsFromContext(ctx),
+	)
 }
 
 func resolveSdmxEntityShape(

--- a/internal/server/spanner/query_multientity_test.go
+++ b/internal/server/spanner/query_multientity_test.go
@@ -1055,7 +1055,7 @@ func TestPrepareSdmxAvailabilityQuery(t *testing.T) {
 }
 
 func TestPrepareSdmxAvailabilityQueryWithRemoteContainedInPlace(t *testing.T) {
-	queryBuilder, err := NewMultiEntityQueryBuilder(DefaultTableConfig(), MultiEntityQueryConfig{})
+	queryBuilder, err := NewMultiEntityQueryBuilder(DefaultTableConfig(), QueryConfig{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/server/spanner/query_multientity_test.go
+++ b/internal/server/spanner/query_multientity_test.go
@@ -1083,6 +1083,56 @@ func TestPrepareSdmxAvailabilityQuery(t *testing.T) {
 	}
 }
 
+func TestPrepareSdmxAvailabilityQueryWithRemoteContainedInPlace(t *testing.T) {
+	queryBuilder, err := NewMultiEntityQueryBuilder(DefaultTableConfig(), MultiEntityQueryConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	relation := datacommons.ContainedInPlaceConstraint{Ancestor: "northamerica", ChildPlaceType: "Country"}
+	ctx := dispatcher.WithSdmxContainedInPlaceToRemoteDCIDs(
+		context.Background(),
+		dispatcher.SdmxContainedInPlaceToRemoteDCIDs{relation: {"country/CAN", "country/USA"}},
+	)
+	stmt, err := prepareSdmxAvailabilityQuery(
+		ctx,
+		&sdmxpb.SdmxAvailabilityQuery{
+			ComponentId: "destinationCountry",
+			Constraints: map[string]*sdmxpb.SdmxComponentConstraint{
+				datacommons.ComponentVariableMeasured: sdmxComponentConstraint("Count_Migration"),
+				"sourceCountry":                       sdmxContainedInPlaceConstraint(relation.Ancestor, relation.ChildPlaceType),
+			},
+		},
+		func(context.Context, []string, *v2.Arc, int, int) (map[string][]*Edge, error) {
+			return map[string][]*Edge{
+				"Count_Migration": observationPropertiesEdges("destinationCountry", "sourceCountry"),
+			}, nil
+		},
+		queryBuilder,
+	)
+	if err != nil {
+		t.Fatalf("prepareSdmxAvailabilityQuery() error = %v", err)
+	}
+	wantParams := map[string]interface{}{
+		datacommons.ComponentVariableMeasured: []string{"Count_Migration"},
+		"containment_0_ancestor":              relation.Ancestor,
+		"containment_0_child_place_type":      relation.ChildPlaceType,
+		"containment_0_remote_places":         []string{"country/CAN", "country/USA"},
+	}
+	if diff := cmp.Diff(wantParams, stmt.Params); diff != "" {
+		t.Fatalf("prepareSdmxAvailabilityQuery() params mismatch (-want +got):\n%s", diff)
+	}
+	for _, fragment := range []string{
+		"UNION DISTINCT",
+		"FROM UNNEST(@containment_0_remote_places) AS place_id",
+		"ON t.entity2 = anchor.place_id",
+		"SELECT DISTINCT t.value AS value",
+	} {
+		if !strings.Contains(stmt.SQL, fragment) {
+			t.Errorf("prepareSdmxAvailabilityQuery() SQL does not contain %q:\n%s", fragment, stmt.SQL)
+		}
+	}
+}
+
 func TestPrepareSdmxAvailabilityQueryValidation(t *testing.T) {
 	queryBuilder, err := NewMultiEntityQueryBuilder(DefaultTableConfig(), MultiEntityQueryConfig{})
 	if err != nil {
@@ -1422,7 +1472,7 @@ func TestMultiEntitySdmxRejectsUnsupportedOperator(t *testing.T) {
 	}
 }
 
-func TestMultiEntitySdmxAvailabilityRejectsPropertyConstraints(t *testing.T) {
+func TestMultiEntitySdmxAvailabilityRejectsIncompletePropertyConstraints(t *testing.T) {
 	_, err := (&multiEntityClient{}).GetSdmxAvailability(context.Background(), &sdmxpb.SdmxAvailabilityQuery{
 		ComponentId: datacommons.ComponentObservationAbout,
 		Constraints: map[string]*sdmxpb.SdmxComponentConstraint{
@@ -1434,8 +1484,8 @@ func TestMultiEntitySdmxAvailabilityRejectsPropertyConstraints(t *testing.T) {
 			},
 		},
 	})
-	if status.Code(err) != codes.Unimplemented {
-		t.Fatalf("GetSdmxAvailability() code = %v, want %v; err = %v", status.Code(err), codes.Unimplemented, err)
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("GetSdmxAvailability() code = %v, want %v; err = %v", status.Code(err), codes.InvalidArgument, err)
 	}
 }
 

--- a/internal/server/spanner/statements_multientity.go
+++ b/internal/server/spanner/statements_multientity.go
@@ -38,6 +38,8 @@ type MultiEntityStatements struct {
 	getSdmxContainedInPlace                        string
 	getSdmxContainedInPlaceWithDates               string
 	getSdmxContainedInPlaceLatest                  string
+	getSdmxContainedAvailability                   string
+	getSdmxContainedAvailabilityWithDates          string
 	sdmxContainedPlacesCTE                         string
 	sdmxContainedPlacesWithRemoteCTE               string
 	sdmxContainedSeriesCTE                         string
@@ -393,13 +395,7 @@ func NewMultiEntityStatements(cfg TableConfig) (*MultiEntityStatements, error) {
 
 		sdmxContainedSeriesCTE: fmt.Sprintf(`series AS (
 			SELECT
-				t.variable_measured,
-				t.entity1,
-				t.extra_entities_id,
-				t.facet_id,
-				t.provenance,
-				t.facet,
-				t.entities
+				%%[6]s
 			FROM %%[1]s anchor
 			JOIN@{JOIN_METHOD=APPLY_JOIN} %s@{FORCE_INDEX=%%[2]s} t
 				ON t.%%[3]s = anchor.place_id
@@ -478,6 +474,27 @@ func NewMultiEntityStatements(cfg TableConfig) (*MultiEntityStatements, error) {
 			t.facet AS facets,
 			t.entities
 		FROM series t`, cfg.ObservationTable),
+
+		getSdmxContainedAvailability: `		%[1]sWITH %[2]s,
+			%[3]s
+			SELECT DISTINCT t.value AS value
+			FROM series t
+			WHERE t.value IS NOT NULL
+				AND t.value != ''
+			ORDER BY value
+`,
+
+		getSdmxContainedAvailabilityWithDates: fmt.Sprintf(`		%%[1]sWITH %%[2]s,
+			%%[3]s
+			SELECT DISTINCT t.value AS value
+			FROM series t
+			JOIN %s o
+			USING (variable_measured, entity1, extra_entities_id, facet_id)
+			WHERE o.date IN UNNEST(@time_periods)
+				AND t.value IS NOT NULL
+				AND t.value != ''
+			ORDER BY value
+`, cfg.ObservationTable),
 
 		// Check existence when both variables and entities are specified
 		getStatVarsByEntityBoth: fmt.Sprintf(`		WITH


### PR DESCRIPTION
## Summary

- Support `containedInPlace+` and `typeOf` property constraints in SDMX Availability queries.
- Apply containment filters to observation properties, including multi-entity components such as `sourceCountry`, `destinationCountry`, and `observationAbout`.
- Reuse the SDMX Data containment path to combine locally available `linkedContainedInPlace` relations with remotely expanded place DCIDs.
- Continue serving Availability results from local Spanner data; the remote source is used only for place expansion.
- Reuse the existing bounded concurrency, expansion limit, relation deduplication, and local-only fallback behavior from SDMX Data.
- Return sorted, distinct, non-empty values for the requested Availability component.
- Support containment queries with either all available dates or explicit `TIME_PERIOD` values.

## Request semantics

Containment filters must include both properties on the same observation property:

- `c[<component>.containedInPlace+]=<ancestor>`
- `c[<component>.typeOf]=<child-place-type>`

For example:

- `c[sourceCountry.containedInPlace+]=northamerica`
- `c[sourceCountry.typeOf]=Country`

Direct component values and property constraints cannot be combined on the same component.

`TIME_PERIOD=LATEST` remains unsupported for Availability; callers must use explicit dates.

## Example queries

### Find units available for Count_Person observations in AdministrativeArea1 descendants of India

```bash
curl 'http://localhost:8081/sdmx/v3/availability/dataflow/DC/DF_OBS/1.0.0/*/unit?c%5BvariableMeasured%5D=Count_Person&c%5BobservationAbout.containedInPlace%2B%5D=country%2FIND&c%5BobservationAbout.typeOf%5D=AdministrativeArea1'
```

### Find destination countries for migration or refugee series whose source country is in North America

```bash
curl 'http://localhost:8081/sdmx/v3/availability/dataflow/DC/DF_OBS/1.0.0/*/destinationCountry?c%5BvariableMeasured%5D=Count_Migration%2CCount_Refugee&c%5BsourceCountry.containedInPlace%2B%5D=northamerica&c%5BsourceCountry.typeOf%5D=Country'
```

### Apply the same containment constraint for explicit time periods

```bash
curl 'http://localhost:8081/sdmx/v3/availability/dataflow/DC/DF_OBS/1.0.0/*/destinationCountry?c%5BvariableMeasured%5D=Count_Migration%2CCount_Refugee&c%5BsourceCountry.containedInPlace%2B%5D=northamerica&c%5BsourceCountry.typeOf%5D=Country&c%5BTIME_PERIOD%5D=2023%2C2024'
```

The `*` path segment before the requested component is required by the Availability endpoint.

## Testing

- Added Availability parser, validation, service, and dispatcher coverage for property constraints and remote expansion.
- Added query-builder SQL goldens covering:
  - Local containment on entity1.
  - Containment with explicit time periods.
  - Local and remote containment on entity2.
- Added independent Spanner emulator response goldens covering:
  - Non-empty multi-entity containment results.
  - Explicit time-period filtering.
  - Empty containment results.
  - Results produced using remote containment expansion.
- Existing SDMX Data containment tests continue to cover shared containment planning and expansion behavior.

## Impacted API

- `GET /sdmx/v3/availability/dataflow/DC/DF_OBS/1.0.0/*/{component}`

There are no request or response schema changes. Existing Availability requests without property constraints remain unchanged.