### PR TITLE
Resolve external schema properties in Spanner multi-entity SDMX shape

### DIFF
--- a/internal/server/spanner/query_multientity.go
+++ b/internal/server/spanner/query_multientity.go
@@ -891,7 +891,7 @@ func resolveSdmxEntityShape(
 			if edge.Predicate != "observationProperties" {
 				continue
 			}
-			property := strings.TrimSpace(edge.Value)
+			property := edgeObservationProperty(edge)
 			if property == "" {
 				continue
 			}
@@ -1003,4 +1003,16 @@ func sortedUniqueStrings(values []string) []string {
 		seen[value] = struct{}{}
 	}
 	return slices.Sorted(maps.Keys(seen))
+}
+
+// edgeObservationProperty returns the observation property name from an edge,
+// preferring ObjectID for external reference nodes and falling back to Value.
+func edgeObservationProperty(edge *Edge) string {
+	if edge == nil {
+		return ""
+	}
+	if id := strings.TrimSpace(edge.ObjectID); id != "" {
+		return id
+	}
+	return strings.TrimSpace(edge.Value)
 }

--- a/internal/server/spanner/query_multientity.go
+++ b/internal/server/spanner/query_multientity.go
@@ -1006,13 +1006,14 @@ func sortedUniqueStrings(values []string) []string {
 }
 
 // edgeObservationProperty returns the observation property name from an edge,
-// preferring ObjectID for external reference nodes and falling back to Value.
+// preferring Value for locally resolved nodes and falling back to ObjectID
+// for external reference nodes not materialized in the local Node table.
 func edgeObservationProperty(edge *Edge) string {
 	if edge == nil {
 		return ""
 	}
-	if id := strings.TrimSpace(edge.ObjectID); id != "" {
-		return id
+	if val := strings.TrimSpace(edge.Value); val != "" {
+		return val
 	}
-	return strings.TrimSpace(edge.Value)
+	return strings.TrimSpace(edge.ObjectID)
 }

--- a/internal/server/spanner/query_multientity_test.go
+++ b/internal/server/spanner/query_multientity_test.go
@@ -1783,6 +1783,75 @@ func TestResolveSdmxEntityShape(t *testing.T) {
 	}
 }
 
