### PR TITLE
Optimize multi-type direct `containedInPlace` Node queries

### DIFF
--- a/internal/server/spanner/golden/query_builder/get_node_edges_contained_in_place_multiple_types_ancestor_first.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_contained_in_place_multiple_types_ancestor_first.sql
@@ -1,0 +1,38 @@
+		@{SCAN_METHOD=COLUMNAR}
+		GRAPH DCGraph MATCH (m:Node
+		WHERE
+			m.subject_id = 'geoId/5508971700')<-[e:Edge
+		WHERE
+			e.predicate = 'containedInPlace']-(n:Node),
+		@{FORCE_JOIN_ORDER=TRUE}
+		(n)-[@{FORCE_INDEX=InEdge}filter0:Edge
+		WHERE
+			filter0.predicate = 'typeOf'
+			AND filter0.object_id IN ('County','City')]->
+		RETURN
+			m.subject_id,
+			n.subject_id AS object_id,
+			e.predicate,
+			e.provenance
+		NEXT MATCH (n)
+		WHERE
+		  n.subject_id = object_id
+		RETURN
+			subject_id,
+			predicate,
+			provenance,
+			IFNULL(ANY_VALUE(n.value), '') AS value,
+			ANY_VALUE(n.bytes) AS bytes,
+			IFNULL(ANY_VALUE(n.name), '') AS name,
+			IFNULL(ANY_VALUE(n.types), []) AS types
+		GROUP BY
+			subject_id,
+			predicate,
+			object_id,
+			provenance
+		ORDER BY
+			subject_id,
+			predicate,
+			object_id,
+			provenance
+		LIMIT 501

--- a/internal/server/spanner/golden/query_builder/get_node_edges_contained_in_place_single_type.sql
+++ b/internal/server/spanner/golden/query_builder/get_node_edges_contained_in_place_single_type.sql
@@ -1,0 +1,36 @@
+		GRAPH DCGraph MATCH (m:Node
+		WHERE
+			m.subject_id = 'geoId/5508971700')<-[e:Edge
+		WHERE
+			e.predicate = 'containedInPlace']-(n:Node),
+		(n)-[@{FORCE_INDEX=InEdge}filter0:Edge
+		WHERE
+			filter0.predicate = 'typeOf'
+			AND filter0.object_id = 'County']->
+		RETURN
+			m.subject_id,
+			n.subject_id AS object_id,
+			e.predicate,
+			e.provenance
+		NEXT MATCH (n)
+		WHERE
+		  n.subject_id = object_id
+		RETURN
+			subject_id,
+			predicate,
+			provenance,
+			IFNULL(ANY_VALUE(n.value), '') AS value,
+			ANY_VALUE(n.bytes) AS bytes,
+			IFNULL(ANY_VALUE(n.name), '') AS name,
+			IFNULL(ANY_VALUE(n.types), []) AS types
+		GROUP BY
+			subject_id,
+			predicate,
+			object_id,
+			provenance
+		ORDER BY
+			subject_id,
+			predicate,
+			object_id,
+			provenance
+		LIMIT 501

--- a/internal/server/spanner/golden/query_builder_test.go
+++ b/internal/server/spanner/golden/query_builder_test.go
@@ -127,6 +127,44 @@ func TestGetNodeContainedInPlaceAccessPathQuery(t *testing.T) {
 	}
 }
 
+func TestGetNodeDirectContainedInPlaceQuery(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name       string
+		placeTypes []string
+		golden     string
+	}{
+		{
+			name:       "single type remains unforced",
+			placeTypes: []string{"County"},
+			golden:     "get_node_edges_contained_in_place_single_type",
+		},
+		{
+			name:       "multiple types use ancestor first",
+			placeTypes: []string{"County", "City"},
+			golden:     "get_node_edges_contained_in_place_multiple_types_ancestor_first",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			runQueryBuilderGoldenTest(t, tc.golden+".sql", func(ctx context.Context) (interface{}, error) {
+				return spanner.GetNodeEdgesByIDQuery(
+					[]string{"geoId/5508971700"},
+					&v2.Arc{
+						SingleProp: v2.ContainedInPlaceProperty,
+						Filter: map[string][]string{
+							"typeOf": tc.placeTypes,
+						},
+					},
+					datasources.DefaultPageSize,
+					0,
+					spanner.QueryConfig{},
+				)
+			})
+		})
+	}
+}
+
 func TestGetObservationsQuery(t *testing.T) {
 	t.Parallel()
 

--- a/internal/server/spanner/node_query_plan.go
+++ b/internal/server/spanner/node_query_plan.go
@@ -43,35 +43,64 @@ func planNodeQuery(arc *v2.Arc, queryConfig QueryConfig) (nodeQueryPlan, error) 
 	}
 
 	if childPlaceTypes, ok := matchNodeContainedInPlace(arc); ok {
-		return nodeQueryPlan{
-			kind: nodeQueryContainedInPlace,
-			containedInPlace: containedInPlacePlan{
-				accessPath: queryConfig.containedInPlaceAccessPath(childPlaceTypes...),
-			},
-		}, nil
+		accessPath := containedInPlaceTypeFirst
+		if len(childPlaceTypes) > 1 {
+			accessPath = containedInPlaceAncestorFirst
+		}
+		return newNodeContainedInPlacePlan(accessPath), nil
+	}
+
+	if childPlaceTypes, ok := matchNodeLinkedContainedInPlace(arc); ok {
+		return newNodeContainedInPlacePlan(
+			queryConfig.containedInPlaceAccessPath(childPlaceTypes...),
+		), nil
 	}
 
 	return nodeQueryPlan{kind: nodeQueryGeneric}, nil
 }
 
