### PR TITLE
Set V2 diversion on prod standalone mixer to 100%

### DIFF
--- a/deploy/featureflags/prod.yaml
+++ b/deploy/featureflags/prod.yaml
@@ -11,3 +11,4 @@ flags:
   EnableSDMXDataApi: true
   UseSpannerKeyValueStore: true
   UseNewIngestionHistorySchema: true
+  V2DivertFraction: 1.0


### PR DESCRIPTION
Following the release schedule, doing full ramp of Spanner diversion on standalone mixer, after successful website release