### PR TITLE
 Scope Node containment optimization to configured place types

### DIFF
--- a/internal/server/spanner/golden/query_builder/get_node_edges_linked_contained_in_place.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_linked_contained_in_place.sql
@@ -1,13 +1,12 @@
-		GRAPH DCGraph MATCH (n:Node)-[@{FORCE_INDEX=InEdge}filter0:Edge
-		WHERE
-			filter0.predicate = 'typeOf'
-			AND filter0.object_id IN ('County','County:E2yH3sRpXO/vAw/W3Hwy+utigKeV/acLAXGXtg47eHM=')]->,
-		@{FORCE_JOIN_ORDER=TRUE}
-		(m:Node
+		GRAPH DCGraph MATCH (m:Node
 		WHERE
 			m.subject_id = 'country/USA')<-[e:Edge
 		WHERE
-			e.predicate = 'linkedContainedInPlace']-(n:Node)
+			e.predicate = 'linkedContainedInPlace']-(n:Node),
+		(n)-[@{FORCE_INDEX=InEdge}filter0:Edge
+		WHERE
+			filter0.predicate = 'typeOf'
+			AND filter0.object_id = 'County']->
 		RETURN
 			m.subject_id,
 			n.subject_id AS object_id,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_linked_contained_in_place_ancestor_first.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_linked_contained_in_place_ancestor_first.sql
@@ -1,3 +1,4 @@
+		@{SCAN_METHOD=COLUMNAR}
 		GRAPH DCGraph MATCH (m:Node
 		WHERE
 			m.subject_id IN ('country/USA','country/IND'))<-[e:Edge
@@ -7,7 +8,7 @@
 		(n)-[@{FORCE_INDEX=InEdge}filter0:Edge
 		WHERE
 			filter0.predicate = 'typeOf'
-			AND filter0.object_id IN ('Place','Place:6UY9zPBUGpd4WJaRVD/Wkkl1nV3mqXzVfWQgw+XZK6o=')]->
+			AND filter0.object_id = 'Place']->
 		RETURN
 			m.subject_id,
 			n.subject_id AS object_id,

--- a/internal/server/spanner/golden/query_builder/get_node_edges_linked_contained_in_place_ancestor_first_multiple_types.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_linked_contained_in_place_ancestor_first_multiple_types.sql
@@ -1,12 +1,14 @@
+		@{SCAN_METHOD=COLUMNAR}
 		GRAPH DCGraph MATCH (m:Node
 		WHERE
 			m.subject_id IN ('country/USA','country/IND'))<-[e:Edge
 		WHERE
 			e.predicate = 'linkedContainedInPlace']-(n:Node),
+		@{FORCE_JOIN_ORDER=TRUE}
 		(n)-[@{FORCE_INDEX=InEdge}filter0:Edge
 		WHERE
 			filter0.predicate = 'typeOf'
-			AND filter0.object_id = 'County']->
+			AND filter0.object_id IN ('County','Place')]->
 		RETURN
 			m.subject_id,
 			n.subject_id AS object_id,

