### PR TITLE
Ignore remote errors in SDMX endpoints

### DIFF
--- a/internal/server/datasources/datasources.go
+++ b/internal/server/datasources/datasources.go
@@ -254,6 +254,10 @@ func (ds *DataSources) SdmxAvailability(ctx context.Context, in *sdmxpb.SdmxAvai
 		func(all []*sdmxpb.SdmxAvailabilityResult) (*sdmxpb.SdmxAvailabilityResult, error) {
 			values := map[string]bool{}
 			for _, result := range all {
+				// Skip nil results from data sources that encountered non-fatal errors or returned no data.
+				if result == nil {
+					continue
+				}
 				for _, value := range result.GetValues() {
 					if value != "" {
 						values[value] = true

--- a/internal/server/datasources/sdmx_availability_test.go
+++ b/internal/server/datasources/sdmx_availability_test.go
@@ -79,6 +79,22 @@ func TestSdmxAvailabilityMergesValues(t *testing.T) {
 	}
 }
 
+func TestSdmxAvailabilityMergesLocalResultWithNilRemoteResult(t *testing.T) {
+	ds := NewDataSources([]datasource.DataSource{
+		&availabilityDataSource{id: "local", values: []string{"country/USA", "geoId/06"}},
+		&availabilityDataSource{id: "remote", values: nil},
+	}, nil)
+
+	got, err := ds.SdmxAvailability(context.Background(), &sdmxpb.SdmxAvailabilityQuery{})
+	if err != nil {
+		t.Fatalf("SdmxAvailability() error = %v", err)
+	}
+	want := []string{"country/USA", "geoId/06"}
+	if diff := cmp.Diff(want, got.GetValues()); diff != "" {
+		t.Fatalf("SdmxAvailability() values mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestSdmxDataMergesIdenticalShapes(t *testing.T) {
 	shape := testSdmxShape([]string{datacommons.ComponentObservationAbout})
 	ds := NewDataSources([]datasource.DataSource{
@@ -125,6 +141,28 @@ func TestSdmxDataMergesLocalResultWithEmptyRemoteResult(t *testing.T) {
 	ds := NewDataSources([]datasource.DataSource{
 		&sdmxDataSource{id: "local", result: localResult},
 		&sdmxDataSource{id: "remote", result: &sdmxpb.SdmxDataResult{}},
+	}, nil)
+
+	got, err := ds.SdmxData(context.Background(), &sdmxpb.SdmxDataQuery{})
+	if err != nil {
+		t.Fatalf("SdmxData() error = %v", err)
+	}
+	if diff := cmp.Diff(localResult, got, protocmp.Transform()); diff != "" {
+		t.Fatalf("SdmxData() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestSdmxDataMergesLocalResultWithNilRemoteResult(t *testing.T) {
+	shape := testSdmxShape([]string{datacommons.ComponentObservationAbout})
+	localResult := &sdmxpb.SdmxDataResult{
+		Shape: shape,
+		Series: []*sdmxpb.SdmxTimeSeries{
+			{Dimensions: map[string]string{datacommons.ComponentVariableMeasured: "Count_Person"}},
+		},
+	}
+	ds := NewDataSources([]datasource.DataSource{
+		&sdmxDataSource{id: "local", result: localResult},
+		&sdmxDataSource{id: "remote", result: nil},
 	}, nil)
 
 	got, err := ds.SdmxData(context.Background(), &sdmxpb.SdmxDataQuery{})

--- a/internal/server/remote/client.go
+++ b/internal/server/remote/client.go
@@ -17,6 +17,7 @@ package remote
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -154,7 +155,13 @@ func (rc *RemoteClient) SdmxData(req *sdmxpb.SdmxDataQuery) (*sdmxpb.SdmxDataRes
 	resp := &sdmxpb.SdmxDataResult{}
 	err := util.FetchRemote(rc.metadata, rc.httpClient, "/v2/internal/sdmx/data", req, resp)
 	if err != nil {
-		return nil, err
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, err
+		}
+		// Suppress non-cancellation errors from remote mixer so that upstream failures
+		// (e.g. 400 constraint mismatch, 404, or 500) do not cancel concurrent local data sources.
+		slog.Warn("RemoteClient: failed to fetch remote SDMX data, ignoring remote error", "error", err)
+		return nil, nil
 	}
 	return resp, nil
 }
@@ -163,7 +170,13 @@ func (rc *RemoteClient) SdmxAvailability(req *sdmxpb.SdmxAvailabilityQuery) (*sd
 	resp := &sdmxpb.SdmxAvailabilityResult{}
 	err := util.FetchRemote(rc.metadata, rc.httpClient, "/v2/internal/sdmx/availability", req, resp)
 	if err != nil {
-		return nil, err
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, err
+		}
+		// Suppress non-cancellation errors from remote mixer so that upstream failures
+		// (e.g. 400 constraint mismatch, 404, or 500) do not cancel concurrent local data sources.
+		slog.Warn("RemoteClient: failed to fetch remote SDMX availability, ignoring remote error", "error", err)
+		return nil, nil
 	}
 	return resp, nil
 }

--- a/internal/server/remote/client_test.go
+++ b/internal/server/remote/client_test.go
@@ -20,6 +20,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	sdmxpb "github.com/datacommonsorg/mixer/internal/proto/sdmx"
 	pbv2 "github.com/datacommonsorg/mixer/internal/proto/v2"
 	"github.com/datacommonsorg/mixer/internal/server/resource"
 	"google.golang.org/grpc/metadata"
@@ -93,5 +94,58 @@ func TestRemoteClient_Observation_SurfaceHeader(t *testing.T) {
 	}
 	if receivedRemote != "true" {
 		t.Errorf("expected X-Remote header %q, got %q", "true", receivedRemote)
+	}
+}
+
+func TestRemoteClient_Sdmx_ErrorTolerance(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		wantNil    bool
+	}{
+		{
+			name:       "success 200",
+			statusCode: http.StatusOK,
+			body:       `{"series":[{"dimensions":{"variableMeasured":"Count_Person"}}]}`,
+			wantNil:    false,
+		},
+		{
+			name:       "remote error 400",
+			statusCode: http.StatusBadRequest,
+			body:       `{"error":"unsupported component filter"}`,
+			wantNil:    true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tc.statusCode)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer ts.Close()
+
+			meta := &resource.Metadata{
+				RemoteMixerDomain: ts.URL,
+				RemoteMixerAPIKey: "test-api-key",
+			}
+			client, err := NewRemoteClient(meta)
+			if err != nil {
+				t.Fatalf("NewRemoteClient failed: %v", err)
+			}
+
+			got, err := client.SdmxData(&sdmxpb.SdmxDataQuery{})
+			if err != nil {
+				t.Fatalf("client.SdmxData() unexpected error = %v", err)
+			}
+			if tc.wantNil && got != nil {
+				t.Errorf("client.SdmxData() = %v, want nil", got)
+			}
+			if !tc.wantNil && got == nil {
+				t.Errorf("client.SdmxData() = nil, want non-nil result")
+			}
+		})
 	}
 }


### PR DESCRIPTION
### Problem
In federated setups, upstream errors (e.g., HTTP 400 from unsupported component constraints, 404, or 500) from the remote mixer caused the entire federated SDMX query to fail with HTTP 500 (`codes.Internal`), aborting concurrent local Spanner queries.

### Changes
- Updated `RemoteClient.SdmxData` and `RemoteClient.SdmxAvailability` to suppress non-cancellation errors, log warnings, and return `nil, nil`.
- Added nil checks during availability result merging in `DataSources.SdmxAvailability`.

### Verification

#### 1. Unsupported component constraint (`country` on a stat var with only `sex` dimension)
```bash
curl -g -i "http://localhost:8081/sdmx/v3/data/dataflow/DC/DF_OBS/1.0.0/*?c[variableMeasured]=who/Adult_curr_cig_smokers_by_sex&c[country]=country/ALB"
```
* **Before**: HTTP 500 (`{"code":13,"message":"Internal server error occurred while processing the request."}`)
* **After**: HTTP 400 (`{"code":3,"message":"unsupported SDMX component filter \"country\"; filterable components are [...]"}`)

#### 2. Query with valid local dimension (`sex=country/ALB`)
```bash
curl -g -i "http://localhost:8081/sdmx/v3/data/dataflow/DC/DF_OBS/1.0.0/*?c[variableMeasured]=who/Adult_curr_cig_smokers_by_sex&c[sex]=country/ALB"
```
* **Before**: HTTP 500 (local Spanner query cancelled when remote failed)
* **After**: HTTP 200 (returns observations from local Spanner as CSV)