### PR TITLE
Make SDMX availability JSON pysdmx compatible

### DIFF
--- a/internal/server/sdmx/format/sdmxjson/v2/README.md
+++ b/internal/server/sdmx/format/sdmxjson/v2/README.md
@@ -55,8 +55,8 @@ internal/server/sdmx/format/sdmxjson/v2/golden/availability_time_period_empty.js
 
 - Use the structure-message schema for Availability API responses.
 - Do not validate availability responses against the SDMX data-message schema.
-- Availability responses include a top-level `$schema` field pointing to the
-  canonical schema URL. Do not emit `meta.schema` unless the response also
-  includes the other SDMX-required `meta` fields.
+- Availability responses include `meta.schema` pointing to the canonical schema
+  URL. When `meta` is present, it also includes the SDMX-required `id`,
+  `prepared`, and `sender.id` fields.
 - The formatter intentionally omits `values: []` for empty availability
   results. The schema requires non-empty `values` when that field is present.

--- a/internal/server/sdmx/format/sdmxjson/v2/availability_formatter.go
+++ b/internal/server/sdmx/format/sdmxjson/v2/availability_formatter.go
@@ -16,6 +16,7 @@ package sdmxjsonv2
 
 import (
 	"encoding/json"
+	"time"
 
 	"github.com/datacommonsorg/mixer/internal/server/sdmx/datacommons"
 )
