### PR TITLE
Add flag-gated use of flattened LinkedEdge table

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -68,7 +68,7 @@ const (
 
 var (
 	// Server config
-	port           = flag.Int("port", 12345, "Port on which to run the server.")
+	port                = flag.Int("port", 12345, "Port on which to run the server.")
 	hostProject         = flag.String("host_project", "", "The GCP project to run the mixer instance.")
 	genAIClientLocation = flag.String("genai_client_location", "", "The GCP location for GenAI client.")
 	writeUsageLogs      = flag.Bool("write_usage_logs", false, "Whether to write usage logs.")
@@ -219,6 +219,7 @@ func main() {
 			ContainedInPlaceAncestorFirstTypes:             flags.ContainedInPlaceAncestorFirstTypes,
 			ContainedInPlacePreferTimeSeriesScanPlaceTypes: flags.ContainedInPlacePreferTimeSeriesScanPlaceTypes,
 			ContainedInPlaceEntityScanMinVariables:         flags.ContainedInPlaceEntityScanMinVariables,
+			UseMaterializedContainedInPlace:                flags.UseMaterializedContainedInPlace,
 		}
 		if err := queryConfig.Validate(); err != nil {
 			slog.Error("Invalid Spanner query config", "error", err)

--- a/internal/featureflags/featureflags.go
+++ b/internal/featureflags/featureflags.go
@@ -159,6 +159,9 @@ func (f *Flags) validateFlagValues() error {
 			return fmt.Errorf("BulkSVGBuildRightNodes must not contain surrounding whitespace")
 		}
 	}
+	if f.UseMaterializedContainedInPlace && !f.UseSpannerGraph {
+		return fmt.Errorf("UseMaterializedContainedInPlace requires UseSpannerGraph to be true")
+	}
 	return nil
 }
 

--- a/internal/featureflags/featureflags.go
+++ b/internal/featureflags/featureflags.go
@@ -66,6 +66,8 @@ type Flags struct {
 	ContainedInPlaceEntityScanMinVariables int `yaml:"ContainedInPlaceEntityScanMinVariables"`
 	// StatVarGroup nodes that should build the TimeSeries side of filtered child-SVG hash joins for N <= 1 requests.
 	BulkSVGBuildRightNodes []string `yaml:"BulkSVGBuildRightNodes"`
+	// Use materialized ContainedInPlace table.
+	UseMaterializedContainedInPlace bool `yaml:"UseMaterializedContainedInPlace"`
 }
 
 // setDefaultValues creates a new Flags struct with default values.
@@ -89,6 +91,7 @@ func setDefaultValues() *Flags {
 		ContainedInPlacePreferTimeSeriesScanPlaceTypes: []string{"Place"},
 		ContainedInPlaceEntityScanMinVariables:         50,
 		BulkSVGBuildRightNodes:                         []string{"dc/g/Root"},
+		UseMaterializedContainedInPlace:                false,
 	}
 }
 

--- a/internal/featureflags/featureflags_test.go
+++ b/internal/featureflags/featureflags_test.go
@@ -413,6 +413,29 @@ flags:
 			}),
 			wantErr: false,
 		},
