### PR TITLE
Ramp up spanner mirror traffic on prod 25% -> 50%

### DIFF
--- a/deploy/featureflags/prod.yaml
+++ b/deploy/featureflags/prod.yaml
@@ -2,7 +2,7 @@ clusters:
   - projects/datcom-mixer/locations/us-central1/clusters/mixer-us-central1
 liveUrl: https://api.datacommons.org
 flags:
-  V3MirrorFraction: 0.1
+  V3MirrorFraction: 0.5
   SpannerGraphDatabase: projects/datcom-store/instances/dc-graph-prod/databases/dc_graph
   WriteUsageLogs: 1.0
   UseSpannerGraph: true

--- a/deploy/featureflags/prod_website.yaml
+++ b/deploy/featureflags/prod_website.yaml
@@ -4,7 +4,7 @@ clusters:
   - projects/datcom-website-prod/locations/us-west1/clusters/website-us-west1
 liveUrl: https://datacommons.org
 flags:
-  V3MirrorFraction: 0.1
+  V3MirrorFraction: 0.5
   WriteUsageLogs: 1.0
   UseSpannerGraph: true
   SpannerGraphDatabase: projects/datcom-store/instances/dc-graph-prod/databases/dc_graph


### PR DESCRIPTION
Manually had ramped up to 25% previously (so there's a discrepancy with what's in the yaml, which still is at 10%) 