### PR TITLE
[v0/v1 migration] Apigee endpoint turndowns

### DIFF
--- a/deploy/apigee/target_endpoints/api.template.xml
+++ b/deploy/apigee/target_endpoints/api.template.xml
@@ -60,13 +60,15 @@
             (proxy.pathsuffix MatchesPath "/stat/value") OR
             (proxy.pathsuffix MatchesPath "/translate") OR
             (proxy.pathsuffix MatchesPath "/update-cache") OR
+            (proxy.pathsuffix MatchesPath "/v1/bulk/find/entities") OR
             ((proxy.pathsuffix MatchesPath "/v1/bulk/info/place") OR (proxy.pathsuffix MatchesPath "/v1/bulk/info/place/**")) OR
+            ((proxy.pathsuffix MatchesPath "/v1/bulk/info/variable") OR (proxy.pathsuffix MatchesPath "/v1/bulk/info/variable/**")) OR
+            ((proxy.pathsuffix MatchesPath "/v1/bulk/info/variable-group") OR (proxy.pathsuffix MatchesPath "/v1/bulk/info/variable-group/**")) OR
             ((proxy.pathsuffix MatchesPath "/v1/bulk/observation-dates/linked") OR (proxy.pathsuffix MatchesPath "/v1/bulk/observation-dates/linked/**")) OR
             (proxy.pathsuffix MatchesPath "/v1/bulk/observation-existence") OR
             ((proxy.pathsuffix MatchesPath "/v1/bulk/observations/point") OR (proxy.pathsuffix MatchesPath "/v1/bulk/observations/point/**")) OR
             (proxy.pathsuffix MatchesPath "/v1/bulk/observations/point/linked") OR
             ((proxy.pathsuffix MatchesPath "/v1/bulk/properties") OR (proxy.pathsuffix MatchesPath "/v1/bulk/properties/**")) OR
-            ((proxy.pathsuffix MatchesPath "/v1/bulk/property/values/in/linked") OR (proxy.pathsuffix MatchesPath "/v1/bulk/property/values/in/linked/**")) OR
             ((proxy.pathsuffix MatchesPath "/v1/bulk/triples") OR (proxy.pathsuffix MatchesPath "/v1/bulk/triples/**")) OR
             (proxy.pathsuffix MatchesPath "/v1/bulk/variables") OR
             (proxy.pathsuffix MatchesPath "/v1/events") OR
@@ -80,16 +82,20 @@
             ((proxy.pathsuffix MatchesPath "/v1/observations/point") OR (proxy.pathsuffix MatchesPath "/v1/observations/point/**")) OR
             ((proxy.pathsuffix MatchesPath "/v1/observations/series") OR (proxy.pathsuffix MatchesPath "/v1/observations/series/**")) OR
             (proxy.pathsuffix MatchesPath "/v1/observations/series/derived") OR
+            (proxy.pathsuffix MatchesPath "/v1/place/ranking") OR
             ((proxy.pathsuffix MatchesPath "/v1/place/related") OR (proxy.pathsuffix MatchesPath "/v1/place/related/**")) OR
             (proxy.pathsuffix MatchesPath "/v1/place/stat-vars/union") OR
             (proxy.pathsuffix MatchesPath "/v1/properties") OR (proxy.pathsuffix MatchesPath "/v1/properties/**") OR
             (proxy.pathsuffix MatchesPath "/v1/property/values") OR (proxy.pathsuffix MatchesPath "/v1/property/values/**") OR
             (proxy.pathsuffix MatchesPath "/v1/query") OR
             (proxy.pathsuffix MatchesPath "/v1/recognize/entities") OR
+            (proxy.pathsuffix MatchesPath "/v1/recognize/places") OR
             ((proxy.pathsuffix MatchesPath "/v1/recon/entity/resolve") OR (proxy.pathsuffix MatchesPath "/v1/recon/entity/resolve/**")) OR
             ((proxy.pathsuffix MatchesPath "/v1/recon/resolve/coordinate") OR (proxy.pathsuffix MatchesPath "/v1/recon/resolve/coordinate/**")) OR
             (proxy.pathsuffix MatchesPath "/v1/stat/date/within-place") OR
             ((proxy.pathsuffix MatchesPath "/v1/triples") OR (proxy.pathsuffix MatchesPath "/v1/triples/**")) OR
