### PR TITLE
refactor(spanner): remove legacy Cache table queries and default to KeyValueStore

### DIFF
--- a/internal/server/spanner/golden/query_builder/get_provenance_summary.sql
+++ b/internal/server/spanner/golden/query_builder/get_provenance_summary.sql
@@ -1,9 +1,9 @@
 		SELECT
 			key,
 			provenance,
-			TO_JSON_STRING(value) AS value,
+			TO_JSON_STRING(value) AS value
 		FROM
-			Cache
+			KeyValueStore
 		WHERE
 			type = 'ProvenanceSummary'
 			AND key IN ('Count_Household_FamilyHousehold','Count_Household_HasComputer','foo')

--- a/internal/server/spanner/query.go
+++ b/internal/server/spanner/query.go
@@ -212,23 +212,15 @@ func (sc *spannerDatabaseClient) CheckVariableSourceExistence(ctx context.Contex
 
 	var existenceQueryStmt spanner.Statement
 	if predicate == "" {
-		sql := statements.checkSVSourceExistence
-		if sc.useSpannerKeyValueStore {
-			sql = statements.checkSVSourceExistenceFromKV
-		}
 		existenceQueryStmt = spanner.Statement{
-			SQL: sql,
+			SQL: statements.checkSVSourceExistence,
 			Params: map[string]interface{}{
 				"variables": variables,
 			},
 		}
 	} else {
-		sql := statements.checkGroupSourceExistence
-		if sc.useSpannerKeyValueStore {
-			sql = statements.checkGroupSourceExistenceFromKV
-		}
 		existenceQueryStmt = spanner.Statement{
-			SQL: sql,
+			SQL: statements.checkGroupSourceExistence,
 			Params: map[string]interface{}{
 				"variables": variables,
 				"predicate": predicate,

--- a/internal/server/spanner/query_builder.go
+++ b/internal/server/spanner/query_builder.go
@@ -532,7 +532,7 @@ func SparqlQuery(nodes []types.Node, queries []*types.Query, opts *types.QueryOp
 	}, nil
 }
 
-// GetKeyValueStoreQuery builds a query targeting KeyValueStore (or legacy Cache table when useKeyValueStore is false).
+// GetKeyValueStoreQuery builds a query targeting KeyValueStore.
 func GetKeyValueStoreQuery(typeFilter KeyValueStoreType, keys []string, useKeyValueStore bool) *spanner.Statement {
 	keyFilter, keyVal := getParamStatement("key", keys)
 	params := map[string]interface{}{
@@ -540,13 +540,8 @@ func GetKeyValueStoreQuery(typeFilter KeyValueStoreType, keys []string, useKeyVa
 		"key":  keyVal,
 	}
 
-	sql := statements.getCacheData
-	if useKeyValueStore {
-		sql = statements.getKeyValueStoreData
-	}
-
 	return &spanner.Statement{
-		SQL:    fmt.Sprintf(sql, keyFilter),
+		SQL:    fmt.Sprintf(statements.getKeyValueStoreData, keyFilter),
 		Params: params,
 	}
 }

--- a/internal/server/spanner/statements.go
+++ b/internal/server/spanner/statements.go
@@ -93,8 +93,6 @@ var statements = struct {
 	nodeFilter string
 	// Generic triple pattern.
 	triple string
-	// Get data from legacy Cache table.
-	getCacheData string
 	// Get data from KeyValueStore table.
 	getKeyValueStoreData string
 	// Fetch event dates for a given type and location.
@@ -133,12 +131,8 @@ var statements = struct {
 	filterNodesByTypes string
 	// Check existence of SVs against sources.
 	checkSVSourceExistence string
-	// Check existence of SVs against sources using KeyValueStore table.
-	checkSVSourceExistenceFromKV string
 	// Check existence of variable groups against sources.
 	checkGroupSourceExistence string
-	// Check existence of variable groups against sources using KeyValueStore table.
-	checkGroupSourceExistenceFromKV string
 	// Check existence of variable groups against places.
 	checkGroupPlaceExistence string
 }{
@@ -375,15 +369,6 @@ OR CreationTimestamp > (
 		WHERE
 			%[1]s.subject_id IN UNNEST(@%[1]s)`,
 	triple: `(%[1]s:Node%[2]s)-[:Edge {predicate: @predicate%[3]d}]->(%[4]s:Node%[5]s)`,
-	getCacheData: `		SELECT
-			key,
-			provenance,
-			TO_JSON_STRING(value) AS value,
-		FROM
-			Cache
-		WHERE
-			type = @type
-			AND key %s`,
 	getKeyValueStoreData: `		SELECT
 			key,
 			provenance,
@@ -703,29 +688,13 @@ OR CreationTimestamp > (
 			APPROX_COSINE_DISTANCE(@embeddings, embeddings, options => JSON '%[2]s')
 		LIMIT @limit`,
 	checkSVSourceExistence: `		SELECT DISTINCT c.key AS variable, e2.object_id AS source
-		FROM Cache c
-		JOIN Edge e2 ON c.provenance = e2.subject_id
-		WHERE c.type = 'ProvenanceSummary'
-		  AND e2.predicate IN ('source', 'isPartOf')
-		  AND c.key IN UNNEST(@variables)
-		ORDER BY variable, source`,
-	checkGroupSourceExistence: `		SELECT DISTINCT e3.object_id AS variable, e2.object_id AS source
-		FROM Cache c
-		JOIN Edge e2 ON c.provenance = e2.subject_id
-		JOIN Edge@{FORCE_INDEX=InEdge} e3 ON c.key = e3.subject_id
-		WHERE c.type = 'ProvenanceSummary'
-		  AND e2.predicate IN ('source', 'isPartOf')
-		  AND e3.predicate = @predicate
-		  AND e3.object_id IN UNNEST(@variables)
-		ORDER BY variable, source`,
-	checkSVSourceExistenceFromKV: `		SELECT DISTINCT c.key AS variable, e2.object_id AS source
 		FROM KeyValueStore c
 		JOIN Edge e2 ON c.provenance = e2.subject_id
 		WHERE c.type = 'ProvenanceSummary'
 		  AND e2.predicate IN ('source', 'isPartOf')
 		  AND c.key IN UNNEST(@variables)
 		ORDER BY variable, source`,
-	checkGroupSourceExistenceFromKV: `		SELECT DISTINCT e3.object_id AS variable, e2.object_id AS source
+	checkGroupSourceExistence: `		SELECT DISTINCT e3.object_id AS variable, e2.object_id AS source
 		FROM KeyValueStore c
 		JOIN Edge e2 ON c.provenance = e2.subject_id
 		JOIN Edge@{FORCE_INDEX=InEdge} e3 ON c.key = e3.subject_id


### PR DESCRIPTION
### Summary
Removes legacy Cache table SQL statements and queries from `datcom-mixer` spanner implementation following the migration to `KeyValueStore`.

### Changes
- Updated `checkSVSourceExistence` and `checkGroupSourceExistence` to query `KeyValueStore` directly.
- Removed obsolete `getCacheData`, `checkSVSourceExistenceFromKV`, and `checkGroupSourceExistenceFromKV` SQL statements.
- Updated `GetKeyValueStoreQuery` to always query `KeyValueStore`.
- Removed `useSpannerKeyValueStore` branching in `CheckVariableSourceExistence`.
- Updated golden query test expectation for `get_provenance_summary.sql`.