### PR TITLE
 Select contained-in-place observation access paths by place type

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -215,8 +215,9 @@ func main() {
 	var spannerClient spanner.SpannerClient
 	if shouldUseSpannerGraph {
 		queryConfig := spanner.QueryConfig{
-			ContainedInPlaceAncestorFirstTypes:     flags.ContainedInPlaceAncestorFirstTypes,
-			ContainedInPlaceEntityScanMinVariables: flags.ContainedInPlaceEntityScanMinVariables,
+			ContainedInPlaceAncestorFirstTypes:             flags.ContainedInPlaceAncestorFirstTypes,
+			ContainedInPlacePreferTimeSeriesScanPlaceTypes: flags.ContainedInPlacePreferTimeSeriesScanPlaceTypes,
+			ContainedInPlaceEntityScanMinVariables:         flags.ContainedInPlaceEntityScanMinVariables,
 		}
 		if err := queryConfig.Validate(); err != nil {
 			slog.Error("Invalid Spanner query config", "error", err)

--- a/internal/featureflags/featureflags.go
+++ b/internal/featureflags/featureflags.go
@@ -60,29 +60,32 @@ type Flags struct {
 	UseSpannerKeyValueStore bool `yaml:"UseSpannerKeyValueStore"`
 	// Child place types whose core Observation and Node contained-in-place queries should filter by ancestor before type.
 	ContainedInPlaceAncestorFirstTypes []string `yaml:"ContainedInPlaceAncestorFirstTypes"`
-	// Minimum number of unique variables that selects an entity1 range scan for core contained-in-place observation queries. Zero disables the optimization.
+	// Child place types eligible for a TimeSeriesByEntity1 range scan in core contained-in-place observation queries.
+	ContainedInPlacePreferTimeSeriesScanPlaceTypes []string `yaml:"ContainedInPlacePreferTimeSeriesScanPlaceTypes"`
+	// Minimum number of unique variables that selects an entity1 range scan for eligible child place types. Zero disables the optimization.
 	ContainedInPlaceEntityScanMinVariables int `yaml:"ContainedInPlaceEntityScanMinVariables"`
 }
 
 // setDefaultValues creates a new Flags struct with default values.
 func setDefaultValues() *Flags {
 	return &Flags{
-		EnableV3:                               false,
-		V3MirrorFraction:                       0.0,
-		UseSpannerGraph:                        false,
-		UseMultiEntitySchema:                   false,
-		SpannerGraphDatabase:                   "",
-		UseStaleReads:                          false,
-		EnableEmbeddingsResolver:               true,
-		V2DivertFraction:                       0.0,
-		UseStatisticalCalculation:              false,
-		EnableSDMXDataApi:                      false,
-		SDMXRemotePlaceExpansionLimit:          10000,
-		EnableSpannerSearchEmbeddings:          false,
-		UseNewIngestionHistorySchema:           false,
-		UseSpannerKeyValueStore:                false,
-		ContainedInPlaceAncestorFirstTypes:     []string{"Place"},
-		ContainedInPlaceEntityScanMinVariables: 50,
+		EnableV3:                                       false,
+		V3MirrorFraction:                               0.0,
+		UseSpannerGraph:                                false,
+		UseMultiEntitySchema:                           false,
+		SpannerGraphDatabase:                           "",
+		UseStaleReads:                                  false,
+		EnableEmbeddingsResolver:                       true,
+		V2DivertFraction:                               0.0,
+		UseStatisticalCalculation:                      false,
+		EnableSDMXDataApi:                              false,
+		SDMXRemotePlaceExpansionLimit:                  10000,
+		EnableSpannerSearchEmbeddings:                  false,
+		UseNewIngestionHistorySchema:                   false,
+		UseSpannerKeyValueStore:                        false,
+		ContainedInPlaceAncestorFirstTypes:             []string{"Place"},
+		ContainedInPlacePreferTimeSeriesScanPlaceTypes: []string{"Place"},
+		ContainedInPlaceEntityScanMinVariables:         50,
 	}
 }
 
@@ -127,6 +130,15 @@ func (f *Flags) validateFlagValues() error {
 		}
 		if trimmed != placeType {
 			return fmt.Errorf("ContainedInPlaceAncestorFirstTypes must not contain surrounding whitespace")
+		}
+	}
+	for _, placeType := range f.ContainedInPlacePreferTimeSeriesScanPlaceTypes {
+		trimmed := strings.TrimSpace(placeType)
+		if trimmed == "" {
+			return fmt.Errorf("ContainedInPlacePreferTimeSeriesScanPlaceTypes must not contain empty values")
+		}
+		if trimmed != placeType {
+			return fmt.Errorf("ContainedInPlacePreferTimeSeriesScanPlaceTypes must not contain surrounding whitespace")
 		}
 	}
 	if f.ContainedInPlaceEntityScanMinVariables < 0 {

--- a/internal/featureflags/featureflags_test.go
+++ b/internal/featureflags/featureflags_test.go
@@ -50,6 +50,12 @@ func TestDefaultContainedInPlaceAncestorFirstTypes(t *testing.T) {
 	}
 }
 
+func TestDefaultContainedInPlacePreferTimeSeriesScanPlaceTypes(t *testing.T) {
+	if diff := cmp.Diff([]string{"Place"}, setDefaultValues().ContainedInPlacePreferTimeSeriesScanPlaceTypes); diff != "" {
+		t.Fatalf("ContainedInPlacePreferTimeSeriesScanPlaceTypes mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestDefaultContainedInPlaceEntityScanMinVariables(t *testing.T) {
 	if got, want := setDefaultValues().ContainedInPlaceEntityScanMinVariables, 50; got != want {
 		t.Fatalf("ContainedInPlaceEntityScanMinVariables = %d, want %d", got, want)
@@ -135,6 +141,49 @@ flags:
 			fileContent: `
 flags:
   ContainedInPlaceAncestorFirstTypes:
+    - " Place "
+`,
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "contained in place TimeSeries scan place types override",
+			fileContent: `
+flags:
+  ContainedInPlacePreferTimeSeriesScanPlaceTypes:
+    - County
+`,
+			want: expectedFlags(func(f *Flags) {
+				f.ContainedInPlacePreferTimeSeriesScanPlaceTypes = []string{"County"}
+			}),
+			wantErr: false,
+		},
+		{
+			name: "contained in place TimeSeries scan place types disabled",
+			fileContent: `
+flags:
+  ContainedInPlacePreferTimeSeriesScanPlaceTypes: []
+`,
+			want: expectedFlags(func(f *Flags) {
+				f.ContainedInPlacePreferTimeSeriesScanPlaceTypes = []string{}
+			}),
+			wantErr: false,
+		},
+		{
+			name: "validation error - empty contained in place TimeSeries scan place type",
+			fileContent: `
+flags:
+  ContainedInPlacePreferTimeSeriesScanPlaceTypes:
+    - " "
+`,
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "validation error - padded contained in place TimeSeries scan place type",
+			fileContent: `
+flags:
+  ContainedInPlacePreferTimeSeriesScanPlaceTypes:
     - " Place "
 `,
 			want:    nil,

--- a/internal/server/spanner/golden/emulator/get_observations_test.go
+++ b/internal/server/spanner/golden/emulator/get_observations_test.go
@@ -1,0 +1,118 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package emulator
+
+import (
+	"context"
+	"testing"
+
+	mixerspanner "github.com/datacommonsorg/mixer/internal/server/spanner"
+	v2 "github.com/datacommonsorg/mixer/internal/server/v2"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestGetObservationsContainedInPlaceAccessPaths(t *testing.T) {
+	s := requireSuite(t)
+	containedInPlace := &v2.ContainedInPlace{
+		Ancestor:       "northamerica",
+		ChildPlaceType: "Country",
+	}
+	variables := []string{"Count_Person", "Count_TimeSeries"}
+	want := []*mixerspanner.Observation{
+		{
+			VariableMeasured:  "Count_Person",
+			ObservationAbout:  "country/USA",
+			FacetId:           "facet",
+			Observations:      mixerspanner.TimeSeries{{Date: "2024", Value: "100"}},
+			ProvenanceID:      "dc/base/HumanReadableStatVars",
+			ObservationPeriod: "P1Y",
+			MeasurementMethod: "Census",
+			Unit:              "Count",
+		},
+		{
+			VariableMeasured:  "Count_TimeSeries",
+			ObservationAbout:  "country/USA",
+			FacetId:           "facet-a",
+			Observations:      mixerspanner.TimeSeries{{Date: "2022", Value: "12"}},
+			ProvenanceID:      "dc/base/HumanReadableStatVars",
+			ObservationPeriod: "P1Y",
+			MeasurementMethod: "Census",
+			Unit:              "Count",
+		},
+		{
+			VariableMeasured:  "Count_TimeSeries",
+			ObservationAbout:  "country/USA",
+			FacetId:           "facet-b",
+			Observations:      mixerspanner.TimeSeries{{Date: "2023", Value: "23"}},
+			ProvenanceID:      "dc/base/HumanReadableStatVars",
+			ObservationPeriod: "P1Y",
+			MeasurementMethod: "Survey",
+			Unit:              "Count",
+		},
+	}
+
+	tests := []struct {
+		name        string
+		queryConfig mixerspanner.QueryConfig
+	}{
+		{
+			name: "variable seeks for non-preferred place type",
+			queryConfig: mixerspanner.QueryConfig{
+				ContainedInPlacePreferTimeSeriesScanPlaceTypes: []string{"Place"},
+				ContainedInPlaceEntityScanMinVariables:         2,
+			},
+		},
+		{
+			name: "entity scan for preferred place type",
+			queryConfig: mixerspanner.QueryConfig{
+				ContainedInPlacePreferTimeSeriesScanPlaceTypes: []string{"Country"},
+				ContainedInPlaceEntityScanMinVariables:         2,
+			},
+		},
+	}
+
+	// Query-builder goldens assert which index hint each configuration emits.
+	// These emulator cases complement them by proving that both access paths
+	// execute against the same data and preserve the latest-observation result.
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client, err := s.newSpannerClient(context.Background(), test.queryConfig)
+			if err != nil {
+				t.Fatalf("newSpannerClient() error = %v", err)
+			}
+			defer client.Close()
+
+			got, err := client.GetObservationsContainedInPlace(
+				context.Background(), variables, containedInPlace, "latest")
+			if err != nil {
+				t.Fatalf("GetObservationsContainedInPlace() error = %v", err)
+			}
+
+			less := func(a, b *mixerspanner.Observation) bool {
+				if a.VariableMeasured != b.VariableMeasured {
+					return a.VariableMeasured < b.VariableMeasured
+				}
+				if a.ObservationAbout != b.ObservationAbout {
+					return a.ObservationAbout < b.ObservationAbout
+				}
+				return a.FacetId < b.FacetId
+			}
+			if diff := cmp.Diff(want, got, cmpopts.SortSlices(less)); diff != "" {
+				t.Errorf("observations mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/server/spanner/golden/emulator/suite_test.go
+++ b/internal/server/spanner/golden/emulator/suite_test.go
@@ -50,6 +50,7 @@ type emulatorSuite struct {
 	instanceAdmin *instanceadmin.InstanceAdminClient
 	databaseAdmin *databaseadmin.DatabaseAdminClient
 	spannerClient mixerspanner.SpannerClient
+	spannerConfig string
 	instanceName  string
 	databaseNames []string
 	provisionMu   sync.Mutex
@@ -162,14 +163,20 @@ func newEmulatorSuite(ctx context.Context) (_ *emulatorSuite, err error) {
 	}
 
 	config := fmt.Sprintf("project: %s\ninstance: %s\ndatabase: %s\n", emulatorProjectID, instanceID, databaseID)
-	resources.spannerClient, err = mixerspanner.NewSpannerClient(ctx, config, &mixerspanner.SpannerClientOptions{
-		UseMultiEntitySchema:         true,
-		SpannerEmulatorCompatibility: true,
-	})
+	resources.spannerConfig = config
+	resources.spannerClient, err = resources.newSpannerClient(ctx, mixerspanner.QueryConfig{})
 	if err != nil {
 		return nil, err
 	}
 	return resources, nil
+}
+
+func (s *emulatorSuite) newSpannerClient(ctx context.Context, queryConfig mixerspanner.QueryConfig) (mixerspanner.SpannerClient, error) {
+	return mixerspanner.NewSpannerClient(ctx, s.spannerConfig, &mixerspanner.SpannerClientOptions{
+		UseMultiEntitySchema:         true,
+		QueryConfig:                  queryConfig,
+		SpannerEmulatorCompatibility: true,
+	})
 }
 
 func (s *emulatorSuite) close(ctx context.Context) error {

--- a/internal/server/spanner/golden/query_builder/get_multientity_obs_contained_in_place_non_preferred_type_latest.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_obs_contained_in_place_non_preferred_type_latest.sql
@@ -1,0 +1,53 @@
+		@{SCAN_METHOD=COLUMNAR, EXECUTION_METHOD=BATCH}
+		WITH places AS (
+			SELECT DISTINCT contained.subject_id AS place_id
+			FROM Edge typed
+			JOIN@{FORCE_JOIN_ORDER=TRUE} Edge contained ON contained.subject_id = typed.subject_id
+			WHERE typed.predicate = 'typeOf'
+				AND typed.object_id = 'Country'
+				AND contained.predicate = 'linkedContainedInPlace'
+				AND contained.object_id = 'Earth'
+		),
+		series AS (
+			SELECT
+				t.variable_measured,
+				t.entity1,
+				t.extra_entities_id,
+				t.facet_id,
+				t.provenance,
+				t.facet
+			FROM places p
+			JOIN@{JOIN_METHOD=APPLY_JOIN} TimeSeries@{FORCE_INDEX=_BASE_TABLE} t
+				ON t.variable_measured IN ('Count_Person','Count_TimeSeries')
+				AND t.entity1 = p.place_id
+		)
+		SELECT
+			t.variable_measured,
+			t.entity1 AS observation_about,
+			t.facet_id,
+			t.provenance,
+			COALESCE(
+				(
+					SELECT ARRAY(
+						SELECT AS STRUCT
+							o.date AS date,
+							o.value AS str_value
+						FROM Observation o
+						WHERE o.variable_measured = t.variable_measured
+							AND o.entity1 = t.entity1
+							AND o.extra_entities_id = t.extra_entities_id
+							AND o.facet_id = t.facet_id
+						ORDER BY o.date DESC
+						LIMIT 1
+					)
+				),
+				ARRAY(
+					SELECT AS STRUCT
+						CAST(NULL AS STRING) AS date,
+						CAST(NULL AS STRING) AS str_value
+					FROM UNNEST([1])
+					WHERE FALSE
+				)
+			) AS dates_and_values,
+			t.facet AS facets
+		FROM series t

--- a/internal/server/spanner/golden/query_builder_multientity_test.go
+++ b/internal/server/spanner/golden/query_builder_multientity_test.go
@@ -92,8 +92,9 @@ func TestMultiEntityGetObservationsContainedInPlaceQuery(t *testing.T) {
 			goldenFile := c.golden + ".sql"
 			runQueryBuilderGoldenTest(t, goldenFile, func(ctx context.Context) (interface{}, error) {
 				builder, err := spanner.NewMultiEntityQueryBuilder(spanner.DefaultTableConfig(), spanner.QueryConfig{
-					ContainedInPlaceAncestorFirstTypes:     c.ancestorFirstTypes,
-					ContainedInPlaceEntityScanMinVariables: c.entityScanMinVars,
+					ContainedInPlaceAncestorFirstTypes:             c.ancestorFirstTypes,
+					ContainedInPlacePreferTimeSeriesScanPlaceTypes: c.preferTimeSeriesScanPlaceTypes,
+					ContainedInPlaceEntityScanMinVariables:         c.entityScanMinVars,
 				})
 				if err != nil {
 					return nil, err
@@ -588,7 +589,8 @@ func TestMultiEntityQueryBuildersUseCustomTableConfig(t *testing.T) {
 	cfg.TimeSeriesByEntity2Index = "CustomEntity2Index"
 	cfg.TimeSeriesByEntity3Index = "CustomEntity3Index"
 	builder, err := spanner.NewMultiEntityQueryBuilder(cfg, spanner.QueryConfig{
-		ContainedInPlaceEntityScanMinVariables: 1,
+		ContainedInPlacePreferTimeSeriesScanPlaceTypes: []string{"County"},
+		ContainedInPlaceEntityScanMinVariables:         1,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/server/spanner/golden/query_multientity_cases_test.go
+++ b/internal/server/spanner/golden/query_multientity_cases_test.go
@@ -126,14 +126,15 @@ var multiEntityCheckGroupPlaceExistenceTestCases = []struct {
 }
 
 var multiEntityObservationsContainedInPlaceTestCases = []struct {
-	name               string
-	variables          []string
-	ancestor           string
-	childPlaceType     string
-	ancestorFirstTypes []string
-	entityScanMinVars  int
-	date               string
-	golden             string
+	name                           string
+	variables                      []string
+	ancestor                       string
+	childPlaceType                 string
+	ancestorFirstTypes             []string
+	preferTimeSeriesScanPlaceTypes []string
+	entityScanMinVars              int
+	date                           string
+	golden                         string
 }{
 	{
 		name:               "contained in place with variables",
@@ -152,6 +153,17 @@ var multiEntityObservationsContainedInPlaceTestCases = []struct {
 		ancestorFirstTypes: []string{"Place"},
 		date:               "latest",
 		golden:             "get_multientity_obs_contained_in_place_latest",
+	},
+	{
+		name:                           "contained in place non-preferred type uses variable seeks",
+		variables:                      []string{"Count_Person", "Count_TimeSeries"},
+		ancestor:                       "Earth",
+		childPlaceType:                 "Country",
+		ancestorFirstTypes:             []string{"Place"},
+		preferTimeSeriesScanPlaceTypes: []string{"Place"},
+		entityScanMinVars:              2,
+		date:                           "latest",
+		golden:                         "get_multientity_obs_contained_in_place_non_preferred_type_latest",
 	},
 	{
 		name:               "contained in place specific date with variables",
@@ -190,31 +202,34 @@ var multiEntityObservationsContainedInPlaceTestCases = []struct {
 		golden:             "get_multientity_obs_contained_in_place_ancestor_first_date",
 	},
 	{
-		name:              "contained in place entity scan with variables",
-		variables:         []string{"AirPollutant_Cancer_Risk", "Count_Person"},
-		ancestor:          "geoId/10",
-		childPlaceType:    "County",
-		entityScanMinVars: 2,
-		date:              "",
-		golden:            "get_multientity_obs_contained_in_place_entity_scan_both",
+		name:                           "contained in place entity scan with variables",
+		variables:                      []string{"AirPollutant_Cancer_Risk", "Count_Person"},
+		ancestor:                       "geoId/10",
+		childPlaceType:                 "County",
+		preferTimeSeriesScanPlaceTypes: []string{"County"},
+		entityScanMinVars:              2,
+		date:                           "",
+		golden:                         "get_multientity_obs_contained_in_place_entity_scan_both",
 	},
 	{
-		name:              "contained in place entity scan latest date with variables",
-		variables:         []string{"AirPollutant_Cancer_Risk", "Count_Person"},
-		ancestor:          "geoId/10",
-		childPlaceType:    "County",
-		entityScanMinVars: 2,
-		date:              "latest",
-		golden:            "get_multientity_obs_contained_in_place_entity_scan_latest",
+		name:                           "contained in place entity scan latest date with variables",
+		variables:                      []string{"AirPollutant_Cancer_Risk", "Count_Person"},
+		ancestor:                       "geoId/10",
+		childPlaceType:                 "County",
+		preferTimeSeriesScanPlaceTypes: []string{"County"},
+		entityScanMinVars:              2,
+		date:                           "latest",
+		golden:                         "get_multientity_obs_contained_in_place_entity_scan_latest",
 	},
 	{
-		name:              "contained in place entity scan specific date with variables",
-		variables:         []string{"AirPollutant_Cancer_Risk", "Count_Person"},
-		ancestor:          "geoId/10",
-		childPlaceType:    "County",
-		entityScanMinVars: 2,
-		date:              "2015",
-		golden:            "get_multientity_obs_contained_in_place_entity_scan_date",
+		name:                           "contained in place entity scan specific date with variables",
+		variables:                      []string{"AirPollutant_Cancer_Risk", "Count_Person"},
+		ancestor:                       "geoId/10",
+		childPlaceType:                 "County",
+		preferTimeSeriesScanPlaceTypes: []string{"County"},
+		entityScanMinVars:              2,
+		date:                           "2015",
+		golden:                         "get_multientity_obs_contained_in_place_entity_scan_date",
 	},
 }
 

--- a/internal/server/spanner/query_builder_multientity.go
+++ b/internal/server/spanner/query_builder_multientity.go
@@ -164,12 +164,19 @@ func (b *multiEntityQueryBuilder) GetObservationsContainedInPlaceQuery(variables
 
 	selectedStatements := containedInPlaceStatements.variableSeek
 	minVariables := b.queryConfig.ContainedInPlaceEntityScanMinVariables
-	if minVariables > 0 && len(uniqueVariables) >= minVariables {
-		// The base-table plan performs one sparse seek per place-variable pair.
-		// For broad variable lists, scanning each entity1 index range once and
-		// applying variable_measured as a residual filter can be cheaper. This
-		// threshold is a heuristic because the builder does not know how many
-		// TimeSeries rows belong to each selected place.
+	preferTimeSeriesScan := slices.Contains(
+		b.queryConfig.ContainedInPlacePreferTimeSeriesScanPlaceTypes,
+		containedInPlace.ChildPlaceType,
+	)
+	if preferTimeSeriesScan && minVariables > 0 && len(uniqueVariables) >= minVariables {
+		// Choose between two TimeSeries access paths. The base table performs sparse
+		// seeks for each (variable, place) pair. The entity1 index instead scans each
+		// place's TimeSeries range and applies variable_measured as a residual filter.
+		//
+		// Neither path is always cheaper. Scanning helped sparse Place entities under
+		// nuts/DE40, while targeted seeks were faster for dense Country entities under
+		// Earth. Use the scan only for an explicitly configured child place type and
+		// a broad variable list.
 		selectedStatements = containedInPlaceStatements.entityScan
 	}
 

--- a/internal/server/spanner/query_config.go
+++ b/internal/server/spanner/query_config.go
@@ -26,9 +26,13 @@ type QueryConfig struct {
 	// should filter by ancestor before type when the query builder supports
 	// that access path.
 	ContainedInPlaceAncestorFirstTypes []string
+	// ContainedInPlacePreferTimeSeriesScanPlaceTypes contains child place types
+	// eligible for the TimeSeriesByEntity1 range-scan plan. The variable-count
+	// threshold must also be reached before Mixer selects this access path.
+	ContainedInPlacePreferTimeSeriesScanPlaceTypes []string
 	// ContainedInPlaceEntityScanMinVariables is the minimum number of unique
-	// requested variables that selects the entity1 range-scan plan for core
-	// contained-in-place queries. Zero disables the optimization.
+	// requested variables that selects the entity1 range-scan plan for eligible
+	// child place types. Zero disables the optimization.
 	ContainedInPlaceEntityScanMinVariables int
 }
 
@@ -51,6 +55,15 @@ func (config QueryConfig) Validate() error {
 		}
 		if trimmed != placeType {
 			return fmt.Errorf("QueryConfig: ContainedInPlaceAncestorFirstTypes must not contain surrounding whitespace")
+		}
+	}
+	for _, placeType := range config.ContainedInPlacePreferTimeSeriesScanPlaceTypes {
+		trimmed := strings.TrimSpace(placeType)
+		if trimmed == "" {
+			return fmt.Errorf("QueryConfig: ContainedInPlacePreferTimeSeriesScanPlaceTypes must not contain empty values")
+		}
+		if trimmed != placeType {
+			return fmt.Errorf("QueryConfig: ContainedInPlacePreferTimeSeriesScanPlaceTypes must not contain surrounding whitespace")
 		}
 	}
 	return nil

--- a/internal/server/spanner/query_config_test.go
+++ b/internal/server/spanner/query_config_test.go
@@ -58,6 +58,18 @@ func TestQueryConfigValidation(t *testing.T) {
 				ContainedInPlaceEntityScanMinVariables: -1,
 			},
 		},
+		{
+			name: "empty TimeSeries scan place type",
+			config: QueryConfig{
+				ContainedInPlacePreferTimeSeriesScanPlaceTypes: []string{" "},
+			},
+		},
+		{
+			name: "padded TimeSeries scan place type",
+			config: QueryConfig{
+				ContainedInPlacePreferTimeSeriesScanPlaceTypes: []string{" Place "},
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if err := tc.config.Validate(); err == nil {

--- a/internal/server/spanner/query_multientity_test.go
+++ b/internal/server/spanner/query_multientity_test.go
@@ -385,7 +385,7 @@ func TestMultiEntityCoreQueryBuildersDeduplicateParameters(t *testing.T) {
 	}
 }
 
-func TestMultiEntityContainedInPlaceSelectsAccessPathByUniqueVariableCount(t *testing.T) {
+func TestMultiEntityContainedInPlaceSelectsAccessPathByPlaceTypeAndUniqueVariableCount(t *testing.T) {
 	const (
 		variableSeekHint = "FORCE_INDEX=_BASE_TABLE"
 		entityScanHint   = "FORCE_INDEX=TimeSeriesByEntity1, SEEKABLE_KEY_SIZE=1"
@@ -407,10 +407,11 @@ func TestMultiEntityContainedInPlaceSelectsAccessPathByUniqueVariableCount(t *te
 			childPlaceType: "County",
 		},
 		{
-			name:      "below threshold",
+			name:      "configured type below threshold",
 			variables: []string{"var1", "var2"},
 			queryConfig: QueryConfig{
-				ContainedInPlaceEntityScanMinVariables: 3,
+				ContainedInPlacePreferTimeSeriesScanPlaceTypes: []string{"County"},
+				ContainedInPlaceEntityScanMinVariables:         3,
 			},
 			childPlaceType: "County",
 		},
@@ -418,7 +419,25 @@ func TestMultiEntityContainedInPlaceSelectsAccessPathByUniqueVariableCount(t *te
 			name:      "duplicates do not reach threshold",
 			variables: []string{"var1", "var2", "var2"},
 			queryConfig: QueryConfig{
-				ContainedInPlaceEntityScanMinVariables: 3,
+				ContainedInPlacePreferTimeSeriesScanPlaceTypes: []string{"County"},
+				ContainedInPlaceEntityScanMinVariables:         3,
+			},
+			childPlaceType: "County",
+		},
+		{
+			name:      "unconfigured type at threshold",
+			variables: []string{"var1", "var2", "var3"},
+			queryConfig: QueryConfig{
+				ContainedInPlacePreferTimeSeriesScanPlaceTypes: []string{"Place"},
+				ContainedInPlaceEntityScanMinVariables:         3,
+			},
+			childPlaceType: "Country",
+		},
+		{
+			name:      "configured type with disabled threshold",
+			variables: []string{"var1", "var2", "var3"},
+			queryConfig: QueryConfig{
+				ContainedInPlacePreferTimeSeriesScanPlaceTypes: []string{"County"},
 			},
 			childPlaceType: "County",
 		},
@@ -426,7 +445,8 @@ func TestMultiEntityContainedInPlaceSelectsAccessPathByUniqueVariableCount(t *te
 			name:      "all dates at threshold",
 			variables: []string{"var1", "var2", "var3"},
 			queryConfig: QueryConfig{
-				ContainedInPlaceEntityScanMinVariables: 3,
+				ContainedInPlacePreferTimeSeriesScanPlaceTypes: []string{"County"},
+				ContainedInPlaceEntityScanMinVariables:         3,
 			},
 			childPlaceType: "County",
 			wantEntityScan: true,
@@ -436,7 +456,8 @@ func TestMultiEntityContainedInPlaceSelectsAccessPathByUniqueVariableCount(t *te
 			variables: []string{"var1", "var2", "var3"},
 			date:      "latest",
 			queryConfig: QueryConfig{
-				ContainedInPlaceEntityScanMinVariables: 3,
+				ContainedInPlacePreferTimeSeriesScanPlaceTypes: []string{"County"},
+				ContainedInPlaceEntityScanMinVariables:         3,
 			},
 			childPlaceType: "County",
 			wantEntityScan: true,
@@ -446,7 +467,8 @@ func TestMultiEntityContainedInPlaceSelectsAccessPathByUniqueVariableCount(t *te
 			variables: []string{"var1", "var2", "var3"},
 			date:      "2020",
 			queryConfig: QueryConfig{
-				ContainedInPlaceEntityScanMinVariables: 3,
+				ContainedInPlacePreferTimeSeriesScanPlaceTypes: []string{"County"},
+				ContainedInPlaceEntityScanMinVariables:         3,
 			},
 			childPlaceType: "County",
 			wantEntityScan: true,
@@ -455,8 +477,9 @@ func TestMultiEntityContainedInPlaceSelectsAccessPathByUniqueVariableCount(t *te
 			name:      "ancestor first at threshold",
 			variables: []string{"var1", "var2", "var3"},
 			queryConfig: QueryConfig{
-				ContainedInPlaceAncestorFirstTypes:     []string{"Place"},
-				ContainedInPlaceEntityScanMinVariables: 3,
+				ContainedInPlaceAncestorFirstTypes:             []string{"Place"},
+				ContainedInPlacePreferTimeSeriesScanPlaceTypes: []string{"Place"},
+				ContainedInPlaceEntityScanMinVariables:         3,
 			},
 			childPlaceType:       "Place",
 			wantEntityScan:       true,
@@ -491,9 +514,44 @@ func TestMultiEntityContainedInPlaceSelectsAccessPathByUniqueVariableCount(t *te
 	}
 }
 
+func TestMultiEntityContainedInPlaceUsesEmulatorCompatibleHints(t *testing.T) {
+	tableConfig := DefaultTableConfig()
+	tableConfig.spannerEmulatorCompatibility = true
+	queryBuilder, err := NewMultiEntityQueryBuilder(tableConfig, QueryConfig{
+		ContainedInPlacePreferTimeSeriesScanPlaceTypes: []string{"Country"},
+		ContainedInPlaceEntityScanMinVariables:         2,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, date := range []string{"", "latest", "2020"} {
+		stmt, err := queryBuilder.GetObservationsContainedInPlaceQuery(
+			[]string{"var1", "var2"},
+			&v2.ContainedInPlace{Ancestor: "Earth", ChildPlaceType: "Country"},
+			date,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, unsupportedHint := range []string{"SCAN_METHOD=COLUMNAR", "EXECUTION_METHOD=BATCH"} {
+			if strings.Contains(stmt.SQL, unsupportedHint) {
+				t.Errorf("date %q SQL contains unsupported emulator hint %q:\n%s", date, unsupportedHint, stmt.SQL)
+			}
+		}
+		if !strings.Contains(stmt.SQL, "FORCE_INDEX=TimeSeriesByEntity1") {
+			t.Errorf("date %q SQL does not retain the selected entity-scan access path:\n%s", date, stmt.SQL)
+		}
+		if strings.Contains(stmt.SQL, "SEEKABLE_KEY_SIZE") {
+			t.Errorf("date %q SQL contains unsupported emulator hint SEEKABLE_KEY_SIZE:\n%s", date, stmt.SQL)
+		}
+	}
+}
+
 func TestMultiEntityEntityScanThresholdDoesNotAffectDirectObservations(t *testing.T) {
 	queryBuilder, err := NewMultiEntityQueryBuilder(DefaultTableConfig(), QueryConfig{
-		ContainedInPlaceEntityScanMinVariables: 1,
+		ContainedInPlacePreferTimeSeriesScanPlaceTypes: []string{"County"},
+		ContainedInPlaceEntityScanMinVariables:         1,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -509,8 +567,9 @@ func TestMultiEntityEntityScanThresholdDoesNotAffectDirectObservations(t *testin
 
 func TestNewMultiEntityClientUsesSharedQueryConfig(t *testing.T) {
 	queryConfig := QueryConfig{
-		ContainedInPlaceAncestorFirstTypes:     []string{"Place"},
-		ContainedInPlaceEntityScanMinVariables: 50,
+		ContainedInPlaceAncestorFirstTypes:             []string{"Place"},
+		ContainedInPlacePreferTimeSeriesScanPlaceTypes: []string{"Place"},
+		ContainedInPlaceEntityScanMinVariables:         50,
 	}
 	client, err := newMultiEntityClient(&spannerDatabaseClient{queryConfig: queryConfig}, DefaultTableConfig())
 	if err != nil {

--- a/internal/server/spanner/statements_multientity.go
+++ b/internal/server/spanner/statements_multientity.go
@@ -826,6 +826,16 @@ const ancestorFirstPlacesCTE = `places AS (
 		)`
 
 func newContainedInPlaceAccessPathStatements(cfg TableConfig, placesCTE string) containedInPlaceAccessPathStatements {
+	entityScanSource := fmt.Sprintf(
+		"%s@{FORCE_INDEX=%s, SEEKABLE_KEY_SIZE=1}",
+		cfg.TimeSeriesTable,
+		cfg.TimeSeriesByEntity1Index,
+	)
+	if cfg.spannerEmulatorCompatibility {
+		// The emulator does not implement SEEKABLE_KEY_SIZE. FORCE_INDEX still
+		// exercises the entity1 index while production keeps the seekable prefix.
+		entityScanSource = fmt.Sprintf("%s@{FORCE_INDEX=%s}", cfg.TimeSeriesTable, cfg.TimeSeriesByEntity1Index)
+	}
 	return containedInPlaceAccessPathStatements{
 		variableSeek: newContainedInPlaceStatements(
 			cfg,
@@ -838,16 +848,19 @@ func newContainedInPlaceAccessPathStatements(cfg TableConfig, placesCTE string) 
 		entityScan: newContainedInPlaceStatements(
 			cfg,
 			placesCTE,
-			fmt.Sprintf("%s@{FORCE_INDEX=%s, SEEKABLE_KEY_SIZE=1}", cfg.TimeSeriesTable, cfg.TimeSeriesByEntity1Index),
+			entityScanSource,
 		),
 	}
 }
 
 func newContainedInPlaceStatements(cfg TableConfig, placesCTE, timeSeriesSource string) containedInPlaceStatements {
+	statementHint := "\t\t@{SCAN_METHOD=COLUMNAR, EXECUTION_METHOD=BATCH}\n"
+	if cfg.spannerEmulatorCompatibility {
+		statementHint = ""
+	}
 	return containedInPlaceStatements{
 		// Join all dates before aggregation to optimize total result throughput.
-		all: fmt.Sprintf(`		@{SCAN_METHOD=COLUMNAR, EXECUTION_METHOD=BATCH}
-		WITH %[3]s,
+		all: statementHint + fmt.Sprintf(`		WITH %[3]s,
 		series AS (
 			SELECT
 				t.variable_measured,
@@ -884,8 +897,7 @@ func newContainedInPlaceStatements(cfg TableConfig, placesCTE, timeSeriesSource 
 
 		// Join to Observation so TimeSeries without the requested date are
 		// discarded in Spanner.
-		withDate: fmt.Sprintf(`		@{SCAN_METHOD=COLUMNAR, EXECUTION_METHOD=BATCH}
-		WITH %[3]s,
+		withDate: statementHint + fmt.Sprintf(`		WITH %[3]s,
 		series AS (
 			SELECT
 				t.variable_measured,
@@ -917,8 +929,7 @@ func newContainedInPlaceStatements(cfg TableConfig, placesCTE, timeSeriesSource 
 
 		// Use a correlated full-key lookup so the date-descending child scan can
 		// stop after one row.
-		latest: fmt.Sprintf(`		@{SCAN_METHOD=COLUMNAR, EXECUTION_METHOD=BATCH}
-		WITH %[3]s,
+		latest: statementHint + fmt.Sprintf(`		WITH %[3]s,
 		series AS (
 			SELECT
 				t.variable_measured,


### PR DESCRIPTION
## Summary

- Make the multi-entity contained-in-place observation access path conditional on both the child place type and the number of unique requested variables.
- Add `ContainedInPlacePreferTimeSeriesScanPlaceTypes`, defaulting to `["Place"]`.
- Use `TimeSeriesByEntity1` with `SEEKABLE_KEY_SIZE=1` only when:
  - the child place type is explicitly configured; and
  - the request has at least `ContainedInPlaceEntityScanMinVariables` unique variables.
- Keep targeted `_BASE_TABLE` variable seeks for other place types, including `Country` by default.

This prevents the large-stat-variable optimization from being applied to workloads where scanning all time series for each entity is more expensive than targeted seeks.

## Performance

The two access paths perform differently depending on the place type and data distribution.

- Sparse `Place` workload under `nuts/DE40`, with 3,313 places and 266 variables:
  - Variable seeks: 55.35s elapsed, 1,028.3s CPU, 881,258 seeks
  - Entity scan: 5.28s elapsed, 3.98s CPU
  - Preferred path: entity scan

- `Country` workload under `Earth`:
  - Variable seeks: 4.07s elapsed, 35,338 rows scanned
  - Entity scan: 19.46s elapsed, 2,695,148 rows scanned
  - Both returned the same 17,163 rows using the same optimizer version and statistics package
  - Preferred path: variable seeks

These results show that variable count alone is not a sufficient selector. Child place type is used as a configurable heuristic for the expected TimeSeries density.

## API impact

- No request or response contract changes.
- Only multi-entity core Observation contained-in-place queries are affected.
- The default configuration enables entity scans for `Place` requests with at least 50 unique variables.
- Deployments can change the eligible place types, use an empty list to disable them, or set the variable threshold to zero to disable the optimization.

## Testing

- Added unit coverage for access-path selection by place type and unique-variable threshold.
- Added a query-builder golden proving that a non-preferred `Country` request remains on `_BASE_TABLE` even when it reaches the threshold.
- Retained production goldens for all-date, latest, and specific-date queries using:
  `TimeSeriesByEntity1@{SEEKABLE_KEY_SIZE=1}`.
- Added emulator coverage that executes both access paths against the same seeded data and verifies identical, non-empty latest-observation results.
- Added emulator compatibility handling for production hints unsupported by the Spanner emulator.

Validation:

- `go test ./internal/featureflags ./internal/server/spanner ./internal/server/spanner/golden -count=1`
- Spanner emulator test package with `RUN_SPANNER_EMULATOR_TESTS=true`
- `./run_test.sh -f`
- `git diff --check`