### PR TITLE
[Enable Stale Timestamp Reads] Enable the new ingestion history schema for mixer

### DIFF
--- a/deploy/featureflags/autopush.yaml
+++ b/deploy/featureflags/autopush.yaml
@@ -11,3 +11,4 @@ flags:
   EnableSDMXDataApi: true
   UseSpannerKeyValueStore: true
   V2DivertFraction: 1.0
+  UseNewIngestionHistorySchema: true

--- a/deploy/featureflags/autopush_website.yaml
+++ b/deploy/featureflags/autopush_website.yaml
@@ -11,3 +11,4 @@ flags:
   UseMultiEntitySchema: true
   EnableSDMXDataApi: true
   UseSpannerKeyValueStore: true
+  UseNewIngestionHistorySchema: true

--- a/deploy/featureflags/dev.yaml
+++ b/deploy/featureflags/dev.yaml
@@ -11,3 +11,4 @@ flags:
   V2DivertFraction: 1.0
   EnableSDMXDataApi: true
   UseSpannerKeyValueStore: true
+  UseNewIngestionHistorySchema: true

--- a/deploy/featureflags/dev_website.yaml
+++ b/deploy/featureflags/dev_website.yaml
@@ -11,3 +11,4 @@ flags:
   UseMultiEntitySchema: true
   V2DivertFraction: 1.0
   UseSpannerKeyValueStore: true
+  UseNewIngestionHistorySchema: true

--- a/deploy/featureflags/staging.yaml
+++ b/deploy/featureflags/staging.yaml
@@ -11,3 +11,4 @@ flags:
   EnableSDMXDataApi: true
   UseSpannerKeyValueStore: true
   V2DivertFraction: 1.0
+  UseNewIngestionHistorySchema: true

--- a/deploy/featureflags/staging_website.yaml
+++ b/deploy/featureflags/staging_website.yaml
@@ -10,3 +10,4 @@ flags:
   EnableSpannerSearchEmbeddings: true
   UseMultiEntitySchema: true
   UseSpannerKeyValueStore: true
+  UseNewIngestionHistorySchema: true


### PR DESCRIPTION
Once enabled and tested, we can update prod config as well
https://github.com/datacommonsorg/mixer/pull/2051