+		{
+			name: "validation error - UseMaterializedContainedInPlace without UseSpannerGraph",
+			fileContent: `
+flags:
+  UseSpannerGraph: false
+  UseMaterializedContainedInPlace: true
+`,
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "valid UseMaterializedContainedInPlace with UseSpannerGraph",
+			fileContent: `
+flags:
+  UseSpannerGraph: true
+  UseMaterializedContainedInPlace: true
+`,
+			want: expectedFlags(func(f *Flags) {
+				f.UseSpannerGraph = true
+				f.UseMaterializedContainedInPlace = true
+			}),
+			wantErr: false,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/server/spanner/golden/emulator/get_observations_test.go
+++ b/internal/server/spanner/golden/emulator/get_observations_test.go
@@ -76,10 +76,26 @@ func TestGetObservationsContainedInPlaceAccessPaths(t *testing.T) {
 			},
 		},
 		{
+			name: "variable seeks for non-preferred place type with materialized table",
+			queryConfig: mixerspanner.QueryConfig{
+				ContainedInPlacePreferTimeSeriesScanPlaceTypes: []string{"Place"},
+				ContainedInPlaceEntityScanMinVariables:         2,
+				UseMaterializedContainedInPlace:                true,
+			},
+		},
+		{
 			name: "entity scan for preferred place type",
 			queryConfig: mixerspanner.QueryConfig{
 				ContainedInPlacePreferTimeSeriesScanPlaceTypes: []string{"Country"},
 				ContainedInPlaceEntityScanMinVariables:         2,
+			},
+		},
+		{
+			name: "entity scan for preferred place type with materialized table",
+			queryConfig: mixerspanner.QueryConfig{
+				ContainedInPlacePreferTimeSeriesScanPlaceTypes: []string{"Country"},
+				ContainedInPlaceEntityScanMinVariables:         2,
+				UseMaterializedContainedInPlace:                true,
 			},
 		},
 	}