@@ -29,6 +30,7 @@ type AvailabilityJSONFormatter struct {
 	AgencyID   string
 	ResourceID string
 	Version    string
+	now        func() time.Time
 }
 
 type AvailabilityComponentValues struct {
@@ -37,8 +39,19 @@ type AvailabilityComponentValues struct {
 }
 
 type availabilityMessage struct {
-	Schema string           `json:"$schema,omitempty"`
-	Data   availabilityData `json:"data"`
+	Meta availabilityMeta `json:"meta"`
+	Data availabilityData `json:"data"`
+}
+
+type availabilityMeta struct {
+	Schema   string             `json:"schema"`
+	ID       string             `json:"id"`
+	Prepared string             `json:"prepared"`
+	Sender   availabilitySender `json:"sender"`
+}
+
+type availabilitySender struct {
+	ID string `json:"id"`
 }
 
 type availabilityData struct {
@@ -60,9 +73,13 @@ type availabilityCubeRegion struct {
 }
 
 type availabilityCubeRegionValue struct {
-	ID      string   `json:"id"`
-	Include bool     `json:"include"`
-	Values  []string `json:"values,omitempty"`
+	ID      string                       `json:"id"`
+	Include bool                         `json:"include"`
+	Values  []availabilityComponentValue `json:"values,omitempty"`
+}
+
+type availabilityComponentValue struct {
+	Value string `json:"value"`
 }
 
 func (f *AvailabilityJSONFormatter) Format(componentID string, values []string) (string, error) {
@@ -85,10 +102,14 @@ func (f *AvailabilityJSONFormatter) FormatComponents(components []AvailabilityCo
 		if len(component.Values) == 0 {
 			continue
 		}
+		values := make([]availabilityComponentValue, len(component.Values))
+		for i, value := range component.Values {
+			values[i] = availabilityComponentValue{Value: value}
+		}
 		keyValues = append(keyValues, availabilityCubeRegionValue{
 			ID:      component.ID,
 			Include: true,
-			Values:  component.Values,
+			Values:  values,
 		})
 	}
 	if len(keyValues) > 0 {
@@ -99,8 +120,19 @@ func (f *AvailabilityJSONFormatter) FormatComponents(components []AvailabilityCo
 			},
 		}
 	}
+	now := time.Now
+	if f.now != nil {
+		now = f.now
+	}
 	payload := availabilityMessage{
-		Schema: StructureJSONSchema,
+		Meta: availabilityMeta{
+			Schema:   StructureJSONSchema,
+			ID:       constraint.ID,
+			Prepared: now().UTC().Format(time.RFC3339),
+			Sender: availabilitySender{
+				ID: datacommons.DataflowAgencyID,
+			},
+		},
 		Data: availabilityData{
 			DataConstraints: []availabilityDataConstraint{constraint},
 		},

--- a/internal/server/sdmx/format/sdmxjson/v2/availability_formatter_test.go
+++ b/internal/server/sdmx/format/sdmxjson/v2/availability_formatter_test.go
@@ -18,13 +18,17 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 )
 
+var availabilityTestTime = time.Date(2026, time.August, 10, 12, 34, 56, 0, time.UTC)
+
 func TestAvailabilityJSONFormatter_Format(t *testing.T) {
-	formatter := &AvailabilityJSONFormatter{}
+	formatter := newTestAvailabilityJSONFormatter()
 
 	got, err := formatter.Format("observationAbout", []string{"country/USA", "geoId/06"})
 	if err != nil {
@@ -32,10 +36,14 @@ func TestAvailabilityJSONFormatter_Format(t *testing.T) {
 	}
 
 	assertAvailabilityGolden(t, "availability_observation_about.json", got)
+	assertAvailabilityComponentValues(t, got, []availabilityComponentValue{
+		{Value: "country/USA"},
+		{Value: "geoId/06"},
+	})
 }
 
 func TestAvailabilityJSONFormatter_EmptyValues(t *testing.T) {
-	formatter := &AvailabilityJSONFormatter{}
+	formatter := newTestAvailabilityJSONFormatter()
 
 	got, err := formatter.Format("TIME_PERIOD", nil)
 	if err != nil {
@@ -46,7 +54,7 @@ func TestAvailabilityJSONFormatter_EmptyValues(t *testing.T) {
 }
 
 func TestAvailabilityJSONFormatter_MultipleComponents(t *testing.T) {
-	formatter := &AvailabilityJSONFormatter{}
+	formatter := newTestAvailabilityJSONFormatter()
 
 	got, err := formatter.FormatComponents([]AvailabilityComponentValues{
 		{ID: "observationAbout", Values: []string{"country/USA", "geoId/06"}},
@@ -59,8 +67,15 @@ func TestAvailabilityJSONFormatter_MultipleComponents(t *testing.T) {
 	assertAvailabilityGolden(t, "availability_multiple_components.json", got)
 }
 
+func newTestAvailabilityJSONFormatter() *AvailabilityJSONFormatter {
+	return &AvailabilityJSONFormatter{
+		now: func() time.Time { return availabilityTestTime },
+	}
+}
+
 func assertAvailabilityGolden(t *testing.T, goldenFile string, got string) {
 	t.Helper()
+	assertAvailabilityMeta(t, got)
 
 	var gotMap map[string]interface{}
 	if err := json.Unmarshal([]byte(got), &gotMap); err != nil {
@@ -92,5 +107,54 @@ func assertAvailabilityGolden(t *testing.T, goldenFile string, got string) {
 
 	if diff := cmp.Diff(wantMap, gotMap); diff != "" {
 		t.Errorf("Formatter output mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func assertAvailabilityMeta(t *testing.T, got string) {
+	t.Helper()
+
+	if !strings.HasPrefix(got, `{"meta":`) {
+		t.Errorf("Formatter output does not start with meta: %s", got)
+	}
+
+	var message availabilityMessage
+	if err := json.Unmarshal([]byte(got), &message); err != nil {
+		t.Fatalf("Failed to unmarshal output as availability message: %v", err)
+	}
+	want := availabilityMeta{
+		Schema:   StructureJSONSchema,
+		ID:       "DF_OBS_AVAILABILITY",
+		Prepared: availabilityTestTime.Format(time.RFC3339),
+		Sender:   availabilitySender{ID: "DC"},
+	}
+	if diff := cmp.Diff(want, message.Meta); diff != "" {
+		t.Errorf("Availability meta mismatch (-want +got):\n%s", diff)
+	}
+	if _, err := time.Parse(time.RFC3339, message.Meta.Prepared); err != nil {
+		t.Errorf("meta.prepared = %q, want RFC3339 timestamp: %v", message.Meta.Prepared, err)
+	}
+	if !strings.HasSuffix(message.Meta.Prepared, "Z") {
+		t.Errorf("meta.prepared = %q, want UTC timestamp", message.Meta.Prepared)
+	}
+
+	var topLevel map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(got), &topLevel); err != nil {
+		t.Fatalf("Failed to unmarshal top-level output: %v", err)
+	}
+	if _, found := topLevel["$schema"]; found {
+		t.Errorf("Formatter output contains deprecated top-level $schema: %s", got)
+	}
+}
+
+func assertAvailabilityComponentValues(t *testing.T, got string, want []availabilityComponentValue) {
+	t.Helper()
+
+	var message availabilityMessage
+	if err := json.Unmarshal([]byte(got), &message); err != nil {
+		t.Fatalf("Failed to unmarshal component values as objects: %v", err)
+	}
+	values := message.Data.DataConstraints[0].CubeRegions[0].KeyValues[0].Values
+	if diff := cmp.Diff(want, values); diff != "" {
+		t.Errorf("Availability component values mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/internal/server/sdmx/format/sdmxjson/v2/golden/availability_multiple_components.json
+++ b/internal/server/sdmx/format/sdmxjson/v2/golden/availability_multiple_components.json
@@ -1,5 +1,12 @@
 {
-  "$schema": "https://json.sdmx.org/2.0.0/sdmx-json-structure-schema.json",
+  "meta": {
+    "schema": "https://json.sdmx.org/2.0.0/sdmx-json-structure-schema.json",
+    "id": "DF_OBS_AVAILABILITY",
+    "prepared": "2026-08-10T12:34:56Z",
+    "sender": {
+      "id": "DC"
+    }
+  },
   "data": {
     "dataConstraints": [
       {
@@ -12,16 +19,24 @@
                 "id": "observationAbout",
                 "include": true,
                 "values": [
-                  "country/USA",
-                  "geoId/06"
+                  {
+                    "value": "country/USA"
+                  },
+                  {
+                    "value": "geoId/06"
+                  }
                 ]
               },
               {
                 "id": "TIME_PERIOD",
                 "include": true,
                 "values": [
-                  "2020",
-                  "2021"
+                  {
+                    "value": "2020"
+                  },
+                  {
+                    "value": "2021"
+                  }
                 ]
               }
             ]

--- a/internal/server/sdmx/format/sdmxjson/v2/golden/availability_observation_about.json
+++ b/internal/server/sdmx/format/sdmxjson/v2/golden/availability_observation_about.json
@@ -1,5 +1,12 @@
 {
-  "$schema": "https://json.sdmx.org/2.0.0/sdmx-json-structure-schema.json",
+  "meta": {
+    "schema": "https://json.sdmx.org/2.0.0/sdmx-json-structure-schema.json",
+    "id": "DF_OBS_AVAILABILITY",
+    "prepared": "2026-08-10T12:34:56Z",
+    "sender": {
+      "id": "DC"
+    }
+  },
   "data": {
     "dataConstraints": [
       {
@@ -12,8 +19,12 @@
                 "id": "observationAbout",
                 "include": true,
                 "values": [
-                  "country/USA",
-                  "geoId/06"
+                  {
+                    "value": "country/USA"
+                  },
+                  {
+                    "value": "geoId/06"
+                  }
                 ]
               }
             ]

--- a/internal/server/sdmx/format/sdmxjson/v2/golden/availability_time_period_empty.json
+++ b/internal/server/sdmx/format/sdmxjson/v2/golden/availability_time_period_empty.json
@@ -1,5 +1,12 @@
 {
-  "$schema": "https://json.sdmx.org/2.0.0/sdmx-json-structure-schema.json",
+  "meta": {
+    "schema": "https://json.sdmx.org/2.0.0/sdmx-json-structure-schema.json",
+    "id": "DF_OBS_AVAILABILITY",
+    "prepared": "2026-08-10T12:34:56Z",
+    "sender": {
+      "id": "DC"
+    }
+  },
   "data": {
     "dataConstraints": [
       {

--- a/internal/server/spanner/golden/emulator/sdmx_test.go
+++ b/internal/server/spanner/golden/emulator/sdmx_test.go
@@ -775,13 +775,25 @@ func normalizeCSV(_ *testing.T, value string) string {
 
 func normalizedJSON(t *testing.T, value string) string {
 	t.Helper()
-	var decoded interface{}
+	var decoded map[string]interface{}
 	if err := json.Unmarshal([]byte(value), &decoded); err != nil {
 		t.Fatalf("invalid JSON response: %v", err)
+	}
+	if meta, ok := decoded["meta"].(map[string]interface{}); ok {
+		delete(meta, "prepared")
 	}
 	formatted, err := json.MarshalIndent(decoded, "", "  ")
 	if err != nil {
 		t.Fatalf("format JSON response: %v", err)
 	}
 	return string(formatted)
+}
+
+func TestNormalizedJSONIgnoresPrepared(t *testing.T) {
+	first := normalizedJSON(t, `{"meta":{"id":"message","prepared":"2026-08-10T12:34:56Z"},"data":{}}`)
+	second := normalizedJSON(t, `{"meta":{"id":"message","prepared":"2026-08-10T12:35:56Z"},"data":{}}`)
+
+	if diff := cmp.Diff(first, second); diff != "" {
+		t.Errorf("normalized JSON differs by meta.prepared (-first +second):\n%s", diff)
+	}
 }

--- a/internal/server/spanner/golden/emulator/testdata/sdmx/availability_contained_empty.json
+++ b/internal/server/spanner/golden/emulator/testdata/sdmx/availability_contained_empty.json
@@ -1,5 +1,12 @@
 {
-  "$schema": "https://json.sdmx.org/2.0.0/sdmx-json-structure-schema.json",
+  "meta": {
+    "schema": "https://json.sdmx.org/2.0.0/sdmx-json-structure-schema.json",
+    "id": "DF_OBS_AVAILABILITY",
+    "prepared": "2026-08-10T12:34:56Z",
+    "sender": {
+      "id": "DC"
+    }
+  },
   "data": {
     "dataConstraints": [
       {

--- a/internal/server/spanner/golden/emulator/testdata/sdmx/availability_contained_source_country.json
+++ b/internal/server/spanner/golden/emulator/testdata/sdmx/availability_contained_source_country.json
@@ -1,5 +1,12 @@
 {
-  "$schema": "https://json.sdmx.org/2.0.0/sdmx-json-structure-schema.json",
+  "meta": {
+    "schema": "https://json.sdmx.org/2.0.0/sdmx-json-structure-schema.json",
+    "id": "DF_OBS_AVAILABILITY",
+    "prepared": "2026-08-10T12:34:56Z",
+    "sender": {
+      "id": "DC"
+    }
+  },
   "data": {
     "dataConstraints": [
       {
@@ -12,7 +19,9 @@
                 "id": "destinationCountry",
                 "include": true,
                 "values": [
-                  "country/CAN"
+                  {
+                    "value": "country/CAN"
+                  }
                 ]
               }
             ]

--- a/internal/server/spanner/golden/emulator/testdata/sdmx/availability_contained_source_country_with_time_periods.json
+++ b/internal/server/spanner/golden/emulator/testdata/sdmx/availability_contained_source_country_with_time_periods.json
@@ -1,5 +1,12 @@
 {
-  "$schema": "https://json.sdmx.org/2.0.0/sdmx-json-structure-schema.json",
+  "meta": {
+    "schema": "https://json.sdmx.org/2.0.0/sdmx-json-structure-schema.json",
+    "id": "DF_OBS_AVAILABILITY",
+    "prepared": "2026-08-10T12:34:56Z",
+    "sender": {
+      "id": "DC"
+    }
+  },
   "data": {
     "dataConstraints": [
       {
@@ -12,7 +19,9 @@
                 "id": "destinationCountry",
                 "include": true,
                 "values": [
-                  "country/CAN"
+                  {
+                    "value": "country/CAN"
+                  }
                 ]
               }
             ]

--- a/internal/server/spanner/golden/emulator/testdata/sdmx/availability_destination_country.json
+++ b/internal/server/spanner/golden/emulator/testdata/sdmx/availability_destination_country.json
@@ -1,5 +1,12 @@
 {
-  "$schema": "https://json.sdmx.org/2.0.0/sdmx-json-structure-schema.json",
+  "meta": {
+    "schema": "https://json.sdmx.org/2.0.0/sdmx-json-structure-schema.json",
+    "id": "DF_OBS_AVAILABILITY",
+    "prepared": "2026-08-10T12:34:56Z",
+    "sender": {
+      "id": "DC"
+    }
+  },
   "data": {
     "dataConstraints": [
       {
@@ -12,8 +19,12 @@
                 "id": "destinationCountry",
                 "include": true,
                 "values": [
-                  "country/CAN",
-                  "country/MEX"
+                  {
+                    "value": "country/CAN"
+                  },
+                  {
+                    "value": "country/MEX"
+                  }
                 ]
               }
             ]

--- a/internal/server/spanner/golden/emulator/testdata/sdmx/availability_empty.json
+++ b/internal/server/spanner/golden/emulator/testdata/sdmx/availability_empty.json
@@ -1,5 +1,12 @@
 {
-  "$schema": "https://json.sdmx.org/2.0.0/sdmx-json-structure-schema.json",
+  "meta": {
+    "schema": "https://json.sdmx.org/2.0.0/sdmx-json-structure-schema.json",
+    "id": "DF_OBS_AVAILABILITY",
+    "prepared": "2026-08-10T12:34:56Z",
+    "sender": {
+      "id": "DC"
+    }
+  },
   "data": {
     "dataConstraints": [
       {

--- a/internal/server/spanner/golden/emulator/testdata/sdmx/availability_explicit_observation_about.json
+++ b/internal/server/spanner/golden/emulator/testdata/sdmx/availability_explicit_observation_about.json
@@ -1,5 +1,12 @@
 {
-  "$schema": "https://json.sdmx.org/2.0.0/sdmx-json-structure-schema.json",
+  "meta": {
+    "schema": "https://json.sdmx.org/2.0.0/sdmx-json-structure-schema.json",
+    "id": "DF_OBS_AVAILABILITY",
+    "prepared": "2026-08-10T12:34:56Z",
+    "sender": {
+      "id": "DC"
+    }
+  },
   "data": {
     "dataConstraints": [
       {
@@ -12,7 +19,9 @@
                 "id": "observationAbout",
                 "include": true,
                 "values": [
-                  "country/MEX"
+                  {
+                    "value": "country/MEX"
+                  }
                 ]
               }
             ]

--- a/internal/server/spanner/golden/emulator/testdata/sdmx/availability_fallback_compatible_stat_vars.json
+++ b/internal/server/spanner/golden/emulator/testdata/sdmx/availability_fallback_compatible_stat_vars.json
@@ -1,5 +1,12 @@
 {
-  "$schema": "https://json.sdmx.org/2.0.0/sdmx-json-structure-schema.json",
+  "meta": {
+    "schema": "https://json.sdmx.org/2.0.0/sdmx-json-structure-schema.json",
+    "id": "DF_OBS_AVAILABILITY",
+    "prepared": "2026-08-10T12:34:56Z",
+    "sender": {
+      "id": "DC"
+    }
+  },
   "data": {
     "dataConstraints": [
       {
@@ -12,8 +19,12 @@
                 "id": "observationAbout",
                 "include": true,
                 "values": [
-                  "country/USA",
-                  "geoId/06"
+                  {
+                    "value": "country/USA"
+                  },
+                  {
+                    "value": "geoId/06"
+                  }
                 ]
               }
             ]

--- a/internal/server/spanner/golden/emulator/testdata/sdmx/availability_fallback_observation_about.json
+++ b/internal/server/spanner/golden/emulator/testdata/sdmx/availability_fallback_observation_about.json
@@ -1,5 +1,12 @@
 {
-  "$schema": "https://json.sdmx.org/2.0.0/sdmx-json-structure-schema.json",
+  "meta": {
+    "schema": "https://json.sdmx.org/2.0.0/sdmx-json-structure-schema.json",
+    "id": "DF_OBS_AVAILABILITY",
+    "prepared": "2026-08-10T12:34:56Z",
+    "sender": {
+      "id": "DC"
+    }
+  },
   "data": {
     "dataConstraints": [
       {
@@ -12,7 +19,9 @@
                 "id": "observationAbout",
                 "include": true,
                 "values": [
-                  "country/USA"
+                  {
+                    "value": "country/USA"
+                  }
                 ]
               }
             ]

--- a/internal/server/spanner/golden/emulator/testdata/sdmx/availability_remote_contained_source_country.json
+++ b/internal/server/spanner/golden/emulator/testdata/sdmx/availability_remote_contained_source_country.json
@@ -1,5 +1,12 @@
 {
-  "$schema": "https://json.sdmx.org/2.0.0/sdmx-json-structure-schema.json",
+  "meta": {
+    "schema": "https://json.sdmx.org/2.0.0/sdmx-json-structure-schema.json",
+    "id": "DF_OBS_AVAILABILITY",
+    "prepared": "2026-08-10T12:34:56Z",
+    "sender": {
+      "id": "DC"
+    }
+  },
   "data": {
     "dataConstraints": [
       {
@@ -12,7 +19,9 @@
                 "id": "destinationCountry",
                 "include": true,
                 "values": [
-                  "country/CAN"
+                  {
+                    "value": "country/CAN"
+                  }
                 ]
               }
             ]

--- a/internal/server/spanner/golden/emulator/testdata/sdmx/availability_time_period_date_list.json
+++ b/internal/server/spanner/golden/emulator/testdata/sdmx/availability_time_period_date_list.json
@@ -1,5 +1,12 @@
 {
-  "$schema": "https://json.sdmx.org/2.0.0/sdmx-json-structure-schema.json",
+  "meta": {
+    "schema": "https://json.sdmx.org/2.0.0/sdmx-json-structure-schema.json",
+    "id": "DF_OBS_AVAILABILITY",
+    "prepared": "2026-08-10T12:34:56Z",
+    "sender": {
+      "id": "DC"
+    }
+  },
   "data": {
     "dataConstraints": [
       {
@@ -12,8 +19,12 @@
                 "id": "measurementMethod",
                 "include": true,
                 "values": [
-                  "Census",
-                  "Survey"
+                  {
+                    "value": "Census"
+                  },
+                  {
+                    "value": "Survey"
+                  }
                 ]
               }
             ]

--- a/internal/server/spanner/golden/emulator/testdata/sdmx/availability_time_period_single_date.json
+++ b/internal/server/spanner/golden/emulator/testdata/sdmx/availability_time_period_single_date.json
@@ -1,5 +1,12 @@
 {
-  "$schema": "https://json.sdmx.org/2.0.0/sdmx-json-structure-schema.json",
+  "meta": {
+    "schema": "https://json.sdmx.org/2.0.0/sdmx-json-structure-schema.json",
+    "id": "DF_OBS_AVAILABILITY",
+    "prepared": "2026-08-10T12:34:56Z",
+    "sender": {
+      "id": "DC"
+    }
+  },
   "data": {
     "dataConstraints": [
       {
@@ -12,7 +19,9 @@
                 "id": "measurementMethod",
                 "include": true,
                 "values": [
-                  "Census"
+                  {
+                    "value": "Census"
+                  }
                 ]
               }
             ]

--- a/internal/server/spanner/golden/emulator/testdata/sdmx/availability_transport_mode.json
+++ b/internal/server/spanner/golden/emulator/testdata/sdmx/availability_transport_mode.json
@@ -1,5 +1,12 @@
 {
-  "$schema": "https://json.sdmx.org/2.0.0/sdmx-json-structure-schema.json",
+  "meta": {
+    "schema": "https://json.sdmx.org/2.0.0/sdmx-json-structure-schema.json",
+    "id": "DF_OBS_AVAILABILITY",
+    "prepared": "2026-08-10T12:34:56Z",
+    "sender": {
+      "id": "DC"
+    }
+  },
   "data": {
     "dataConstraints": [
       {
@@ -12,8 +19,12 @@
                 "id": "transportMode",
                 "include": true,
                 "values": [
-                  "Air",
-                  "Sea"
+                  {
+                    "value": "Air"
+                  },
+                  {
+                    "value": "Sea"
+                  }
                 ]
               }
             ]

--- a/internal/server/spanner/golden/emulator/testdata/sdmx/availability_unit.json
+++ b/internal/server/spanner/golden/emulator/testdata/sdmx/availability_unit.json
@@ -1,5 +1,12 @@
 {
-  "$schema": "https://json.sdmx.org/2.0.0/sdmx-json-structure-schema.json",
+  "meta": {
+    "schema": "https://json.sdmx.org/2.0.0/sdmx-json-structure-schema.json",
+    "id": "DF_OBS_AVAILABILITY",
+    "prepared": "2026-08-10T12:34:56Z",
+    "sender": {
+      "id": "DC"
+    }
+  },
   "data": {
     "dataConstraints": [
       {
@@ -12,8 +19,12 @@
                 "id": "unit",
                 "include": true,
                 "values": [
-                  "Count",
-                  "Percent"
+                  {
+                    "value": "Count"
+                  },
+                  {
+                    "value": "Percent"
+                  }
                 ]
               }
             ]

--- a/internal/server/spanner/golden/emulator/testdata/sdmx/availability_variable_measured.json
+++ b/internal/server/spanner/golden/emulator/testdata/sdmx/availability_variable_measured.json
@@ -1,5 +1,12 @@
 {
-  "$schema": "https://json.sdmx.org/2.0.0/sdmx-json-structure-schema.json",
+  "meta": {
+    "schema": "https://json.sdmx.org/2.0.0/sdmx-json-structure-schema.json",
+    "id": "DF_OBS_AVAILABILITY",
+    "prepared": "2026-08-10T12:34:56Z",
+    "sender": {
+      "id": "DC"
+    }
+  },
   "data": {
     "dataConstraints": [
       {
@@ -12,8 +19,12 @@
                 "id": "variableMeasured",
                 "include": true,
                 "values": [
-                  "Count_Migration",
-                  "Count_Refugee"
+                  {
+                    "value": "Count_Migration"
+                  },
+                  {
+                    "value": "Count_Refugee"
+                  }
                 ]
               }
             ]


### PR DESCRIPTION
 Updated SDMX availability Structure JSON for pySDMX 1.18.0 compatibility:
  - Replaced top-level `$schema` with required `meta` fields.
  - Added current UTC RFC3339 `prepared` timestamp.
  - Serialized component values as `{"value": "..."}` objects.
  - Kept `meta` before `data`.

- Added deterministic formatter tests covering metadata, field order, removal of `$schema`, UTC timestamps, and object-form values.

- Updated the three formatter goldens and all 14 Spanner emulator availability goldens to the new response shape.

- Normalized dynamic `meta.prepared` values in emulator golden comparisons and added regression coverage.

- Updated schema-validation documentation to describe the new metadata envelope.

- Left routes, request parsing, dispatcher behavior, Spanner queries, and Content-Type unchanged.