### PR TITLE
Enrich unresolved nodes via federated node queries

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -501,14 +501,21 @@ func main() {
 			processors = append(processors, &redisProcessor)
 		}
 
-		// Relation Expression Processor
 		if remoteDataSource != nil {
+			// Relation Expression Processor
 			slog.Info("remoteDataSource is configured, setting up relation expression processor")
 			var relationExpressionProcessor dispatcher.Processor = dispatcher.NewRelationExpressionProcessor(
 				remoteDataSource,
 				flags.SDMXRemotePlaceExpansionLimit,
 			)
 			processors = append(processors, &relationExpressionProcessor)
+
+			// Unresolved Node Processor
+			slog.Info("remoteDataSource is configured, setting up unresolved node processor")
+			var unresolvedNodeProcessor dispatcher.Processor = dispatcher.NewUnresolvedNodeProcessor(
+				remoteDataSource,
+			)
+			processors = append(processors, &unresolvedNodeProcessor)
 		}
 
 		// Calculation Processor

--- a/internal/server/dispatcher/unresolved_node_processor.go
+++ b/internal/server/dispatcher/unresolved_node_processor.go
@@ -170,6 +170,9 @@ func hydrateNodeResponse(resp *pbv2.NodeResponse, infoByDcid map[string]*entityI
 	for _, graph := range resp.GetData() {
 		for _, arc := range graph.GetArcs() {
 			for _, node := range arc.GetNodes() {
+				if node == nil {
+					continue
+				}
 				info, ok := infoByDcid[node.GetDcid()]
 				if !ok {
 					continue

--- a/internal/server/dispatcher/unresolved_node_processor.go
+++ b/internal/server/dispatcher/unresolved_node_processor.go
@@ -1,0 +1,185 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dispatcher
+
+import (
+	"fmt"
+	"log/slog"
+	"slices"
+
+	pb "github.com/datacommonsorg/mixer/internal/proto"
+	pbv2 "github.com/datacommonsorg/mixer/internal/proto/v2"
+	"github.com/datacommonsorg/mixer/internal/server/datasource"
+	"github.com/datacommonsorg/mixer/internal/server/datasources"
+)
+
+const (
+	unresolvedNodeType = "Thing"
+	nodeInfoProperty   = "->[name, typeOf]"
+	predicateName      = "name"
+	predicateTypeOf    = "typeOf"
+)
+
+type entityInfo struct {
+	name  string
+	types []string
+}
+
+// UnresolvedNodeProcessor post-processes NodeResponses to resolve and hydrate
+// properties (name, types) for unresolved nodes using the provided datasource.
+type UnresolvedNodeProcessor struct {
+	source datasource.DataSource
+}
+
+// NewUnresolvedNodeProcessor creates a new UnresolvedNodeProcessor.
+func NewUnresolvedNodeProcessor(source datasource.DataSource) *UnresolvedNodeProcessor {
+	return &UnresolvedNodeProcessor{
+		source: source,
+	}
+}
+
+// PreProcess is a no-op for UnresolvedNodeProcessor.
+func (p *UnresolvedNodeProcessor) PreProcess(rc *RequestContext) (Outcome, error) {
+	return Continue, nil
+}
+
+// PostProcess resolves unresolved nodes in the NodeResponse by fetching their
+// properties from the configured datasource.
+func (p *UnresolvedNodeProcessor) PostProcess(rc *RequestContext) (Outcome, error) {
+	if rc.Type != TypeNode || p.source == nil || rc.CurrentResponse == nil {
+		return Continue, nil
+	}
+
+	resp, ok := rc.CurrentResponse.(*pbv2.NodeResponse)
+	if !ok {
+		slog.Error("UnresolvedNodeProcessor: failed to cast response to NodeResponse", "type", rc.Type)
+		return Continue, fmt.Errorf("failed to cast response to NodeResponse")
+	}
+
+	unresolvedDcids := collectUnresolvedDCIDs(resp)
+	if len(unresolvedDcids) == 0 {
+		return Continue, nil
+	}
+
+	slog.Info("UnresolvedNodeProcessor: fetching properties for unresolved nodes", "count", len(unresolvedDcids))
+
+	req := &pbv2.NodeRequest{
+		Nodes:    unresolvedDcids,
+		Property: nodeInfoProperty,
+	}
+
+	sourceResp, err := datasource.NodeFetchAll(rc.Context, p.source, req, datasources.DefaultPageSize)
+	if err != nil {
+		slog.Warn("UnresolvedNodeProcessor: failed to fetch unresolved node properties", "error", err)
+		return Continue, nil
+	}
+
+	infoByDcid := extractEntityInfo(sourceResp)
+	slog.Info("UnresolvedNodeProcessor: extracted properties for unresolved nodes", "count", len(infoByDcid))
+	hydrateNodeResponse(resp, infoByDcid)
+
+	return Continue, nil
+}
+
+// collectUnresolvedDCIDs gathers unique DCIDs of all unresolved entities in the response.
+func collectUnresolvedDCIDs(resp *pbv2.NodeResponse) []string {
+	seen := make(map[string]struct{})
+	var dcids []string
+
+	for _, graph := range resp.GetData() {
+		for _, arc := range graph.GetArcs() {
+			for _, node := range arc.GetNodes() {
+				if isUnresolved(node) {
+					dcid := node.GetDcid()
+					if _, exists := seen[dcid]; !exists {
+						seen[dcid] = struct{}{}
+						dcids = append(dcids, dcid)
+					}
+				}
+			}
+		}
+	}
+
+	return dcids
+}
+
+// isUnresolved checks whether an entity node is an unresolved reference.
+// NOTE: Local data sources (e.g. Spanner) emit dangling foreign-key nodes with
+// Types = ["Thing"] and empty Name. We use this heuristic instead of explicit
+// context attributes to keep data source interfaces simple and avoid extra wiring.
+func isUnresolved(entity *pb.EntityInfo) bool {
+	return len(entity.GetTypes()) == 1 &&
+		entity.GetTypes()[0] == unresolvedNodeType &&
+		entity.GetName() == "" &&
+		entity.GetDcid() != "" &&
+		entity.GetValue() == ""
+}
+
+// extractEntityInfo extracts the name and types for each DCID from a NodeResponse.
+func extractEntityInfo(resp *pbv2.NodeResponse) map[string]*entityInfo {
+	infoByDcid := make(map[string]*entityInfo)
+
+	for dcid, graph := range resp.GetData() {
+		info := &entityInfo{}
+
+		if nameArc, ok := graph.GetArcs()[predicateName]; ok {
+			for _, node := range nameArc.GetNodes() {
+				if val := node.GetValue(); val != "" {
+					info.name = val
+					break
+				}
+				if name := node.GetName(); name != "" {
+					info.name = name
+					break
+				}
+			}
+		}
+
+		if typeArc, ok := graph.GetArcs()[predicateTypeOf]; ok {
+			for _, node := range typeArc.GetNodes() {
+				if typeDcid := node.GetDcid(); typeDcid != "" {
+					info.types = append(info.types, typeDcid)
+				} else if val := node.GetValue(); val != "" {
+					info.types = append(info.types, val)
+				}
+			}
+		}
+
+		infoByDcid[dcid] = info
+	}
+
+	return infoByDcid
+}
+
+// hydrateNodeResponse enriches unresolved entities in the response with their fetched name and types.
+func hydrateNodeResponse(resp *pbv2.NodeResponse, infoByDcid map[string]*entityInfo) {
+	for _, graph := range resp.GetData() {
+		for _, arc := range graph.GetArcs() {
+			for _, node := range arc.GetNodes() {
+				info, ok := infoByDcid[node.GetDcid()]
+				if !ok {
+					continue
+				}
+
+				if info.name != "" {
+					node.Name = info.name
+				}
+				if len(info.types) > 0 {
+					node.Types = slices.Clone(info.types)
+				}
+			}
+		}
+	}
+}

--- a/internal/server/dispatcher/unresolved_node_processor.go
+++ b/internal/server/dispatcher/unresolved_node_processor.go
@@ -112,6 +112,8 @@ func collectUnresolvedDCIDs(resp *pbv2.NodeResponse) []string {
 		}
 	}
 
+	// Sort DCIDs for deterministic request order and cache stability.
+	slices.Sort(dcids)
 	return dcids
 }
 

--- a/internal/server/dispatcher/unresolved_node_processor.go
+++ b/internal/server/dispatcher/unresolved_node_processor.go
@@ -151,10 +151,12 @@ func extractEntityInfo(resp *pbv2.NodeResponse) map[string]*entityInfo {
 
 		if typeArc, ok := graph.GetArcs()[predicateTypeOf]; ok {
 			for _, node := range typeArc.GetNodes() {
-				if typeDcid := node.GetDcid(); typeDcid != "" {
-					info.types = append(info.types, typeDcid)
-				} else if val := node.GetValue(); val != "" {
-					info.types = append(info.types, val)
+				typeStr := node.GetDcid()
+				if typeStr == "" {
+					typeStr = node.GetValue()
+				}
+				if typeStr != "" && !slices.Contains(info.types, typeStr) {
+					info.types = append(info.types, typeStr)
 				}
 			}
 		}

--- a/internal/server/dispatcher/unresolved_node_processor_test.go
+++ b/internal/server/dispatcher/unresolved_node_processor_test.go
@@ -1,0 +1,367 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dispatcher
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	pb "github.com/datacommonsorg/mixer/internal/proto"
+	pbv2 "github.com/datacommonsorg/mixer/internal/proto/v2"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+func TestUnresolvedNodeProcessor_PostProcess(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name             string
+		requestType      RequestType
+		hasSource        bool
+		initialResponse  proto.Message
+		mockNodeResponse *pbv2.NodeResponse
+		mockNodeError    error
+		expectNodeCalled bool
+		expectedOutcome  Outcome
+		expectedErr      bool
+		expectedResponse proto.Message
+	}{
+		{
+			name:        "Happy Path: Hydrates name and types for unresolved nodes",
+			requestType: TypeNode,
+			hasSource:   true,
+			initialResponse: &pbv2.NodeResponse{
+				Data: map[string]*pbv2.LinkedGraph{
+					"country/BLZ": {
+						Arcs: map[string]*pbv2.Nodes{
+							"specializationOf": {
+								Nodes: []*pb.EntityInfo{
+									{
+										Dcid:         "unresolved_geo_entity",
+										Types:        []string{"Thing"},
+										ProvenanceId: "dc/base/Wikidata",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			mockNodeResponse: &pbv2.NodeResponse{
+				Data: map[string]*pbv2.LinkedGraph{
+					"unresolved_geo_entity": {
+						Arcs: map[string]*pbv2.Nodes{
+							"name": {
+								Nodes: []*pb.EntityInfo{
+									{Value: "Unresolved Geo Entity"},
+								},
+							},
+							"typeOf": {
+								Nodes: []*pb.EntityInfo{
+									{Dcid: "Place"},
+									{Dcid: "AdministrativeArea"},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectNodeCalled: true,
+			expectedOutcome:  Continue,
+			expectedErr:      false,
+			expectedResponse: &pbv2.NodeResponse{
+				Data: map[string]*pbv2.LinkedGraph{
+					"country/BLZ": {
+						Arcs: map[string]*pbv2.Nodes{
+							"specializationOf": {
+								Nodes: []*pb.EntityInfo{
+									{
+										Dcid:         "unresolved_geo_entity",
+										Name:         "Unresolved Geo Entity",
+										Types:        []string{"Place", "AdministrativeArea"},
+										ProvenanceId: "dc/base/Wikidata",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "No-op: Already resolved entities are not queried",
+			requestType: TypeNode,
+			hasSource:   true,
+			initialResponse: &pbv2.NodeResponse{
+				Data: map[string]*pbv2.LinkedGraph{
+					"country/USA": {
+						Arcs: map[string]*pbv2.Nodes{
+							"typeOf": {
+								Nodes: []*pb.EntityInfo{
+									{
+										Dcid:         "Country",
+										Name:         "Country",
+										Types:        []string{"Class"},
+										ProvenanceId: "dc/base/Wikidata",
+									},
+								},
+							},
+							"name": {
+								Nodes: []*pb.EntityInfo{
+									{
+										Value:        "United States",
+										ProvenanceId: "dc/base/Wikidata",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectNodeCalled: false,
+			expectedOutcome:  Continue,
+			expectedErr:      false,
+			expectedResponse: &pbv2.NodeResponse{
+				Data: map[string]*pbv2.LinkedGraph{
+					"country/USA": {
+						Arcs: map[string]*pbv2.Nodes{
+							"typeOf": {
+								Nodes: []*pb.EntityInfo{
+									{
+										Dcid:         "Country",
+										Name:         "Country",
+										Types:        []string{"Class"},
+										ProvenanceId: "dc/base/Wikidata",
+									},
+								},
+							},
+							"name": {
+								Nodes: []*pb.EntityInfo{
+									{
+										Value:        "United States",
+										ProvenanceId: "dc/base/Wikidata",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "Fallback on error: Preserves placeholder when datasource call fails",
+			requestType: TypeNode,
+			hasSource:   true,
+			initialResponse: &pbv2.NodeResponse{
+				Data: map[string]*pbv2.LinkedGraph{
+					"country/BLZ": {
+						Arcs: map[string]*pbv2.Nodes{
+							"specializationOf": {
+								Nodes: []*pb.EntityInfo{
+									{
+										Dcid:         "unresolved_geo_entity",
+										Types:        []string{"Thing"},
+										ProvenanceId: "dc/base/Wikidata",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			mockNodeError:    errors.New("datasource network timeout"),
+			expectNodeCalled: true,
+			expectedOutcome:  Continue,
+			expectedErr:      false,
+			expectedResponse: &pbv2.NodeResponse{
+				Data: map[string]*pbv2.LinkedGraph{
+					"country/BLZ": {
+						Arcs: map[string]*pbv2.Nodes{
+							"specializationOf": {
+								Nodes: []*pb.EntityInfo{
+									{
+										Dcid:         "unresolved_geo_entity",
+										Types:        []string{"Thing"},
+										ProvenanceId: "dc/base/Wikidata",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "Entity missing in datasource: Preserves placeholder when no metadata returned",
+			requestType: TypeNode,
+			hasSource:   true,
+			initialResponse: &pbv2.NodeResponse{
+				Data: map[string]*pbv2.LinkedGraph{
+					"country/BLZ": {
+						Arcs: map[string]*pbv2.Nodes{
+							"specializationOf": {
+								Nodes: []*pb.EntityInfo{
+									{
+										Dcid:         "unresolved_geo_entity",
+										Types:        []string{"Thing"},
+										ProvenanceId: "dc/base/Wikidata",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			mockNodeResponse: &pbv2.NodeResponse{
+				Data: map[string]*pbv2.LinkedGraph{},
+			},
+			expectNodeCalled: true,
+			expectedOutcome:  Continue,
+			expectedErr:      false,
+			expectedResponse: &pbv2.NodeResponse{
+				Data: map[string]*pbv2.LinkedGraph{
+					"country/BLZ": {
+						Arcs: map[string]*pbv2.Nodes{
+							"specializationOf": {
+								Nodes: []*pb.EntityInfo{
+									{
+										Dcid:         "unresolved_geo_entity",
+										Types:        []string{"Thing"},
+										ProvenanceId: "dc/base/Wikidata",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:             "No-op: Non-Node request type",
+			requestType:      TypeObservation,
+			hasSource:        true,
+			initialResponse:  &pbv2.ObservationResponse{},
+			expectNodeCalled: false,
+			expectedOutcome:  Continue,
+			expectedErr:      false,
+			expectedResponse: &pbv2.ObservationResponse{},
+		},
+		{
+			name:        "No-op: No source configured",
+			requestType: TypeNode,
+			hasSource:   false,
+			initialResponse: &pbv2.NodeResponse{
+				Data: map[string]*pbv2.LinkedGraph{
+					"country/BLZ": {
+						Arcs: map[string]*pbv2.Nodes{
+							"specializationOf": {
+								Nodes: []*pb.EntityInfo{
+									{
+										Dcid:  "unresolved_geo_entity",
+										Types: []string{"Thing"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectNodeCalled: false,
+			expectedOutcome:  Continue,
+			expectedErr:      false,
+			expectedResponse: &pbv2.NodeResponse{
+				Data: map[string]*pbv2.LinkedGraph{
+					"country/BLZ": {
+						Arcs: map[string]*pbv2.Nodes{
+							"specializationOf": {
+								Nodes: []*pb.EntityInfo{
+									{
+										Dcid:  "unresolved_geo_entity",
+										Types: []string{"Thing"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			nodeCalled := false
+			var capturedReq *pbv2.NodeRequest
+
+			mock := &mockSource{
+				id: "mock-source",
+				nodeFunc: func(ctx context.Context, req *pbv2.NodeRequest, pageSize int) (*pbv2.NodeResponse, error) {
+					nodeCalled = true
+					capturedReq = req
+					if tc.mockNodeError != nil {
+						return nil, tc.mockNodeError
+					}
+					if tc.mockNodeResponse != nil {
+						return tc.mockNodeResponse, nil
+					}
+					return &pbv2.NodeResponse{}, nil
+				},
+			}
+
+			var processor *UnresolvedNodeProcessor
+			if tc.hasSource {
+				processor = NewUnresolvedNodeProcessor(mock)
+			} else {
+				processor = NewUnresolvedNodeProcessor(nil)
+			}
+
+			rc := &RequestContext{
+				Context:         ctx,
+				Type:            tc.requestType,
+				CurrentResponse: tc.initialResponse,
+			}
+
+			outcome, err := processor.PostProcess(rc)
+
+			if (err != nil) != tc.expectedErr {
+				t.Fatalf("PostProcess() error = %v, expectedErr %v", err, tc.expectedErr)
+			}
+
+			if outcome != tc.expectedOutcome {
+				t.Errorf("PostProcess() outcome = %v, want %v", outcome, tc.expectedOutcome)
+			}
+
+			if nodeCalled != tc.expectNodeCalled {
+				t.Errorf("PostProcess() nodeCalled = %v, want %v", nodeCalled, tc.expectNodeCalled)
+			}
+
+			if tc.expectNodeCalled && capturedReq != nil {
+				if capturedReq.Property != nodeInfoProperty {
+					t.Errorf("NodeRequest.Property = %q, want %q", capturedReq.Property, nodeInfoProperty)
+				}
+			}
+
+			cmpOpts := cmp.Options{
+				protocmp.Transform(),
+			}
+			if diff := cmp.Diff(rc.CurrentResponse, tc.expectedResponse, cmpOpts); diff != "" {
+				t.Errorf("CurrentResponse mismatch (-got +want):\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/server/dispatcher/unresolved_node_processor_test.go
+++ b/internal/server/dispatcher/unresolved_node_processor_test.go
@@ -75,6 +75,7 @@ func TestUnresolvedNodeProcessor_PostProcess(t *testing.T) {
 								Nodes: []*pb.EntityInfo{
 									{Dcid: "Place"},
 									{Dcid: "AdministrativeArea"},
+									{Dcid: "Place"},
 								},
 							},
 						},


### PR DESCRIPTION
- Add `UnresolvedNodeProcessor` to dispatcher pipeline to enrich responses by federating node queries for unresolved nodes to a remote data source (i.e. base DC)
- Wire processor into server startup when a remote data source is configured

### Notes
- This requires DCP spanner instances to specify an informational (`NOT ENFORCED`) foreign key on `Edge.object_id` referencing `Node.subject_id` so the query optimizer does not drop edges pointing to unresolved destination nodes:
  ```sql
  ALTER TABLE Edge
  ADD CONSTRAINT FK_Edge_Object_Node
  FOREIGN KEY (object_id) REFERENCES Node (subject_id) NOT ENFORCED;
  ```

### Testing
- Tested locally with a DCP database and remote DC instance, confirming unresolved nodes are returned and enriched with their name and types.