--- a/internal/server/spanner/golden/emulator/suite_test.go
+++ b/internal/server/spanner/golden/emulator/suite_test.go
@@ -447,14 +447,14 @@ func TestEmulatorSchemaStatements(t *testing.T) {
 	if err != nil {
 		t.Fatalf("emulatorSchemaStatements() error = %v", err)
 	}
-	if len(statements) != 10 {
-		t.Fatalf("emulatorSchemaStatements() returned %d statements, want 10", len(statements))
+	if len(statements) != 11 {
+		t.Fatalf("emulatorSchemaStatements() returned %d statements, want 11", len(statements))
 	}
 	if !strings.HasPrefix(statements[0], "CREATE TABLE Node") {
 		t.Errorf("first schema statement = %q, want CREATE TABLE Node", statements[0])
 	}
-	if !strings.HasPrefix(statements[len(statements)-1], "CREATE PROPERTY GRAPH DCGraph") {
-		t.Errorf("last schema statement = %q, want CREATE PROPERTY GRAPH DCGraph", statements[len(statements)-1])
+	if !strings.HasPrefix(statements[len(statements)-1], "CREATE TABLE ContainedInPlace") {
+		t.Errorf("last schema statement = %q, want CREATE TABLE ContainedInPlace", statements[len(statements)-1])
 	}
 }
 
@@ -516,13 +516,13 @@ func TestEmulatorSeedStatements(t *testing.T) {
 	if err != nil {
 		t.Fatalf("emulatorSeedStatements() error = %v", err)
 	}
-	if len(statements) != 4 {
-		t.Fatalf("emulatorSeedStatements() returned %d statements, want 4", len(statements))
+	if len(statements) != 5 {
+		t.Fatalf("emulatorSeedStatements() returned %d statements, want 5", len(statements))
 	}
 	if !strings.HasPrefix(statements[0], "INSERT INTO Node") {
 		t.Errorf("first seed statement = %q, want INSERT INTO Node", statements[0])
 	}
-	if !strings.HasPrefix(statements[len(statements)-1], "INSERT INTO Observation") {
-		t.Errorf("last seed statement = %q, want INSERT INTO Observation", statements[len(statements)-1])
+	if !strings.HasPrefix(statements[len(statements)-1], "INSERT INTO ContainedInPlace") {
+		t.Errorf("last seed statement = %q, want INSERT INTO ContainedInPlace", statements[len(statements)-1])
 	}
 }

--- a/internal/server/spanner/golden/emulator/testdata/schema.sql
+++ b/internal/server/spanner/golden/emulator/testdata/schema.sql
@@ -87,3 +87,10 @@ CREATE PROPERTY GRAPH DCGraph
         provenance,
         subject_id)
   );
+
+CREATE TABLE ContainedInPlace (
+  ancestor STRING(1024) NOT NULL,
+  child_type STRING(1024) NOT NULL,
+  child STRING(1024) NOT NULL,
+  provenance STRING(1024) NOT NULL
+) PRIMARY KEY(ancestor, child_type, child, provenance);

--- a/internal/server/spanner/golden/emulator/testdata/seed.sql
+++ b/internal/server/spanner/golden/emulator/testdata/seed.sql
@@ -84,3 +84,12 @@ VALUES
   ('Count_MigrationByTransportMode', 'country/CAN', 'migration-air', 'facet', '2024', '7', PENDING_COMMIT_TIMESTAMP()),
   ('Count_MigrationByTransportMode', 'country/CAN', 'migration-sea', 'facet', '2024', '3', PENDING_COMMIT_TIMESTAMP()),
   ('Count_MigrationByObservationAbout', 'country/CAN', 'migration-about', 'facet', '2024', '5', PENDING_COMMIT_TIMESTAMP());
+
+INSERT INTO ContainedInPlace (ancestor, child_type, child, provenance)
+VALUES
+  ('northamerica', 'Country', 'country/CAN', 'dc/base/WikidataOtherIdGeos'),
+  ('northamerica', 'Country', 'country/MEX', 'dc/base/WikidataOtherIdGeos'),
+  ('northamerica', 'Country', 'country/USA', 'dc/base/WikidataOtherIdGeos'),
+  ('europe', 'Country', 'country/FRA', 'dc/base/WikidataOtherIdGeos'),
+  ('europe', 'Country', 'country/GBR', 'dc/base/WikidataOtherIdGeos'),
+  ('asia', 'Country', 'country/IND', 'dc/base/WikidataOtherIdGeos');

--- a/internal/server/spanner/golden/query_builder/get_multientity_obs_contained_in_place_materialized_both.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_obs_contained_in_place_materialized_both.sql
@@ -1,0 +1,40 @@
+		@{SCAN_METHOD=COLUMNAR, EXECUTION_METHOD=BATCH}
+		WITH places AS (
+			SELECT DISTINCT child AS place_id
+			FROM ContainedInPlace
+			WHERE ancestor = 'geoId/10'
+			AND child_type = 'County'
+		),
+		series AS (
+			SELECT
+				t.variable_measured,
+				t.entity1,
+				t.extra_entities_id,
+				t.facet_id,
+				t.provenance,
+				t.facet
+			FROM places p
+			JOIN@{JOIN_METHOD=APPLY_JOIN} TimeSeries@{FORCE_INDEX=_BASE_TABLE} t
+				ON t.variable_measured = 'AirPollutant_Cancer_Risk'
+				AND t.entity1 = p.place_id
+		)
+		SELECT
+			t.variable_measured,
+			t.entity1 AS observation_about,
+			t.facet_id,
+			ANY_VALUE(t.provenance) AS provenance,
+			ARRAY_AGG(
+				STRUCT(
+					o.date AS date,
+					o.value AS str_value
+				)
+			) AS dates_and_values,
+			ANY_VALUE(t.facet) AS facets
+		FROM series t
+		JOIN@{JOIN_METHOD=APPLY_JOIN} Observation o
+		USING (variable_measured, entity1, extra_entities_id, facet_id)
+		GROUP BY
+			t.variable_measured,
+			t.entity1,
+			t.extra_entities_id,
+			t.facet_id

--- a/internal/server/spanner/golden/query_builder/get_multientity_obs_contained_in_place_materialized_date.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_obs_contained_in_place_materialized_date.sql
@@ -1,0 +1,35 @@
+		@{SCAN_METHOD=COLUMNAR, EXECUTION_METHOD=BATCH}
+		WITH places AS (
+			SELECT DISTINCT child AS place_id
+			FROM ContainedInPlace
+			WHERE ancestor = 'geoId/10'
+			AND child_type = 'County'
+		),
+		series AS (
+			SELECT
+				t.variable_measured,
+				t.entity1,
+				t.extra_entities_id,
+				t.facet_id,
+				t.provenance,
+				t.facet
+			FROM places p
+			JOIN@{JOIN_METHOD=APPLY_JOIN} TimeSeries@{FORCE_INDEX=_BASE_TABLE} t
+				ON t.variable_measured IN ('AirPollutant_Cancer_Risk','Count_Person')
+				AND t.entity1 = p.place_id
+		)
+		SELECT
+			t.variable_measured,
+			t.entity1 AS observation_about,
+			t.facet_id,
+			t.provenance,
+			ARRAY(
+				SELECT AS STRUCT
+					o.date AS date,
+					o.value AS str_value
+			) AS dates_and_values,
+			t.facet AS facets
+		FROM series t
+		JOIN@{JOIN_METHOD=APPLY_JOIN} Observation o
+		USING (variable_measured, entity1, extra_entities_id, facet_id)
+		WHERE o.date = '2015'

--- a/internal/server/spanner/golden/query_builder/get_multientity_obs_contained_in_place_materialized_latest.sql
+++ b/internal/server/spanner/golden/query_builder/get_multientity_obs_contained_in_place_materialized_latest.sql
@@ -1,0 +1,50 @@
+		@{SCAN_METHOD=COLUMNAR, EXECUTION_METHOD=BATCH}
+		WITH places AS (
+			SELECT DISTINCT child AS place_id
+			FROM ContainedInPlace
+			WHERE ancestor = 'geoId/10'
+			AND child_type = 'County'
+		),
+		series AS (
+			SELECT
+				t.variable_measured,
+				t.entity1,
+				t.extra_entities_id,
+				t.facet_id,
+				t.provenance,
+				t.facet
+			FROM places p
+			JOIN@{JOIN_METHOD=APPLY_JOIN} TimeSeries@{FORCE_INDEX=_BASE_TABLE} t
+				ON t.variable_measured = 'AirPollutant_Cancer_Risk'
+				AND t.entity1 = p.place_id
+		)
+		SELECT
+			t.variable_measured,
+			t.entity1 AS observation_about,
+			t.facet_id,
+			t.provenance,
+			COALESCE(
+				(
+					SELECT ARRAY(
+						SELECT AS STRUCT
+							o.date AS date,
+							o.value AS str_value
+						FROM Observation o
+						WHERE o.variable_measured = t.variable_measured
+							AND o.entity1 = t.entity1
+							AND o.extra_entities_id = t.extra_entities_id
+							AND o.facet_id = t.facet_id
+						ORDER BY o.date DESC
+						LIMIT 1
+					)
+				),
+				ARRAY(
+					SELECT AS STRUCT
+						CAST(NULL AS STRING) AS date,
+						CAST(NULL AS STRING) AS str_value
+					FROM UNNEST([1])
+					WHERE FALSE
+				)
+			) AS dates_and_values,
+			t.facet AS facets
+		FROM series t

--- a/internal/server/spanner/golden/query_builder_multientity_test.go
+++ b/internal/server/spanner/golden/query_builder_multientity_test.go
@@ -95,6 +95,7 @@ func TestMultiEntityGetObservationsContainedInPlaceQuery(t *testing.T) {
 					ContainedInPlaceAncestorFirstTypes:             c.ancestorFirstTypes,
 					ContainedInPlacePreferTimeSeriesScanPlaceTypes: c.preferTimeSeriesScanPlaceTypes,
 					ContainedInPlaceEntityScanMinVariables:         c.entityScanMinVars,
+					UseMaterializedContainedInPlace:                c.useMaterializedContainedInPlace,
 				})
 				if err != nil {
 					return nil, err

--- a/internal/server/spanner/golden/query_multientity_cases_test.go
+++ b/internal/server/spanner/golden/query_multientity_cases_test.go
@@ -126,15 +126,16 @@ var multiEntityCheckGroupPlaceExistenceTestCases = []struct {
 }
 
 var multiEntityObservationsContainedInPlaceTestCases = []struct {
-	name                           string
-	variables                      []string
-	ancestor                       string
-	childPlaceType                 string
-	ancestorFirstTypes             []string
-	preferTimeSeriesScanPlaceTypes []string
-	entityScanMinVars              int
-	date                           string
-	golden                         string
+	name                            string
+	variables                       []string
+	ancestor                        string
+	childPlaceType                  string
+	ancestorFirstTypes              []string
+	preferTimeSeriesScanPlaceTypes  []string
+	entityScanMinVars               int
+	useMaterializedContainedInPlace bool
+	date                            string
+	golden                          string
 }{
 	{
 		name:               "contained in place with variables",
@@ -146,6 +147,16 @@ var multiEntityObservationsContainedInPlaceTestCases = []struct {
 		golden:             "get_multientity_obs_contained_in_place_both",
 	},
 	{
+		name:                            "contained in place materialized with variables",
+		variables:                       []string{"AirPollutant_Cancer_Risk"},
+		ancestor:                        "geoId/10",
+		childPlaceType:                  "County",
+		ancestorFirstTypes:              []string{"Place"},
+		useMaterializedContainedInPlace: true,
+		date:                            "",
+		golden:                          "get_multientity_obs_contained_in_place_materialized_both",
+	},
+	{
 		name:               "contained in place latest date with variables",
 		variables:          []string{"AirPollutant_Cancer_Risk"},
 		ancestor:           "geoId/10",
@@ -153,6 +164,16 @@ var multiEntityObservationsContainedInPlaceTestCases = []struct {
 		ancestorFirstTypes: []string{"Place"},
 		date:               "latest",
 		golden:             "get_multientity_obs_contained_in_place_latest",
+	},
+	{
+		name:                            "contained in place materialized latest date with variables",
+		variables:                       []string{"AirPollutant_Cancer_Risk"},
+		ancestor:                        "geoId/10",
+		childPlaceType:                  "County",
+		ancestorFirstTypes:              []string{"Place"},
+		useMaterializedContainedInPlace: true,
+		date:                            "latest",
+		golden:                          "get_multientity_obs_contained_in_place_materialized_latest",
 	},
 	{
 		name:                           "contained in place non-preferred type uses variable seeks",
@@ -173,6 +194,16 @@ var multiEntityObservationsContainedInPlaceTestCases = []struct {
 		ancestorFirstTypes: []string{"Place"},
 		date:               "2015",
 		golden:             "get_multientity_obs_contained_in_place_date",
+	},
+	{
+		name:                            "contained in place materialized specific date with variables",
+		variables:                       []string{"AirPollutant_Cancer_Risk", "Count_Person"},
+		ancestor:                        "geoId/10",
+		childPlaceType:                  "County",
+		ancestorFirstTypes:              []string{"Place"},
+		useMaterializedContainedInPlace: true,
+		date:                            "2015",
+		golden:                          "get_multientity_obs_contained_in_place_materialized_date",
 	},
 	{
 		name:               "contained in place ancestor first with variables",

--- a/internal/server/spanner/query_builder_multientity.go
+++ b/internal/server/spanner/query_builder_multientity.go
@@ -157,9 +157,13 @@ func (b *multiEntityQueryBuilder) GetObservationsContainedInPlaceQuery(variables
 		"variables":      uniqueVariables,
 	}
 
-	containedInPlaceStatements := stmts.getObsByContainedInPlaceTypeFirst
-	if b.queryConfig.containedInPlaceAccessPath(containedInPlace.ChildPlaceType) == containedInPlaceAncestorFirst {
+	var containedInPlaceStatements containedInPlaceAccessPathStatements
+	if b.queryConfig.UseMaterializedContainedInPlace {
+		containedInPlaceStatements = stmts.getObsByContainedInPlaceMaterialized
+	} else if b.queryConfig.containedInPlaceAccessPath(containedInPlace.ChildPlaceType) == containedInPlaceAncestorFirst {
 		containedInPlaceStatements = stmts.getObsByContainedInPlaceAncestorFirst
+	} else {
+		containedInPlaceStatements = stmts.getObsByContainedInPlaceTypeFirst
 	}
 
 	selectedStatements := containedInPlaceStatements.variableSeek

--- a/internal/server/spanner/query_config.go
+++ b/internal/server/spanner/query_config.go
@@ -40,6 +40,9 @@ type QueryConfig struct {
 	// SpannerEmulatorCompatibility indicates whether queries should be
 	// formatted for Cloud Spanner Emulator (e.g. omitting unsupported hints).
 	SpannerEmulatorCompatibility bool
+	// UseMaterializedContainedInPlace indicates whether queries should use the
+	// ContainedInPlace table.
+	UseMaterializedContainedInPlace bool
 }
 
 type containedInPlaceAccessPath int

--- a/internal/server/spanner/statements_multientity.go
+++ b/internal/server/spanner/statements_multientity.go
@@ -29,6 +29,7 @@ type MultiEntityStatements struct {
 	getObsEntitiesOnlyLatest                       string
 	getObsByContainedInPlaceTypeFirst              containedInPlaceAccessPathStatements
 	getObsByContainedInPlaceAncestorFirst          containedInPlaceAccessPathStatements
+	getObsByContainedInPlaceMaterialized           containedInPlaceAccessPathStatements
 	getSdmxObs                                     string
 	getSdmxObsWithDates                            string
 	getSdmxObsLatest                               string
@@ -98,6 +99,7 @@ func NewMultiEntityStatements(cfg TableConfig) (*MultiEntityStatements, error) {
 	}
 	typeFirstContainedInPlace := newContainedInPlaceAccessPathStatements(cfg, typeFirstPlacesCTE)
 	ancestorFirstContainedInPlace := newContainedInPlaceAccessPathStatements(cfg, ancestorFirstPlacesCTE)
+	materializedContainedInPlace := newContainedInPlaceAccessPathStatements(cfg, materializedPlacesCTE)
 
 	return &MultiEntityStatements{
 		// Retrieve observations where both variables and entities are present (full series)
@@ -270,6 +272,7 @@ func NewMultiEntityStatements(cfg TableConfig) (*MultiEntityStatements, error) {
 
 		getObsByContainedInPlaceTypeFirst:     typeFirstContainedInPlace,
 		getObsByContainedInPlaceAncestorFirst: ancestorFirstContainedInPlace,
+		getObsByContainedInPlaceMaterialized:  materializedContainedInPlace,
 		getSdmxObs: fmt.Sprintf("\t\tSELECT \n"+`			t.variable_measured,
 			t.entity1 AS observation_about,
 			t.facet_id,
@@ -836,6 +839,13 @@ const ancestorFirstPlacesCTE = `places AS (
 				AND contained.object_id = @ancestor
 				AND typed.predicate = 'typeOf'
 				AND typed.object_id = @childPlaceType
+		)`
+
+const materializedPlacesCTE = `places AS (
+			SELECT DISTINCT child AS place_id
+			FROM ContainedInPlace
+			WHERE ancestor = @ancestor
+			AND child_type = @childPlaceType
 		)`
 
 func newContainedInPlaceAccessPathStatements(cfg TableConfig, placesCTE string) containedInPlaceAccessPathStatements {


### PR DESCRIPTION
When flag UseMaterializedLinkedEdge is enabled, will use a new "LinkedEdge" table for containedInPlace observation requests, instead of joining Edge table.

At the moment this is disabled everywhere. 

Note: The query changes currently only affect observation requests (not sdmx or node), since I wanted to align on the new schema + approach first. Other request types can be updated as a follow up. This also only affects the placesCTE, so does not impact seek conditions for time series table. 

The table is populated in dc_graph_1 with schema 
```
CREATE TABLE LinkedEdge (
  predicate STRING(1024) NOT NULL,
  ancestor STRING(1024) NOT NULL,
  child_type STRING(1024) NOT NULL,
  child STRING(1024) NOT NULL,
  provenance STRING(1024) NOT NULL,
) PRIMARY KEY(predicate, ancestor, child_type, child, provenance);
```

To test with local mixer, can set the flags in local.yaml:
```
SpannerGraphDatabase: projects/datcom-store/instances/dc-graph-staging/databases/dc_graph_1
UseMaterializedLinkedEdge: true
```

Some query comparisons (for Count_Person) (old vs new) 
counties in USA
- All dates
  - Elapsed time: 2.44s vs 2.23s 
  - CPU time: 2.53s vs 2.36s
  - Rows scanned: 577,191 vs 573,647
  - Remote calls:  2 vs 1
- Latest date
  - Elapsed time: 374.3ms vs 716.13ms
  - CPU time: 420.95ms vs 748.01ms
  - Rows scanned: 66,645 vs 63,101
  - Remote calls:  2 vs 1
- Specific date (2010)
  - Elapsed time: 522.38ms vs 372.95ms
  - CPU time: 520.3ms vs 372.7ms
  - Rows scanned: 56,583 vs 53,039
  - Remote calls: 2 vs 1
 
countries in Earth
- All dates
  - Elapsed time: 174.31ms vs 196.94ms
  - CPU time: 178.67ms vs 148.92ms
  - Rows scanned: 32,625 vs 31,868
  - Remote calls:  1 vs 1
- Latest date
  - Elapsed time: 81.26ms vs 50.01ms
  - CPU time: 72.96ms vs 43.23ms
  - Rows scanned: 2,770 vs 2,013
  - Remote calls:  1 vs 1
- Specific date (2010)
  - Elapsed time: 60.34ms vs 51.87ms
  - CPU time: 57.3ms vs 46.42ms
  - Rows scanned: 2,508 vs 1,751
  - Remote calls: 1 vs 1

cities in California
- All dates 
  - Elapsed time: 940.51ms vs 479.67ms 
  - CPU time: 955.45ms vs 507.5ms
  - Rows scanned: 222,166 vs 97,073
  - Remote calls:  8 vs 1
- Latest date
  - Elapsed time: 719.37ms vs 213.88ms
  - CPU time: 708.78ms vs 218.15ms
  - Rows scanned: 145,441 vs 20,348
  - Remote calls: 8 vs 1
- Specific date (2010)
  - Elapsed time: 641.83ms vs 108.31ms
  - CPU time: 644.77ms vs 112.07ms
  - Rows scanned: 140,441 vs 15,348
  - Remote calls:  8 vs 1

places in nuts/DE40
- All dates 
  - Elapsed time: 114.94ms vs 76.52ms
  - CPU time: 84.32ms vs 55.46ms
  - Rows scanned: 3,569 vs 256
  - Remote calls:  2 vs 2
- Latest date
  - Elapsed time: 107.7ms vs 60.62ms
  - CPU time: 87.68ms vs 43.53ms
  - Rows scanned: 3,568 vs 255
  - Remote calls: 2 vs 1
- Specific date (2020)
  - Elapsed time: 155.56ms vs 44.19ms
  - CPU time: 86.92ms vs 38.79ms
  - Rows scanned: 3,567 vs 254
  - Remote calls:  2 vs 1

administrative area 4 in Santa Clara County
- All dates 
  - Elapsed time: 2.31s vs 31.3ms
  - CPU time: 2.32s vs  25.14ms
  - Rows scanned: 539,907 vs 0
  - Remote calls: 27 vs 0
- Latest date
  - Elapsed time: 2.33s vs 42.51ms
  - CPU time: 2.46s vs 39.24ms
  - Rows scanned: 539,907 vs 0
  - Remote calls: 27 vs 0
- Specific date (2010)
  - Elapsed time: 2.18s vs 31.99ms
  - CPU time: 2.3s vs 29.2ms 
  - Rows scanned: 539,907 vs 0
  - Remote calls:  27 vs 0