### PR TITLE
[feature-flags] Replace timezone lock with PR review warning annotations and assign oncaller CODEOWNERS for prod flags

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Specific rule for a particular file:
+# This line should come AFTER the general rule.
+# The last matching pattern takes precedence.
+deploy/featureflags/prod* @datacommonsorg/oncallers

--- a/.github/workflows/feature-flag-checks.yml
+++ b/.github/workflows/feature-flag-checks.yml
@@ -19,16 +19,21 @@ on:
 permissions:
   contents: read
   packages: read
+  pull-requests: read
 
 jobs:
   enforce_feature_flag_merge_restrictions:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+      pull-requests: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Detect changes to prod feature flag files
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: changes
         with:
           filters: |

--- a/.github/workflows/feature-flag-checks.yml
+++ b/.github/workflows/feature-flag-checks.yml
@@ -35,21 +35,18 @@ jobs:
             prod_flags:
               - 'deploy/featureflags/prod*'
 
-      - name: Restrict prod feature flag changes to allowed hours
+      - name: Display production feature flag review warning and checklist
         if: steps.changes.outputs.prod_flags == 'true'
         run: |
-          # Check if the current time is between 8 AM and 5 PM California time
-          # on Monday, Tuesday, Wednesday, or Thursday.
-          set -e
-          export TZ="America/Los_Angeles"
-          CURRENT_HOUR=$(date +"%-H")
-          CURRENT_DAY=$(date -d "$DATE" +"%u") # 1 for Monday, 7 for Sunday
+          # Output GitHub annotation warning so it appears in PR Conversation and Files Changed UI
+          WARNING_MSG="⚠️ Please conduct a careful review before merging this production change & coordinate with the oncaller.%0A"
+          WARNING_MSG+="%0AMerging this PR will trigger a rolling restart of all Kubernetes pods in production.%0A"
+          WARNING_MSG+="%0AThings to check before approving:%0A"
+          WARNING_MSG+="1. Staging Validated: Have these exact flag changes been tested and verified in staging?%0A"
+          WARNING_MSG+="2. Rolling Restart: Merging will trigger a rolling restart of all Kubernetes pods in production.%0A"
+          WARNING_MSG+="3. Cache Invalidation: If API responses change, remember to clear the Redis cache after merging.%0A"
+          WARNING_MSG+="4. Time Window: Ensure updates occur during global working hours; request lead approval for Friday–Sunday updates.%0A"
+          WARNING_MSG+="5. Oncall Communication: Please additionally announce this update on the oncall thread.%0A"
+          WARNING_MSG+="6. Type Safety: Verify that flag value types match what the server binary expects."
 
-          if [[ "$CURRENT_DAY" -ge 1 && "$CURRENT_DAY" -le 4 ]]; then
-            if [[ "$CURRENT_HOUR" -ge 8 && "$CURRENT_HOUR" -lt 17 ]]; then
-              echo "Current time is within the allowed window for prod flag changes."
-              exit 0
-            fi
-          fi
-          echo "Error: Prod flag changes are only allowed between 8 AM and 5 PM California time on Monday-Thursday."
-          exit 1
+          echo "::warning title=Production Feature Flag Change - Review Checklist::${WARNING_MSG}"

--- a/deploy/featureflags/deploy_flags.sh
+++ b/deploy/featureflags/deploy_flags.sh
@@ -35,6 +35,20 @@
 
 set -e
 
+# If this script is NOT running on Cloud Build, show a warning and require confirmation.
+if [[ -z "$BUILD_ID" ]]; then
+  echo "WARNING: This script is not running on Cloud Build."
+  echo "Feature flags should only be updated via build trigger after careful PR review."
+  echo ""
+  echo "Please coordinate with the oncaller before updating production servers."
+  echo "Remember to additionally announce this on the oncall thread."
+  read -r -p "Proceed with UNSAFE deployment? (y/N) " response
+  if [[ ! "$response" =~ ^([yY])$ ]]; then
+    echo "Deployment aborted."
+    exit 1
+  fi
+fi
+
 if [[ "$#" -lt 1 || "$#" -gt 2 ]]; then
   echo "Usage: $0 <config_dir> [environment]"
   echo "  <config_dir>: Directory containing the feature flag YAML files."
@@ -44,21 +58,6 @@ fi
 
 CONFIG_DIR=$1
 TARGET_ENV=$2
-
-# If this script is NOT running on Cloud Build, show a warning and require confirmation.
-if [[ -z "$BUILD_ID" ]]; then
-  echo "WARNING: This script is not running on Cloud Build."
-  echo "Feature flags should only be updated via build trigger after PR review."
-  if [[ "$TARGET_ENV" == *"prod"* || -z "$TARGET_ENV" ]]; then
-    echo "Please conduct a careful review before restarting production servers & coordinate with the oncaller."
-    echo "Remember to additionally announce this on the oncall thread."
-  fi
-  read -r -p "Proceed with UNSAFE deployment? (y/N) " response
-  if [[ ! "$response" =~ ^([yY])$ ]]; then
-    echo "Deployment aborted."
-    exit 1
-  fi
-fi
 
 # Source cluster iterator from the same directory as this script.
 source "$(dirname "${BASH_SOURCE[0]}")/cluster_iterator.sh"

