### PR TITLE
Add support for FilterStatVarsByEntity request type in redis processor

### DIFF
--- a/internal/server/redis/processor.go
+++ b/internal/server/redis/processor.go
@@ -97,6 +97,8 @@ func newEmptyResponse(requestType dispatcher.RequestType) (proto.Message, error)
 		return &sdmxpb.SdmxDataResult{}, nil
 	case dispatcher.TypeSdmxAvailability:
 		return &sdmxpb.SdmxAvailabilityResult{}, nil
+	case dispatcher.TypeFilterStatVarsByEntity:
+		return &pb.FilterStatVarsByEntityResponse{}, nil
 	default:
 		return nil, fmt.Errorf("unknown request type for caching: %v", requestType)
 	}


### PR DESCRIPTION
## Description

Autopush has both redis on in mixer and and `divert_to_spanner`. 

This resulted in an error "unknown request type for caching" when making a call to `v2/variable/filter`, causing the search in the stat var explorer to fail with a `500` error.

This PR fixes the error by adding a missing case for this type in `newEmptyResponse`.

## Testing

Set up redis cache: `docker run --name local-redis -p 6379:6379 -d redis`
Run mixer using that cache:

```
./run_server.sh \
    --feature_flags_path=$PWD/deploy/featureflags/local.yaml \
    --spanner_graph_info="$(cat deploy/storage/spanner_graph_info.yaml)" \
    --use_spanner_graph=false \
    --use_base_bigtable=true \
    --embeddings_server_url=http://localhost:6060 \
    --use_redis=true \
    --redis_info="instances: [{host: localhost, port: 6379}]"
```

Start website using local mixer:

```
./run_server.sh -l -m
```

Run

```
curl -i "http://localhost:8080/api/stats/stat-var-search?query=population&entities=country/USA"
```

In master, this will error out with the above error. In this branch, it will return a response.

Alternatively you can test the stat var hierarchy search itself in both cases: in master we will see the same 500 error as in autopush; in this branch we will receive results.