### PR TITLE
Prod flag updates

### DIFF
--- a/deploy/featureflags/prod.yaml
+++ b/deploy/featureflags/prod.yaml
@@ -2,10 +2,10 @@ clusters:
   - projects/datcom-mixer/locations/us-central1/clusters/mixer-us-central1
 liveUrl: https://api.datacommons.org
 flags:
-  EnableV3: true
-  V3MirrorFraction: 0.8
+  V3MirrorFraction: 0.1
+  SpannerGraphDatabase: projects/datcom-store/instances/dc-graph-prod/databases/dc_graph
   WriteUsageLogs: 1.0
   UseSpannerGraph: true
-  SpannerGraphDatabase: dc_graph_2026_01_27
-  UseStaleReads: true
+  UseMultiEntitySchema: true
+  EnableSDMXDataApi: true
   UseSpannerKeyValueStore: true

--- a/deploy/featureflags/prod_website.yaml
+++ b/deploy/featureflags/prod_website.yaml
@@ -4,10 +4,10 @@ clusters:
   - projects/datcom-website-prod/locations/us-west1/clusters/website-us-west1
 liveUrl: https://datacommons.org
 flags:
-  EnableV3: true
-  V3MirrorFraction: 0.8
+  V3MirrorFraction: 0.1
   WriteUsageLogs: 1.0
   UseSpannerGraph: true
-  SpannerGraphDatabase: dc_graph_2026_01_27
-  UseStaleReads: true
+  SpannerGraphDatabase: projects/datcom-store/instances/dc-graph-prod/databases/dc_graph
+  UseMultiEntitySchema: true
+  EnableSDMXDataApi: true
   UseSpannerKeyValueStore: true


### PR DESCRIPTION
* Use prod spanner database
* Decrease mirror fraction to 10% - this is because some recent query optimizations are not yet rolled out to prod, so using a smaller fraction to avoid many timeouts but to enable initial latency analysis/validation. We can ramp back up slowly
* Enable new spanner flags: UseMultiEntitySchema, EnableSDMXDataApi
* Clean up legacy spanner flags: EnableV3, UseStaleReads - these have been incorporated into UseSpannerGraph flag, and will be enabled by default when this flag is true