### PR TITLE
Clone request and response synchronously before background mirroring

### DIFF
--- a/internal/server/mirror.go
+++ b/internal/server/mirror.go
@@ -77,6 +77,10 @@ func (s *Server) mirrorV3(
 	cmpOpts []cmp.Option,
 	v3WaitGroup *sync.WaitGroup,
 ) {
+	if originalReq == nil || originalResp == nil {
+		return
+	}
+
 	if v3WaitGroup != nil {
 		v3WaitGroup.Add(1)
 	}
@@ -119,8 +123,6 @@ func (s *Server) doMirror(
 	cmpOpts []cmp.Option,
 	skipCache bool,
 ) {
-	reqClone := proto.Clone(originalReq)
-
 	v3StartTime := time.Now()
 	var v3Resp proto.Message
 	var v3Err error
@@ -128,7 +130,7 @@ func (s *Server) doMirror(
 	if skipCache {
 		v3Ctx = metadata.NewIncomingContext(v3Ctx, metadata.Pairs(string(util.XSkipCache), "true"))
 	}
-	v3Resp, v3Err = v3Call(v3Ctx, reqClone)
+	v3Resp, v3Err = v3Call(v3Ctx, originalReq)
 	v3Latency := time.Since(v3StartTime)
 
 	latencyDiff := v3Latency - originalLatency

--- a/internal/server/mirror.go
+++ b/internal/server/mirror.go
@@ -81,6 +81,11 @@ func (s *Server) mirrorV3(
 		v3WaitGroup.Add(1)
 	}
 
+	// Deep clone request and response synchronously before returning to the caller
+	// to prevent data races and go-cmp determinism panics during background diffing.
+	reqClone := proto.Clone(originalReq)
+	respClone := proto.Clone(originalResp)
+
 	// This is run in a separate goroutine to not block the response to the original
 	// request.
 	go func() {
@@ -97,7 +102,7 @@ func (s *Server) mirrorV3(
 		defer cancel()
 
 		// Call without skipping cache to simulate production behavior, which will have a cache.
-		s.doMirror(mirrorCtx, originalReq, originalResp, originalLatency, v3Call, cmpOpts, false /* skipCache */)
+		s.doMirror(mirrorCtx, reqClone, respClone, originalLatency, v3Call, cmpOpts, false /* skipCache */)
 	}()
 }
 

--- a/internal/server/mirror_test.go
+++ b/internal/server/mirror_test.go
@@ -684,3 +684,31 @@ func TestMirrorV3_FallsBackToDefaultDeadline(t *testing.T) {
 		t.Errorf("Expected v3Call to be executed exactly 1 time, got %d", callCount)
 	}
 }
+
+func TestMirrorV3_NilInput(t *testing.T) {
+	ctx := context.Background()
+	s := &Server{
+		flags: &featureflags.Flags{
+			V3MirrorFraction: 1.0,
+		},
+	}
+	var mirrorWg sync.WaitGroup
+	callCount := 0
+	v3Call := func(v3Ctx context.Context, req proto.Message) (proto.Message, error) {
+		callCount++
+		return &pbv2.NodeResponse{}, nil
+	}
+
+	// Test nil request
+	s.mirrorV3(ctx, nil, &pbv2.NodeResponse{}, 0, v3Call, GetV2NodeCmpOpts(), &mirrorWg)
+	// Test nil response
+	s.mirrorV3(ctx, &pbv2.NodeRequest{}, nil, 0, v3Call, GetV2NodeCmpOpts(), &mirrorWg)
+	// Test both nil
+	s.mirrorV3(ctx, nil, nil, 0, v3Call, GetV2NodeCmpOpts(), &mirrorWg)
+
+	mirrorWg.Wait()
+	if callCount != 0 {
+		t.Errorf("Expected v3Call to not be executed when request or response is nil, got %d", callCount)
+	}
+}
+


### PR DESCRIPTION
* Resolves production panics ("non-deterministic function detected") occurring during background V3 response comparison
* Context: The comparison library verifies transformer determinism by executing comparison functions twice on input messages (concurrently and sequentially); if an input changes between or during those checks, it panics
* Root Cause: When an API handler finishes, mirroring launches a detached background task passing request and response pointers directly before returning the response to the caller or serializer. Concurrent serialization or downstream reading/writing of protobuf messages in the main thread (which updates internal protobuf caching fields) creates a data race against the background diffing task
* Fix: Deep-clone both the request and response synchronously before launching the background task, ensuring background comparisons operate on isolated, immutable data