### PR TITLE
[dcp] enable UseNewIngestionHistorySchema in DCP feature flags

### DIFF
--- a/deploy/featureflags/dcp.yaml
+++ b/deploy/featureflags/dcp.yaml
@@ -6,5 +6,5 @@ flags:
   EnableSDMXDataApi: true
   EnableEmbeddingsResolver: false
   EnableSpannerSearchEmbeddings: true
-  UseNewIngestionHistorySchema: false
+  UseNewIngestionHistorySchema: true
   UseSpannerKeyValueStore: true


### PR DESCRIPTION
This is a no-op for DCP, the value is already set to true in terraform: https://github.com/datacommonsorg/datacommons/blob/0ca01aa61c93e9f9fdfff0850fb8c88090129774/infra/dcp/modules/datacommons_services/main.tf#L110