### PR TITLE
  Enable SDMX query parameter handling in staging and prod ESPv2

### DIFF
--- a/deploy/helm_charts/envs/mixer_prod.yaml
+++ b/deploy/helm_charts/envs/mixer_prod.yaml
@@ -18,7 +18,7 @@ mixer:
 
 esp:
   transcodingIgnoreUnknownQueryParameters: true
-  transcodingQueryParametersDisableUnescapePlus: true
+  transcodingQueryParametersDisableUnescapePlus: false
 
 ingress:
   enabled: true

--- a/deploy/helm_charts/envs/mixer_prod.yaml
+++ b/deploy/helm_charts/envs/mixer_prod.yaml
@@ -16,6 +16,10 @@ mixer:
           port: "6379"
   enableOtlp: true
 
+esp:
+  transcodingIgnoreUnknownQueryParameters: true
+  transcodingQueryParametersDisableUnescapePlus: true
+
 ingress:
   enabled: true
   name: mixer-ingress-prod

--- a/deploy/helm_charts/envs/mixer_staging.yaml
+++ b/deploy/helm_charts/envs/mixer_staging.yaml
@@ -20,7 +20,7 @@ mixer:
 
 esp:
   transcodingIgnoreUnknownQueryParameters: true
-  transcodingQueryParametersDisableUnescapePlus: true
+  transcodingQueryParametersDisableUnescapePlus: false
 
 ingress:
   enabled: true

--- a/deploy/helm_charts/envs/mixer_staging.yaml
+++ b/deploy/helm_charts/envs/mixer_staging.yaml
@@ -18,6 +18,10 @@ mixer:
           port: "6379"
   enableOtlp: true
 
+esp:
+  transcodingIgnoreUnknownQueryParameters: true
+  transcodingQueryParametersDisableUnescapePlus: true
+
 ingress:
   enabled: true
   name: mixer-ingress-staging


### PR DESCRIPTION
## Summary

- Enable `transcodingIgnoreUnknownQueryParameters` in staging and production.
- This allows ESPv2 to transcode SDMX requests containing dynamic query parameters such as `c[variableMeasured]`.
- Keep `transcodingQueryParametersDisableUnescapePlus` disabled to preserve the existing `+` handling for protobuf-backed query parameters.

## Why

SDMX query parameters such as `c[...]` are not fields on `SdmxRestRequest`. Without ignoring unknown query parameters, ESPv2 passes the HTTP request through without transcoding, and Mixer’s gRPC backend returns:

`415 invalid gRPC request content-type ""`

SDMX parses its query parameters from the original request URL, so it preserves `+` without changing ESPv2's global plus-decoding behavior. Enabling the global option would also affect APIs such as `/v2/node` and `/v2/resolve`.

## Verification

Tested the equivalent configuration on autopush with `X-Skip-Cache: true`:

- A valid SDMX data request returned `200` with SDMX CSV.
- A valid SDMX availability request returned `200` with SDMX Structure JSON.
- `Count_Person+Count_Person_Femal` returned the expected `501` SDMX error: `SDMX AND filters are not implemented yet`, rather than 415.
- `observationAbout.containedInPlace+` with `Count_Person` returned `200` for both data and availability.
- Raw `+` and encoded `%2B` produced identical responses.
- `git diff --check` passed.