### PR TITLE
Use staging db and multi-entity schema as default

### DIFF
--- a/deploy/featureflags/local.yaml
+++ b/deploy/featureflags/local.yaml
@@ -2,3 +2,4 @@ flags:
   EnableSDMXDataApi: true
   UseSpannerGraph: true
   UseSpannerKeyValueStore: true
+  UseMultiEntitySchema: true

--- a/deploy/storage/spanner_graph_info.yaml
+++ b/deploy/storage/spanner_graph_info.yaml
@@ -1,3 +1,3 @@
 project: datcom-store
-instance: dc-kg-test
-database: dc_graph_2026_01_27
+instance: dc-graph-staging
+database: dc_graph


### PR DESCRIPTION
Use staging spanner db as default (ie. when not specified via flag override) and enable multi-entity schema on local by default

This is prep to fully move to multi-entity retrieval and deprecate the old paths/dbs 