--- a/deploy/featureflags/deploy_flags.sh
+++ b/deploy/featureflags/deploy_flags.sh
@@ -39,8 +39,10 @@ set -e
 if [[ -z "$BUILD_ID" ]]; then
   echo "WARNING: This script is not running on Cloud Build."
   echo "Feature flags should only be updated via build trigger after PR review."
-  echo "Please conduct a careful review before restarting production servers & coordinate with the oncaller."
-  echo "Remember to additionally announce this on the oncall thread."
+  if [[ "$2" == *"prod"* || -z "$2" ]]; then
+    echo "Please conduct a careful review before restarting production servers & coordinate with the oncaller."
+    echo "Remember to additionally announce this on the oncall thread."
+  fi
   read -r -p "Proceed with UNSAFE deployment? (y/N) " response
   if [[ ! "$response" =~ ^([yY])$ ]]; then
     echo "Deployment aborted."

--- a/deploy/featureflags/deploy_flags.sh
+++ b/deploy/featureflags/deploy_flags.sh
@@ -39,6 +39,8 @@ set -e
 if [[ -z "$BUILD_ID" ]]; then
   echo "WARNING: This script is not running on Cloud Build."
   echo "Feature flags should only be updated via build trigger after PR review."
+  echo "Please conduct a careful review before restarting production servers & coordinate with the oncaller."
+  echo "Remember to additionally announce this on the oncall thread."
   read -r -p "Proceed with UNSAFE deployment? (y/N) " response
   if [[ ! "$response" =~ ^([yY])$ ]]; then
     echo "Deployment aborted."

--- a/deploy/featureflags/deploy_flags.sh
+++ b/deploy/featureflags/deploy_flags.sh
@@ -35,21 +35,6 @@
 
 set -e
 
-# If this script is NOT running on Cloud Build, show a warning and require confirmation.
-if [[ -z "$BUILD_ID" ]]; then
-  echo "WARNING: This script is not running on Cloud Build."
-  echo "Feature flags should only be updated via build trigger after PR review."
-  if [[ "$2" == *"prod"* || -z "$2" ]]; then
-    echo "Please conduct a careful review before restarting production servers & coordinate with the oncaller."
-    echo "Remember to additionally announce this on the oncall thread."
-  fi
-  read -r -p "Proceed with UNSAFE deployment? (y/N) " response
-  if [[ ! "$response" =~ ^([yY])$ ]]; then
-    echo "Deployment aborted."
-    exit 1
-  fi
-fi
-
 if [[ "$#" -lt 1 || "$#" -gt 2 ]]; then
   echo "Usage: $0 <config_dir> [environment]"
   echo "  <config_dir>: Directory containing the feature flag YAML files."
@@ -59,6 +44,21 @@ fi
 
 CONFIG_DIR=$1
 TARGET_ENV=$2
+
+# If this script is NOT running on Cloud Build, show a warning and require confirmation.
+if [[ -z "$BUILD_ID" ]]; then
+  echo "WARNING: This script is not running on Cloud Build."
+  echo "Feature flags should only be updated via build trigger after PR review."
+  if [[ "$TARGET_ENV" == *"prod"* || -z "$TARGET_ENV" ]]; then
+    echo "Please conduct a careful review before restarting production servers & coordinate with the oncaller."
+    echo "Remember to additionally announce this on the oncall thread."
+  fi
+  read -r -p "Proceed with UNSAFE deployment? (y/N) " response
+  if [[ ! "$response" =~ ^([yY])$ ]]; then
+    echo "Deployment aborted."
+    exit 1
+  fi
+fi
 
 # Source cluster iterator from the same directory as this script.
 source "$(dirname "${BASH_SOURCE[0]}")/cluster_iterator.sh"


### PR DESCRIPTION
## Summary
This PR updates the production feature flag review process in `mixer` by assigning `@datacommonsorg/oncallers` in `CODEOWNERS`, replacing the hardcoded California business-hours merge lock with an advisory PR review checklist annotation, and adding CLI reminders.

## Changes
- **CODEOWNERS (.github/CODEOWNERS)**:
  - Added a rule assigning `@datacommonsorg/oncallers` as the Code Owner for `deploy/featureflags/prod*`.
- **GitHub PR Review Checklist & Workflow (.github/workflows/feature-flag-checks.yml)**:
  - Removed the hardcoded California business-hours timezone restriction check (`Restrict prod feature flag changes to allowed hours`).
  - Added an inline PR warning annotation (`::warning::`) that triggers when `deploy/featureflags/prod*` files are modified, surfacing the 6-point review checklist (staging validation, rolling restart awareness, Redis cache invalidation, global working hours / lead approval for Fri–Sun, oncall coordination, and type safety).
- **CLI Deployment Safety (deploy/featureflags/deploy_flags.sh)**:
  - Added warning messages before the manual/unsafe deployment prompt advising engineers to conduct a careful review, coordinate with the oncaller, and announce updates on the oncall thread.

## Testing
- Verified YAML formatting and multi-line annotation message construction in `.github/workflows/feature-flag-checks.yml`.
- Verified bash syntax in `deploy_flags.sh`.