+func newNodeContainedInPlacePlan(accessPath containedInPlaceAccessPath) nodeQueryPlan {
+	return nodeQueryPlan{
+		kind: nodeQueryContainedInPlace,
+		containedInPlace: containedInPlacePlan{
+			accessPath: accessPath,
+		},
+	}
+}
+
 func matchNodeContainedInPlace(arc *v2.Arc) ([]string, bool) {
+	return matchNodeContainmentProperty(arc, v2.ContainedInPlaceProperty)
+}
+
+func matchNodeLinkedContainedInPlace(arc *v2.Arc) ([]string, bool) {
+	return matchNodeContainmentProperty(arc, linkedContainedInPlaceProperty)
+}
+
+func matchNodeContainmentProperty(arc *v2.Arc, property string) ([]string, bool) {
 	if arc == nil ||
 		arc.Out ||
-		arc.SingleProp != linkedContainedInPlaceProperty ||
+		arc.SingleProp != property ||
 		arc.Decorator != "" ||
 		len(arc.BracketProps) > 0 ||
 		len(arc.BracketFilters) > 0 ||
 		len(arc.Filter) != 1 {
 		return nil, false
 	}
-	childPlaceTypes, ok := arc.Filter[predTypeOf]
-	if !ok || len(childPlaceTypes) == 0 {
+	values, ok := arc.Filter[predTypeOf]
+	if !ok || len(values) == 0 {
 		return nil, false
 	}
-	for _, childPlaceType := range childPlaceTypes {
+	childPlaceTypes := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, childPlaceType := range values {
 		if strings.TrimSpace(childPlaceType) == "" {
 			return nil, false
 		}
+		if _, ok := seen[childPlaceType]; ok {
+			continue
+		}
+		seen[childPlaceType] = struct{}{}
+		childPlaceTypes = append(childPlaceTypes, childPlaceType)
 	}
 	return childPlaceTypes, true
 }

--- a/internal/server/spanner/node_query_plan_test.go
+++ b/internal/server/spanner/node_query_plan_test.go
@@ -47,6 +47,48 @@ func TestPlanNodeQuery(t *testing.T) {
 			},
 		},
 		{
+			name: "direct contained in place single type remains unforced",
+			arc: &v2.Arc{
+				SingleProp: v2.ContainedInPlaceProperty,
+				Filter:     map[string][]string{predTypeOf: {"County"}},
+			},
+			queryConfig: QueryConfig{
+				ContainedInPlaceAncestorFirstTypes: []string{"County"},
+			},
+			want: nodeQueryPlan{
+				kind: nodeQueryContainedInPlace,
+				containedInPlace: containedInPlacePlan{
+					accessPath: containedInPlaceTypeFirst,
+				},
+			},
+		},
+		{
+			name: "direct contained in place multiple types uses ancestor first",
+			arc: &v2.Arc{
+				SingleProp: v2.ContainedInPlaceProperty,
+				Filter:     map[string][]string{predTypeOf: {"County", "City"}},
+			},
+			want: nodeQueryPlan{
+				kind: nodeQueryContainedInPlace,
+				containedInPlace: containedInPlacePlan{
+					accessPath: containedInPlaceAncestorFirst,
+				},
+			},
+		},
+		{
+			name: "direct contained in place duplicate type remains unforced",
+			arc: &v2.Arc{
+				SingleProp: v2.ContainedInPlaceProperty,
+				Filter:     map[string][]string{predTypeOf: {"County", "County"}},
+			},
+			want: nodeQueryPlan{
+				kind: nodeQueryContainedInPlace,
+				containedInPlace: containedInPlacePlan{
+					accessPath: containedInPlaceTypeFirst,
+				},
+			},
+		},
+		{
 			name: "contained in place ancestor first",
 			arc: &v2.Arc{
 				SingleProp: linkedContainedInPlaceProperty,
@@ -147,6 +189,17 @@ func TestPlanNodeQuery(t *testing.T) {
 			want: nodeQueryPlan{kind: nodeQueryGeneric},
 		},
 		{
+			name: "direct contained in place with multiple filters",
+			arc: &v2.Arc{
+				SingleProp: v2.ContainedInPlaceProperty,
+				Filter: map[string][]string{
+					"name":     {"x"},
+					predTypeOf: {"County", "City"},
+				},
+			},
+			want: nodeQueryPlan{kind: nodeQueryGeneric},
+		},
+		{
 			name: "missing type filter",
 			arc: &v2.Arc{
 				SingleProp: linkedContainedInPlaceProperty,
@@ -221,6 +274,30 @@ func TestPlanNodeQueryFromPropertyExpression(t *testing.T) {
 	got, err := planNodeQuery(arcs[0], QueryConfig{
 		ContainedInPlaceAncestorFirstTypes: []string{"Place"},
 	})
+	if err != nil {
+		t.Fatalf("planNodeQuery() unexpected error: %v", err)
+	}
+	if diff := cmp.Diff(want, got, cmp.AllowUnexported(nodeQueryPlan{}, containedInPlacePlan{})); diff != "" {
+		t.Errorf("planNodeQuery() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestPlanDirectContainedInPlaceQueryFromPropertyExpression(t *testing.T) {
+	arcs, err := v2.ParseProperty("<-containedInPlace{typeOf:[County,City]}")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(arcs) != 1 {
+		t.Fatalf("ParseProperty() returned %d arcs, want 1", len(arcs))
+	}
+
+	want := nodeQueryPlan{
+		kind: nodeQueryContainedInPlace,
+		containedInPlace: containedInPlacePlan{
+			accessPath: containedInPlaceAncestorFirst,
+		},
+	}
+	got, err := planNodeQuery(arcs[0], QueryConfig{})
 	if err != nil {
 		t.Fatalf("planNodeQuery() unexpected error: %v", err)
 	}


### PR DESCRIPTION
## Summary

- Extend Node containment planning to direct inbound `containedInPlace` queries.
- For queries with exactly one `typeOf` filter:
  - Two or more distinct type values use ancestor-first execution.
  - A single type value retains the existing unforced query.
- Preserve the configured behavior for `linkedContainedInPlace` and the generic fallback for other graph queries.
- Retain the existing `FORCE_INDEX=InEdge` hint.

The ancestor-first path emits `FORCE_JOIN_ORDER=TRUE` and `SCAN_METHOD=COLUMNAR`.

## Motivation

We receive frequent requests for direct children of small places with a broad list of place types. When such a request returns no results, Spanner may start from the global `typeOf` side, scan millions of edges, and then perform containment lookups for every candidate.

For example:

`geoId/5508971700<-containedInPlace{typeOf:[EurostatNUTS3,...,State]}`

The saved plans used the same optimizer version and statistics package and both returned zero rows:

| Metric | Unforced | Forced ancestor-first |
| --- | ---: | ---: |
| Elapsed time | 9.66 s | 118.54 ms |
| CPU time | 17.65 s | 102.65 ms |
| Rows scanned | 2,331,598 | 1 |
| Remote calls | 127 | 1 |
| Data read | 50.3 MB | 416 KB |

The unforced plan scanned approximately 2.3 million `typeOf` edges and performed approximately 2.3 million containment probes. Forcing ancestor-first started from the requested place and avoided that global scan.

The saved A/B comparison isolated `FORCE_JOIN_ORDER`; columnar scanning was validated separately and is already part of the existing ancestor-first Node query path.

## Testing

- Added planner coverage for direct single-value, multi-value, duplicate-value, and unsupported filter shapes.
- Added SQL goldens verifying:
  - Single-value direct containment remains unforced.
  - Multi-value direct containment uses ancestor-first ordering, columnar scan, and `InEdge`.
- Confirmed existing linked-containment goldens remain unchanged.
- Ran:
  - `go test ./internal/server/spanner/... -count=1`
  - `./run_test.sh -f`