### PR TITLE
Add CORS support to apigee proxy

### DIFF
--- a/deploy/apigee/envs/nonprod.yaml
+++ b/deploy/apigee/envs/nonprod.yaml
@@ -2,6 +2,7 @@ project_id: datcom-apigee-dev
 proxies:
   - name: api
     policies:
+      - add-cors
       - copy-key-param-to-header
       - verify-api-key-in-header
       - rewrite-missing-key-message

--- a/deploy/apigee/envs/prod.yaml
+++ b/deploy/apigee/envs/prod.yaml
@@ -2,6 +2,7 @@ project_id: datcom-apigee
 proxies:
   - name: api
     policies:
+      - add-cors
       - copy-key-param-to-header
       - verify-api-key-in-header
       - rewrite-missing-key-message

--- a/deploy/apigee/policies/add-cors.xml
+++ b/deploy/apigee/policies/add-cors.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<CORS continueOnError="false" enabled="true" name="add-cors">
+  <DisplayName>Add CORS</DisplayName>
+  <AllowOrigins>*</AllowOrigins>
+  <AllowMethods>GET,POST,PUT,DELETE,OPTIONS</AllowMethods>
+  <AllowHeaders>Authorization,Content-Type,Accept,Origin,X-Requested-With,X-Api-Key</AllowHeaders>
+  <MaxAge>3600</MaxAge>
+  <GeneratePreflightResponse>true</GeneratePreflightResponse>
+  <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+</CORS>

--- a/deploy/apigee/proxies/api.xml
+++ b/deploy/apigee/proxies/api.xml
@@ -4,6 +4,7 @@
   <Description/>
   <BasePaths>/api</BasePaths>
   <Policies>
+    <Policy>add-cors</Policy>
     <Policy>copy-key-param-to-header</Policy>
     <Policy>verify-api-key-in-header</Policy>
     <Policy>rewrite-missing-key-message</Policy>

--- a/deploy/apigee/proxy_endpoints/api.xml
+++ b/deploy/apigee/proxy_endpoints/api.xml
@@ -3,7 +3,11 @@
   <Description />
   <FaultRules />
   <PreFlow name="PreFlow">
-    <Request />
+    <Request>
+      <Step>
+        <Name>add-cors</Name>
+      </Step>
+    </Request>
     <Response />
   </PreFlow>
   <PostFlow name="PostFlow">


### PR DESCRIPTION
## Summary

- add an Apigee CORS policy for all routes behind the API proxy
- allow browser requests using `X-Api-Key` and common API headers
- handle preflight requests before target authentication while preserving API-key validation for actual requests
- register the policy in production and nonproduction proxy bundles

- The CORS policy could run from the API TargetEndpoint PreFlow before the authentication flow. However, it is intentionally attached to the ProxyEndpoint because CORS is a northbound transport policy and the requirement is catch-all handling for all `/api` routes. This also lets preflight terminate before route selection or any TargetEndpoint processing. The authentication, quota, and key-rewriting policies remain on the TargetEndpoint because they apply to the actual API request and backend call.

## Testing

- validated modified XML with `xmllint`
- validated prod and nonprod YAML and bundle resource references
- ran `git diff --check`