### PR TITLE
Fix place resolution by description ordering in the Spanner /v2/resolve flow

### DIFF
--- a/internal/server/spanner/datasource.go
+++ b/internal/server/spanner/datasource.go
@@ -21,7 +21,6 @@ import (
 	"maps"
 	"os"
 	"slices"
-	"sort"
 	"strings"
 
 	"github.com/datacommonsorg/mixer/internal/embedder"
@@ -836,7 +835,8 @@ func (sds *SpannerDataSource) resolveDescription(
 		resEntity := &pbv2.ResolveResponse_Entity{
 			Node: node,
 		}
-		candidateSet := map[string]struct{}{}
+		// Deduplicate without changing the population-ranked order from ResolveDCIDs.
+		seen := map[string]struct{}{}
 		for _, typeOf := range typeOfs {
 			e := recon.EntityInfo{Description: node, TypeOf: typeOf}
 			if dcids, ok := entityInfoToDCIDs[e]; ok {
@@ -851,19 +851,16 @@ func (sds *SpannerDataSource) resolveDescription(
 							continue
 						}
 					}
-					candidateSet[dcid] = struct{}{}
+					if _, ok := seen[dcid]; ok {
+						continue
+					}
+					seen[dcid] = struct{}{}
+					resEntity.Candidates = append(resEntity.Candidates, &pbv2.ResolveResponse_Entity_Candidate{
+						Dcid: dcid,
+					})
 				}
 			}
 		}
-		for candidate := range candidateSet {
-			resEntity.Candidates = append(resEntity.Candidates, &pbv2.ResolveResponse_Entity_Candidate{
-				Dcid: candidate,
-			})
-		}
-		// Sort candidates for determinism.
-		sort.Slice(resEntity.Candidates, func(i, j int) bool {
-			return resEntity.Candidates[i].Dcid < resEntity.Candidates[j].Dcid
-		})
 		resp.Entities = append(resp.Entities, resEntity)
 	}
 

--- a/internal/server/spanner/golden/datasource_test.go
+++ b/internal/server/spanner/golden/datasource_test.go
@@ -226,6 +226,66 @@ func TestSpannerResolve(t *testing.T) {
 	}
 }
 
+func TestSpannerResolveDescriptionPreservesPopulationOrder(t *testing.T) {
+	const (
+		mountainViewCalifornia = "geoId/0649670"
+		mountainViewArkansas   = "geoId/0547540"
+	)
+
+	recogPlaceStore := &files.RecogPlaceStore{
+		DcidToNames: map[string][]string{
+			mountainViewCalifornia: {"Mountain View"},
+			mountainViewArkansas:   {"Mountain View"},
+		},
+		RecogPlaceMap: map[string]*pb.RecogPlaces{
+			"mountain": {
+				Places: []*pb.RecogPlace{
+					{
+						Dcid:       mountainViewArkansas,
+						Population: 10,
+						Names: []*pb.RecogPlace_Name{
+							{Parts: []string{"mountain", "view"}},
+						},
+					},
+					{
+						Dcid:       mountainViewCalifornia,
+						Population: 100,
+						Names: []*pb.RecogPlace_Name{
+							{Parts: []string{"mountain", "view"}},
+						},
+					},
+				},
+			},
+		},
+	}
+	ds := spanner.NewSpannerDataSource(&mockSpannerClient{}, &spanner.SpannerDataSourceOptions{
+		RecogPlaceStore: recogPlaceStore,
+		MapsClient:      &maps.FakeMapsClient{},
+	})
+
+	got, err := ds.Resolve(context.Background(), &pbv2.ResolveRequest{
+		Nodes:    []string{"Mountain View"},
+		Property: "<-description->dcid",
+	})
+	if err != nil {
+		t.Fatalf("Resolve() error: %v", err)
+	}
+	want := &pbv2.ResolveResponse{
+		Entities: []*pbv2.ResolveResponse_Entity{
+			{
+				Node: "Mountain View",
+				Candidates: []*pbv2.ResolveResponse_Entity_Candidate{
+					{Dcid: mountainViewCalifornia},
+					{Dcid: mountainViewArkansas},
+				},
+			},
+		},
+	}
+	if diff := cmp.Diff(want, got, protocmp.Transform()); diff != "" {
+		t.Errorf("Resolve() mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestSpannerNode(t *testing.T) {
 	client := test.NewSpannerClient()
 	if client == nil {


### PR DESCRIPTION
## Summary

Preserve the population-ranked candidate order produced by `ResolveDCIDs` when assembling Spanner description-resolution responses (legacy BT behavior).

Previously, Spanner collected candidates in a map and then sorted them alphabetically by DCID. This caused `/v2/resolve` to return Mountain View, Arkansas before Mountain View, California, despite California ranking higher by population.

The change:

- uses a `seen` set only for deduplication
- appends candidates while iterating the already-ranked DCID slice
- preserves existing type filtering
- removes the final alphabetical DCID sort

## Testing

Added a focused Spanner regression test with two Mountain View candidates whose population order differs from their alphabetical DCID order.

```text
go test ./internal/server/spanner ./internal/server/spanner/golden