--- a/internal/server/spanner/golden/query_builder_test.go
+++ b/internal/server/spanner/golden/query_builder_test.go
@@ -82,22 +82,30 @@ func TestGetNodeContainedInPlaceAccessPathQuery(t *testing.T) {
 
 	for _, tc := range []struct {
 		name        string
-		placeType   string
+		placeTypes  []string
 		queryConfig spanner.QueryConfig
 		golden      string
 	}{
 		{
-			name:      "type first",
-			placeType: "County",
-			golden:    "get_node_edges_linked_contained_in_place_type_first",
+			name:       "legacy fallback",
+			placeTypes: []string{"County"},
+			golden:     "get_node_edges_linked_contained_in_place_type_first",
 		},
 		{
-			name:      "ancestor first",
-			placeType: "Place",
+			name:       "ancestor first",
+			placeTypes: []string{"Place"},
 			queryConfig: spanner.QueryConfig{
 				ContainedInPlaceAncestorFirstTypes: []string{"Place"},
 			},
 			golden: "get_node_edges_linked_contained_in_place_ancestor_first",
+		},
+		{
+			name:       "ancestor first when any type matches",
+			placeTypes: []string{"County", "Place"},
+			queryConfig: spanner.QueryConfig{
+				ContainedInPlaceAncestorFirstTypes: []string{"Place"},
+			},
+			golden: "get_node_edges_linked_contained_in_place_ancestor_first_multiple_types",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -107,7 +115,7 @@ func TestGetNodeContainedInPlaceAccessPathQuery(t *testing.T) {
 					&v2.Arc{
 						SingleProp: "linkedContainedInPlace",
 						Filter: map[string][]string{
-							"typeOf": {tc.placeType},
+							"typeOf": tc.placeTypes,
 						},
 					},
 					datasources.DefaultPageSize,

--- a/internal/server/spanner/node_query_plan.go
+++ b/internal/server/spanner/node_query_plan.go
@@ -29,7 +29,11 @@ const (
 )
 
 type nodeQueryPlan struct {
-	kind       nodeQueryKind
+	kind             nodeQueryKind
+	containedInPlace containedInPlacePlan
+}
+
+type containedInPlacePlan struct {
 	accessPath containedInPlaceAccessPath
 }
 
@@ -38,35 +42,36 @@ func planNodeQuery(arc *v2.Arc, queryConfig QueryConfig) (nodeQueryPlan, error) 
 		return nodeQueryPlan{}, fmt.Errorf("node query arc must not be nil")
 	}
 
-	childPlaceType, ok := matchNodeContainedInPlace(arc)
-	if !ok {
-		return nodeQueryPlan{kind: nodeQueryGeneric}, nil
+	if childPlaceTypes, ok := matchNodeContainedInPlace(arc); ok {
+		return nodeQueryPlan{
+			kind: nodeQueryContainedInPlace,
+			containedInPlace: containedInPlacePlan{
+				accessPath: queryConfig.containedInPlaceAccessPath(childPlaceTypes...),
+			},
+		}, nil
 	}
-	return nodeQueryPlan{
-		kind:       nodeQueryContainedInPlace,
-		accessPath: queryConfig.containedInPlaceAccessPath(childPlaceType),
-	}, nil
+
+	return nodeQueryPlan{kind: nodeQueryGeneric}, nil
 }
 
-func matchNodeContainedInPlace(arc *v2.Arc) (string, bool) {
+func matchNodeContainedInPlace(arc *v2.Arc) ([]string, bool) {
 	if arc == nil ||
 		arc.Out ||
 		arc.SingleProp != linkedContainedInPlaceProperty ||
 		arc.Decorator != "" ||
 		len(arc.BracketProps) > 0 ||
-		len(arc.BracketFilters) > 0 {
-		return "", false
+		len(arc.BracketFilters) > 0 ||
+		len(arc.Filter) != 1 {
+		return nil, false
 	}
-	return singleFilterValue(arc.Filter, predTypeOf)
-}
-
-func singleFilterValue(filters map[string][]string, property string) (string, bool) {
-	if len(filters) != 1 {
-		return "", false
+	childPlaceTypes, ok := arc.Filter[predTypeOf]
+	if !ok || len(childPlaceTypes) == 0 {
+		return nil, false
 	}
-	values, ok := filters[property]
-	if !ok || len(values) != 1 || strings.TrimSpace(values[0]) == "" {
-		return "", false
+	for _, childPlaceType := range childPlaceTypes {
+		if strings.TrimSpace(childPlaceType) == "" {
+			return nil, false
+		}
 	}
-	return values[0], true
+	return childPlaceTypes, true
 }

--- a/internal/server/spanner/node_query_plan_test.go
+++ b/internal/server/spanner/node_query_plan_test.go
@@ -37,11 +37,13 @@ func TestPlanNodeQuery(t *testing.T) {
 		wantErr     bool
 	}{
 		{
-			name: "contained in place type first",
+			name: "contained in place legacy fallback",
 			arc:  containedInPlaceArc(),
 			want: nodeQueryPlan{
-				kind:       nodeQueryContainedInPlace,
-				accessPath: containedInPlaceTypeFirst,
+				kind: nodeQueryContainedInPlace,
+				containedInPlace: containedInPlacePlan{
+					accessPath: containedInPlaceTypeFirst,
+				},
 			},
 		},
 		{
@@ -54,8 +56,26 @@ func TestPlanNodeQuery(t *testing.T) {
 				ContainedInPlaceAncestorFirstTypes: []string{"Place"},
 			},
 			want: nodeQueryPlan{
-				kind:       nodeQueryContainedInPlace,
-				accessPath: containedInPlaceAncestorFirst,
+				kind: nodeQueryContainedInPlace,
+				containedInPlace: containedInPlacePlan{
+					accessPath: containedInPlaceAncestorFirst,
+				},
+			},
+		},
+		{
+			name: "contained in place ancestor first when any type matches",
+			arc: &v2.Arc{
+				SingleProp: linkedContainedInPlaceProperty,
+				Filter:     map[string][]string{predTypeOf: {"County", "Place"}},
+			},
+			queryConfig: QueryConfig{
+				ContainedInPlaceAncestorFirstTypes: []string{"Place"},
+			},
+			want: nodeQueryPlan{
+				kind: nodeQueryContainedInPlace,
+				containedInPlace: containedInPlacePlan{
+					accessPath: containedInPlaceAncestorFirst,
+				},
 			},
 		},
 		{
@@ -148,7 +168,12 @@ func TestPlanNodeQuery(t *testing.T) {
 				SingleProp: linkedContainedInPlaceProperty,
 				Filter:     map[string][]string{predTypeOf: {"County", "City"}},
 			},
-			want: nodeQueryPlan{kind: nodeQueryGeneric},
+			want: nodeQueryPlan{
+				kind: nodeQueryContainedInPlace,
+				containedInPlace: containedInPlacePlan{
+					accessPath: containedInPlaceTypeFirst,
+				},
+			},
 		},
 		{
 			name: "blank type",
@@ -170,7 +195,7 @@ func TestPlanNodeQuery(t *testing.T) {
 			if err != nil {
 				t.Fatalf("planNodeQuery() unexpected error: %v", err)
 			}
-			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(nodeQueryPlan{})); diff != "" {
+			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(nodeQueryPlan{}, containedInPlacePlan{})); diff != "" {
 				t.Errorf("planNodeQuery() mismatch (-want +got):\n%s", diff)
 			}
 		})
@@ -178,7 +203,7 @@ func TestPlanNodeQuery(t *testing.T) {
 }
 
 func TestPlanNodeQueryFromPropertyExpression(t *testing.T) {
-	arcs, err := v2.ParseProperty("<-containedInPlace+{typeOf:County}")
+	arcs, err := v2.ParseProperty("<-containedInPlace+{typeOf:[County,Place]}")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -188,14 +213,18 @@ func TestPlanNodeQueryFromPropertyExpression(t *testing.T) {
 	addOptimizationsToNodeRequest(arcs[0])
 
 	want := nodeQueryPlan{
-		kind:       nodeQueryContainedInPlace,
-		accessPath: containedInPlaceTypeFirst,
+		kind: nodeQueryContainedInPlace,
+		containedInPlace: containedInPlacePlan{
+			accessPath: containedInPlaceAncestorFirst,
+		},
 	}
-	got, err := planNodeQuery(arcs[0], QueryConfig{})
+	got, err := planNodeQuery(arcs[0], QueryConfig{
+		ContainedInPlaceAncestorFirstTypes: []string{"Place"},
+	})
 	if err != nil {
 		t.Fatalf("planNodeQuery() unexpected error: %v", err)
 	}
-	if diff := cmp.Diff(want, got, cmp.AllowUnexported(nodeQueryPlan{})); diff != "" {
+	if diff := cmp.Diff(want, got, cmp.AllowUnexported(nodeQueryPlan{}, containedInPlacePlan{})); diff != "" {
 		t.Errorf("planNodeQuery() mismatch (-want +got):\n%s", diff)
 	}
 }
@@ -209,6 +238,19 @@ func TestGetNodeEdgesByIDQueryRejectsNilArc(t *testing.T) {
 func TestBuildNodeEdgesByIDQueryRejectsUnsupportedPlan(t *testing.T) {
 	arc := &v2.Arc{SingleProp: "name"}
 	plan := nodeQueryPlan{kind: nodeQueryKind(100)}
+	if _, err := buildNodeEdgesByIDQuery(nil, arc, 1, 0, plan); err == nil {
+		t.Fatal("buildNodeEdgesByIDQuery() expected error, got nil")
+	}
+}
+
+func TestBuildNodeEdgesByIDQueryRejectsUnsupportedContainedInPlacePlan(t *testing.T) {
+	arc := &v2.Arc{SingleProp: linkedContainedInPlaceProperty}
+	plan := nodeQueryPlan{
+		kind: nodeQueryContainedInPlace,
+		containedInPlace: containedInPlacePlan{
+			accessPath: containedInPlaceAccessPath(100),
+		},
+	}
 	if _, err := buildNodeEdgesByIDQuery(nil, arc, 1, 0, plan); err == nil {
 		t.Fatal("buildNodeEdgesByIDQuery() expected error, got nil")
 	}

--- a/internal/server/spanner/query_builder.go
+++ b/internal/server/spanner/query_builder.go
@@ -149,18 +149,16 @@ func buildNodeEdgesByIDQuery(
 	pageSize, offset int,
 	plan nodeQueryPlan,
 ) (*spanner.Statement, error) {
-	containedInPlace := false
-	typeFirst := false
+	useContainedInPlaceAncestorFirst := false
 	switch plan.kind {
 	case nodeQueryGeneric:
 	case nodeQueryContainedInPlace:
-		containedInPlace = true
-		switch plan.accessPath {
+		switch plan.containedInPlace.accessPath {
 		case containedInPlaceTypeFirst:
-			typeFirst = true
 		case containedInPlaceAncestorFirst:
+			useContainedInPlaceAncestorFirst = true
 		default:
-			return nil, fmt.Errorf("unsupported contained-in-place access path: %d", plan.accessPath)
+			return nil, fmt.Errorf("unsupported contained-in-place access path: %d", plan.containedInPlace.accessPath)
 		}
 	default:
 		return nil, fmt.Errorf("unsupported node query kind: %d", plan.kind)
@@ -209,7 +207,7 @@ func buildNodeEdgesByIDQuery(
 			// 2. Standard Property Processing
 			params["prop"+strconv.Itoa(i)] = prop
 			objectFilter := ""
-			filterVal := addObjectValues(arc.Filter[prop])
+			filterVal := objectFilterValues(prop, arc.Filter[prop])
 			if len(filterVal) > 0 {
 				objectFilter = fmt.Sprintf(statements.filterValues, i)
 				params["val"+strconv.Itoa(i)] = filterVal
@@ -218,11 +216,7 @@ func buildNodeEdgesByIDQuery(
 			if len(filterVal) > 0 {
 				indexHint = "@{FORCE_INDEX=InEdge}"
 			}
-			nodeLabel := ""
-			if typeFirst {
-				nodeLabel = ":Node"
-			}
-			subqueries = append(subqueries, fmt.Sprintf(statements.filterProperty, i, indexHint, objectFilter, nodeLabel))
+			subqueries = append(subqueries, fmt.Sprintf(statements.filterProperty, i, indexHint, objectFilter))
 			i++
 		}
 	}
@@ -285,11 +279,7 @@ func buildNodeEdgesByIDQuery(
 			subquery = fmt.Sprintf(statements.getEdgesByObjectID, idFilter, filterPredicate, nodeFilterStr)
 		}
 	}
-	if typeFirst {
-		subqueries = append(subqueries, subquery)
-	} else {
-		subqueries = append([]string{subquery}, subqueries...)
-	}
+	subqueries = append([]string{subquery}, subqueries...)
 
 	// Generate prefix and return statement.
 	var prefix, returnEdges string
@@ -305,10 +295,10 @@ func buildNodeEdgesByIDQuery(
 			returnEdges = statements.returnEdges
 		}
 	}
-
-	separator := ",\n\t\t"
-	if containedInPlace {
-		separator += "@{FORCE_JOIN_ORDER=TRUE}\n\t\t"
+	separator := statements.graphPatternSeparator
+	if useContainedInPlaceAncestorFirst {
+		prefix = statements.graphColumnarScanHint + prefix
+		separator = statements.graphPatternForceJoinOrder
 	}
 	template := prefix + strings.Join(subqueries, separator) + returnEdges
 	template = applyNodeQueryPagination(template, pageSize, offset)
@@ -477,8 +467,8 @@ func SparqlQuery(nodes []types.Node, queries []*types.Query, opts *types.QueryOp
 			default:
 				return nil, fmt.Errorf("unsupported object type: %T", q.Obj)
 			}
-			if q.Pred != "typeOf" && q.Pred != "dcid" { // typeOf has reference object.
-				vals = addObjectValues(vals)
+			if q.Pred != "dcid" {
+				vals = objectFilterValues(q.Pred, vals)
 			}
 			if q.Pred == "dcid" {
 				sFilter = fmt.Sprintf(statements.nodeFilter, sId)
@@ -710,6 +700,13 @@ func addObjectValues(input []string) []string {
 		result = append(result, generateObjectValue(v))
 	}
 	return result
+}
+
+func objectFilterValues(predicate string, input []string) []string {
+	if predicate == predTypeOf {
+		return input
+	}
+	return addObjectValues(input)
 }
 
 // getParamStatement returns the appropriate SQL statement and parameter value for filtering by a parameter.

--- a/internal/server/spanner/query_config.go
+++ b/internal/server/spanner/query_config.go
@@ -23,8 +23,8 @@ import (
 // QueryConfig controls Spanner query-planning behavior.
 type QueryConfig struct {
 	// ContainedInPlaceAncestorFirstTypes contains child place types that
-	// should filter by ancestor before type. Other child place types filter by
-	// type first.
+	// should filter by ancestor before type when the query builder supports
+	// that access path.
 	ContainedInPlaceAncestorFirstTypes []string
 	// ContainedInPlaceEntityScanMinVariables is the minimum number of unique
 	// requested variables that selects the entity1 range-scan plan for core
@@ -56,9 +56,11 @@ func (config QueryConfig) Validate() error {
 	return nil
 }
 
-func (config QueryConfig) containedInPlaceAccessPath(childPlaceType string) containedInPlaceAccessPath {
-	if slices.Contains(config.ContainedInPlaceAncestorFirstTypes, childPlaceType) {
-		return containedInPlaceAncestorFirst
+func (config QueryConfig) containedInPlaceAccessPath(childPlaceTypes ...string) containedInPlaceAccessPath {
+	for _, childPlaceType := range childPlaceTypes {
+		if slices.Contains(config.ContainedInPlaceAncestorFirstTypes, childPlaceType) {
+			return containedInPlaceAncestorFirst
+		}
 	}
 	return containedInPlaceTypeFirst
 }

--- a/internal/server/spanner/query_config_test.go
+++ b/internal/server/spanner/query_config_test.go
@@ -27,6 +27,12 @@ func TestQueryConfig(t *testing.T) {
 	if got := config.containedInPlaceAccessPath("County"); got != containedInPlaceTypeFirst {
 		t.Errorf("containedInPlaceAccessPath(County) = %v, want type first", got)
 	}
+	if got := config.containedInPlaceAccessPath("County", "Place"); got != containedInPlaceAncestorFirst {
+		t.Errorf("containedInPlaceAccessPath(County, Place) = %v, want ancestor first", got)
+	}
+	if got := config.containedInPlaceAccessPath("County", "City"); got != containedInPlaceTypeFirst {
+		t.Errorf("containedInPlaceAccessPath(County, City) = %v, want type first", got)
+	}
 }
 
 func TestQueryConfigValidation(t *testing.T) {

--- a/internal/server/spanner/statements.go
+++ b/internal/server/spanner/statements.go
@@ -33,6 +33,12 @@ var statements = struct {
 	graphPrefix string
 	// Prefix for a graph query that matches any path.
 	graphPrefixAny string
+	// Statement hint for columnar graph execution.
+	graphColumnarScanHint string
+	// Separator between graph match patterns.
+	graphPatternSeparator string
+	// Separator that forces graph patterns to execute in textual order.
+	graphPatternForceJoinOrder string
 	// Fetch Edges for out arcs with a single hop.
 	getEdgesBySubjectID string
 	// Fetch Edges for out arcs with chaining.
@@ -179,8 +185,11 @@ OR CreationTimestamp > (
 		ORDER BY
 			subject_id,
 			predicate`,
-	graphPrefix:    `		GRAPH DCGraph MATCH `,
-	graphPrefixAny: `		GRAPH DCGraph MATCH ANY `,
+	graphPrefix:                `		GRAPH DCGraph MATCH `,
+	graphPrefixAny:             `		GRAPH DCGraph MATCH ANY `,
+	graphColumnarScanHint:      "\t\t@{SCAN_METHOD=COLUMNAR}\n",
+	graphPatternSeparator:      ",\n\t\t",
+	graphPatternForceJoinOrder: ",\n\t\t@{FORCE_JOIN_ORDER=TRUE}\n\t\t",
 	getEdgesBySubjectID: `(m:Node
 		WHERE
 			m.subject_id %[1]s)-[e:Edge%[2]s]->(n:Node)%[3]s`,
@@ -203,7 +212,7 @@ OR CreationTimestamp > (
 	filterPredicates: `
 		WHERE
 			e.predicate IN UNNEST(@predicate)`,
-	filterProperty: `(n%[4]s)-[%[2]sfilter%[1]d:Edge
+	filterProperty: `(n)-[%[2]sfilter%[1]d:Edge
 		WHERE
 			filter%[1]d.predicate = @prop%[1]d%[3]s]->`,
 	filterValues: `


### PR DESCRIPTION
This is a corrective follow-up to `7054073d` (#2029), which introduced the shared Spanner `QueryConfig` and Node query planner.

- Apply ancestor-first ordering, `FORCE_JOIN_ORDER`, and columnar scanning only when any requested `typeOf` value appears in `ContainedInPlaceAncestorFirstTypes`—currently `Place` by default.
- Keep legacy, optimizer-controlled SQL for all other place types.
- Stop generating scalar hash variants for `typeOf` values. A `typeOf` object is a reference DCID, so values such as `Place:<hash>` and `City:<hash>` cannot match valid `typeOf` edges.
- Support multiple `typeOf` values and select ancestor-first when any value matches the configuration.
- Separate containment-query recognition from access-path selection through a query-specific nested plan.
- Move static Graph query hints and pattern fragments into `statements.go`.

The existing `FORCE_INDEX=InEdge` behavior is unchanged. This PR does not introduce `_BASE_TABLE` or additional index hints.

## Performance impact

Spanner query profiles showed that forcing type-first execution broadly caused severe regressions:

| Query | Previous forced path | Selected path | Impact |
|---|---:|---:|---|
| `City` descendants of USA | 86.93 s | 2.06 s legacy unforced | Approximately 42× faster |
| `Place` descendants of USA | 38.54 s type-first | 13.88 s ancestor-first | Approximately 2.8× faster |
| `Place`, ancestor-first | 13.88 s row scan | 10.04 s columnar scan | Approximately 28% lower elapsed time |

For the City query, restoring the legacy unforced path reduced remote calls from 125,107 to 19 and data read from 15.85 GB to 0.86 GB.

For the Place query, ancestor-first execution reduced remote calls from 167 to 7 and data read from 6.37 GB to 376 MB compared with forced type-first execution. Adding columnar scanning reduced CPU from 18.94 seconds to 15.38 seconds.

A separate parameterized profile using only the valid raw `Place` value completed in 7.51 seconds and scanned 1.12 million rows, compared with approximately 15.29 million rows when the impossible hashed value was also included.

## References

- `d881ac60` (#1662) introduced the Node `containedInPlace+` → `linkedContainedInPlace` optimization.
- `7054073d` (#2029) introduced shared query configuration and explicit Node containment planning.
- This PR retains that architecture while limiting forced execution to the access path supported by the measured Spanner profiles.

## Testing

- `go test ./internal/server/spanner/... ./internal/server/v2`
- `golangci-lint run`
- Node query-builder goldens cover legacy fallback, ancestor-first execution, and multiple `typeOf` values.
