### PR TITLE
Thread context to FetchRemote and capture remote error response bodies

### DIFF
--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -100,7 +100,7 @@ func (s *Server) GetRelatedLocations(
 		s.metadata.RemoteMixerDomain != "" {
 		remoteResp := &pb.GetRelatedLocationsResponse{}
 		if err := util.FetchRemote(
-			s.metadata, s.httpClient, "/v1/place/related", in, remoteResp); err != nil {
+			ctx, s.metadata, s.httpClient, "/v1/place/related", in, remoteResp); err != nil {
 			return nil, err
 		}
 		return remoteResp, nil
@@ -120,7 +120,7 @@ func (s *Server) getLocationsRankings(
 		s.metadata.RemoteMixerDomain != "" {
 		remoteResp := &pb.GetLocationsRankingsResponse{}
 		if err := util.FetchRemote(
-			s.metadata, s.httpClient, remoteAPIPath, in, remoteResp); err != nil {
+			ctx, s.metadata, s.httpClient, remoteAPIPath, in, remoteResp); err != nil {
 			return nil, err
 		}
 		return remoteResp, nil

--- a/internal/server/handler_v1.go
+++ b/internal/server/handler_v1.go
@@ -83,6 +83,7 @@ func (s *Server) BulkPlaceInfo(
 		if len(in.Nodes) > 0 {
 			remoteResp := &pbv1.BulkPlaceInfoResponse{}
 			if err := util.FetchRemote(
+				ctx,
 				s.metadata,
 				s.httpClient,
 				"/v1/bulk/info/place",
@@ -130,7 +131,7 @@ func (s *Server) fetchAndMergeBulkVariableInfo(
 
 	if s.metadata.RemoteMixerDomain != "" {
 		errGroup.Go(func() error {
-			remoteResponse, err := remoteBulkVariableInfoFunc(s, in, remoteAPIPath)
+			remoteResponse, err := remoteBulkVariableInfoFunc(errCtx, s, in, remoteAPIPath)
 			if err != nil {
 				return err
 			}
@@ -182,6 +183,7 @@ func (s *Server) fetchAndMergeBulkVariableGroupInfo(
 		}
 		remoteResp := &pbv1.BulkVariableGroupInfoResponse{}
 		if err := util.FetchRemote(
+			ctx,
 			s.metadata,
 			s.httpClient,
 			remoteAPIPath,
@@ -325,7 +327,7 @@ func (s *Server) BulkObservationDatesLinked(
 		errGroup.Go(func() error {
 			remoteResp := &pbv1.BulkObservationDatesLinkedResponse{}
 			err := util.FetchRemote(
-				s.metadata, s.httpClient, "/v1/bulk/observation-dates/linked", in, remoteResp)
+				errCtx, s.metadata, s.httpClient, "/v1/bulk/observation-dates/linked", in, remoteResp)
 			if err != nil {
 				return err
 			}
@@ -355,6 +357,7 @@ func (s *Server) PlacePage(ctx context.Context, in *pbv1.PlacePageRequest) (
 	if len(localResp.GetStatVarSeries()) == 0 && s.metadata.RemoteMixerDomain != "" {
 		remoteResp := &pbv1.PlacePageResponse{}
 		if err := util.FetchRemote(
+			ctx,
 			s.metadata,
 			s.httpClient,
 			"/v1/internal/page/place",
@@ -379,6 +382,7 @@ func (s *Server) VariableAncestors(
 	if len(localResp.Ancestors) == 0 && s.metadata.RemoteMixerDomain != "" {
 		remoteResp := &pbv1.VariableAncestorsResponse{}
 		if err := util.FetchRemote(
+			ctx,
 			s.metadata,
 			s.httpClient,
 			"/v1/variable/ancestors",
@@ -421,6 +425,7 @@ func (s *Server) SearchStatVar(
 	remoteResp := &pb.SearchStatVarResponse{}
 	if s.metadata.RemoteMixerDomain != "" {
 		if err := util.FetchRemote(
+			ctx,
 			s.metadata,
 			s.httpClient,
 			"/v1/variable/search",

--- a/internal/server/handler_v1_func.go
+++ b/internal/server/handler_v1_func.go
@@ -17,6 +17,8 @@
 package server
 
 import (
+	"context"
+
 	pbv1 "github.com/datacommonsorg/mixer/internal/proto/v1"
 	"github.com/datacommonsorg/mixer/internal/server/v1/info"
 	"github.com/datacommonsorg/mixer/internal/util"
@@ -25,12 +27,14 @@ import (
 var localBulkVariableInfoFunc = info.BulkVariableInfo
 
 var remoteBulkVariableInfoFunc = func(
+	ctx context.Context,
 	s *Server,
 	remoteReq *pbv1.BulkVariableInfoRequest,
 	remoteAPIPath string,
 ) (*pbv1.BulkVariableInfoResponse, error) {
 	remoteResp := &pbv1.BulkVariableInfoResponse{}
 	return remoteResp, util.FetchRemote(
+		ctx,
 		s.metadata,
 		s.httpClient,
 		remoteAPIPath,

--- a/internal/server/handler_v1_test.go
+++ b/internal/server/handler_v1_test.go
@@ -222,7 +222,7 @@ func TestBulkVariableInfo(t *testing.T) {
 		localBulkVariableInfoFunc = func(_ context.Context, _ *pbv1.BulkVariableInfoRequest, _ *store.Store) (*pbv1.BulkVariableInfoResponse, error) {
 			return tc.localResponse, nil
 		}
-		remoteBulkVariableInfoFunc = func(_ *Server, _ *pbv1.BulkVariableInfoRequest, remoteAPIPath string) (*pbv1.BulkVariableInfoResponse, error) {
+		remoteBulkVariableInfoFunc = func(_ context.Context, _ *Server, _ *pbv1.BulkVariableInfoRequest, remoteAPIPath string) (*pbv1.BulkVariableInfoResponse, error) {
 			expectedPath := "/v1/bulk/info/variable"
 			if remoteAPIPath != expectedPath {
 				t.Errorf("%s: expected remoteAPIPath to be %s, got %s", tc.desc, expectedPath, remoteAPIPath)

--- a/internal/server/handler_v2.go
+++ b/internal/server/handler_v2.go
@@ -89,7 +89,7 @@ func (s *Server) V2Resolve(
 	if callRemote {
 		errGroup.Go(func() error {
 			remoteResp := &pbv2.ResolveResponse{}
-			err := util.FetchRemote(s.metadata, s.httpClient, "/v2/resolve", normalizedResolveRequest.Request, remoteResp)
+			err := util.FetchRemote(errCtx, s.metadata, s.httpClient, "/v2/resolve", normalizedResolveRequest.Request, remoteResp)
 			if err != nil {
 				return err
 			}
@@ -206,7 +206,7 @@ func (s *Server) V2Node(ctx context.Context, in *pbv2.NodeRequest) (
 		if s.metadata.RemoteMixerDomain != "" {
 			errGroup.Go(func() error {
 				remoteResp := &pbv2.NodeResponse{}
-				err := util.FetchRemote(s.metadata, s.httpClient, "/v2/node", in, remoteResp)
+				err := util.FetchRemote(errCtx, s.metadata, s.httpClient, "/v2/node", in, remoteResp)
 				if err != nil {
 					return err
 				}
@@ -256,7 +256,7 @@ func (s *Server) V2Node(ctx context.Context, in *pbv2.NodeRequest) (
 				// Call remote.
 				remoteResp := &pbv2.NodeResponse{}
 				if err := util.FetchRemote(
-					s.metadata, s.httpClient, "/v2/node", in, remoteResp); err != nil {
+					errCtx, s.metadata, s.httpClient, "/v2/node", in, remoteResp); err != nil {
 					return err
 				}
 				remoteRespChan <- remoteResp
@@ -346,7 +346,7 @@ func (s *Server) handleV2Event(
 	if s.metadata.RemoteMixerDomain != "" {
 		errGroup.Go(func() error {
 			remoteResp := &pbv2.EventResponse{}
-			err := util.FetchRemote(s.metadata, s.httpClient, "/v2/event", in, remoteResp)
+			err := util.FetchRemote(errCtx, s.metadata, s.httpClient, "/v2/event", in, remoteResp)
 			if err != nil {
 				return err
 			}
@@ -491,7 +491,7 @@ func (s *Server) FilterStatVarsByEntity(
 
 	v2StartTime := time.Now()
 
-	errGroup, _ := errgroup.WithContext(ctx)
+	errGroup, errCtx := errgroup.WithContext(ctx)
 
 	localResponseChan := make(chan *pb.FilterStatVarsByEntityResponse, 1)
 	remoteResponseChan := make(chan *pb.FilterStatVarsByEntityResponse, 1)
@@ -509,6 +509,7 @@ func (s *Server) FilterStatVarsByEntity(
 	if s.metadata.RemoteMixerDomain != "" {
 		errGroup.Go(func() error {
 			if err := util.FetchRemote(
+				errCtx,
 				s.metadata,
 				s.httpClient,
 				"/v2/variable/filter",

--- a/internal/server/handler_v2.go
+++ b/internal/server/handler_v2.go
@@ -497,7 +497,7 @@ func (s *Server) FilterStatVarsByEntity(
 	remoteResponseChan := make(chan *pb.FilterStatVarsByEntityResponse, 1)
 
 	errGroup.Go(func() error {
-		localResponse, err := search.FilterStatVarsByEntity(ctx, in, s.store, s.cachedata.Load())
+		localResponse, err := search.FilterStatVarsByEntity(errCtx, in, s.store, s.cachedata.Load())
 		if err != nil {
 			return err
 		}

--- a/internal/server/remote/client.go
+++ b/internal/server/remote/client.go
@@ -50,14 +50,6 @@ func NewRemoteClient(metadata *resource.Metadata) (*RemoteClient, error) {
 	}, nil
 }
 
-func getSurface(ctx context.Context) string {
-	if ctx == nil {
-		return ""
-	}
-	surface, _ := util.GetMetadata(ctx)
-	return surface
-}
-
 func (rc *RemoteClient) Node(ctx context.Context, req *pbv2.NodeRequest) (*pbv2.NodeResponse, error) {
 	err := updateNodeRequestNextToken(req, rc.id)
 	if err != nil {
@@ -65,7 +57,7 @@ func (rc *RemoteClient) Node(ctx context.Context, req *pbv2.NodeRequest) (*pbv2.
 	}
 
 	resp := &pbv2.NodeResponse{}
-	err = util.FetchRemote(rc.metadata, rc.httpClient, "/v2/node", req, resp, getSurface(ctx))
+	err = util.FetchRemote(ctx, rc.metadata, rc.httpClient, "/v2/node", req, resp)
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +72,7 @@ func (rc *RemoteClient) Node(ctx context.Context, req *pbv2.NodeRequest) (*pbv2.
 
 func (rc *RemoteClient) Observation(ctx context.Context, req *pbv2.ObservationRequest) (*pbv2.ObservationResponse, error) {
 	resp := &pbv2.ObservationResponse{}
-	err := util.FetchRemote(rc.metadata, rc.httpClient, "/v2/observation", req, resp, getSurface(ctx))
+	err := util.FetchRemote(ctx, rc.metadata, rc.httpClient, "/v2/observation", req, resp)
 	if err != nil {
 		return nil, err
 	}
@@ -89,7 +81,7 @@ func (rc *RemoteClient) Observation(ctx context.Context, req *pbv2.ObservationRe
 
 func (rc *RemoteClient) NodeSearch(ctx context.Context, req *pbv2.NodeSearchRequest) (*pbv2.NodeSearchResponse, error) {
 	resp := &pbv2.NodeSearchResponse{}
-	err := util.FetchRemote(rc.metadata, rc.httpClient, "/v3/node_search", req, resp, getSurface(ctx))
+	err := util.FetchRemote(ctx, rc.metadata, rc.httpClient, "/v3/node_search", req, resp)
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +90,7 @@ func (rc *RemoteClient) NodeSearch(ctx context.Context, req *pbv2.NodeSearchRequ
 
 func (rc *RemoteClient) Resolve(ctx context.Context, req *pbv2.ResolveRequest) (*pbv2.ResolveResponse, error) {
 	resp := &pbv2.ResolveResponse{}
-	err := util.FetchRemote(rc.metadata, rc.httpClient, "/v2/resolve", req, resp, getSurface(ctx))
+	err := util.FetchRemote(ctx, rc.metadata, rc.httpClient, "/v2/resolve", req, resp)
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +99,7 @@ func (rc *RemoteClient) Resolve(ctx context.Context, req *pbv2.ResolveRequest) (
 
 func (rc *RemoteClient) Sparql(ctx context.Context, req *pb.SparqlRequest) (*pb.QueryResponse, error) {
 	resp := &pb.QueryResponse{}
-	err := util.FetchRemote(rc.metadata, rc.httpClient, "/v2/sparql", req, resp, getSurface(ctx))
+	err := util.FetchRemote(ctx, rc.metadata, rc.httpClient, "/v2/sparql", req, resp)
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +108,7 @@ func (rc *RemoteClient) Sparql(ctx context.Context, req *pb.SparqlRequest) (*pb.
 
 func (rc *RemoteClient) Event(ctx context.Context, req *pbv2.EventRequest) (*pbv2.EventResponse, error) {
 	resp := &pbv2.EventResponse{}
-	err := util.FetchRemote(rc.metadata, rc.httpClient, "/v2/event", req, resp, getSurface(ctx))
+	err := util.FetchRemote(ctx, rc.metadata, rc.httpClient, "/v2/event", req, resp)
 	if err != nil {
 		return nil, err
 	}
@@ -125,7 +117,7 @@ func (rc *RemoteClient) Event(ctx context.Context, req *pbv2.EventRequest) (*pbv
 
 func (rc *RemoteClient) BulkVariableInfo(ctx context.Context, req *pbv1.BulkVariableInfoRequest) (*pbv1.BulkVariableInfoResponse, error) {
 	resp := &pbv1.BulkVariableInfoResponse{}
-	err := util.FetchRemote(rc.metadata, rc.httpClient, "/v2/bulk/info/variable", req, resp, getSurface(ctx))
+	err := util.FetchRemote(ctx, rc.metadata, rc.httpClient, "/v2/bulk/info/variable", req, resp)
 	if err != nil {
 		return nil, err
 	}
@@ -134,7 +126,7 @@ func (rc *RemoteClient) BulkVariableInfo(ctx context.Context, req *pbv1.BulkVari
 
 func (rc *RemoteClient) BulkVariableGroupInfo(ctx context.Context, req *pbv1.BulkVariableGroupInfoRequest) (*pbv1.BulkVariableGroupInfoResponse, error) {
 	resp := &pbv1.BulkVariableGroupInfoResponse{}
-	err := util.FetchRemote(rc.metadata, rc.httpClient, "/v2/bulk/info/variable-group", req, resp, getSurface(ctx))
+	err := util.FetchRemote(ctx, rc.metadata, rc.httpClient, "/v2/bulk/info/variable-group", req, resp)
 	if err != nil {
 		return nil, err
 	}
@@ -143,7 +135,7 @@ func (rc *RemoteClient) BulkVariableGroupInfo(ctx context.Context, req *pbv1.Bul
 
 func (rc *RemoteClient) FilterStatVarsByEntity(ctx context.Context, req *pb.FilterStatVarsByEntityRequest) (*pb.FilterStatVarsByEntityResponse, error) {
 	resp := &pb.FilterStatVarsByEntityResponse{}
-	err := util.FetchRemote(rc.metadata, rc.httpClient, "/v2/variable/filter", req, resp, getSurface(ctx))
+	err := util.FetchRemote(ctx, rc.metadata, rc.httpClient, "/v2/variable/filter", req, resp)
 	if err != nil {
 		slog.Error("Failed to fetch remote variable filter", "error", err)
 		return nil, err
@@ -151,31 +143,37 @@ func (rc *RemoteClient) FilterStatVarsByEntity(ctx context.Context, req *pb.Filt
 	return resp, nil
 }
 
-func (rc *RemoteClient) SdmxData(req *sdmxpb.SdmxDataQuery) (*sdmxpb.SdmxDataResult, error) {
+func (rc *RemoteClient) SdmxData(ctx context.Context, req *sdmxpb.SdmxDataQuery) (*sdmxpb.SdmxDataResult, error) {
 	resp := &sdmxpb.SdmxDataResult{}
-	err := util.FetchRemote(rc.metadata, rc.httpClient, "/v2/internal/sdmx/data", req, resp)
+	err := util.FetchRemote(ctx, rc.metadata, rc.httpClient, "/v2/internal/sdmx/data", req, resp)
 	if err != nil {
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return nil, err
 		}
 		// Suppress non-cancellation errors from remote mixer so that upstream failures
 		// (e.g. 400 constraint mismatch, 404, or 500) do not cancel concurrent local data sources.
-		slog.Warn("RemoteClient: failed to fetch remote SDMX data, ignoring remote error", "error", err)
+		slog.Warn("RemoteClient: failed to fetch remote SDMX data, ignoring remote error",
+			"error", err,
+			"path", "/v2/internal/sdmx/data",
+		)
 		return nil, nil
 	}
 	return resp, nil
 }
 
-func (rc *RemoteClient) SdmxAvailability(req *sdmxpb.SdmxAvailabilityQuery) (*sdmxpb.SdmxAvailabilityResult, error) {
+func (rc *RemoteClient) SdmxAvailability(ctx context.Context, req *sdmxpb.SdmxAvailabilityQuery) (*sdmxpb.SdmxAvailabilityResult, error) {
 	resp := &sdmxpb.SdmxAvailabilityResult{}
-	err := util.FetchRemote(rc.metadata, rc.httpClient, "/v2/internal/sdmx/availability", req, resp)
+	err := util.FetchRemote(ctx, rc.metadata, rc.httpClient, "/v2/internal/sdmx/availability", req, resp)
 	if err != nil {
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return nil, err
 		}
 		// Suppress non-cancellation errors from remote mixer so that upstream failures
 		// (e.g. 400 constraint mismatch, 404, or 500) do not cancel concurrent local data sources.
-		slog.Warn("RemoteClient: failed to fetch remote SDMX availability, ignoring remote error", "error", err)
+		slog.Warn("RemoteClient: failed to fetch remote SDMX availability, ignoring remote error",
+			"error", err,
+			"path", "/v2/internal/sdmx/availability",
+		)
 		return nil, nil
 	}
 	return resp, nil

--- a/internal/server/remote/client.go
+++ b/internal/server/remote/client.go
@@ -156,7 +156,7 @@ func (rc *RemoteClient) SdmxData(ctx context.Context, req *sdmxpb.SdmxDataQuery)
 			"error", err,
 			"path", "/v2/internal/sdmx/data",
 		)
-		return nil, nil
+		return &sdmxpb.SdmxDataResult{}, nil
 	}
 	return resp, nil
 }
@@ -174,7 +174,7 @@ func (rc *RemoteClient) SdmxAvailability(ctx context.Context, req *sdmxpb.SdmxAv
 			"error", err,
 			"path", "/v2/internal/sdmx/availability",
 		)
-		return nil, nil
+		return &sdmxpb.SdmxAvailabilityResult{}, nil
 	}
 	return resp, nil
 }

--- a/internal/server/remote/client_test.go
+++ b/internal/server/remote/client_test.go
@@ -26,38 +26,6 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-func TestGetSurface(t *testing.T) {
-	tests := []struct {
-		name string
-		ctx  context.Context
-		want string
-	}{
-		{
-			name: "nil context",
-			ctx:  nil,
-			want: "",
-		},
-		{
-			name: "empty background context",
-			ctx:  context.Background(),
-			want: "",
-		},
-		{
-			name: "context with x-surface header",
-			ctx:  metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-surface", "mcp-server")),
-			want: "mcp-server",
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := getSurface(tc.ctx); got != tc.want {
-				t.Errorf("getSurface(%v) = %q, want %q", tc.ctx, got, tc.want)
-			}
-		})
-	}
-}
-
 func TestRemoteClient_Observation_SurfaceHeader(t *testing.T) {
 	var receivedSurface string
 	var receivedRemote string
@@ -136,7 +104,7 @@ func TestRemoteClient_Sdmx_ErrorTolerance(t *testing.T) {
 				t.Fatalf("NewRemoteClient failed: %v", err)
 			}
 
-			got, err := client.SdmxData(&sdmxpb.SdmxDataQuery{})
+			got, err := client.SdmxData(context.Background(), &sdmxpb.SdmxDataQuery{})
 			if err != nil {
 				t.Fatalf("client.SdmxData() unexpected error = %v", err)
 			}

--- a/internal/server/remote/client_test.go
+++ b/internal/server/remote/client_test.go
@@ -70,19 +70,19 @@ func TestRemoteClient_Sdmx_ErrorTolerance(t *testing.T) {
 		name       string
 		statusCode int
 		body       string
-		wantNil    bool
+		wantSeries int
 	}{
 		{
 			name:       "success 200",
 			statusCode: http.StatusOK,
 			body:       `{"series":[{"dimensions":{"variableMeasured":"Count_Person"}}]}`,
-			wantNil:    false,
+			wantSeries: 1,
 		},
 		{
 			name:       "remote error 400",
 			statusCode: http.StatusBadRequest,
 			body:       `{"error":"unsupported component filter"}`,
-			wantNil:    true,
+			wantSeries: 0,
 		},
 	}
 
@@ -108,11 +108,11 @@ func TestRemoteClient_Sdmx_ErrorTolerance(t *testing.T) {
 			if err != nil {
 				t.Fatalf("client.SdmxData() unexpected error = %v", err)
 			}
-			if tc.wantNil && got != nil {
-				t.Errorf("client.SdmxData() = %v, want nil", got)
+			if got == nil {
+				t.Fatalf("client.SdmxData() returned nil result, want non-nil")
 			}
-			if !tc.wantNil && got == nil {
-				t.Errorf("client.SdmxData() = nil, want non-nil result")
+			if len(got.GetSeries()) != tc.wantSeries {
+				t.Errorf("len(client.SdmxData().GetSeries()) = %d, want %d", len(got.GetSeries()), tc.wantSeries)
 			}
 		})
 	}

--- a/internal/server/remote/datasource.go
+++ b/internal/server/remote/datasource.go
@@ -46,8 +46,6 @@ func (rds *RemoteDataSource) Id() string {
 
 func (rds *RemoteDataSource) Node(ctx context.Context, req *pbv2.NodeRequest, pageSize int) (*pbv2.NodeResponse, error) {
 	// The remote datasource currently calls V2 node, which does not use custom pageSize.
-	// TODO: Configure a bounded HTTP timeout in FetchRemote so remote requests honor
-	// cancellation and deadlines.
 	return rds.client.Node(ctx, req)
 }
 
@@ -80,11 +78,11 @@ func (rds *RemoteDataSource) BulkVariableGroupInfo(ctx context.Context, req *pbv
 }
 
 func (rds *RemoteDataSource) SdmxData(ctx context.Context, req *sdmxpb.SdmxDataQuery) (*sdmxpb.SdmxDataResult, error) {
-	return rds.client.SdmxData(req)
+	return rds.client.SdmxData(ctx, req)
 }
 
 func (rds *RemoteDataSource) SdmxAvailability(ctx context.Context, req *sdmxpb.SdmxAvailabilityQuery) (*sdmxpb.SdmxAvailabilityResult, error) {
-	return rds.client.SdmxAvailability(req)
+	return rds.client.SdmxAvailability(ctx, req)
 }
 
 func (rds *RemoteDataSource) FilterStatVarsByEntity(ctx context.Context, req *pb.FilterStatVarsByEntityRequest) (*pb.FilterStatVarsByEntityResponse, error) {

--- a/internal/server/statvar/fetcher/formula_fetcher.go
+++ b/internal/server/statvar/fetcher/formula_fetcher.go
@@ -134,7 +134,7 @@ func FetchFormulas(
 					NextToken: nextToken,
 				}
 				statCalResp := &pbv2.NodeResponse{}
-				err := util.FetchRemote(metadata, &http.Client{}, v2node, statCalReq, statCalResp)
+				err := util.FetchRemote(errCtx, metadata, &http.Client{}, v2node, statCalReq, statCalResp)
 				if err != nil {
 					return err
 				}
@@ -156,7 +156,7 @@ func FetchFormulas(
 					Property:  "->[" + outputProperty + ", " + inputPropertyExpression + "]",
 					NextToken: nextToken,
 				}
-				err := util.FetchRemote(metadata, &http.Client{}, v2node, propReq, currResp)
+				err := util.FetchRemote(errCtx, metadata, &http.Client{}, v2node, propReq, currResp)
 				if err != nil {
 					return err
 				}

--- a/internal/server/v2/observation/observation.go
+++ b/internal/server/v2/observation/observation.go
@@ -267,12 +267,12 @@ func ObservationInternal(
 		errGroup.Go(func() error {
 			remoteResp := &pbv2.ObservationResponse{}
 			err := util.FetchRemote(
+				errCtx,
 				metadata,
 				httpClient,
 				"/v2/observation",
 				in,
 				remoteResp,
-				surface,
 			)
 			if err != nil {
 				return err

--- a/internal/server/v2/shared/contained_in_test.go
+++ b/internal/server/v2/shared/contained_in_test.go
@@ -95,7 +95,7 @@ func TestFetchChildPlaces(t *testing.T) {
 		getPlacesIn = func(_ context.Context, _ *store.Store, _ []string, _ string) (map[string][]string, error) {
 			return tc.storeResponse, nil
 		}
-		fetchRemote = func(_ *resource.Metadata, _ *http.Client, _ string, _ *pbv2.NodeRequest) (*pbv2.NodeResponse, error) {
+		fetchRemote = func(_ context.Context, _ *resource.Metadata, _ *http.Client, _ string, _ *pbv2.NodeRequest) (*pbv2.NodeResponse, error) {
 			return tc.remoteMixerResponse, nil
 		}
 		if got, _ := FetchChildPlaces(ctx, s, metadata, httpClient, tc.remoteMixer, tc.ancestor, tc.childType); !reflect.DeepEqual(got, tc.want) {

--- a/internal/server/v2/shared/shared.go
+++ b/internal/server/v2/shared/shared.go
@@ -62,13 +62,14 @@ var (
 )
 
 func fetchRemoteWrapper(
+	ctx context.Context,
 	metadata *resource.Metadata,
 	httpClient *http.Client,
 	apiPath string,
 	remoteReq *pbv2.NodeRequest,
 ) (*pbv2.NodeResponse, error) {
 	remoteResp := &pbv2.NodeResponse{}
-	err := util.FetchRemote(metadata, httpClient, apiPath, remoteReq, remoteResp)
+	err := util.FetchRemote(ctx, metadata, httpClient, apiPath, remoteReq, remoteResp)
 	if err != nil {
 		return nil, err
 	}
@@ -84,6 +85,7 @@ func storeFetchChildPlaces(
 }
 
 func remoteMixerFetchChildPlaces(
+	ctx context.Context,
 	metadata *resource.Metadata,
 	httpClient *http.Client,
 	ancestor, childType string,
@@ -92,7 +94,7 @@ func remoteMixerFetchChildPlaces(
 		Nodes:    []string{ancestor},
 		Property: fmt.Sprintf("<-containedInPlace+{typeOf:%s}", childType),
 	}
-	return fetchRemote(metadata, httpClient, "/v2/node", remoteReq)
+	return fetchRemote(ctx, metadata, httpClient, "/v2/node", remoteReq)
 }
 
 // FetchChildPlaces fetches child places
@@ -119,7 +121,7 @@ func FetchChildPlaces(
 
 	if remoteMixer != "" {
 		errGroup.Go(func() error {
-			remoteMixerResponse, err := remoteMixerFetchChildPlaces(metadata, httpClient, ancestor, childType)
+			remoteMixerResponse, err := remoteMixerFetchChildPlaces(errCtx, metadata, httpClient, ancestor, childType)
 			if err != nil {
 				return err
 			}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -671,21 +671,26 @@ func StringSliceToSet(s []string) map[string]struct{} {
 	return res
 }
 
+const maxRemoteErrorBodyBytes = 8192
+
 func FetchRemote(
+	ctx context.Context,
 	metadata *resource.Metadata,
 	httpClient *http.Client,
 	apiPath string,
 	in proto.Message,
 	out proto.Message,
-	surfaceHeaderValue ...string,
 ) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 
 	url := metadata.RemoteMixerDomain + apiPath
 	jsonValue, err := protojson.Marshal(in)
 	if err != nil {
 		return err
 	}
-	request, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonValue))
+	request, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(jsonValue))
 	if err != nil {
 		return err
 	}
@@ -694,9 +699,9 @@ func FetchRemote(
 	// X-Remote indicates that the mixer call is made to a remote mixer
 	// which is typically from a Custom DC instance.
 	request.Header.Set("X-Remote", "true")
-	// Pass in the surfaceHeaderValue from the call to remote mixer.
-	if len(surfaceHeaderValue) > 0 && surfaceHeaderValue[0] != "" {
-		request.Header.Set("X-Surface", surfaceHeaderValue[0])
+	// Pass in the surface header from the incoming request context if present.
+	if surface, _ := GetMetadata(ctx); surface != "" {
+		request.Header.Set("X-Surface", surface)
 	}
 	slog.Info(fmt.Sprintf("[DC][RemoteMixerCall] url=%s", url), "url", url)
 	response, err := httpClient.Do(request)
@@ -705,12 +710,18 @@ func FetchRemote(
 	}
 	//nolint:errcheck // TODO: Fix pre-existing issue and remove comment.
 	defer response.Body.Close()
-	// Read response body
-	var responseBodyBytes []byte
 	if response.StatusCode != http.StatusOK {
+		bodyBytes, _ := io.ReadAll(io.LimitReader(response.Body, maxRemoteErrorBodyBytes))
+		bodyStr := strings.TrimSpace(string(bodyBytes))
+		if len(bodyBytes) == maxRemoteErrorBodyBytes {
+			bodyStr += " ... (truncated)"
+		}
+		if bodyStr != "" {
+			return fmt.Errorf("remote mixer response not ok: %s, body: %s", response.Status, bodyStr)
+		}
 		return fmt.Errorf("remote mixer response not ok: %s", response.Status)
 	}
-	responseBodyBytes, err = io.ReadAll(response.Body)
+	responseBodyBytes, err := io.ReadAll(response.Body)
 	if err != nil {
 		return err
 	}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -711,10 +711,10 @@ func FetchRemote(
 	//nolint:errcheck // TODO: Fix pre-existing issue and remove comment.
 	defer response.Body.Close()
 	if response.StatusCode != http.StatusOK {
-		bodyBytes, _ := io.ReadAll(io.LimitReader(response.Body, maxRemoteErrorBodyBytes))
+		bodyBytes, _ := io.ReadAll(io.LimitReader(response.Body, maxRemoteErrorBodyBytes+1))
 		bodyStr := strings.TrimSpace(string(bodyBytes))
-		if len(bodyBytes) == maxRemoteErrorBodyBytes {
-			bodyStr += " ... (truncated)"
+		if len(bodyBytes) > maxRemoteErrorBodyBytes {
+			bodyStr = strings.TrimSpace(string(bodyBytes[:maxRemoteErrorBodyBytes])) + " ... (truncated)"
 		}
 		if bodyStr != "" {
 			return fmt.Errorf("remote mixer response not ok: %s, body: %s", response.Status, bodyStr)

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -15,13 +15,19 @@
 package util
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
+	"strings"
 	"testing"
 
 	pb "github.com/datacommonsorg/mixer/internal/proto"
 	v1 "github.com/datacommonsorg/mixer/internal/proto/v1"
 	pbv2 "github.com/datacommonsorg/mixer/internal/proto/v2"
+	"github.com/datacommonsorg/mixer/internal/server/resource"
 	"github.com/google/go-cmp/cmp"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -494,5 +500,121 @@ func TestSortedStringKeys(t *testing.T) {
 	got := SortedStringKeys(input)
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("SortedStringKeys mismatch (-got +want):\n%s", diff)
+	}
+}
+
+func TestFetchRemote(t *testing.T) {
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	largeErrorBody := strings.Repeat("A", 10000)
+
+	tests := []struct {
+		name              string
+		ctx               context.Context
+		statusCode        int
+		responseBody      string
+		wantErr           bool
+		errContains       string
+		checkHeader       bool
+		wantSurfaceHeader string
+		wantRemoteHeader  string
+		wantNodeName      string
+	}{
+		{
+			name:         "success 200",
+			ctx:          context.Background(),
+			statusCode:   http.StatusOK,
+			responseBody: `{"data":{"geoId/06":{"arcs":{"name":{"nodes":[{"name":"California"}]}}}}}`,
+			wantErr:      false,
+			wantNodeName: "California",
+		},
+		{
+			name:         "error 400 with json body",
+			ctx:          context.Background(),
+			statusCode:   http.StatusBadRequest,
+			responseBody: `{"error":"invalid argument: place not found"}`,
+			wantErr:      true,
+			errContains:  "remote mixer response not ok: 400 Bad Request, body: {\"error\":\"invalid argument: place not found\"}",
+		},
+		{
+			name:         "error 500 with truncated body",
+			ctx:          context.Background(),
+			statusCode:   http.StatusInternalServerError,
+			responseBody: largeErrorBody,
+			wantErr:      true,
+			errContains:  "... (truncated)",
+		},
+		{
+			name:        "context canceled",
+			ctx:         cancelledCtx,
+			statusCode:  http.StatusOK,
+			wantErr:     true,
+			errContains: "context canceled",
+		},
+		{
+			name:              "surface header forwarded from context",
+			ctx:               metadata.NewIncomingContext(context.Background(), metadata.Pairs("x-surface", "mcp-server")),
+			statusCode:        http.StatusOK,
+			responseBody:      `{}`,
+			wantErr:           false,
+			checkHeader:       true,
+			wantSurfaceHeader: "mcp-server",
+			wantRemoteHeader:  "true",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotSurfaceHeader, gotRemoteHeader string
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotSurfaceHeader = r.Header.Get("X-Surface")
+				gotRemoteHeader = r.Header.Get("X-Remote")
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tc.statusCode)
+				_, _ = w.Write([]byte(tc.responseBody))
+			}))
+			defer ts.Close()
+
+			meta := &resource.Metadata{
+				RemoteMixerDomain: ts.URL,
+				RemoteMixerAPIKey: "test-api-key",
+			}
+			httpClient := ts.Client()
+
+			req := &pbv2.NodeRequest{Nodes: []string{"geoId/06"}}
+			resp := &pbv2.NodeResponse{}
+
+			err := FetchRemote(tc.ctx, meta, httpClient, "/v2/node", req, resp)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("FetchRemote() expected error, got nil")
+				}
+				if tc.errContains != "" && !strings.Contains(err.Error(), tc.errContains) {
+					t.Errorf("FetchRemote() error = %q, want containing %q", err.Error(), tc.errContains)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("FetchRemote() unexpected error = %v", err)
+			}
+
+			if tc.checkHeader {
+				if gotSurfaceHeader != tc.wantSurfaceHeader {
+					t.Errorf("got X-Surface header %q, want %q", gotSurfaceHeader, tc.wantSurfaceHeader)
+				}
+				if gotRemoteHeader != tc.wantRemoteHeader {
+					t.Errorf("got X-Remote header %q, want %q", gotRemoteHeader, tc.wantRemoteHeader)
+				}
+			}
+
+			if tc.wantNodeName != "" {
+				nodes := resp.GetData()["geoId/06"].GetArcs()["name"].GetNodes()
+				if len(nodes) == 0 || nodes[0].GetName() != tc.wantNodeName {
+					t.Errorf("FetchRemote() parsed resp = %v, want name %q", resp, tc.wantNodeName)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
- Threaded `context.Context` to `FetchRemote` and bound it to outgoing HTTP requests.
- Extracted the `X-Surface` header directly from request context metadata in `FetchRemote`.
- Included the remote response body (bounded to 8KB) in non-200 error messages returned by `FetchRemote`.
- Updated `RemoteClient`, `RemoteDataSource`, and server handlers to pass `context.Context` to `FetchRemote`.