### PR TITLE
Use V2 for remote mixer calls for legacy V2 implementations

### DIFF
--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -108,7 +108,7 @@ func (s *Server) GetRelatedLocations(
 	return localResp, nil
 }
 
-// GetLocationsRankings implements API for Mixer.GetLocationsRankings.
+// fetchGetLocationsRankings fetches local location rankings, falling back to remote mixer if local data is empty.
 func (s *Server) fetchGetLocationsRankings(
 	ctx context.Context, in *pb.GetLocationsRankingsRequest, remoteAPIPath string,
 ) (*pb.GetLocationsRankingsResponse, error) {

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -108,8 +108,8 @@ func (s *Server) GetRelatedLocations(
 	return localResp, nil
 }
 
-// fetchGetLocationsRankings fetches local location rankings, falling back to remote mixer if local data is empty.
-func (s *Server) fetchGetLocationsRankings(
+// getLocationsRankings fetches local location rankings, falling back to remote mixer if local data is empty.
+func (s *Server) getLocationsRankings(
 	ctx context.Context, in *pb.GetLocationsRankingsRequest, remoteAPIPath string,
 ) (*pb.GetLocationsRankingsResponse, error) {
 	localResp, err := place.GetLocationsRankings(ctx, in, s.store)
@@ -132,7 +132,7 @@ func (s *Server) fetchGetLocationsRankings(
 func (s *Server) GetLocationsRankings(
 	ctx context.Context, in *pb.GetLocationsRankingsRequest,
 ) (*pb.GetLocationsRankingsResponse, error) {
-	return s.fetchGetLocationsRankings(ctx, in, "/v1/place/ranking")
+	return s.getLocationsRankings(ctx, in, "/v1/place/ranking")
 }
 
 // GetPlaceStatVars implements API for Mixer.GetPlaceStatVars.

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -109,8 +109,8 @@ func (s *Server) GetRelatedLocations(
 }
 
 // GetLocationsRankings implements API for Mixer.GetLocationsRankings.
-func (s *Server) GetLocationsRankings(
-	ctx context.Context, in *pb.GetLocationsRankingsRequest,
+func (s *Server) fetchGetLocationsRankings(
+	ctx context.Context, in *pb.GetLocationsRankingsRequest, remoteAPIPath string,
 ) (*pb.GetLocationsRankingsResponse, error) {
 	localResp, err := place.GetLocationsRankings(ctx, in, s.store)
 	if err != nil {
@@ -120,12 +120,19 @@ func (s *Server) GetLocationsRankings(
 		s.metadata.RemoteMixerDomain != "" {
 		remoteResp := &pb.GetLocationsRankingsResponse{}
 		if err := util.FetchRemote(
-			s.metadata, s.httpClient, "/v1/place/ranking", in, remoteResp); err != nil {
+			s.metadata, s.httpClient, remoteAPIPath, in, remoteResp); err != nil {
 			return nil, err
 		}
 		return remoteResp, nil
 	}
 	return localResp, nil
+}
+
+// GetLocationsRankings implements API for Mixer.GetLocationsRankings.
+func (s *Server) GetLocationsRankings(
+	ctx context.Context, in *pb.GetLocationsRankingsRequest,
+) (*pb.GetLocationsRankingsResponse, error) {
+	return s.fetchGetLocationsRankings(ctx, in, "/v1/place/ranking")
 }
 
 // GetPlaceStatVars implements API for Mixer.GetPlaceStatVars.

--- a/internal/server/handler_v1.go
+++ b/internal/server/handler_v1.go
@@ -109,6 +109,7 @@ func (s *Server) BulkPlaceInfo(
 }
 
 // fetchAndMergeBulkVariableInfo fetches and merges local and remote BulkVariableInfo responses.
+// This helper function is used by both the V1 and V2 BulkVariableInfo handlers.
 func (s *Server) fetchAndMergeBulkVariableInfo(
 	ctx context.Context, in *pbv1.BulkVariableInfoRequest, remoteAPIPath string,
 ) (*pbv1.BulkVariableInfoResponse, error) {
@@ -158,6 +159,7 @@ func (s *Server) BulkVariableInfo(
 }
 
 // fetchAndMergeBulkVariableGroupInfo fetches and merges local and remote BulkVariableGroupInfo responses.
+// This helper function is used by both the V1 and V2 BulkVariableGroupInfo handlers.
 func (s *Server) fetchAndMergeBulkVariableGroupInfo(
 	ctx context.Context, in *pbv1.BulkVariableGroupInfoRequest, remoteAPIPath string,
 ) (*pbv1.BulkVariableGroupInfoResponse, error) {

--- a/internal/server/handler_v1.go
+++ b/internal/server/handler_v1.go
@@ -108,9 +108,8 @@ func (s *Server) BulkPlaceInfo(
 	return result, nil
 }
 
-// BulkVariableInfo implements API for mixer.BulkVariableInfo.
-func (s *Server) BulkVariableInfo(
-	ctx context.Context, in *pbv1.BulkVariableInfoRequest,
+func (s *Server) fetchAndMergeBulkVariableInfo(
+	ctx context.Context, in *pbv1.BulkVariableInfoRequest, remoteAPIPath string,
 ) (*pbv1.BulkVariableInfoResponse, error) {
 
 	errGroup, errCtx := errgroup.WithContext(ctx)
@@ -129,7 +128,7 @@ func (s *Server) BulkVariableInfo(
 
 	if s.metadata.RemoteMixerDomain != "" {
 		errGroup.Go(func() error {
-			remoteResponse, err := remoteBulkVariableInfoFunc(s, in)
+			remoteResponse, err := remoteBulkVariableInfoFunc(s, in, remoteAPIPath)
 			if err != nil {
 				return err
 			}
@@ -150,9 +149,15 @@ func (s *Server) BulkVariableInfo(
 	return result, nil
 }
 
-// BulkVariableGroupInfo implements API for mixer.BulkVariableGroupInfo.
-func (s *Server) BulkVariableGroupInfo(
-	ctx context.Context, in *pbv1.BulkVariableGroupInfoRequest,
+// BulkVariableInfo implements API for mixer.BulkVariableInfo.
+func (s *Server) BulkVariableInfo(
+	ctx context.Context, in *pbv1.BulkVariableInfoRequest,
+) (*pbv1.BulkVariableInfoResponse, error) {
+	return s.fetchAndMergeBulkVariableInfo(ctx, in, "/v1/bulk/info/variable")
+}
+
+func (s *Server) fetchAndMergeBulkVariableGroupInfo(
+	ctx context.Context, in *pbv1.BulkVariableGroupInfoRequest, remoteAPIPath string,
 ) (*pbv1.BulkVariableGroupInfoResponse, error) {
 	localResp, err := info.BulkVariableGroupInfo(ctx, in, s.store, s.cachedata.Load())
 	if err != nil {
@@ -175,7 +180,7 @@ func (s *Server) BulkVariableGroupInfo(
 		if err := util.FetchRemote(
 			s.metadata,
 			s.httpClient,
-			"/v1/bulk/info/variable-group",
+			remoteAPIPath,
 			in,
 			remoteResp,
 		); err != nil {
@@ -263,6 +268,13 @@ func (s *Server) BulkVariableGroupInfo(
 		return result.Data[i].Node < result.Data[j].Node
 	})
 	return result, nil
+}
+
+// BulkVariableGroupInfo implements API for mixer.BulkVariableGroupInfo.
+func (s *Server) BulkVariableGroupInfo(
+	ctx context.Context, in *pbv1.BulkVariableGroupInfoRequest,
+) (*pbv1.BulkVariableGroupInfoResponse, error) {
+	return s.fetchAndMergeBulkVariableGroupInfo(ctx, in, "/v1/bulk/info/variable-group")
 }
 
 // BulkObservationsPoint implements API for mixer.BulkObservationsPoint.

--- a/internal/server/handler_v1.go
+++ b/internal/server/handler_v1.go
@@ -108,6 +108,7 @@ func (s *Server) BulkPlaceInfo(
 	return result, nil
 }
 
+// fetchAndMergeBulkVariableInfo fetches and merges local and remote BulkVariableInfo responses.
 func (s *Server) fetchAndMergeBulkVariableInfo(
 	ctx context.Context, in *pbv1.BulkVariableInfoRequest, remoteAPIPath string,
 ) (*pbv1.BulkVariableInfoResponse, error) {
@@ -156,6 +157,7 @@ func (s *Server) BulkVariableInfo(
 	return s.fetchAndMergeBulkVariableInfo(ctx, in, "/v1/bulk/info/variable")
 }
 
+// fetchAndMergeBulkVariableGroupInfo fetches and merges local and remote BulkVariableGroupInfo responses.
 func (s *Server) fetchAndMergeBulkVariableGroupInfo(
 	ctx context.Context, in *pbv1.BulkVariableGroupInfoRequest, remoteAPIPath string,
 ) (*pbv1.BulkVariableGroupInfoResponse, error) {

--- a/internal/server/handler_v1_func.go
+++ b/internal/server/handler_v1_func.go
@@ -27,12 +27,13 @@ var localBulkVariableInfoFunc = info.BulkVariableInfo
 var remoteBulkVariableInfoFunc = func(
 	s *Server,
 	remoteReq *pbv1.BulkVariableInfoRequest,
+	remoteAPIPath string,
 ) (*pbv1.BulkVariableInfoResponse, error) {
 	remoteResp := &pbv1.BulkVariableInfoResponse{}
 	return remoteResp, util.FetchRemote(
 		s.metadata,
 		s.httpClient,
-		"/v1/bulk/info/variable",
+		remoteAPIPath,
 		remoteReq,
 		remoteResp,
 	)

--- a/internal/server/handler_v1_test.go
+++ b/internal/server/handler_v1_test.go
@@ -222,7 +222,7 @@ func TestBulkVariableInfo(t *testing.T) {
 		localBulkVariableInfoFunc = func(_ context.Context, _ *pbv1.BulkVariableInfoRequest, _ *store.Store) (*pbv1.BulkVariableInfoResponse, error) {
 			return tc.localResponse, nil
 		}
-		remoteBulkVariableInfoFunc = func(_ *Server, _ *pbv1.BulkVariableInfoRequest) (*pbv1.BulkVariableInfoResponse, error) {
+		remoteBulkVariableInfoFunc = func(_ *Server, _ *pbv1.BulkVariableInfoRequest, _ string) (*pbv1.BulkVariableInfoResponse, error) {
 			return tc.remoteResponse, nil
 		}
 		s.metadata.RemoteMixerDomain = tc.remoteMixer

--- a/internal/server/handler_v1_test.go
+++ b/internal/server/handler_v1_test.go
@@ -222,7 +222,11 @@ func TestBulkVariableInfo(t *testing.T) {
 		localBulkVariableInfoFunc = func(_ context.Context, _ *pbv1.BulkVariableInfoRequest, _ *store.Store) (*pbv1.BulkVariableInfoResponse, error) {
 			return tc.localResponse, nil
 		}
-		remoteBulkVariableInfoFunc = func(_ *Server, _ *pbv1.BulkVariableInfoRequest, _ string) (*pbv1.BulkVariableInfoResponse, error) {
+		remoteBulkVariableInfoFunc = func(_ *Server, _ *pbv1.BulkVariableInfoRequest, remoteAPIPath string) (*pbv1.BulkVariableInfoResponse, error) {
+			expectedPath := "/v1/bulk/info/variable"
+			if remoteAPIPath != expectedPath {
+				t.Errorf("%s: expected remoteAPIPath to be %s, got %s", tc.desc, expectedPath, remoteAPIPath)
+			}
 			return tc.remoteResponse, nil
 		}
 		s.metadata.RemoteMixerDomain = tc.remoteMixer

--- a/internal/server/handler_v2.go
+++ b/internal/server/handler_v2.go
@@ -562,6 +562,10 @@ func (s *Server) V2BulkVariableInfo(
 	if err != nil {
 		return nil, err
 	}
+	if v2Resp == nil {
+		return &pbv1.BulkVariableInfoResponse{}, nil
+	}
+	v2Resp = proto.Clone(v2Resp).(*pbv1.BulkVariableInfoResponse)
 
 	// The new response will not contain all legacy V1 fields.
 	// To ensure the new response is sufficient, clear all legacy fields until swapping over to the new backend.
@@ -609,11 +613,14 @@ func (s *Server) V2BulkVariableGroupInfo(
 	v2StartTime := time.Now()
 
 	// Fetch and merge local data and remote data, using the v2 API path for remote fetch.
-	v1Resp, err := s.fetchAndMergeBulkVariableGroupInfo(ctx, in, "/v2/bulk/info/variable-group")
+	v2Resp, err := s.fetchAndMergeBulkVariableGroupInfo(ctx, in, "/v2/bulk/info/variable-group")
 	if err != nil {
 		return nil, err
 	}
-	v2Resp := proto.Clone(v1Resp).(*pbv1.BulkVariableGroupInfoResponse)
+	if v2Resp == nil {
+		return &pbv1.BulkVariableGroupInfoResponse{}, nil
+	}
+	v2Resp = proto.Clone(v2Resp).(*pbv1.BulkVariableGroupInfoResponse)
 
 	convertV1ToV2BulkVariableGroupInfo(v2Resp)
 
@@ -655,14 +662,14 @@ func (s *Server) V2GetLocationsRankings(
 ) (*pb.GetLocationsRankingsResponse, error) {
 
 	// Fetch and merge local data and remote data, using the v2 API path for remote fetch.
-	v1Resp, err := s.fetchGetLocationsRankings(ctx, in, "/v2/place/ranking")
+	v2Resp, err := s.fetchGetLocationsRankings(ctx, in, "/v2/place/ranking")
 	if err != nil {
 		return nil, err
 	}
-	if v1Resp == nil {
+	if v2Resp == nil {
 		return &pb.GetLocationsRankingsResponse{}, nil
 	}
-	v2Resp := proto.Clone(v1Resp).(*pb.GetLocationsRankingsResponse)
+	v2Resp = proto.Clone(v2Resp).(*pb.GetLocationsRankingsResponse)
 
 	// Set the Legacy field to true to indicate that this response is from the V1 implementation.
 	v2Resp.Legacy = true

--- a/internal/server/handler_v2.go
+++ b/internal/server/handler_v2.go
@@ -661,7 +661,7 @@ func (s *Server) V2GetLocationsRankings(
 	ctx context.Context, in *pb.GetLocationsRankingsRequest,
 ) (*pb.GetLocationsRankingsResponse, error) {
 
-	// Fetch and merge local data and remote data, using the v2 API path for remote fetch.
+	// Fetch local location rankings, falling back to the remote mixer using the v2 API path for remote fetch.
 	v2Resp, err := s.fetchGetLocationsRankings(ctx, in, "/v2/place/ranking")
 	if err != nil {
 		return nil, err

--- a/internal/server/handler_v2.go
+++ b/internal/server/handler_v2.go
@@ -662,7 +662,7 @@ func (s *Server) V2GetLocationsRankings(
 ) (*pb.GetLocationsRankingsResponse, error) {
 
 	// Fetch local location rankings, falling back to the remote mixer using the v2 API path for remote fetch.
-	v2Resp, err := s.fetchGetLocationsRankings(ctx, in, "/v2/place/ranking")
+	v2Resp, err := s.getLocationsRankings(ctx, in, "/v2/place/ranking")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/handler_v2.go
+++ b/internal/server/handler_v2.go
@@ -557,8 +557,8 @@ func (s *Server) V2BulkVariableInfo(
 
 	v2StartTime := time.Now()
 
-	// Use the V1 implementation for now.
-	v2Resp, err := s.BulkVariableInfo(ctx, in)
+	// Fetch and merge local data and remote data, using the v2 API path for remote fetch.
+	v2Resp, err := s.fetchAndMergeBulkVariableInfo(ctx, in, "/v2/bulk/info/variable")
 	if err != nil {
 		return nil, err
 	}
@@ -608,8 +608,8 @@ func (s *Server) V2BulkVariableGroupInfo(
 
 	v2StartTime := time.Now()
 
-	// Use the V1 implementation for now.
-	v1Resp, err := s.BulkVariableGroupInfo(ctx, in)
+	// Fetch and merge local data and remote data, using the v2 API path for remote fetch.
+	v1Resp, err := s.fetchAndMergeBulkVariableGroupInfo(ctx, in, "/v2/bulk/info/variable-group")
 	if err != nil {
 		return nil, err
 	}
@@ -654,8 +654,8 @@ func (s *Server) V2GetLocationsRankings(
 	ctx context.Context, in *pb.GetLocationsRankingsRequest,
 ) (*pb.GetLocationsRankingsResponse, error) {
 
-	// Use the V1 implementation for now.
-	v1Resp, err := s.GetLocationsRankings(ctx, in)
+	// Fetch and merge local data and remote data, using the v2 API path for remote fetch.
+	v1Resp, err := s.fetchGetLocationsRankings(ctx, in, "/v2/place/ranking")
 	if err != nil {
 		return nil, err
 	}

--- a/internal/server/handler_v2_test.go
+++ b/internal/server/handler_v2_test.go
@@ -17,6 +17,7 @@ package server
 import (
 	"bytes"
 	"context"
+	"io"
 	"log/slog"
 	"net/http"
 	"regexp"
@@ -24,6 +25,8 @@ import (
 	"testing"
 
 	"github.com/datacommonsorg/mixer/internal/featureflags"
+	pb "github.com/datacommonsorg/mixer/internal/proto"
+	pbv1 "github.com/datacommonsorg/mixer/internal/proto/v1"
 	pbv2 "github.com/datacommonsorg/mixer/internal/proto/v2"
 	"github.com/datacommonsorg/mixer/internal/server/cache"
 	"github.com/datacommonsorg/mixer/internal/server/datasource"
@@ -484,5 +487,58 @@ func TestShouldRouteResolveToDispatcher(t *testing.T) {
 				t.Errorf("shouldRouteResolveToDispatcher() = %v, want %v", gotRoute, tc.wantRoute)
 			}
 		})
+	}
+}
+
+type mockRemoteTransport struct {
+	lastPath string
+}
+
+func (m *mockRemoteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	m.lastPath = req.URL.Path
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(`{}`)),
+	}, nil
+}
+
+func TestV2RemoteAPIPaths(t *testing.T) {
+	ctx := context.Background()
+	transport := &mockRemoteTransport{}
+	s := &Server{
+		store:      &store.Store{},
+		metadata:   &resource.Metadata{RemoteMixerDomain: "http://mock-remote"},
+		flags:      &featureflags.Flags{},
+		httpClient: &http.Client{
+			Transport: transport,
+		},
+	}
+	s.cachedata.Store(&cache.Cache{})
+
+	// Temporarily override local fetch to avoid nil panics during test.
+	oldLocalInfo := localBulkVariableInfoFunc
+	localBulkVariableInfoFunc = func(_ context.Context, _ *pbv1.BulkVariableInfoRequest, _ *store.Store) (*pbv1.BulkVariableInfoResponse, error) {
+		return &pbv1.BulkVariableInfoResponse{}, nil
+	}
+	defer func() { localBulkVariableInfoFunc = oldLocalInfo }()
+
+	// 1. V2BulkVariableInfo
+	_, _ = s.V2BulkVariableInfo(ctx, &pbv1.BulkVariableInfoRequest{Nodes: []string{"node1"}})
+	if transport.lastPath != "/v2/bulk/info/variable" {
+		t.Errorf("V2BulkVariableInfo passed remote path %q, want %q", transport.lastPath, "/v2/bulk/info/variable")
+	}
+
+	// 2. V2BulkVariableGroupInfo
+	// Empty Nodes slice safely bypasses local fetch and triggers remote fetch.
+	_, _ = s.V2BulkVariableGroupInfo(ctx, &pbv1.BulkVariableGroupInfoRequest{Nodes: []string{}})
+	if transport.lastPath != "/v2/bulk/info/variable-group" {
+		t.Errorf("V2BulkVariableGroupInfo passed remote path %q, want %q", transport.lastPath, "/v2/bulk/info/variable-group")
+	}
+
+	// 3. V2GetLocationsRankings
+	// Must provide PlaceType and StatVarDcids to avoid early argument error.
+	_, _ = s.V2GetLocationsRankings(ctx, &pb.GetLocationsRankingsRequest{PlaceType: "City", StatVarDcids: []string{"Count_Person"}})
+	if transport.lastPath != "/v2/place/ranking" {
+		t.Errorf("V2GetLocationsRankings passed remote path %q, want %q", transport.lastPath, "/v2/place/ranking")
 	}
 }


### PR DESCRIPTION
Previously legacy v2 implementations for certain endpoints were directly calling the v1 implementations which had hardcoded v1 remote api requests. This meant that custom dc instances not on spanner were still making v1 calls to remote mixer. 

This PR updates these v2 endpoints to make corresponding v2 remote mixer calls instead by abstracting out the core endpoint implementation to be called by both v1 and v2 versions with the corresponding remoteAPIPath as an input

Affected endpoints
- V2BulkVariableInfo
- V2BulkVariableGroupInfo
- V2GetLocationsRankings