+            ((proxy.pathsuffix MatchesPath "/v1/variable/ancestors") OR (proxy.pathsuffix MatchesPath "/v1/variable/ancestors/**")) OR
+            (proxy.pathsuffix MatchesPath "/v1/variable/search") OR
             ((proxy.pathsuffix MatchesPath "/v1/variables") OR (proxy.pathsuffix MatchesPath "/v1/variables/**")) OR
             (proxy.pathsuffix MatchesPath "/v2/sparql") OR
             (proxy.pathsuffix MatchesPath "/v3/sparql")
@@ -125,7 +131,6 @@
             <!-- List of endpoints that do NOT require a key -->
             !(
               (proxy.pathsuffix MatchesPath "/v1/recon/resolve/id") OR
-              (proxy.pathsuffix MatchesPath "/v1/variable/search") OR
               <!-- /v2/resolve is public ONLY for legacy requests (no 'resolver' param). -->
               ((proxy.pathsuffix MatchesPath "/v2/resolve") AND (request.queryparam.resolver Is null) AND (extracted_json_param_resolver Is null)) OR
               (proxy.pathsuffix MatchesPath "/version") OR

--- a/deploy/apigee/target_endpoints/api.template.xml
+++ b/deploy/apigee/target_endpoints/api.template.xml
@@ -42,6 +42,7 @@
         </Step>
         <Step>
           <Condition>
+            ((proxy.pathsuffix MatchesPath "/bulk/stats") OR (proxy.pathsuffix MatchesPath "/bulk/stats/**")) OR
             (proxy.pathsuffix MatchesPath "/internal/bio") OR
             (proxy.pathsuffix MatchesPath "/internal/import-table") OR
             (proxy.pathsuffix MatchesPath "/node/places-in") OR
@@ -59,9 +60,13 @@
             (proxy.pathsuffix MatchesPath "/stat/value") OR
             (proxy.pathsuffix MatchesPath "/translate") OR
             (proxy.pathsuffix MatchesPath "/update-cache") OR
+            ((proxy.pathsuffix MatchesPath "/v1/bulk/info/place") OR (proxy.pathsuffix MatchesPath "/v1/bulk/info/place/**")) OR
+            ((proxy.pathsuffix MatchesPath "/v1/bulk/observation-dates/linked") OR (proxy.pathsuffix MatchesPath "/v1/bulk/observation-dates/linked/**")) OR
             (proxy.pathsuffix MatchesPath "/v1/bulk/observation-existence") OR
+            ((proxy.pathsuffix MatchesPath "/v1/bulk/observations/point") OR (proxy.pathsuffix MatchesPath "/v1/bulk/observations/point/**")) OR
             (proxy.pathsuffix MatchesPath "/v1/bulk/observations/point/linked") OR
             ((proxy.pathsuffix MatchesPath "/v1/bulk/properties") OR (proxy.pathsuffix MatchesPath "/v1/bulk/properties/**")) OR
+            ((proxy.pathsuffix MatchesPath "/v1/bulk/property/values/in/linked") OR (proxy.pathsuffix MatchesPath "/v1/bulk/property/values/in/linked/**")) OR
             ((proxy.pathsuffix MatchesPath "/v1/bulk/triples") OR (proxy.pathsuffix MatchesPath "/v1/bulk/triples/**")) OR
             (proxy.pathsuffix MatchesPath "/v1/bulk/variables") OR
             (proxy.pathsuffix MatchesPath "/v1/events") OR
@@ -71,14 +76,18 @@
             ((proxy.pathsuffix MatchesPath "/v1/info/variable") OR (proxy.pathsuffix MatchesPath "/v1/info/variable/**")) OR
             ((proxy.pathsuffix MatchesPath "/v1/info/variable-group") OR (proxy.pathsuffix MatchesPath "/v1/info/variable-group/**")) OR
             ((proxy.pathsuffix MatchesPath "/v1/internal/page/bio") OR (proxy.pathsuffix MatchesPath "/v1/internal/page/bio/**")) OR
+            ((proxy.pathsuffix MatchesPath "/v1/internal/page/place") OR (proxy.pathsuffix MatchesPath "/v1/internal/page/place/**")) OR
             ((proxy.pathsuffix MatchesPath "/v1/observations/point") OR (proxy.pathsuffix MatchesPath "/v1/observations/point/**")) OR
             ((proxy.pathsuffix MatchesPath "/v1/observations/series") OR (proxy.pathsuffix MatchesPath "/v1/observations/series/**")) OR
             (proxy.pathsuffix MatchesPath "/v1/observations/series/derived") OR
+            ((proxy.pathsuffix MatchesPath "/v1/place/related") OR (proxy.pathsuffix MatchesPath "/v1/place/related/**")) OR
             (proxy.pathsuffix MatchesPath "/v1/place/stat-vars/union") OR
             (proxy.pathsuffix MatchesPath "/v1/properties") OR (proxy.pathsuffix MatchesPath "/v1/properties/**") OR
             (proxy.pathsuffix MatchesPath "/v1/property/values") OR (proxy.pathsuffix MatchesPath "/v1/property/values/**") OR
             (proxy.pathsuffix MatchesPath "/v1/query") OR
             (proxy.pathsuffix MatchesPath "/v1/recognize/entities") OR
+            ((proxy.pathsuffix MatchesPath "/v1/recon/entity/resolve") OR (proxy.pathsuffix MatchesPath "/v1/recon/entity/resolve/**")) OR
+            ((proxy.pathsuffix MatchesPath "/v1/recon/resolve/coordinate") OR (proxy.pathsuffix MatchesPath "/v1/recon/resolve/coordinate/**")) OR
             (proxy.pathsuffix MatchesPath "/v1/stat/date/within-place") OR
             ((proxy.pathsuffix MatchesPath "/v1/triples") OR (proxy.pathsuffix MatchesPath "/v1/triples/**")) OR
             ((proxy.pathsuffix MatchesPath "/v1/variables") OR (proxy.pathsuffix MatchesPath "/v1/variables/**")) OR
@@ -115,12 +124,6 @@
           <Condition>
             <!-- List of endpoints that do NOT require a key -->
             !(
-              (proxy.pathsuffix MatchesPath "/bulk/stats") OR
-              (proxy.pathsuffix MatchesPath "/search") OR
-              (proxy.pathsuffix MatchesPath "/v1/place/ranking") OR
-              (proxy.pathsuffix MatchesPath "/v1/place/related") OR
-              (proxy.pathsuffix MatchesPath "/v1/recon/entity/resolve") OR
-              (proxy.pathsuffix MatchesPath "/v1/recon/resolve/coordinate") OR
               (proxy.pathsuffix MatchesPath "/v1/recon/resolve/id") OR
               (proxy.pathsuffix MatchesPath "/v1/variable/search") OR
               <!-- /v2/resolve is public ONLY for legacy requests (no 'resolver' param). -->


### PR DESCRIPTION
## Description

This PR turns down the following endpoints:

* `/bulk/stats`
* `/v1/bulk/find/entities`
* `/v1/bulk/info/place`
* `/v1/bulk/info/variable`
* `/v1/bulk/info/variable-group`
* `/v1/bulk/observation-dates/linked`
* `/v1/bulk/observations/point`
* `/v1/place/ranking`
* `/v1/place/related`
* `/v1/recognize/entities`
* `/v1/recon/entity/resolve`
* `/v1/recon/resolve/coordinate`
* `/v1/variable/ancestors`
* `/v1/variable/search`

This PR leaves in place endpoints associated with the Sheets API.

## Note

This PR will not go in until traffic patterns have been verified (in particular, `v1/bulk/info/variable-group` receives a significant amount of traffic.