### PR TITLE
Optimize Root BulkVariableGroupInfo hash join for N <= 1

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -215,6 +215,7 @@ func main() {
 	var spannerClient spanner.SpannerClient
 	if shouldUseSpannerGraph {
 		queryConfig := spanner.QueryConfig{
+			BulkSVGBuildRightNodes:                         flags.BulkSVGBuildRightNodes,
 			ContainedInPlaceAncestorFirstTypes:             flags.ContainedInPlaceAncestorFirstTypes,
 			ContainedInPlacePreferTimeSeriesScanPlaceTypes: flags.ContainedInPlacePreferTimeSeriesScanPlaceTypes,
 			ContainedInPlaceEntityScanMinVariables:         flags.ContainedInPlaceEntityScanMinVariables,

--- a/internal/featureflags/featureflags.go
+++ b/internal/featureflags/featureflags.go
@@ -64,6 +64,8 @@ type Flags struct {
 	ContainedInPlacePreferTimeSeriesScanPlaceTypes []string `yaml:"ContainedInPlacePreferTimeSeriesScanPlaceTypes"`
 	// Minimum number of unique variables that selects an entity1 range scan for eligible child place types. Zero disables the optimization.
 	ContainedInPlaceEntityScanMinVariables int `yaml:"ContainedInPlaceEntityScanMinVariables"`
+	// StatVarGroup nodes that should build the TimeSeries side of filtered child-SVG hash joins for N <= 1 requests.
+	BulkSVGBuildRightNodes []string `yaml:"BulkSVGBuildRightNodes"`
 }
 
 // setDefaultValues creates a new Flags struct with default values.
@@ -86,6 +88,7 @@ func setDefaultValues() *Flags {
 		ContainedInPlaceAncestorFirstTypes:             []string{"Place"},
 		ContainedInPlacePreferTimeSeriesScanPlaceTypes: []string{"Place"},
 		ContainedInPlaceEntityScanMinVariables:         50,
+		BulkSVGBuildRightNodes:                         []string{"dc/g/Root"},
 	}
 }
 
@@ -143,6 +146,15 @@ func (f *Flags) validateFlagValues() error {
 	}
 	if f.ContainedInPlaceEntityScanMinVariables < 0 {
 		return fmt.Errorf("ContainedInPlaceEntityScanMinVariables must be non-negative")
+	}
+	for _, node := range f.BulkSVGBuildRightNodes {
+		trimmed := strings.TrimSpace(node)
+		if trimmed == "" {
+			return fmt.Errorf("BulkSVGBuildRightNodes must not contain empty values")
+		}
+		if trimmed != node {
+			return fmt.Errorf("BulkSVGBuildRightNodes must not contain surrounding whitespace")
+		}
 	}
 	return nil
 }

--- a/internal/featureflags/featureflags_test.go
+++ b/internal/featureflags/featureflags_test.go
@@ -62,6 +62,12 @@ func TestDefaultContainedInPlaceEntityScanMinVariables(t *testing.T) {
 	}
 }
 
