### PR TITLE
Avoid duplicate counts and rows across import-scoped provenances

### DIFF
--- a/internal/server/spanner/golden/query_builder/get_filtered_svg_num_entities_existence.sql
+++ b/internal/server/spanner/golden/query_builder/get_filtered_svg_num_entities_existence.sql
@@ -6,7 +6,7 @@
 		JOIN (
 			SELECT
 				e.object_id AS subject_id,
-				COUNT(e.subject_id) AS descendent_stat_var_count
+				COUNT(DISTINCT e.subject_id) AS descendent_stat_var_count
 			FROM Edge e
 			JOIN@{JOIN_TYPE=HASH_JOIN} (
 				SELECT variable_measured

--- a/internal/server/spanner/golden/query_builder/get_filtered_svg_places.sql
+++ b/internal/server/spanner/golden/query_builder/get_filtered_svg_places.sql
@@ -6,7 +6,7 @@
 		JOIN (
 			SELECT
 				e.object_id AS subject_id,
-				COUNT(e.subject_id) AS descendent_stat_var_count
+				COUNT(DISTINCT e.subject_id) AS descendent_stat_var_count
 			FROM Edge e
 			JOIN@{JOIN_TYPE=HASH_JOIN} (
 				SELECT variable_measured

--- a/internal/server/spanner/golden/query_builder/get_filtered_topic_places.sql
+++ b/internal/server/spanner/golden/query_builder/get_filtered_topic_places.sql
@@ -1,6 +1,6 @@
 		SELECT
 			e.object_id AS subject_id,
-			COUNT(e.subject_id) AS descendent_stat_var_count
+			COUNT(DISTINCT e.subject_id) AS descendent_stat_var_count
 		FROM Edge@{FORCE_INDEX=InEdge} e
 		JOIN@{JOIN_TYPE=HASH_JOIN} (
 				SELECT variable_measured

--- a/internal/server/spanner/golden/query_builder/get_filtered_topic_places_multiple_topics.sql
+++ b/internal/server/spanner/golden/query_builder/get_filtered_topic_places_multiple_topics.sql
@@ -1,6 +1,6 @@
 		SELECT
 			e.object_id AS subject_id,
-			COUNT(e.subject_id) AS descendent_stat_var_count
+			COUNT(DISTINCT e.subject_id) AS descendent_stat_var_count
 		FROM Edge@{FORCE_INDEX=InEdge} e
 		JOIN@{JOIN_TYPE=HASH_JOIN} (
 				SELECT variable_measured

--- a/internal/server/spanner/golden/query_builder/get_multientity_filtered_svg_import_num_entities_existence.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_filtered_svg_import_num_entities_existence.sql
@@ -6,7 +6,7 @@
 		JOIN (
 			SELECT
 				e.object_id AS subject_id,
-				COUNT(e.subject_id) AS descendent_stat_var_count
+				COUNT(DISTINCT e.subject_id) AS descendent_stat_var_count
 			FROM Edge e
 			JOIN@{JOIN_TYPE=HASH_JOIN} (
 					SELECT ts.variable_measured

--- a/internal/server/spanner/golden/query_builder/get_multientity_filtered_svg_num_entities_existence.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_filtered_svg_num_entities_existence.sql
@@ -6,7 +6,7 @@
 		JOIN (
 			SELECT
 				e.object_id AS subject_id,
-				COUNT(e.subject_id) AS descendent_stat_var_count
+				COUNT(DISTINCT e.subject_id) AS descendent_stat_var_count
 			FROM Edge e
 			JOIN@{JOIN_TYPE=HASH_JOIN} (
 					SELECT ts.variable_measured

--- a/internal/server/spanner/golden/query_builder/get_multientity_filtered_svg_places.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_filtered_svg_places.sql
@@ -6,7 +6,7 @@
 		JOIN (
 			SELECT
 				e.object_id AS subject_id,
-				COUNT(e.subject_id) AS descendent_stat_var_count
+				COUNT(DISTINCT e.subject_id) AS descendent_stat_var_count
 			FROM Edge e
 			JOIN@{JOIN_TYPE=HASH_JOIN} (
 					SELECT ts.variable_measured

--- a/internal/server/spanner/golden/query_builder/get_multientity_filtered_topic_dataset.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_filtered_topic_dataset.sql
@@ -1,6 +1,6 @@
 		SELECT
 			e.object_id AS subject_id,
-			COUNT(e.subject_id) AS descendent_stat_var_count
+			COUNT(DISTINCT e.subject_id) AS descendent_stat_var_count
 		FROM Edge@{FORCE_INDEX=InEdge} e
 		JOIN@{JOIN_TYPE=HASH_JOIN} (
 					SELECT ts.variable_measured

--- a/internal/server/spanner/golden/query_builder/get_multientity_filtered_topic_import.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_filtered_topic_import.sql
@@ -1,6 +1,6 @@
 		SELECT
 			e.object_id AS subject_id,
-			COUNT(e.subject_id) AS descendent_stat_var_count
+			COUNT(DISTINCT e.subject_id) AS descendent_stat_var_count
 		FROM Edge@{FORCE_INDEX=InEdge} e
 		JOIN@{JOIN_TYPE=HASH_JOIN} (
 					SELECT ts.variable_measured

--- a/internal/server/spanner/golden/query_builder/get_multientity_filtered_topic_import_num_entities_existence.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_filtered_topic_import_num_entities_existence.sql
@@ -1,6 +1,6 @@
 		SELECT
 			e.object_id AS subject_id,
-			COUNT(e.subject_id) AS descendent_stat_var_count
+			COUNT(DISTINCT e.subject_id) AS descendent_stat_var_count
 		FROM Edge@{FORCE_INDEX=InEdge} e
 		JOIN@{JOIN_TYPE=HASH_JOIN} (
 					SELECT ts.variable_measured

--- a/internal/server/spanner/golden/query_builder/get_multientity_filtered_topic_num_entities_existence.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_filtered_topic_num_entities_existence.sql
@@ -1,6 +1,6 @@
 		SELECT
 			e.object_id AS subject_id,
-			COUNT(e.subject_id) AS descendent_stat_var_count
+			COUNT(DISTINCT e.subject_id) AS descendent_stat_var_count
 		FROM Edge@{FORCE_INDEX=InEdge} e
 		JOIN@{JOIN_TYPE=HASH_JOIN} (
 					SELECT ts.variable_measured

--- a/internal/server/spanner/golden/query_builder/get_multientity_filtered_topic_place_import.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_filtered_topic_place_import.sql
@@ -1,6 +1,6 @@
 		SELECT
 			e.object_id AS subject_id,
-			COUNT(e.subject_id) AS descendent_stat_var_count
+			COUNT(DISTINCT e.subject_id) AS descendent_stat_var_count
 		FROM Edge@{FORCE_INDEX=InEdge} e
 		JOIN@{JOIN_TYPE=HASH_JOIN} (
 					SELECT ts.variable_measured

--- a/internal/server/spanner/golden/query_builder/get_multientity_filtered_topic_places.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_filtered_topic_places.sql
@@ -1,6 +1,6 @@
 		SELECT
 			e.object_id AS subject_id,
-			COUNT(e.subject_id) AS descendent_stat_var_count
+			COUNT(DISTINCT e.subject_id) AS descendent_stat_var_count
 		FROM Edge@{FORCE_INDEX=InEdge} e
 		JOIN@{JOIN_TYPE=HASH_JOIN} (
 					SELECT ts.variable_measured

--- a/internal/server/spanner/golden/query_builder/get_multientity_filtered_topic_places_multiple_topics.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_filtered_topic_places_multiple_topics.sql
@@ -1,6 +1,6 @@
 		SELECT
 			e.object_id AS subject_id,
-			COUNT(e.subject_id) AS descendent_stat_var_count
+			COUNT(DISTINCT e.subject_id) AS descendent_stat_var_count
 		FROM Edge@{FORCE_INDEX=InEdge} e
 		JOIN@{JOIN_TYPE=HASH_JOIN} (
 					SELECT ts.variable_measured

--- a/internal/server/spanner/golden/query_builder/get_multientity_stat_var_group_node.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_stat_var_group_node.sql
@@ -17,7 +17,7 @@
 			ChildSVGCounts AS (
 				SELECT
 					e.object_id AS child_svg,
-					COUNT(e.subject_id) AS descendent_stat_var_count
+					COUNT(DISTINCT e.subject_id) AS descendent_stat_var_count
 				FROM UniqueChildSVGs u
 				JOIN@{JOIN_METHOD=APPLY_JOIN} Edge e
 				ON e.object_id = u.child_svg

--- a/internal/server/spanner/golden/query_builder/get_multientity_stat_var_group_node_multi.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_stat_var_group_node_multi.sql
@@ -17,7 +17,7 @@
 			ChildSVGCounts AS (
 				SELECT
 					e.object_id AS child_svg,
-					COUNT(e.subject_id) AS descendent_stat_var_count
+					COUNT(DISTINCT e.subject_id) AS descendent_stat_var_count
 				FROM UniqueChildSVGs u
 				JOIN@{JOIN_METHOD=APPLY_JOIN} Edge e
 				ON e.object_id = u.child_svg

--- a/internal/server/spanner/golden/query_builder/get_multientity_stat_var_group_node_with_definitions.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_stat_var_group_node_with_definitions.sql
@@ -17,7 +17,7 @@
 			ChildSVGCounts AS (
 				SELECT
 					e.object_id AS child_svg,
-					COUNT(e.subject_id) AS descendent_stat_var_count
+					COUNT(DISTINCT e.subject_id) AS descendent_stat_var_count
 				FROM UniqueChildSVGs u
 				JOIN@{JOIN_METHOD=APPLY_JOIN} Edge e
 				ON e.object_id = u.child_svg

--- a/internal/server/spanner/golden/query_builder/get_stat_var_group_node.sql
+++ b/internal/server/spanner/golden/query_builder/get_stat_var_group_node.sql
@@ -17,7 +17,7 @@
 		ChildSVGCounts AS (
 			SELECT 
 				e.object_id AS child_svg, 
-				COUNT(e.subject_id) AS descendent_stat_var_count
+				COUNT(DISTINCT e.subject_id) AS descendent_stat_var_count
 			FROM UniqueChildSVGs u
 			JOIN@{JOIN_METHOD=APPLY_JOIN} Edge e 
 			ON e.object_id = u.child_svg

--- a/internal/server/spanner/golden/query_builder/get_stat_var_group_node_multi.sql
+++ b/internal/server/spanner/golden/query_builder/get_stat_var_group_node_multi.sql
@@ -17,7 +17,7 @@
 		ChildSVGCounts AS (
 			SELECT 
 				e.object_id AS child_svg, 
-				COUNT(e.subject_id) AS descendent_stat_var_count
+				COUNT(DISTINCT e.subject_id) AS descendent_stat_var_count
 			FROM UniqueChildSVGs u
 			JOIN@{JOIN_METHOD=APPLY_JOIN} Edge e 
 			ON e.object_id = u.child_svg

--- a/internal/server/spanner/golden/query_builder/get_stat_var_group_node_with_definitions.sql
+++ b/internal/server/spanner/golden/query_builder/get_stat_var_group_node_with_definitions.sql
@@ -17,7 +17,7 @@
 		ChildSVGCounts AS (
 			SELECT 
 				e.object_id AS child_svg, 
-				COUNT(e.subject_id) AS descendent_stat_var_count
+				COUNT(DISTINCT e.subject_id) AS descendent_stat_var_count
 			FROM UniqueChildSVGs u
 			JOIN@{JOIN_METHOD=APPLY_JOIN} Edge e 
 			ON e.object_id = u.child_svg

--- a/internal/server/spanner/statements.go
+++ b/internal/server/spanner/statements.go
@@ -432,7 +432,7 @@ OR CreationTimestamp > (
 		ChildSVGCounts AS (
 			SELECT 
 				e.object_id AS child_svg, 
-				COUNT(e.subject_id) AS descendent_stat_var_count
+				COUNT(DISTINCT e.subject_id) AS descendent_stat_var_count
 			FROM UniqueChildSVGs u
 			JOIN@{JOIN_METHOD=APPLY_JOIN} Edge e 
 			ON e.object_id = u.child_svg
@@ -494,7 +494,7 @@ OR CreationTimestamp > (
 		ChildSVGCounts AS (
 			SELECT 
 				e.object_id AS child_svg, 
-				COUNT(e.subject_id) AS descendent_stat_var_count
+				COUNT(DISTINCT e.subject_id) AS descendent_stat_var_count
 			FROM UniqueChildSVGs u
 			JOIN@{JOIN_METHOD=APPLY_JOIN} Edge e 
 			ON e.object_id = u.child_svg
@@ -635,7 +635,7 @@ OR CreationTimestamp > (
 		JOIN (
 			SELECT
 				e.object_id AS subject_id,
-				COUNT(e.subject_id) AS descendent_stat_var_count
+				COUNT(DISTINCT e.subject_id) AS descendent_stat_var_count
 			FROM Edge e
 			%s
 			WHERE e.predicate = 'linkedMemberOf'
@@ -653,7 +653,7 @@ OR CreationTimestamp > (
 			ON n.subject_id = e_counts.subject_id`,
 	getFilteredTopic: `		SELECT
 			e.object_id AS subject_id,
-			COUNT(e.subject_id) AS descendent_stat_var_count
+			COUNT(DISTINCT e.subject_id) AS descendent_stat_var_count
 		FROM Edge@{FORCE_INDEX=InEdge} e
 		%[1]s
 		WHERE e.predicate = 'linkedMember'

--- a/internal/server/spanner/statements_multientity.go
+++ b/internal/server/spanner/statements_multientity.go
@@ -613,7 +613,7 @@ func NewMultiEntityStatements(cfg TableConfig) (*MultiEntityStatements, error) {
 			ChildSVGCounts AS (
 				SELECT
 					e.object_id AS child_svg,
-					COUNT(e.subject_id) AS descendent_stat_var_count
+					COUNT(DISTINCT e.subject_id) AS descendent_stat_var_count
 				FROM UniqueChildSVGs u
 				JOIN@{JOIN_METHOD=APPLY_JOIN} Edge e
 				ON e.object_id = u.child_svg
@@ -676,7 +676,7 @@ func NewMultiEntityStatements(cfg TableConfig) (*MultiEntityStatements, error) {
 			ChildSVGCounts AS (
 				SELECT
 					e.object_id AS child_svg,
-					COUNT(e.subject_id) AS descendent_stat_var_count
+					COUNT(DISTINCT e.subject_id) AS descendent_stat_var_count
 				FROM UniqueChildSVGs u
 				JOIN@{JOIN_METHOD=APPLY_JOIN} Edge e
 				ON e.object_id = u.child_svg

--- a/internal/sqldb/statements.go
+++ b/internal/sqldb/statements.go
@@ -256,7 +256,7 @@ var statements = struct {
 		WHERE lookup_key = :key;
 	`,
 	getAllStatVarGroups: `
-		SELECT DISTINCT t1.subject_id svg_id, t2.object_value svg_name, t3.object_id svg_parent_id
+		SELECT t1.subject_id svg_id, t2.object_value svg_name, t3.object_id svg_parent_id
 		FROM 
 			triples t1 
 			JOIN triples t2 ON t1.subject_id = t2.subject_id
@@ -268,7 +268,7 @@ var statements = struct {
 			AND t3.predicate="specializationOf";
 	`,
 	getAllStatVars: `
-		SELECT DISTINCT t1.subject_id sv_id, t2.object_value sv_name, t3.object_id AS svg_id, COALESCE(t4.object_value, '') sv_description
+		SELECT t1.subject_id sv_id, t2.object_value sv_name, t3.object_id AS svg_id, COALESCE(t4.object_value, '') sv_description
 		FROM 
 			triples t1
 			JOIN triples t2 ON t1.subject_id = t2.subject_id

--- a/internal/sqldb/statements.go
+++ b/internal/sqldb/statements.go
@@ -256,7 +256,7 @@ var statements = struct {
 		WHERE lookup_key = :key;
 	`,
 	getAllStatVarGroups: `
-		SELECT t1.subject_id svg_id, t2.object_value svg_name, t3.object_id svg_parent_id
+		SELECT DISTINCT t1.subject_id svg_id, t2.object_value svg_name, t3.object_id svg_parent_id
 		FROM 
 			triples t1 
 			JOIN triples t2 ON t1.subject_id = t2.subject_id
@@ -268,7 +268,7 @@ var statements = struct {
 			AND t3.predicate="specializationOf";
 	`,
 	getAllStatVars: `
-		SELECT t1.subject_id sv_id, t2.object_value sv_name, t3.object_id AS svg_id, COALESCE(t4.object_value, '') sv_description
+		SELECT DISTINCT t1.subject_id sv_id, t2.object_value sv_name, t3.object_id AS svg_id, COALESCE(t4.object_value, '') sv_description
 		FROM 
 			triples t1
 			JOIN triples t2 ON t1.subject_id = t2.subject_id


### PR DESCRIPTION
(Raising this PR for quick feedback as I don't know full the scope of changes necessary for this.)

This PR makes the changes necessary to accommodate the change which updates the provenance for generated nodes and edges from `dc/base/GeneratedGraphs` to `dc/base/generated/<import_name>`