### PR TITLE
Expose target parameter in SearchIndicatorsRequest

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -40,12 +40,23 @@ const (
 	MaxSearchLimit         = 100
 	MinSearchLimit         = 0
 
+	TargetCustomOnly    = "custom_only"
+	TargetBaseOnly      = "base_only"
+	TargetBaseAndCustom = "base_and_custom"
+
 	dateTypeLatest = "latest"
 	dateTypeAll    = "all"
 	dateTypeRange  = "range"
 
 	nodePropertiesQuery = "->[name, typeOf]"
 )
+
+// validTargets contains the sorted set of supported resolution target identifiers.
+var validTargets = []string{
+	TargetBaseAndCustom,
+	TargetBaseOnly,
+	TargetCustomOnly,
+}
 
 // Mixer defines the strict subset of Mixer API capabilities
 // required by the agent package in-process.

--- a/internal/agent/search_indicators.go
+++ b/internal/agent/search_indicators.go
@@ -87,7 +87,7 @@ func (s *Service) SearchIndicators(
 		var err error
 		oversampledLimit := limit * 2
 		// Fetch candidates using embeddings search. Leaf expansion is enabled depending on expandTopics.
-		candidates, err = s.fetchCandidates(gCtx, req.GetQuery(), oversampledLimit, expandTopics)
+		candidates, err = s.fetchCandidates(gCtx, req.GetQuery(), oversampledLimit, expandTopics, req.GetTarget())
 		if err != nil {
 			return err
 		}
@@ -217,6 +217,7 @@ func (s *Service) fetchCandidates(
 	query string,
 	limit int32,
 	expandTopics bool,
+	target string,
 ) ([]*pbv2.ResolveResponse_Entity_Candidate, error) {
 	defer util.TimeTrack(time.Now(), "Agent: fetchCandidates")
 	// Map empty queries to browse root topics
@@ -234,6 +235,7 @@ func (s *Service) fetchCandidates(
 		Nodes:        nodes,
 		Resolver:     resolver,
 		ExpandTopics: expandTopics,
+		Target:       target,
 	}
 
 	resp, err := s.mixer.V2Resolve(ctx, resolveReq)

--- a/internal/agent/search_indicators.go
+++ b/internal/agent/search_indicators.go
@@ -79,7 +79,7 @@ func (s *Service) SearchIndicators(
 
 	g.Go(func() error {
 		var err error
-		resolvedPlaces, parentPlaceDcid, err = s.resolvePlaces(gCtx, places, req.GetParentPlace())
+		resolvedPlaces, parentPlaceDcid, err = s.resolvePlaces(gCtx, places, req.GetParentPlace(), req.GetTarget())
 		return err
 	})
 
@@ -113,7 +113,7 @@ func (s *Service) SearchIndicators(
 		}
 		if len(placeDcids) > 0 {
 			var err error
-			candidates, err = s.filterByPlaceExistence(g2Ctx, candidates, placeDcids)
+			candidates, err = s.filterByPlaceExistence(g2Ctx, candidates, placeDcids, req.GetTarget())
 			return err
 		}
 		return nil
@@ -145,6 +145,9 @@ func validateRequest(req *pbv2.SearchIndicatorsRequest) error {
 	if req.GetParentPlace() != "" && len(req.GetPlaces()) == 0 {
 		return status.Errorf(codes.InvalidArgument, "places must be specified when parent_place is provided")
 	}
+	if target := req.GetTarget(); target != "" && !slices.Contains(validTargets, target) {
+		return status.Errorf(codes.InvalidArgument, "invalid target: %s, valid values are '%s'", target, strings.Join(validTargets, "', '"))
+	}
 	return nil
 }
 
@@ -161,6 +164,7 @@ func (s *Service) resolvePlaces(
 	ctx context.Context,
 	places []string,
 	parentPlaceName string,
+	target string,
 ) (resolvedMap map[string]*resolvedPlaceInfo, parentPlaceDcid string, err error) {
 	defer util.TimeTrack(time.Now(), "Agent: resolvePlaces")
 	var placesToResolve []string
@@ -176,6 +180,7 @@ func (s *Service) resolvePlaces(
 	resolveReq := &pbv2.ResolveRequest{
 		Nodes:    placesToResolve,
 		Property: PropDescription,
+		Target:   target,
 	}
 
 	resp, err := s.mixer.V2Resolve(ctx, resolveReq)
@@ -264,6 +269,7 @@ func (s *Service) filterByPlaceExistence(
 	ctx context.Context,
 	candidates []*pbv2.ResolveResponse_Entity_Candidate,
 	placeDcids []string,
+	target string,
 ) ([]*pbv2.ResolveResponse_Entity_Candidate, error) {
 	defer util.TimeTrack(time.Now(), "Agent: filterByPlaceExistence")
 	slog.Info("Filtering indicators by place existence", "candidatesCount", len(candidates), "placesCount", len(placeDcids))
@@ -276,7 +282,7 @@ func (s *Service) filterByPlaceExistence(
 	topicDcids, directVarDcids := collectSubtopicsAndDirectVars(candidates)
 
 	// Fetch descendant variables of all topics concurrently in a single batch
-	topicDescendants, err := s.fetchDescendantVariables(ctx, topicDcids)
+	topicDescendants, err := s.fetchDescendantVariables(ctx, topicDcids, target)
 	if err != nil {
 		return nil, err
 	}
@@ -502,6 +508,7 @@ func setPlacesWithDataMetadata(c *pbv2.ResolveResponse_Entity_Candidate, places 
 func (s *Service) fetchDescendantVariables(
 	ctx context.Context,
 	topicDcids []string,
+	target string,
 ) (map[string][]string, error) {
 	defer util.TimeTrack(time.Now(), "Agent: fetchDescendantVariables")
 	if len(topicDcids) == 0 {
@@ -512,6 +519,7 @@ func (s *Service) fetchDescendantVariables(
 		Nodes:        topicDcids,
 		Resolver:     ResolverTopic,
 		ExpandTopics: true,
+		Target:       target,
 	}
 
 	resp, err := s.mixer.V2Resolve(ctx, resolveReq)

--- a/internal/agent/search_indicators_test.go
+++ b/internal/agent/search_indicators_test.go
@@ -573,6 +573,7 @@ func TestSearchIndicators_Target(t *testing.T) {
 		name       string
 		request    *pbv2.SearchIndicatorsRequest
 		wantTarget string
+		wantErr    string
 	}{
 		{
 			name: "custom_only target",
@@ -599,6 +600,14 @@ func TestSearchIndicators_Target(t *testing.T) {
 				Places: []string{"geoId/06"},
 			},
 			wantTarget: "",
+		},
+		{
+			name: "invalid target returns error",
+			request: &pbv2.SearchIndicatorsRequest{
+				Query:  "health",
+				Target: proto.String("invalid_target"),
+			},
+			wantErr: "rpc error: code = InvalidArgument desc = invalid target: invalid_target, valid values are 'base_and_custom', 'base_only', 'custom_only'",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -627,6 +636,13 @@ func TestSearchIndicators_Target(t *testing.T) {
 			svc := NewService(mock, cache)
 
 			_, err := svc.SearchIndicators(context.Background(), tc.request)
+			if tc.wantErr != "" {
+				if err == nil || err.Error() != tc.wantErr {
+					t.Fatalf("SearchIndicators error = %v, want: %s", err, tc.wantErr)
+				}
+				return
+			}
+
 			if err != nil {
 				t.Fatalf("SearchIndicators failed unexpectedly: %v", err)
 			}

--- a/internal/agent/search_indicators_test.go
+++ b/internal/agent/search_indicators_test.go
@@ -40,10 +40,16 @@ type mockMixerServer struct {
 	// obsMockData maps a place DCID string to the slice of variable DCIDs
 	// that have active observation series data available for that place.
 	obsMockData map[string][]string
+
+	// lastCandidateResolveReq records the ResolveRequest passed for candidate resolution.
+	lastCandidateResolveReq *pbv2.ResolveRequest
 }
 
 // V2Resolve dynamically maps input query nodes to candidates from its resolveMockData map.
 func (m *mockMixerServer) V2Resolve(ctx context.Context, in *pbv2.ResolveRequest) (*pbv2.ResolveResponse, error) {
+	if in.GetResolver() == ResolverIndicator || (in.GetResolver() == ResolverTopic && len(in.GetNodes()) > 0 && in.GetNodes()[0] != "geoId/06") {
+		m.lastCandidateResolveReq = in
+	}
 	resp := &pbv2.ResolveResponse{}
 
 	// Default empty query browsing maps to empty string lookup key
@@ -557,6 +563,80 @@ func TestSearchIndicators_Basic(t *testing.T) {
 
 			if diff := cmp.Diff(got, tc.wantResponse, cmpOpts); diff != "" {
 				t.Errorf("SearchIndicators returned unexpected response (-got +want):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSearchIndicators_Target(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		request    *pbv2.SearchIndicatorsRequest
+		wantTarget string
+	}{
+		{
+			name: "custom_only target",
+			request: &pbv2.SearchIndicatorsRequest{
+				Query:  "health",
+				Places: []string{"geoId/06"},
+				Target: proto.String("custom_only"),
+			},
+			wantTarget: "custom_only",
+		},
+		{
+			name: "base_only target",
+			request: &pbv2.SearchIndicatorsRequest{
+				Query:  "health",
+				Places: []string{"geoId/06"},
+				Target: proto.String("base_only"),
+			},
+			wantTarget: "base_only",
+		},
+		{
+			name: "unspecified target",
+			request: &pbv2.SearchIndicatorsRequest{
+				Query:  "health",
+				Places: []string{"geoId/06"},
+			},
+			wantTarget: "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := &mockMixerServer{
+				resolveMockData: map[string][]*pbv2.ResolveResponse_Entity_Candidate{
+					"health": {
+						{
+							Dcid:         "Count_Person",
+							DominantType: "StatisticalVariable",
+							Name:         "Population",
+						},
+					},
+					"geoId/06": {
+						{
+							Dcid:         "geoId/06",
+							DominantType: "State",
+						},
+					},
+				},
+				obsMockData: map[string][]string{
+					"geoId/06": {"Count_Person"},
+				},
+			}
+
+			cache := NewCache(mock)
+			svc := NewService(mock, cache)
+
+			_, err := svc.SearchIndicators(context.Background(), tc.request)
+			if err != nil {
+				t.Fatalf("SearchIndicators failed unexpectedly: %v", err)
+			}
+
+			if mock.lastCandidateResolveReq == nil {
+				t.Fatalf("expected V2Resolve candidate search to be called, but lastCandidateResolveReq is nil")
+			}
+
+			if gotTarget := mock.lastCandidateResolveReq.GetTarget(); gotTarget != tc.wantTarget {
+				t.Errorf("V2Resolve target = %q, want: %q", gotTarget, tc.wantTarget)
 			}
 		})
 	}

--- a/internal/proto/v2/agent.pb.go
+++ b/internal/proto/v2/agent.pb.go
@@ -45,8 +45,10 @@ type SearchIndicatorsRequest struct {
 	PerSearchLimit int32                  `protobuf:"varint,4,opt,name=per_search_limit,json=perSearchLimit,proto3" json:"per_search_limit,omitempty"`
 	IncludeTopics  *bool                  `protobuf:"varint,5,opt,name=include_topics,json=includeTopics,proto3,oneof" json:"include_topics,omitempty"`
 	ExpandTopics   *bool                  `protobuf:"varint,6,opt,name=expand_topics,json=expandTopics,proto3,oneof" json:"expand_topics,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// Optional target for indicator resolution ("custom_only", "base_only", "base_and_custom").
+	Target        *string `protobuf:"bytes,7,opt,name=target,proto3,oneof" json:"target,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *SearchIndicatorsRequest) Reset() {
@@ -119,6 +121,13 @@ func (x *SearchIndicatorsRequest) GetExpandTopics() bool {
 		return *x.ExpandTopics
 	}
 	return false
+}
+
+func (x *SearchIndicatorsRequest) GetTarget() string {
+	if x != nil && x.Target != nil {
+		return *x.Target
+	}
+	return ""
 }
 
 // Response payload for the search_indicators tool endpoint.
@@ -1491,16 +1500,18 @@ var File_v2_agent_proto protoreflect.FileDescriptor
 
 const file_v2_agent_proto_rawDesc = "" +
 	"\n" +
-	"\x0ev2/agent.proto\x12\x0edatacommons.v2\x1a\x1cgoogle/protobuf/struct.proto\"\x8f\x02\n" +
+	"\x0ev2/agent.proto\x12\x0edatacommons.v2\x1a\x1cgoogle/protobuf/struct.proto\"\xb7\x02\n" +
 	"\x17SearchIndicatorsRequest\x12\x14\n" +
 	"\x05query\x18\x01 \x01(\tR\x05query\x12\x16\n" +
 	"\x06places\x18\x02 \x03(\tR\x06places\x12!\n" +
 	"\fparent_place\x18\x03 \x01(\tR\vparentPlace\x12(\n" +
 	"\x10per_search_limit\x18\x04 \x01(\x05R\x0eperSearchLimit\x12*\n" +
 	"\x0einclude_topics\x18\x05 \x01(\bH\x00R\rincludeTopics\x88\x01\x01\x12(\n" +
-	"\rexpand_topics\x18\x06 \x01(\bH\x01R\fexpandTopics\x88\x01\x01B\x11\n" +
+	"\rexpand_topics\x18\x06 \x01(\bH\x01R\fexpandTopics\x88\x01\x01\x12\x1b\n" +
+	"\x06target\x18\a \x01(\tH\x02R\x06target\x88\x01\x01B\x11\n" +
 	"\x0f_include_topicsB\x10\n" +
-	"\x0e_expand_topics\"\xec\t\n" +
+	"\x0e_expand_topicsB\t\n" +
+	"\a_target\"\xec\t\n" +
 	"\x18SearchIndicatorsResponse\x12\x16\n" +
 	"\x06status\x18\x01 \x01(\tR\x06status\x12l\n" +
 	"\x12dcid_name_mappings\x18\x02 \x03(\v2>.datacommons.v2.SearchIndicatorsResponse.DcidNameMappingsEntryR\x10dcidNameMappings\x12|\n" +

--- a/proto/v2/agent.proto
+++ b/proto/v2/agent.proto
@@ -27,6 +27,9 @@ message SearchIndicatorsRequest {
   int32 per_search_limit = 4;
   optional bool include_topics = 5;
   optional bool expand_topics = 6;
+
+  // Optional target for indicator resolution ("custom_only", "base_only", "base_and_custom").
+  optional string target = 7;
 }
 
 // Response payload for the search_indicators tool endpoint.


### PR DESCRIPTION
- Added an optional `target` field to `SearchIndicatorsRequest` proto to allow controlling resolution sources (`custom_only`, `base_only`, `base_and_custom`).
- Propagated the `target` parameter from the Agent Service indicator search request to candidate resolution.