### PR TITLE
[Enable Stale Timestamp Reads] Enable the new ingestion history schema for mixer.

### DIFF
--- a/deploy/featureflags/prod.yaml
+++ b/deploy/featureflags/prod.yaml
@@ -10,3 +10,4 @@ flags:
   UseMultiEntitySchema: true
   EnableSDMXDataApi: true
   UseSpannerKeyValueStore: true
+  UseNewIngestionHistorySchema: true


### PR DESCRIPTION
Vishal already applied the new ingestion history schema to prod DB, which means that Mixer is currently finding errors on every ingestion history query due to a schema mismatch.
 
This flag was meant to control the migration from old to new schema. Now that we re on the new schema, we need to enable this flag.