+func TestDefaultBulkSVGBuildRightNodes(t *testing.T) {
+	if diff := cmp.Diff([]string{"dc/g/Root"}, setDefaultValues().BulkSVGBuildRightNodes); diff != "" {
+		t.Fatalf("BulkSVGBuildRightNodes mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestNewFlags(t *testing.T) {
 	testCases := []struct {
 		name        string
@@ -216,6 +222,49 @@ flags:
 			fileContent: `
 flags:
   ContainedInPlaceEntityScanMinVariables: -1
+`,
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "bulk SVG build-right nodes override",
+			fileContent: `
+flags:
+  BulkSVGBuildRightNodes:
+    - dc/g/Demographics
+`,
+			want: expectedFlags(func(f *Flags) {
+				f.BulkSVGBuildRightNodes = []string{"dc/g/Demographics"}
+			}),
+			wantErr: false,
+		},
+		{
+			name: "bulk SVG build-right nodes disabled",
+			fileContent: `
+flags:
+  BulkSVGBuildRightNodes: []
+`,
+			want: expectedFlags(func(f *Flags) {
+				f.BulkSVGBuildRightNodes = []string{}
+			}),
+			wantErr: false,
+		},
+		{
+			name: "validation error - empty bulk SVG build-right node",
+			fileContent: `
+flags:
+  BulkSVGBuildRightNodes:
+    - " "
+`,
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "validation error - padded bulk SVG build-right node",
+			fileContent: `
+flags:
+  BulkSVGBuildRightNodes:
+    - " dc/g/Root "
 `,
 			want:    nil,
 			wantErr: true,

--- a/internal/server/spanner/golden/query_builder/get_multientity_filtered_svg_default_existence_build_right.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_filtered_svg_default_existence_build_right.sql
@@ -1,0 +1,46 @@
+		SELECT
+			n.subject_id,
+			IFNULL(n.name, '') AS name,
+			e_counts.descendent_stat_var_count
+		FROM Node n
+		JOIN (
+			SELECT
+				e.object_id AS subject_id,
+				COUNT(DISTINCT e.subject_id) AS descendent_stat_var_count
+			FROM Edge e
+			JOIN@{
+					JOIN_METHOD=HASH_JOIN,
+					HASH_JOIN_BUILD_SIDE=BUILD_RIGHT
+				} (
+					SELECT ts.variable_measured
+					FROM (
+						SELECT t.variable_measured, t.entity1 AS entity, t.provenance
+						FROM TimeSeries AS t
+						WHERE t.entity1 = 'fireEvent/2026-03-26_0x2de63b0000000000'
+						UNION ALL
+						SELECT t.variable_measured, t.entity2 AS entity, t.provenance
+						FROM TimeSeries@{FORCE_INDEX=TimeSeriesByEntity2} AS t
+						WHERE t.entity2 = 'fireEvent/2026-03-26_0x2de63b0000000000'
+							AND t.entity2 IS NOT NULL
+						UNION ALL
+						SELECT t.variable_measured, t.entity3 AS entity, t.provenance
+						FROM TimeSeries@{FORCE_INDEX=TimeSeriesByEntity3} AS t
+						WHERE t.entity3 = 'fireEvent/2026-03-26_0x2de63b0000000000'
+							AND t.entity3 IS NOT NULL
+							AND t.entity2 IS NOT NULL
+					) AS ts
+					GROUP BY ts.variable_measured
+				) o ON o.variable_measured = e.subject_id
+			WHERE e.predicate = 'linkedMemberOf'
+				AND e.object_id IN (
+					SELECT DISTINCT subject_id
+					FROM Edge
+					WHERE object_id = 'dc/g/Root'
+						AND predicate = 'specializationOf'
+					UNION ALL
+					SELECT 'dc/g/Root' AS subject_id
+				)
+			GROUP BY
+				e.object_id
+		) e_counts
+			ON n.subject_id = e_counts.subject_id

--- a/internal/server/spanner/golden/query_builder_multientity_test.go
+++ b/internal/server/spanner/golden/query_builder_multientity_test.go
@@ -144,6 +144,108 @@ func TestMultiEntityGetFilteredSVGChildrenQuery(t *testing.T) {
 	}
 }
 
+func TestMultiEntityGetFilteredSVGChildrenQueryConfiguredBuildRight(t *testing.T) {
+	t.Parallel()
+
+	runQueryBuilderGoldenTest(t, "get_multientity_filtered_svg_default_existence_build_right.sql", func(ctx context.Context) (interface{}, error) {
+		builder, err := spanner.NewMultiEntityQueryBuilder(spanner.DefaultTableConfig(), spanner.QueryConfig{
+			BulkSVGBuildRightNodes: []string{"dc/g/Root"},
+		})
+		if err != nil {
+			return nil, err
+		}
+		return builder.GetFilteredSVGChildrenQuery(
+			"SVG",
+			"dc/g/Root",
+			[]string{"fireEvent/2026-03-26_0x2de63b0000000000"},
+			"",
+			0,
+			false,
+		)
+	})
+}
+
+func TestMultiEntityGetFilteredSVGChildrenQueryBuildRightSelection(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name                  string
+		template              string
+		node                  string
+		constrainedProvenance string
+		numEntitiesExistence  int
+		wantBuildRight        bool
+	}{
+		{
+			name:                 "configured node with default threshold",
+			template:             "SVG",
+			node:                 "dc/g/Root",
+			numEntitiesExistence: 0,
+			wantBuildRight:       true,
+		},
+		{
+			name:                 "configured node with threshold one",
+			template:             "SVG",
+			node:                 "dc/g/Root",
+			numEntitiesExistence: 1,
+			wantBuildRight:       true,
+		},
+		{
+			name:                 "unconfigured node with threshold one",
+			template:             "SVG",
+			node:                 "dc/g/AboutDataCommons",
+			numEntitiesExistence: 1,
+			wantBuildRight:       false,
+		},
+		{
+			name:                 "unconfigured node above threshold one",
+			template:             "SVG",
+			node:                 "dc/g/AboutDataCommons",
+			numEntitiesExistence: 2,
+			wantBuildRight:       true,
+		},
+		{
+			name:                 "configured node with direct StatVar template",
+			template:             "SV",
+			node:                 "dc/g/Root",
+			numEntitiesExistence: 1,
+			wantBuildRight:       false,
+		},
+		{
+			name:                  "configured node with provenance",
+			template:              "SVG",
+			node:                  "dc/g/Root",
+			constrainedProvenance: "dc/s/WorldBank",
+			numEntitiesExistence:  1,
+			wantBuildRight:        false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			builder, err := spanner.NewMultiEntityQueryBuilder(spanner.DefaultTableConfig(), spanner.QueryConfig{
+				BulkSVGBuildRightNodes: []string{"dc/g/Root"},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			stmt, err := builder.GetFilteredSVGChildrenQuery(
+				tc.template,
+				tc.node,
+				[]string{"country/USA"},
+				tc.constrainedProvenance,
+				tc.numEntitiesExistence,
+				false,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			gotBuildRight := strings.Contains(stmt.SQL, "HASH_JOIN_BUILD_SIDE=BUILD_RIGHT")
+			if gotBuildRight != tc.wantBuildRight {
+				t.Errorf("build-right selected = %t, want %t\nSQL:\n%s", gotBuildRight, tc.wantBuildRight, stmt.SQL)
+			}
+		})
+	}
+}
+
 // TestMultiEntityGetFilteredTopicChildrenQuery returns a query to get Topic children using multi-entity TimeSeries filters.
 func TestMultiEntityGetFilteredTopicChildrenQuery(t *testing.T) {
 	t.Parallel()

--- a/internal/server/spanner/query_builder_multientity.go
+++ b/internal/server/spanner/query_builder_multientity.go
@@ -304,7 +304,10 @@ func multiEntityDescendentStatVarsSlotsSQL(filterPlaces bool, stmts *MultiEntity
 // GetFilteredSVGChildrenQuery returns a query to get SVG children using multi-entity TimeSeries filters.
 func (b *multiEntityQueryBuilder) GetFilteredSVGChildrenQuery(template string, node string, constrainedPlaces []string, constrainedProvenance string, numEntitiesExistence int, includeDefinitions bool) (*spanner.Statement, error) {
 	stmts := b.statements
-	useBuildRight := template == templateSVG && len(constrainedPlaces) > 0 && numEntitiesExistence > 1 && constrainedProvenance == ""
+	useBuildRight := template == templateSVG &&
+		len(constrainedPlaces) > 0 &&
+		constrainedProvenance == "" &&
+		(numEntitiesExistence > 1 || slices.Contains(b.queryConfig.BulkSVGBuildRightNodes, node))
 	subquery := filterMultiEntityDescendentStatVarsQuery(constrainedPlaces, constrainedProvenance, numEntitiesExistence, useBuildRight, stmts)
 	subquery.Params["node"] = node
 

--- a/internal/server/spanner/query_config.go
+++ b/internal/server/spanner/query_config.go
@@ -22,6 +22,9 @@ import (
 
 // QueryConfig controls Spanner query-planning behavior.
 type QueryConfig struct {
+	// BulkSVGBuildRightNodes contains StatVarGroup nodes that should build the
+	// TimeSeries side of filtered child-SVG hash joins for N <= 1 requests.
+	BulkSVGBuildRightNodes []string
 	// ContainedInPlaceAncestorFirstTypes contains child place types that
 	// should filter by ancestor before type when the query builder supports
 	// that access path.
@@ -48,6 +51,15 @@ const (
 
 // Validate verifies that QueryConfig is safe to distribute to query builders.
 func (config QueryConfig) Validate() error {
+	for _, node := range config.BulkSVGBuildRightNodes {
+		trimmed := strings.TrimSpace(node)
+		if trimmed == "" {
+			return fmt.Errorf("QueryConfig: BulkSVGBuildRightNodes must not contain empty values")
+		}
+		if trimmed != node {
+			return fmt.Errorf("QueryConfig: BulkSVGBuildRightNodes must not contain surrounding whitespace")
+		}
+	}
 	if config.ContainedInPlaceEntityScanMinVariables < 0 {
 		return fmt.Errorf("QueryConfig: ContainedInPlaceEntityScanMinVariables must be non-negative")
 	}

--- a/internal/server/spanner/query_config_test.go
+++ b/internal/server/spanner/query_config_test.go
@@ -17,7 +17,10 @@ package spanner
 import "testing"
 
 func TestQueryConfig(t *testing.T) {
-	config := QueryConfig{ContainedInPlaceAncestorFirstTypes: []string{"Place"}}
+	config := QueryConfig{
+		BulkSVGBuildRightNodes:             []string{"dc/g/Root"},
+		ContainedInPlaceAncestorFirstTypes: []string{"Place"},
+	}
 	if err := config.Validate(); err != nil {
 		t.Fatal(err)
 	}
@@ -40,6 +43,18 @@ func TestQueryConfigValidation(t *testing.T) {
 		name   string
 		config QueryConfig
 	}{
+		{
+			name: "empty bulk SVG build-right node",
+			config: QueryConfig{
+				BulkSVGBuildRightNodes: []string{" "},
+			},
+		},
+		{
+			name: "padded bulk SVG build-right node",
+			config: QueryConfig{
+				BulkSVGBuildRightNodes: []string{" dc/g/Root "},
+			},
+		},
 		{
 			name: "empty ancestor-first type",
 			config: QueryConfig{


### PR DESCRIPTION
This follows the child-SVG hash-join optimization from #2041. That change
intentionally preserved the optimizer-selected build side for `N <= 1`
because those queries had not been profiled.

Production now has a high-frequency `BulkVariableGroupInfo` query for
`dc/g/Root` with one constrained fire-event entity and no
`HAVING COUNT(DISTINCT ...)` threshold. Mixer represents this query shape
with `numEntitiesExistence` equal to 0 or 1.

## Production impact

The production one-hour Query Insights summary showed:

| Metric | Value |
|---|---:|
| Executions | 43,559 |
| Average CPU | 1,257.67 ms |
| Average latency | 7,888.6 ms |
| Average rows returned | 0.84 |
| Average rows scanned | 371,248.35 |

This is approximately 12.1 queries per second and 16.17 billion rows scanned
during the hour.

Key Visualizer reported a moving hotspot over:

```text
InEdge(dc/g/Root,specializationOf)
    ->
InEdge(dc/g/Root,specializationOf\000)
```

With the optimizer-selected build side, Spanner first reads the Root child
groups, scans their `linkedMemberOf` membership ranges, and builds a hash
table containing approximately 770K membership rows. It performs this work
even when the constrained entity has no matching TimeSeries data.

## Change

- Add `BulkSVGBuildRightNodes` to the Spanner query configuration.
- Default the list to `dc/g/Root` in code so all environments receive the
  same behavior without duplicating it in environment YAML.
- For configured nodes, use `HASH_JOIN_BUILD_SIDE=BUILD_RIGHT` for
  place-constrained child-SVG queries with `N <= 1` and no provenance
  constraint.
- Preserve the existing unconditional build-right behavior for qualifying
  child-SVG queries with `N > 1`.
- Allow an environment to override the list or disable the extension with
  `BulkSVGBuildRightNodes: []`.
- Validate that configured node identifiers are non-empty and do not contain
  surrounding whitespace.

Building from the filtered TimeSeries result allows an empty TimeSeries side
to terminate the join before reading the graph-membership ranges. For a
sparse existing entity, Spanner still examines the membership index entries,
but it avoids building and processing a hash table containing approximately
770K membership rows.

## Performance impact

Controlled profiles ran against:

- Project: `datcom-store`
- Instance: `dc-graph-staging`
- Database: `dc_graph`
- Optimizer version: 8
- Statistics package: `auto_20260815_21_43_17UTC`

Each result below is the median of three alternating runs. The default and
build-right variants returned identical results.

| Parent and entity constraint | Metric | Default build | Build right | Impact |
|---|---|---:|---:|---:|
| Root, sparse fire event | Elapsed | 1,400 ms | 579.76 ms | 58.6% lower |
| | CPU | 2,710 ms | 794.06 ms | 70.7% lower |
| | Rows scanned | 770,313 | 770,313 | Unchanged |
| | Membership rows emitted | 770,296 | 2 | Reduced |
| | Hash buffer | 14,464 KiB | 64 KiB | Reduced |
| Root, TimeSeries-empty event | Elapsed | 1,360 ms | 56.52 ms | 95.8% lower |
| | CPU | 2,500 ms | 57.44 ms | 97.7% lower |
| | Rows scanned | 770,310 | 0 | Eliminated |
| Root, `country/USA` | Elapsed | 2,810 ms | 1,800 ms | 35.9% lower |
| | CPU | 3,930 ms | 3,190 ms | 18.8% lower |
| | Rows scanned | 974,918 | 974,918 | Unchanged |
| | Membership rows emitted | 770,296 | 412,139 | Reduced |
| | Hash buffer | 14,464 KiB | 3,712 KiB | Reduced |
| Root, USA + India + Canada | Elapsed | 3,550 ms | 2,120 ms | 40.3% lower |
| | CPU | 4,960 ms | 3,310 ms | 33.3% lower |
| | Rows scanned | 998,576 | 998,576 | Unchanged |
| | Membership rows emitted | 770,296 | 435,878 | Reduced |
| | Hash buffer | 14,464 KiB | 3,904 KiB | Reduced |
| About Data Commons, `country/USA` | Elapsed | 400.75 ms | 521.76 ms | **30.2% higher** |
| | CPU | 559.28 ms | 574.52 ms | 2.7% higher |
| | Rows scanned | 204,626 | 204,626 | Unchanged |
| | Main hash-join CPU | 243.96 ms | 402.39 ms | **65.0% higher** |
| | Hash buffer | 64 KiB | 3,712 KiB | **58x larger** |

In a representative sparse-event profile, changing only the hash-build side
also reduced observed data read from 56.0 MB to 38.7 MB and main hash-join CPU
from 964.99 ms to 1.89 ms.

The existing sparse-event case continues to scan the same membership entries.
The improvement comes from reducing hash-table construction, buffering, rows
emitted to downstream operators, and aggregation work. The TimeSeries-empty
case avoids the membership scan entirely because the build side is empty.

## Why this is not enabled globally

The narrow-parent benchmark is a counterexample to globally removing the
existing `numEntitiesExistence > 1` condition.

For `dc/g/AboutDataCommons`, the optimizer-selected plan builds from only 30
membership rows. Forcing build-right instead builds from the broad set of
variables available for USA. That increased elapsed time by 30.2%, main
hash-join CPU by 65.0%, and hash buffering from 64 KiB to 3,712 KiB.

The configured node list therefore extends the optimization only to parents
with matched evidence. Future nodes should be benchmarked before being added.

The change also does not force build-right for:

- direct-StatVar queries;
- Topic queries;
- provenance-constrained queries;
- queries without constrained places; or
- unconfigured `N <= 1` parents.

These shapes either have different graph-membership relationships or lack
evidence that the TimeSeries side is the smaller hash-build input.

## Non-goals

This change does not reduce physical membership scans for an existing entity.
Doing that would require a separate access-path experiment, such as starting
from filtered StatVars and probing the primary `Edge` table with an apply
join. That approach has not been validated and is not included here.

This change does not add indexes, modify the schema, force columnar scanning,
change aggregation semantics, or change the API response.

## Testing

- `go test ./internal/featureflags ./internal/server/spanner/golden ./internal/server/spanner ./cmd/...`
- `go test ./internal/server/spanner/golden -run '^TestMultiEntityGetFilteredSVGChildrenQuery(ConfiguredBuildRight|BuildRightSelection)?$' -count=1`
- `./run_test.sh -l`
- `git diff --check`

Query-builder coverage verifies:

- configured Root with the default `N = 0` uses build-right;
- configured Root with `N = 1` uses build-right;
- an unconfigured `N <= 1` parent preserves the optimizer-selected side;
- the existing `N > 1` behavior is preserved;
- direct-StatVar and provenance-constrained queries do not use this extension;
- the full Root N=0 SQL retains all three entity branches, contains the
  build-right hint, and has no threshold `HAVING` clause.

An emulator test was not added because the emulator cannot validate Cloud
Spanner's physical hash-build side, rows scanned, buffering, or planner
performance. The query-builder golden locks the generated SQL, while the
matched staging profiles validate the physical execution behavior.