### PR TITLE
Add download filename to SDMX-CSV responses

### DIFF
--- a/internal/server/handler_sdmx_v3.go
+++ b/internal/server/handler_sdmx_v3.go
@@ -16,6 +16,7 @@ package server
 
 import (
 	"context"
+	"log/slog"
 
 	sdmxpb "github.com/datacommonsorg/mixer/internal/proto/sdmx"
 	pbsvc "github.com/datacommonsorg/mixer/internal/proto/service"
@@ -23,8 +24,11 @@ import (
 	sdmxgrpc "github.com/datacommonsorg/mixer/internal/server/sdmx/transport/grpc"
 	httpbody "google.golang.org/genproto/googleapis/api/httpbody"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
+
+const contentDispositionHeader = "content-disposition"
 
 // V3SdmxData handles SDMX Data requests.
 func (s *Server) V3SdmxData(in *sdmxpb.SdmxRestRequest, stream pbsvc.Mixer_V3SdmxDataServer) error {
@@ -42,6 +46,12 @@ func (s *Server) V3SdmxData(in *sdmxpb.SdmxRestRequest, stream pbsvc.Mixer_V3Sdm
 	response, err := service.New(s.dispatcher).Data(stream.Context(), req)
 	if err != nil {
 		return err
+	}
+	// Suggest a filename for SDMX-CSV downloads.
+	if response.ContentDisposition != "" {
+		if err := stream.SetHeader(metadata.Pairs(contentDispositionHeader, response.ContentDisposition)); err != nil {
+			slog.Warn("Failed to set SDMX Content-Disposition header", "error", err)
+		}
 	}
 	return stream.Send(&httpbody.HttpBody{
 		ContentType: response.ContentType,

--- a/internal/server/handler_sdmx_v3_test.go
+++ b/internal/server/handler_sdmx_v3_test.go
@@ -16,6 +16,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -42,8 +43,10 @@ func sdmxComponentConstraint(values ...string) *sdmxpb.SdmxComponentConstraint {
 }
 
 type sdmxDataStream struct {
-	ctx  context.Context
-	sent []*httpbody.HttpBody
+	ctx       context.Context
+	header    metadata.MD
+	headerErr error
+	sent      []*httpbody.HttpBody
 }
 
 func (s *sdmxDataStream) Context() context.Context {
@@ -55,7 +58,11 @@ func (s *sdmxDataStream) Send(body *httpbody.HttpBody) error {
 	return nil
 }
 
-func (s *sdmxDataStream) SetHeader(metadata.MD) error {
+func (s *sdmxDataStream) SetHeader(header metadata.MD) error {
+	if s.headerErr != nil {
+		return s.headerErr
+	}
+	s.header = metadata.Join(s.header, header)
 	return nil
 }
 
@@ -144,8 +151,29 @@ func TestV3SdmxDataWrapsServiceResponse(t *testing.T) {
 	if stream.sent[0].GetContentType() != sdmxformat.CSVContentType {
 		t.Fatalf("ContentType = %q, want %q", stream.sent[0].GetContentType(), sdmxformat.CSVContentType)
 	}
+	if got := stream.header.Get("content-disposition"); len(got) != 1 || got[0] != `attachment; filename="data.csv"` {
+		t.Fatalf("Content-Disposition = %v, want attachment filename", got)
+	}
 	if got := string(stream.sent[0].GetData()); !strings.HasPrefix(got, "STRUCTURE,STRUCTURE_ID,ACTION,variableMeasured,observationAbout") {
 		t.Fatalf("Data = %q, want SDMX CSV header", got)
+	}
+}
+
+func TestV3SdmxDataContinuesWhenContentDispositionHeaderFails(t *testing.T) {
+	server := newSdmxHandlerTestServer(&sdmxDataSource{
+		result: testSdmxDataResult([]string{datacommons.ComponentObservationAbout}),
+	})
+	stream := &sdmxDataStream{
+		ctx:       sdmxIncomingContext(sdmxDataURI("c[variableMeasured]=Count_Person&c[observationAbout]=country%2FUSA")),
+		headerErr: errors.New("set header failed"),
+	}
+
+	err := server.V3SdmxData(&sdmxpb.SdmxRestRequest{Tail: sdmxDataTail()}, stream)
+	if err != nil {
+		t.Fatalf("V3SdmxData() error = %v, want nil", err)
+	}
+	if len(stream.sent) != 1 {
+		t.Fatalf("sent %d HttpBody messages, want 1", len(stream.sent))
 	}
 }
 

--- a/internal/server/handler_sdmx_v3_test.go
+++ b/internal/server/handler_sdmx_v3_test.go
@@ -151,7 +151,7 @@ func TestV3SdmxDataWrapsServiceResponse(t *testing.T) {
 	if stream.sent[0].GetContentType() != sdmxformat.CSVContentType {
 		t.Fatalf("ContentType = %q, want %q", stream.sent[0].GetContentType(), sdmxformat.CSVContentType)
 	}
-	if got := stream.header.Get("content-disposition"); len(got) != 1 || got[0] != `attachment; filename="data.csv"` {
+	if got := stream.header.Get("content-disposition"); len(got) != 1 || got[0] != `attachment; filename="dc_data.csv"` {
 		t.Fatalf("Content-Disposition = %v, want attachment filename", got)
 	}
 	if got := string(stream.sent[0].GetData()); !strings.HasPrefix(got, "STRUCTURE,STRUCTURE_ID,ACTION,variableMeasured,observationAbout") {

--- a/internal/server/sdmx/service/data.go
+++ b/internal/server/sdmx/service/data.go
@@ -26,6 +26,8 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+const csvContentDisposition = `attachment; filename="data.csv"`
+
 func (s *Service) Data(ctx context.Context, request Request) (*Response, error) {
 	restRequest, err := restv2.ParseDataRequest(request.Tail, request.OriginalURI)
 	if err != nil {
@@ -86,8 +88,9 @@ func (s *Service) Data(ctx context.Context, request Request) (*Response, error) 
 			return nil, status.Error(codes.Internal, "Internal mapping error occurred.")
 		}
 		return &Response{
-			ContentType: sdmxformat.CSVContentType,
-			Body:        []byte(payload),
+			ContentType:        sdmxformat.CSVContentType,
+			ContentDisposition: csvContentDisposition,
+			Body:               []byte(payload),
 		}, nil
 	}
 

--- a/internal/server/sdmx/service/data.go
+++ b/internal/server/sdmx/service/data.go
@@ -26,7 +26,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-const csvContentDisposition = `attachment; filename="data.csv"`
+const csvContentDisposition = `attachment; filename="dc_data.csv"`
 
 func (s *Service) Data(ctx context.Context, request Request) (*Response, error) {
 	restRequest, err := restv2.ParseDataRequest(request.Tail, request.OriginalURI)

--- a/internal/server/sdmx/service/service.go
+++ b/internal/server/sdmx/service/service.go
@@ -28,8 +28,9 @@ type Request struct {
 }
 
 type Response struct {
-	ContentType string
-	Body        []byte
+	ContentType        string
+	ContentDisposition string
+	Body               []byte
 }
 
 type Service struct {

--- a/internal/server/sdmx/service/service_test.go
+++ b/internal/server/sdmx/service/service_test.go
@@ -331,7 +331,7 @@ func TestDataCSVSuccess(t *testing.T) {
 	if response.ContentType != sdmxformat.CSVContentType {
 		t.Errorf("ContentType = %q, want %q", response.ContentType, sdmxformat.CSVContentType)
 	}
-	if response.ContentDisposition != `attachment; filename="data.csv"` {
+	if response.ContentDisposition != `attachment; filename="dc_data.csv"` {
 		t.Errorf("ContentDisposition = %q, want attachment filename", response.ContentDisposition)
 	}
 

--- a/internal/server/sdmx/service/service_test.go
+++ b/internal/server/sdmx/service/service_test.go
@@ -331,6 +331,9 @@ func TestDataCSVSuccess(t *testing.T) {
 	if response.ContentType != sdmxformat.CSVContentType {
 		t.Errorf("ContentType = %q, want %q", response.ContentType, sdmxformat.CSVContentType)
 	}
+	if response.ContentDisposition != `attachment; filename="data.csv"` {
+		t.Errorf("ContentDisposition = %q, want attachment filename", response.ContentDisposition)
+	}
 
 	want := "STRUCTURE,STRUCTURE_ID,ACTION,variableMeasured,observationAbout,unit,measurementMethod,observationPeriod,provenance,TIME_PERIOD,OBS_VALUE,scalingFactor,facetId\r\n" +
 		"dataflow,DC:DF_OBS(1.0.0),I,Count_Person,country/USA,Person,Census,P1Y,dc/base,2020,1.50,0,stored-facet-id\r\n"


### PR DESCRIPTION
## Summary

- return `Content-Disposition: attachment; filename="data.csv"` for SDMX-CSV responses
- pass the negotiated content disposition from the SDMX service to the gRPC handler
- log header-setting failures while continuing to return the CSV response
- add focused coverage for successful header delivery and best-effort failure handling