+func TestResolveSdmxEntityShapeExternalProperties(t *testing.T) {
+	tests := []struct {
+		name                              string
+		statVarIDs                        []string
+		statVarToObservationPropertyEdges map[string][]*Edge
+		wantProperties                    []string
+		wantSlots                         map[string]string
+	}{
+		{
+			name:       "resolves mixed local and external reference edges",
+			statVarIDs: []string{"HealthAidFunding"},
+			statVarToObservationPropertyEdges: map[string][]*Edge{
+				"HealthAidFunding": {
+					{Predicate: "observationProperties", ObjectID: "donorPlace", Value: "donorPlace", Resolved: true},
+					{Predicate: "observationProperties", ObjectID: "medicalCondition", Value: "", Resolved: false},
+					{Predicate: "observationProperties", ObjectID: "recipientPlace", Value: "recipientPlace", Resolved: true},
+				},
+			},
+			wantProperties: []string{"donorPlace", "medicalCondition", "recipientPlace"},
+			wantSlots: map[string]string{
+				"donorPlace":       "entity1",
+				"medicalCondition": "entity2",
+				"recipientPlace":   "entity3",
+			},
+		},
+		{
+			name:       "resolves external reference with whitespace in object_id",
+			statVarIDs: []string{"var1"},
+			statVarToObservationPropertyEdges: map[string][]*Edge{
+				"var1": {
+					{Predicate: "observationProperties", ObjectID: "  medicalCondition  ", Value: ""},
+				},
+			},
+			wantProperties: []string{"medicalCondition"},
+			wantSlots: map[string]string{
+				"medicalCondition": "entity1",
+			},
+		},
+		{
+			name:       "falls back to value when object_id is whitespace",
+			statVarIDs: []string{"var1"},
+			statVarToObservationPropertyEdges: map[string][]*Edge{
+				"var1": {
+					{Predicate: "observationProperties", ObjectID: "   ", Value: "  sourceCountry  "},
+				},
+			},
+			wantProperties: []string{"sourceCountry"},
+			wantSlots: map[string]string{
+				"sourceCountry": "entity1",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotProps, gotSlots, err := resolveSdmxEntityShape(tc.statVarIDs, tc.statVarToObservationPropertyEdges)
+			if err != nil {
+				t.Fatalf("resolveSdmxEntityShape() unexpected error = %v", err)
+			}
+			if diff := cmp.Diff(tc.wantProperties, gotProps); diff != "" {
+				t.Errorf("observationProperties mismatch (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.wantSlots, gotSlots); diff != "" {
+				t.Errorf("entity slot mapping mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestResolveSdmxEntityShapeAcceptsSameTwoEntityShapeDifferentOrder(t *testing.T) {
 	statVarToObservationPropertyEdges := map[string][]*Edge{
 		"var1": observationPropertiesEdges("sourceCountry", "destinationCountry"),

--- a/internal/server/spanner/query_multientity_test.go
+++ b/internal/server/spanner/query_multientity_test.go
@@ -1809,29 +1809,29 @@ func TestResolveSdmxEntityShapeExternalProperties(t *testing.T) {
 			},
 		},
 		{
-			name:       "resolves external reference with whitespace in object_id",
+			name:       "prefers value when populated",
 			statVarIDs: []string{"var1"},
 			statVarToObservationPropertyEdges: map[string][]*Edge{
 				"var1": {
-					{Predicate: "observationProperties", ObjectID: "  medicalCondition  ", Value: ""},
+					{Predicate: "observationProperties", ObjectID: "donorPlace", Value: "  donorPlace  "},
+				},
+			},
+			wantProperties: []string{"donorPlace"},
+			wantSlots: map[string]string{
+				"donorPlace": "entity1",
+			},
+		},
+		{
+			name:       "falls back to object_id when value is empty or whitespace",
+			statVarIDs: []string{"var1"},
+			statVarToObservationPropertyEdges: map[string][]*Edge{
+				"var1": {
+					{Predicate: "observationProperties", ObjectID: "  medicalCondition  ", Value: "   "},
 				},
 			},
 			wantProperties: []string{"medicalCondition"},
 			wantSlots: map[string]string{
 				"medicalCondition": "entity1",
-			},
-		},
-		{
-			name:       "falls back to value when object_id is whitespace",
-			statVarIDs: []string{"var1"},
-			statVarToObservationPropertyEdges: map[string][]*Edge{
-				"var1": {
-					{Predicate: "observationProperties", ObjectID: "   ", Value: "  sourceCountry  "},
-				},
-			},
-			wantProperties: []string{"sourceCountry"},
-			wantSlots: map[string]string{
-				"sourceCountry": "entity1",
 			},
 		},
 	}


### PR DESCRIPTION
* Updated `resolveSdmxEntityShape` to check `ObjectID` before falling back to `Value` so external schema properties in DCP instances are not omitted from SDMX dimensions.

### Verification

#### 1. DCP Mode (Multi-Entity Database with External Property `medicalCondition`)
* Verified SDMX availability returns HTTP 200 with available component values:
```bash
curl -g -i "http://localhost:8081/sdmx/v3/availability/dataflow/DC/DF_OBS/1.0.0/*/medicalCondition?c[variableMeasured]=HealthAidFunding"
```
* Verified SDMX data returns HTTP 200 with observation CSV rows:
```bash
curl -g -i "http://localhost:8081/sdmx/v3/data/dataflow/DC/DF_OBS/1.0.0/*?c[variableMeasured]=HealthAidFunding&c[medicalCondition]=HIV"
```

#### 2. Base DC Mode
* Verified SDMX data returns HTTP 200 with observation CSV rows:
```bash
curl -g -i "http://localhost:8081/sdmx/v3/data/dataflow/DC/DF_OBS/1.0.0/*?c[variableMeasured]=Median_Age_Person&c[observationAbout]=country/USA"
```
* Verified SDMX availability returns HTTP 200:
```bash
curl -g -i "http://localhost:8081/sdmx/v3/availability/dataflow/DC/DF_OBS/1.0.0/*/observationAbout?c[variableMeasured]=Median_Age_Person&c[observationAbout]=country/USA"
```