### PR TITLE
Make Redis protobuf cache keys deterministic

### DIFF
--- a/internal/server/redis/client.go
+++ b/internal/server/redis/client.go
@@ -83,7 +83,7 @@ func (c *RedisCacheClient) Close() error {
 
 // generateCacheKey generates a unique cache key from a protobuf request.
 func generateCacheKey(request proto.Message) (string, error) {
-	marshaled, err := proto.Marshal(request)
+	marshaled, err := proto.MarshalOptions{Deterministic: true}.Marshal(request)
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal request: %w", err)
 	}

--- a/internal/server/redis/client_test.go
+++ b/internal/server/redis/client_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	pb "github.com/datacommonsorg/mixer/internal/proto"
+	sdmxpb "github.com/datacommonsorg/mixer/internal/proto/sdmx"
 	v2 "github.com/datacommonsorg/mixer/internal/proto/v2"
 	"github.com/datacommonsorg/mixer/internal/util"
 	"github.com/go-redis/redismock/v8"
@@ -85,6 +86,28 @@ func TestCacheClient(t *testing.T) {
 
 	// Ensure all expectations were met
 	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGenerateCacheKeyDeterministicForMapRequest(t *testing.T) {
+	request := &sdmxpb.SdmxDataQuery{Constraints: map[string]*sdmxpb.SdmxComponentConstraint{
+		"variableMeasured": {Predicates: []*sdmxpb.SdmxPredicate{{Value: "Count_Person"}}},
+		"observationAbout": {Predicates: []*sdmxpb.SdmxPredicate{{Value: "country/USA"}}},
+		"TIME_PERIOD":      {Predicates: []*sdmxpb.SdmxPredicate{{Value: "2020"}}},
+	}}
+
+	want, err := generateCacheKey(request)
+	if err != nil {
+		t.Fatalf("generateCacheKey() error = %v", err)
+	}
+	for i := 0; i < 100; i++ {
+		got, err := generateCacheKey(request)
+		if err != nil {
+			t.Fatalf("generateCacheKey() error = %v", err)
+		}
+		if got != want {
+			t.Fatalf("generateCacheKey() = %q, want %q", got, want)
+		}
+	}
 }
 
 func TestCompressionSize(t *testing.T) {


### PR DESCRIPTION
## Summary

- Use deterministic protobuf marshaling when generating Redis cache keys.
- Add coverage ensuring repeated hashing of the same map-bearing SDMX request produces a stable key.

This prevents protobuf map iteration order from producing different cache keys for the same request.

Predicate-list canonicalization is intentionally out of scope.

## Testing

- `go test ./internal/server/redis -count=1`
- `git diff --check`