### PR TITLE
fix(v2): improve error message when property expressions lack direction arrows

### DIFF
--- a/internal/server/v2/parser.go
+++ b/internal/server/v2/parser.go
@@ -142,15 +142,14 @@ func parseArc(arrow, expr string) (*Arc, error) {
 
 // ParseProperty parses an expression string into a list of Arcs.
 func ParseProperty(expr string) ([]*Arc, error) {
-	trimmed := spaceNewLineReplacer.Replace(expr)
-	if trimmed != "" && !strings.HasPrefix(trimmed, "->") && !strings.HasPrefix(trimmed, "<-") {
+	parts := splitExpr(expr)
+	if len(parts) > 0 && parts[0] != "->" && parts[0] != "<-" {
 		return nil, status.Errorf(
 			codes.InvalidArgument,
 			"invalid property expression %q: property expressions must start with a direction arrow (e.g. ->name for outgoing properties, or <-containedInPlace for incoming properties)",
 			expr,
 		)
 	}
-	parts := splitExpr(expr)
 	if len(parts) == 1 {
 		// Handle "->" query, which is to get all properties
 		parts = append(parts, "")

--- a/internal/server/v2/parser.go
+++ b/internal/server/v2/parser.go
@@ -72,7 +72,8 @@ func parseArc(arrow, expr string) (*Arc, error) {
 	default:
 		return nil, status.Errorf(
 			codes.InvalidArgument,
-			"arc string should start with arrow (-> or <-) but got %s",
+			"invalid property arc %q: expression must start with a direction arrow (e.g. ->name for outgoing properties, or <-containedInPlace for incoming properties), but got %q",
+			arrow,
 			arrow,
 		)
 	}
@@ -141,6 +142,14 @@ func parseArc(arrow, expr string) (*Arc, error) {
 
 // ParseProperty parses an expression string into a list of Arcs.
 func ParseProperty(expr string) ([]*Arc, error) {
+	trimmed := spaceNewLineReplacer.Replace(expr)
+	if trimmed != "" && !strings.HasPrefix(trimmed, "->") && !strings.HasPrefix(trimmed, "<-") {
+		return nil, status.Errorf(
+			codes.InvalidArgument,
+			"invalid property expression %q: property expressions must start with a direction arrow (e.g. ->name for outgoing properties, or <-containedInPlace for incoming properties)",
+			expr,
+		)
+	}
 	parts := splitExpr(expr)
 	if len(parts) == 1 {
 		// Handle "->" query, which is to get all properties

--- a/internal/server/v2/parser.go
+++ b/internal/server/v2/parser.go
@@ -72,8 +72,7 @@ func parseArc(arrow, expr string) (*Arc, error) {
 	default:
 		return nil, status.Errorf(
 			codes.InvalidArgument,
-			"invalid property arc %q: expression must start with a direction arrow (e.g. ->name for outgoing properties, or <-containedInPlace for incoming properties), but got %q",
-			arrow,
+			"invalid property arc %q: expression must start with a direction arrow (e.g. ->name for outgoing properties, or <-containedInPlace for incoming properties)",
 			arrow,
 		)
 	}

--- a/internal/server/v2/parser_test.go
+++ b/internal/server/v2/parser_test.go
@@ -338,6 +338,16 @@ func TestParseProperty(t *testing.T) {
 			},
 			true,
 		},
+		{
+			"name",
+			nil,
+			false,
+		},
+		{
+			"[name, description]",
+			nil,
+			false,
+		},
 	} {
 		result, err := ParseProperty(c.expr)
 		if !c.valid {


### PR DESCRIPTION
## Summary

This PR improves the error messages returned by `/v2/node` and `/v2/observation` when property expressions are missing the mandatory direction arrows (`->` or `<-`).

### Context & Problem
In the V2 REST API, callers and LLM agents passing property parameters like:
```json
{
  "nodes": ["country/USA", "country/FRA"],
  "property": "name"
}
```
receive the following opaque gRPC error:
> `arc string should start with arrow (-> or <-) but got name`

This occurs because `ParseProperty` splits on arrow delimiters, gets a single token `"name"`, and attempts to parse `"name"` as the direction delimiter itself. When clients (like Python scripts or LLM tool runners) encounter this error, it is difficult to quickly ascertain how the parameter should be formatted.

### Changes
1. **Early Validation in `ParseProperty`**: Check if non-empty property expressions start with `->` or `<-`. If not, return an actionable error message explaining that property expressions must start with a direction arrow with concrete examples:
   `invalid property expression "name": property expressions must start with a direction arrow (e.g. ->name for outgoing properties, or <-containedInPlace for incoming properties)`
2. **Clarified `parseArc` Error**: Updated `parseArc` error formatting with clearer contextual guidance.
3. **Unit Tests**: Added test cases in `TestParseProperty` covering property strings without direction arrows (e.g., `"name"` and `"[name, description]"`).