### PR TITLE
Revert "Set V2 diversion on prod standalone mixer to 100%"

### DIFF
--- a/deploy/featureflags/prod.yaml
+++ b/deploy/featureflags/prod.yaml
@@ -11,4 +11,3 @@ flags:
   EnableSDMXDataApi: true
   UseSpannerKeyValueStore: true
   UseNewIngestionHistorySchema: true
-  V2DivertFraction: 1.0


### PR DESCRIPTION
Reverts datacommonsorg/mixer#2079

## Note

This is a preemptive PR to revert 100% v2 Spanner diversion on prod standalone mixer. It should only be merged as necessary in the event of issues brought about by the diversion, and will be deleted if unused.