### PR TITLE
[sdmx] add explicit node existence check for variableMeasured

### DIFF
--- a/internal/server/spanner/query.go
+++ b/internal/server/spanner/query.go
@@ -70,15 +70,16 @@ const (
 	ApiTimeoutBuffer = 2 * time.Second
 
 	// Special edge predicates.
-	predAffectedPlace      = "affectedPlace"
-	predStartDate          = "startDate"
-	predStartLocation      = "startLocation"
-	predProvenance         = "provenance"
-	predTypeOf             = "typeOf"
-	predGeoJsonCoordinates = "geoJsonCoordinates"
-	predName               = "name"
-	predUrl                = "url"
-	predDomain             = "domain"
+	predAffectedPlace         = "affectedPlace"
+	predStartDate             = "startDate"
+	predStartLocation         = "startLocation"
+	predProvenance            = "provenance"
+	predTypeOf                = "typeOf"
+	predObservationProperties = "observationProperties"
+	predGeoJsonCoordinates    = "geoJsonCoordinates"
+	predName                  = "name"
+	predUrl                   = "url"
+	predDomain                = "domain"
 
 	// Maximum number of concurrent goroutines for fetching filtered StatVarGroupNode info.
 	maxConcurrentFilteredSVGGoroutines = 10

--- a/internal/server/spanner/query_multientity.go
+++ b/internal/server/spanner/query_multientity.go
@@ -589,14 +589,26 @@ func prepareSdmxShape(
 	statVarIDs := sortedUniqueStrings(sdmxConstraintValues(constraints[datacommons.ComponentVariableMeasured]))
 
 	arc := &v2.Arc{
-		Out:        true,
-		SingleProp: "observationProperties",
+		Out:          true,
+		BracketProps: []string{predObservationProperties, predTypeOf},
 	}
-	statVarToObservationPropertyEdges, err := getNodeEdgesByID(ctx, statVarIDs, arc, observationPropertiesPageSize(len(statVarIDs)), 0)
+	statVarEdges, err := getNodeEdgesByID(ctx, statVarIDs, arc, observationPropertiesPageSize(len(statVarIDs)), 0)
 	if err != nil {
 		return nil, sdmxBackendError("failed to fetch observationProperties", err)
 	}
-	observationProperties, observationPropertyToEntitySlot, err := resolveSdmxEntityShape(statVarIDs, statVarToObservationPropertyEdges)
+
+	for _, statVarID := range statVarIDs {
+		edges, ok := statVarEdges[statVarID]
+		if !ok || len(edges) == 0 {
+			return nil, status.Errorf(
+				codes.NotFound,
+				"requested variableMeasured %q does not exist",
+				statVarID,
+			)
+		}
+	}
+
+	observationProperties, observationPropertyToEntitySlot, err := resolveSdmxEntityShape(statVarIDs, statVarEdges)
 	if err != nil {
 		return nil, err
 	}
@@ -872,7 +884,7 @@ func resolveSdmxEntityShape(
 			if edge == nil {
 				continue
 			}
-			if edge.Predicate != "observationProperties" {
+			if edge.Predicate != predObservationProperties {
 				continue
 			}
 			property := strings.TrimSpace(edge.Value)

--- a/internal/server/spanner/query_multientity.go
+++ b/internal/server/spanner/query_multientity.go
@@ -984,9 +984,9 @@ func sdmxProtoComponentKind(kind datacommons.ComponentKind) sdmxpb.SdmxComponent
 }
 
 func observationPropertiesPageSize(variableCount int) int {
-	// Fetch one more property per variable than the schema supports so unsupported
-	// metadata is detected before SQL generation.
-	pageSize := variableCount * (maxObservationPropertyEntitySlots + 1)
+	// Fetch observationProperties, overflow detector, and typeOf edges per variable
+	// so unsupported metadata is detected before SQL generation.
+	pageSize := variableCount * (maxObservationPropertyEntitySlots + 3)
 	if pageSize < minObservationPropertiesPageSize {
 		return minObservationPropertiesPageSize
 	}

--- a/internal/server/spanner/query_multientity_test.go
+++ b/internal/server/spanner/query_multientity_test.go
@@ -2287,13 +2287,13 @@ func TestObservationPropertiesEntityMappingPageSize(t *testing.T) {
 		},
 		{
 			name:          "uses minimum page size at boundary",
-			variableCount: 25,
+			variableCount: 16,
 			want:          minObservationPropertiesPageSize,
 		},
 		{
 			name:          "scales past minimum",
 			variableCount: 26,
-			want:          104,
+			want:          156,
 		},
 	}
 

--- a/internal/server/spanner/query_multientity_test.go
+++ b/internal/server/spanner/query_multientity_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 
@@ -696,8 +697,8 @@ func TestPrepareSdmxObservationsQuery(t *testing.T) {
 			if diff := cmp.Diff([]string{"var1", "var2"}, ids); diff != "" {
 				t.Fatalf("GetNodeEdgesByID() ids mismatch (-want +got):\n%s", diff)
 			}
-			if arc == nil || !arc.Out || arc.SingleProp != "observationProperties" {
-				t.Fatalf("GetNodeEdgesByID() arc = %+v, want outgoing observationProperties", arc)
+			if arc == nil || !arc.Out || !slices.Equal(arc.BracketProps, []string{predObservationProperties, predTypeOf}) {
+				t.Fatalf("GetNodeEdgesByID() arc = %+v, want outgoing observationProperties and typeOf", arc)
 			}
 			if pageSize != minObservationPropertiesPageSize {
 				t.Fatalf("GetNodeEdgesByID() pageSize = %d, want %d", pageSize, minObservationPropertiesPageSize)
@@ -1006,8 +1007,8 @@ func TestPrepareSdmxAvailabilityQuery(t *testing.T) {
 			if diff := cmp.Diff([]string{"var1", "var2"}, ids); diff != "" {
 				t.Fatalf("GetNodeEdgesByID() ids mismatch (-want +got):\n%s", diff)
 			}
-			if arc == nil || !arc.Out || arc.SingleProp != "observationProperties" {
-				t.Fatalf("GetNodeEdgesByID() arc = %+v, want outgoing observationProperties", arc)
+			if arc == nil || !arc.Out || !slices.Equal(arc.BracketProps, []string{predObservationProperties, predTypeOf}) {
+				t.Fatalf("GetNodeEdgesByID() arc = %+v, want outgoing observationProperties and typeOf", arc)
 			}
 			if pageSize != minObservationPropertiesPageSize || offset != 0 {
 				t.Fatalf("GetNodeEdgesByID() pageSize, offset = %d, %d, want %d, 0", pageSize, offset, minObservationPropertiesPageSize)
@@ -1113,6 +1114,7 @@ func TestPrepareSdmxAvailabilityQueryValidation(t *testing.T) {
 		name       string
 		req        *sdmxpb.SdmxAvailabilityQuery
 		edges      map[string][]*Edge
+		wantCode   codes.Code
 		wantErrSub string
 	}{
 		{
@@ -1124,6 +1126,7 @@ func TestPrepareSdmxAvailabilityQueryValidation(t *testing.T) {
 				},
 			},
 			edges:      map[string][]*Edge{"var1": observationPropertiesEdges("destinationCountry", "sourceCountry")},
+			wantCode:   codes.InvalidArgument,
 			wantErrSub: "unsupported SDMX availability component \"observationAbout\"",
 		},
 		{
@@ -1136,6 +1139,7 @@ func TestPrepareSdmxAvailabilityQueryValidation(t *testing.T) {
 				},
 			},
 			edges:      map[string][]*Edge{"var1": observationPropertiesEdges("destinationCountry", "sourceCountry")},
+			wantCode:   codes.InvalidArgument,
 			wantErrSub: "unsupported SDMX component filter \"customEntity\"",
 		},
 		{
@@ -1147,7 +1151,8 @@ func TestPrepareSdmxAvailabilityQueryValidation(t *testing.T) {
 					datacommons.ComponentFacetID:          sdmxComponentConstraint("facet"),
 				},
 			},
-			edges:      map[string][]*Edge{"var1": nil},
+			edges:      map[string][]*Edge{"var1": observationPropertiesEdges(datacommons.ComponentObservationAbout)},
+			wantCode:   codes.InvalidArgument,
 			wantErrSub: "unsupported SDMX component filter \"facetId\"",
 		},
 		{
@@ -1160,9 +1165,22 @@ func TestPrepareSdmxAvailabilityQueryValidation(t *testing.T) {
 			},
 			edges: map[string][]*Edge{
 				"var1": observationPropertiesEdges("destinationCountry", "sourceCountry"),
-				"var2": nil,
+				"var2": observationPropertiesEdges("destinationCountry", "originCountry"),
 			},
+			wantCode:   codes.InvalidArgument,
 			wantErrSub: "incompatible observationProperties",
+		},
+		{
+			name: "variable measured does not exist",
+			req: &sdmxpb.SdmxAvailabilityQuery{
+				ComponentId: "destinationCountry",
+				Constraints: map[string]*sdmxpb.SdmxComponentConstraint{
+					datacommons.ComponentVariableMeasured: sdmxComponentConstraint("unknownVar"),
+				},
+			},
+			edges:      map[string][]*Edge{},
+			wantCode:   codes.NotFound,
+			wantErrSub: "requested variableMeasured \"unknownVar\" does not exist",
 		},
 	}
 
@@ -1179,8 +1197,12 @@ func TestPrepareSdmxAvailabilityQueryValidation(t *testing.T) {
 			if err == nil {
 				t.Fatal("prepareSdmxAvailabilityQuery() error = nil, want error")
 			}
-			if status.Code(err) != codes.InvalidArgument {
-				t.Fatalf("prepareSdmxAvailabilityQuery() code = %v, want %v; err = %v", status.Code(err), codes.InvalidArgument, err)
+			wantCode := tt.wantCode
+			if wantCode == codes.OK {
+				wantCode = codes.InvalidArgument
+			}
+			if status.Code(err) != wantCode {
+				t.Fatalf("prepareSdmxAvailabilityQuery() code = %v, want %v; err = %v", status.Code(err), wantCode, err)
 			}
 			if !strings.Contains(status.Convert(err).Message(), tt.wantErrSub) {
 				t.Fatalf("prepareSdmxAvailabilityQuery() message = %q, want substring %q", status.Convert(err).Message(), tt.wantErrSub)


### PR DESCRIPTION
## Summary

This PR adds an explicit node existence check for `variableMeasured` in SDMX Data and Availability queries.

Previously, when an SDMX query requested a non-existent or misspelled `variableMeasured`, `prepareSdmxShape()` received 0 `observationProperties` edges and silently defaulted the shape to `[observationAbout]`. Subsequent entity filters (like `c[sex]=Female` or `c[country]=country/ARE`) evaluated against `[observationAbout]` failed with a misleading error: `unsupported SDMX component filter "sex"; filterable components are [observationAbout, ...]` when it should just say that the variable didn't exist.

## Changes

- Uses typeOf property check as an existence check for variableMeasured
- Updates observationPropertiesPageSize multiplier to account for typeOf edges