### PR TITLE
Enable spanner + embeddings on staging

### DIFF
--- a/deploy/featureflags/staging.yaml
+++ b/deploy/featureflags/staging.yaml
@@ -6,7 +6,8 @@ flags:
   WriteUsageLogs: 1.0
   UseSpannerGraph: true
   SpannerGraphDatabase: projects/datcom-store/instances/dc-graph-prod/databases/dc_graph
-  EnableSpannerSearchEmbeddings: false
+  EnableSpannerSearchEmbeddings: true
   UseMultiEntitySchema: true
   EnableSDMXDataApi: true
   UseSpannerKeyValueStore: true
+  V2DivertFraction: 1.0

--- a/deploy/featureflags/staging_website.yaml
+++ b/deploy/featureflags/staging_website.yaml
@@ -7,6 +7,6 @@ flags:
   WriteUsageLogs: 1.0
   UseSpannerGraph: true
   SpannerGraphDatabase: projects/datcom-store/instances/dc-graph-prod/databases/dc_graph
-  EnableSpannerSearchEmbeddings: false
+  EnableSpannerSearchEmbeddings: true
   UseMultiEntitySchema: true
   UseSpannerKeyValueStore: true


### PR DESCRIPTION
Enables embeddings on both mixer and website

Fully diverts mixer to spanner. Website diversion will be handled as follow up via website feature flags (https://github.com/datacommonsorg/website/pull/6488)