### PR TITLE
Add CLI flag and service option to configure agent default topic expansion

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -135,6 +135,11 @@ var (
 		"",
 		"Path to Spanner search config YAML file.",
 	)
+	agentDefaultExpandTopics = flag.Bool(
+		"agent_default_expand_topics",
+		true,
+		"Default value for expand_topics in agent search_indicators if not specified in request.",
+	)
 )
 
 func main() {
@@ -553,6 +558,7 @@ func main() {
 			EmbeddingsServiceClient:           embeddingsServiceClient,
 			UseSpannerGraph:                   *useSpannerGraph,
 			TopicExpander:                     topicExpander,
+			AgentDefaultExpandTopics:          agentDefaultExpandTopics,
 		},
 	)
 	pbs.RegisterMixerServer(srv, mixerServer)

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -54,27 +54,22 @@ type Service struct {
 	defaultExpandTopics bool
 }
 
-// ServiceOption configures a Service instance during construction.
-type ServiceOption func(*Service)
-
-// WithDefaultExpandTopics sets the default topic expansion behavior for search indicators.
-func WithDefaultExpandTopics(expand bool) ServiceOption {
-	return func(s *Service) {
-		s.defaultExpandTopics = expand
-	}
+// ServiceOptions holds optional configuration for agent.Service.
+type ServiceOptions struct {
+	DefaultExpandTopics *bool
 }
 
 // NewService constructs a new Service instance backed by the provided Mixer and Cache.
-func NewService(mixer Mixer, cache *Cache, opts ...ServiceOption) *Service {
-	s := &Service{
+func NewService(mixer Mixer, cache *Cache, opts *ServiceOptions) *Service {
+	defaultExpandTopics := true
+	if opts != nil && opts.DefaultExpandTopics != nil {
+		defaultExpandTopics = *opts.DefaultExpandTopics
+	}
+	return &Service{
 		mixer:               mixer,
 		cache:               cache,
-		defaultExpandTopics: true,
+		defaultExpandTopics: defaultExpandTopics,
 	}
-	for _, opt := range opts {
-		opt(s)
-	}
-	return s
 }
 
 // Reset flushes all cached state inside the service L1 Cache atomically,

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -49,16 +49,32 @@ type Mixer interface {
 // Service orchestrates the aggregation and formatting of lower-level API data in response
 // to conversational assistant/agent queries.
 type Service struct {
-	mixer Mixer
-	cache *Cache
+	mixer               Mixer
+	cache               *Cache
+	defaultExpandTopics bool
+}
+
+// ServiceOption configures a Service instance during construction.
+type ServiceOption func(*Service)
+
+// WithDefaultExpandTopics sets the default topic expansion behavior for search indicators.
+func WithDefaultExpandTopics(expand bool) ServiceOption {
+	return func(s *Service) {
+		s.defaultExpandTopics = expand
+	}
 }
 
 // NewService constructs a new Service instance backed by the provided Mixer and Cache.
-func NewService(mixer Mixer, cache *Cache) *Service {
-	return &Service{
-		mixer: mixer,
-		cache: cache,
+func NewService(mixer Mixer, cache *Cache, opts ...ServiceOption) *Service {
+	s := &Service{
+		mixer:               mixer,
+		cache:               cache,
+		defaultExpandTopics: true,
 	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
 }
 
 // Reset flushes all cached state inside the service L1 Cache atomically,
@@ -67,4 +83,9 @@ func (s *Service) Reset() {
 	if s.cache != nil {
 		s.cache.Reset()
 	}
+}
+
+// DefaultExpandTopics returns the configured default topic expansion behavior.
+func (s *Service) DefaultExpandTopics() bool {
+	return s.defaultExpandTopics
 }

--- a/internal/agent/get_variable_metadata_test.go
+++ b/internal/agent/get_variable_metadata_test.go
@@ -234,7 +234,7 @@ func TestGetVariableMetadata(t *testing.T) {
 				obsData:  tc.obsData,
 				obsErr:   tc.obsErr,
 			}
-			svc := NewService(mock, NewCache(mock))
+			svc := NewService(mock, NewCache(mock), nil)
 
 			got, err := svc.GetVariableMetadata(context.Background(), tc.req)
 			if tc.wantErr {

--- a/internal/agent/observations_test.go
+++ b/internal/agent/observations_test.go
@@ -437,7 +437,7 @@ func TestGetObservations(t *testing.T) {
 
 	t.Run("Validation Failures", func(t *testing.T) {
 		mock := &obsMockMixer{}
-		svc := NewService(mock, nil)
+		svc := NewService(mock, nil, nil)
 
 		tests := []struct {
 			desc    string
@@ -577,7 +577,7 @@ func TestGetObservations(t *testing.T) {
 			},
 		}
 
-		svc := NewService(mock, nil)
+		svc := NewService(mock, nil, nil)
 		got, err := svc.GetObservations(context.Background(), &pbv2.GetObservationsRequest{
 			VariableDcid: "Count_Person",
 			PlaceDcid:    "geoId/06",
@@ -705,7 +705,7 @@ func TestGetObservations(t *testing.T) {
 			},
 		}
 
-		svc := NewService(mock, nil)
+		svc := NewService(mock, nil, nil)
 		got, err := svc.GetObservations(context.Background(), &pbv2.GetObservationsRequest{
 			VariableDcid:   "Count_Person",
 			PlaceDcid:      "geoId/06",
@@ -826,7 +826,7 @@ func TestGetObservations(t *testing.T) {
 			},
 		}
 
-		svc := NewService(mock, nil)
+		svc := NewService(mock, nil, nil)
 		got, err := svc.GetObservations(context.Background(), &pbv2.GetObservationsRequest{
 			VariableDcid: "Count_Person",
 			PlaceDcid:    "geoId/06",
@@ -894,7 +894,7 @@ func TestGetObservations(t *testing.T) {
 			},
 		}
 
-		svc := NewService(mock, nil)
+		svc := NewService(mock, nil, nil)
 		got, err := svc.GetObservations(context.Background(), &pbv2.GetObservationsRequest{
 			VariableDcid:   "Count_Person",
 			PlaceDcid:      "geoId/06",
@@ -987,7 +987,7 @@ func TestGetObservations_Sdmx(t *testing.T) {
 			},
 		}
 
-		svc := NewService(mock, nil)
+		svc := NewService(mock, nil, nil)
 		entitiesMap := map[string]*structpb.Value{
 			"observationAbout": structpb.NewListValue(mustListValue("geoId/06001", "geoId/06003")),
 		}
@@ -1076,7 +1076,7 @@ func TestGetObservations_Sdmx(t *testing.T) {
 			},
 		}
 
-		svc := NewService(mock, nil)
+		svc := NewService(mock, nil, nil)
 		parentSpec, err := structpb.NewStruct(map[string]interface{}{
 			"parent_dcid": "geoId/06",
 			"child_type":  "County",
@@ -1124,7 +1124,7 @@ func TestGetObservations_Sdmx(t *testing.T) {
 	})
 
 	t.Run("Validation Failure: Multi-Parent Expansion Limit", func(t *testing.T) {
-		svc := NewService(&obsMockMixer{}, nil)
+		svc := NewService(&obsMockMixer{}, nil, nil)
 		p1, _ := structpb.NewStruct(map[string]interface{}{"parent_dcid": "geoId/06", "child_type": "County"})
 		p2, _ := structpb.NewStruct(map[string]interface{}{"parent_dcid": "geoId/48", "child_type": "County"})
 
@@ -1143,7 +1143,7 @@ func TestGetObservations_Sdmx(t *testing.T) {
 	})
 
 	t.Run("Validation Failure: Invalid Entities JSON Type", func(t *testing.T) {
-		svc := NewService(&obsMockMixer{}, nil)
+		svc := NewService(&obsMockMixer{}, nil, nil)
 		// Passing boolean kind inside list value to trigger type validation error (Finding 1)
 		listVal, _ := structpb.NewList([]interface{}{"geoId/06", true})
 
@@ -1161,7 +1161,7 @@ func TestGetObservations_Sdmx(t *testing.T) {
 	})
 
 	t.Run("Validation Failure: Empty Struct Value Fields", func(t *testing.T) {
-		svc := NewService(&obsMockMixer{}, nil)
+		svc := NewService(&obsMockMixer{}, nil, nil)
 		// Passing empty parent_dcid string to trigger blank check validation (Finding 2)
 		parentSpec, _ := structpb.NewStruct(map[string]interface{}{
 			"parent_dcid": "",
@@ -1182,7 +1182,7 @@ func TestGetObservations_Sdmx(t *testing.T) {
 	})
 
 	t.Run("Validation Failure: Empty Entity List", func(t *testing.T) {
-		svc := NewService(&obsMockMixer{}, nil)
+		svc := NewService(&obsMockMixer{}, nil, nil)
 		emptyList, _ := structpb.NewList([]interface{}{})
 		entitiesMap := map[string]*structpb.Value{
 			"observationAbout": structpb.NewListValue(emptyList),
@@ -1198,7 +1198,7 @@ func TestGetObservations_Sdmx(t *testing.T) {
 	})
 
 	t.Run("Validation Failure: Empty Slot Name", func(t *testing.T) {
-		svc := NewService(&obsMockMixer{}, nil)
+		svc := NewService(&obsMockMixer{}, nil, nil)
 		listVal, _ := structpb.NewList([]interface{}{"geoId/06"})
 		entitiesMap := map[string]*structpb.Value{
 			"": structpb.NewListValue(listVal),
@@ -1214,7 +1214,7 @@ func TestGetObservations_Sdmx(t *testing.T) {
 	})
 
 	t.Run("Validation Failure: Reserved Slot Name", func(t *testing.T) {
-		svc := NewService(&obsMockMixer{}, nil)
+		svc := NewService(&obsMockMixer{}, nil, nil)
 		listVal, _ := structpb.NewList([]interface{}{"Median_Age_Person"})
 		entitiesMap := map[string]*structpb.Value{
 			"variableMeasured": structpb.NewListValue(listVal),
@@ -1233,7 +1233,7 @@ func TestGetObservations_Sdmx(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 
-		svc := NewService(&obsMockMixer{}, nil)
+		svc := NewService(&obsMockMixer{}, nil, nil)
 		listVal, _ := structpb.NewList([]interface{}{"geoId/06"})
 		entitiesMap := map[string]*structpb.Value{
 			"observationAbout": structpb.NewListValue(listVal),
@@ -1281,7 +1281,7 @@ func TestGetObservations_Sdmx(t *testing.T) {
 			},
 		}
 
-		svc := NewService(mock, nil)
+		svc := NewService(mock, nil, nil)
 		entitiesMap := map[string]*structpb.Value{
 			"observationAbout": structpb.NewListValue(mustListValue("geoId/06001")),
 		}
@@ -1336,7 +1336,7 @@ func TestGetObservations_Sdmx(t *testing.T) {
 			},
 		}
 
-		svc := NewService(mock, nil)
+		svc := NewService(mock, nil, nil)
 		entitiesMap := map[string]*structpb.Value{
 			"observationAbout": structpb.NewListValue(mustListValue("geoId/06001")),
 		}
@@ -1394,7 +1394,7 @@ func TestGetObservations_Sdmx(t *testing.T) {
 			},
 		}
 
-		svc := NewService(mock, nil)
+		svc := NewService(mock, nil, nil)
 		entitiesMap := map[string]*structpb.Value{
 			"observationAbout": structpb.NewListValue(mustListValue("geoId/06001")),
 		}
@@ -1453,7 +1453,7 @@ func TestGetObservations_Sdmx(t *testing.T) {
 			},
 		}
 
-		svc := NewService(mock, nil)
+		svc := NewService(mock, nil, nil)
 		entitiesMap := map[string]*structpb.Value{
 			"observationAbout": structpb.NewListValue(mustListValue("geoId/06001")),
 		}
@@ -1499,7 +1499,7 @@ func TestGetObservations_Sdmx(t *testing.T) {
 			},
 		}
 
-		svc := NewService(mock, nil)
+		svc := NewService(mock, nil, nil)
 		entitiesMap := map[string]*structpb.Value{
 			"observationAbout": structpb.NewListValue(mustListValue("geoId/06001")),
 		}
@@ -1551,7 +1551,7 @@ func TestFetchEntityProperties_Deduplication(t *testing.T) {
 		},
 	}
 
-	svc := NewService(mock, nil)
+	svc := NewService(mock, nil, nil)
 	props, err := svc.fetchEntityProperties(context.Background(), []string{"country/AFG"})
 	if err != nil {
 		t.Fatalf("fetchEntityProperties failed: %v", err)

--- a/internal/agent/resolve_places_test.go
+++ b/internal/agent/resolve_places_test.go
@@ -88,7 +88,7 @@ func TestResolvePlaces(t *testing.T) {
 		},
 	}
 
-	service := NewService(mock, nil)
+	service := NewService(mock, nil, nil)
 
 	t.Run("EmptyPlaces", func(t *testing.T) {
 		req := &pbv2.ResolvePlacesRequest{}

--- a/internal/agent/search_indicators.go
+++ b/internal/agent/search_indicators.go
@@ -59,8 +59,8 @@ func (s *Service) SearchIndicators(
 		includeTopics = req.GetIncludeTopics()
 	}
 
-	// Determine expand_topics default: true unless explicitly set to false
-	expandTopics := true
+	// Determine expand_topics default: service default unless explicitly set
+	expandTopics := s.defaultExpandTopics
 	if req.ExpandTopics != nil {
 		expandTopics = req.GetExpandTopics()
 	}

--- a/internal/agent/search_indicators_test.go
+++ b/internal/agent/search_indicators_test.go
@@ -502,3 +502,79 @@ func TestSearchIndicators_Target(t *testing.T) {
 		})
 	}
 }
+
+func TestSearchIndicators_DefaultExpandTopics(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		serviceOpts      []ServiceOption
+		request          *pbv2.SearchIndicatorsRequest
+		wantExpandTopics bool
+	}{
+		{
+			name:             "default service option expands topics when unspecified in request",
+			serviceOpts:      nil,
+			request:          &pbv2.SearchIndicatorsRequest{Query: "health"},
+			wantExpandTopics: true,
+		},
+		{
+			name:             "service option false does not expand topics when unspecified in request",
+			serviceOpts:      []ServiceOption{WithDefaultExpandTopics(false)},
+			request:          &pbv2.SearchIndicatorsRequest{Query: "health"},
+			wantExpandTopics: false,
+		},
+		{
+			name:             "service option true expands topics when unspecified in request",
+			serviceOpts:      []ServiceOption{WithDefaultExpandTopics(true)},
+			request:          &pbv2.SearchIndicatorsRequest{Query: "health"},
+			wantExpandTopics: true,
+		},
+		{
+			name:        "request override true takes precedence over service option false",
+			serviceOpts: []ServiceOption{WithDefaultExpandTopics(false)},
+			request: &pbv2.SearchIndicatorsRequest{
+				Query:        "health",
+				ExpandTopics: proto.Bool(true),
+			},
+			wantExpandTopics: true,
+		},
+		{
+			name:        "request override false takes precedence over service option true",
+			serviceOpts: []ServiceOption{WithDefaultExpandTopics(true)},
+			request: &pbv2.SearchIndicatorsRequest{
+				Query:        "health",
+				ExpandTopics: proto.Bool(false),
+			},
+			wantExpandTopics: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := &mockMixerServer{
+				resolveMockData: map[string][]*pbv2.ResolveResponse_Entity_Candidate{
+					"health": {
+						{
+							Dcid:         "dc/topic/Health",
+							DominantType: "Topic",
+							Name:         "Health",
+						},
+					},
+				},
+			}
+
+			cache := NewCache(mock)
+			svc := NewService(mock, cache, tc.serviceOpts...)
+
+			_, err := svc.SearchIndicators(context.Background(), tc.request)
+			if err != nil {
+				t.Fatalf("SearchIndicators failed unexpectedly: %v", err)
+			}
+
+			if mock.lastCandidateResolveReq == nil {
+				t.Fatalf("expected V2Resolve candidate search to be called, but lastCandidateResolveReq is nil")
+			}
+
+			if got := mock.lastCandidateResolveReq.GetExpandTopics(); got != tc.wantExpandTopics {
+				t.Errorf("V2Resolve expand_topics = %v, want %v", got, tc.wantExpandTopics)
+			}
+		})
+	}
+}

--- a/internal/agent/search_indicators_test.go
+++ b/internal/agent/search_indicators_test.go
@@ -399,7 +399,7 @@ func TestSearchIndicators(t *testing.T) {
 			}
 
 			cache := NewCache(mock)
-			svc := NewService(mock, cache)
+			svc := NewService(mock, cache, nil)
 
 			got, err := svc.SearchIndicators(context.Background(), tc.request)
 
@@ -478,7 +478,7 @@ func TestSearchIndicators_Target(t *testing.T) {
 			}
 
 			cache := NewCache(mock)
-			svc := NewService(mock, cache)
+			svc := NewService(mock, cache, nil)
 
 			_, err := svc.SearchIndicators(context.Background(), tc.request)
 			if tc.wantErr != "" {
@@ -506,7 +506,7 @@ func TestSearchIndicators_Target(t *testing.T) {
 func TestSearchIndicators_DefaultExpandTopics(t *testing.T) {
 	for _, tc := range []struct {
 		name             string
-		serviceOpts      []ServiceOption
+		serviceOpts      *ServiceOptions
 		request          *pbv2.SearchIndicatorsRequest
 		wantExpandTopics bool
 	}{
@@ -517,20 +517,26 @@ func TestSearchIndicators_DefaultExpandTopics(t *testing.T) {
 			wantExpandTopics: true,
 		},
 		{
-			name:             "service option false does not expand topics when unspecified in request",
-			serviceOpts:      []ServiceOption{WithDefaultExpandTopics(false)},
+			name: "service option false does not expand topics when unspecified in request",
+			serviceOpts: &ServiceOptions{
+				DefaultExpandTopics: proto.Bool(false),
+			},
 			request:          &pbv2.SearchIndicatorsRequest{Query: "health"},
 			wantExpandTopics: false,
 		},
 		{
-			name:             "service option true expands topics when unspecified in request",
-			serviceOpts:      []ServiceOption{WithDefaultExpandTopics(true)},
+			name: "service option true expands topics when unspecified in request",
+			serviceOpts: &ServiceOptions{
+				DefaultExpandTopics: proto.Bool(true),
+			},
 			request:          &pbv2.SearchIndicatorsRequest{Query: "health"},
 			wantExpandTopics: true,
 		},
 		{
-			name:        "request override true takes precedence over service option false",
-			serviceOpts: []ServiceOption{WithDefaultExpandTopics(false)},
+			name: "request override true takes precedence over service option false",
+			serviceOpts: &ServiceOptions{
+				DefaultExpandTopics: proto.Bool(false),
+			},
 			request: &pbv2.SearchIndicatorsRequest{
 				Query:        "health",
 				ExpandTopics: proto.Bool(true),
@@ -538,8 +544,10 @@ func TestSearchIndicators_DefaultExpandTopics(t *testing.T) {
 			wantExpandTopics: true,
 		},
 		{
-			name:        "request override false takes precedence over service option true",
-			serviceOpts: []ServiceOption{WithDefaultExpandTopics(true)},
+			name: "request override false takes precedence over service option true",
+			serviceOpts: &ServiceOptions{
+				DefaultExpandTopics: proto.Bool(true),
+			},
 			request: &pbv2.SearchIndicatorsRequest{
 				Query:        "health",
 				ExpandTopics: proto.Bool(false),
@@ -561,7 +569,7 @@ func TestSearchIndicators_DefaultExpandTopics(t *testing.T) {
 			}
 
 			cache := NewCache(mock)
-			svc := NewService(mock, cache, tc.serviceOpts...)
+			svc := NewService(mock, cache, tc.serviceOpts)
 
 			_, err := svc.SearchIndicators(context.Background(), tc.request)
 			if err != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -177,8 +177,8 @@ func (s *Server) SubscribeBranchCacheUpdate(ctx context.Context) error {
 }
 
 // initAgentService initializes the decoupled agent.Service using Go's implicit satisfaction wiring.
-func (s *Server) initAgentService(expandTopics bool) {
-	s.agentService = agent.NewService(s, agent.NewCache(s), agent.WithDefaultExpandTopics(expandTopics))
+func (s *Server) initAgentService(opts *agent.ServiceOptions) {
+	s.agentService = agent.NewService(s, agent.NewCache(s), opts)
 }
 
 // RegisterLifecycle registers the startup and periodic callbacks for a component under a single name key.
@@ -325,7 +325,7 @@ func NewMixerServer(
 		dispatcher: dispatcher,
 		flags:      flags,
 	}
-	defaultExpandTopics := true
+	var agentOpts *agent.ServiceOptions
 	if opts != nil {
 		s.mapsClient = opts.MapsClient
 		s.spannerStalenessTimestampProvider = opts.SpannerStalenessTimestampProvider
@@ -335,10 +335,12 @@ func NewMixerServer(
 		s.topicExpander = opts.TopicExpander
 		s.cachedata.Store(opts.CacheData)
 		if opts.AgentDefaultExpandTopics != nil {
-			defaultExpandTopics = *opts.AgentDefaultExpandTopics
+			agentOpts = &agent.ServiceOptions{
+				DefaultExpandTopics: opts.AgentDefaultExpandTopics,
+			}
 		}
 	}
-	s.initAgentService(defaultExpandTopics)
+	s.initAgentService(agentOpts)
 
 	return s
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -177,8 +177,8 @@ func (s *Server) SubscribeBranchCacheUpdate(ctx context.Context) error {
 }
 
 // initAgentService initializes the decoupled agent.Service using Go's implicit satisfaction wiring.
-func (s *Server) initAgentService() {
-	s.agentService = agent.NewService(s, agent.NewCache(s))
+func (s *Server) initAgentService(expandTopics bool) {
+	s.agentService = agent.NewService(s, agent.NewCache(s), agent.WithDefaultExpandTopics(expandTopics))
 }
 
 // RegisterLifecycle registers the startup and periodic callbacks for a component under a single name key.
@@ -306,6 +306,7 @@ type MixerServerOptions struct {
 	EmbeddingsServiceClient           *resolve.EmbeddingsServiceClient
 	UseSpannerGraph                   bool
 	TopicExpander                     resolve.TopicExpander
+	AgentDefaultExpandTopics          *bool
 }
 
 // NewMixerServer creates a new mixer server instance.
@@ -324,6 +325,7 @@ func NewMixerServer(
 		dispatcher: dispatcher,
 		flags:      flags,
 	}
+	defaultExpandTopics := true
 	if opts != nil {
 		s.mapsClient = opts.MapsClient
 		s.spannerStalenessTimestampProvider = opts.SpannerStalenessTimestampProvider
@@ -332,8 +334,11 @@ func NewMixerServer(
 		s.useSpannerGraph = opts.UseSpannerGraph
 		s.topicExpander = opts.TopicExpander
 		s.cachedata.Store(opts.CacheData)
+		if opts.AgentDefaultExpandTopics != nil {
+			defaultExpandTopics = *opts.AgentDefaultExpandTopics
+		}
 	}
-	s.initAgentService()
+	s.initAgentService(defaultExpandTopics)
 
 	return s
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/datacommonsorg/mixer/internal/featureflags"
 	"github.com/datacommonsorg/mixer/internal/util"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestShouldDivertV2(t *testing.T) {
@@ -137,6 +138,49 @@ func TestShouldDivertV2(t *testing.T) {
 			got := s.shouldDivertV2(ctx)
 			if got != tt.expected {
 				t.Errorf("shouldDivertV2() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNewMixerServer_AgentDefaultExpandTopics(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		opts             *MixerServerOptions
+		wantExpandTopics bool
+	}{
+		{
+			name:             "nil opts defaults to true",
+			opts:             nil,
+			wantExpandTopics: true,
+		},
+		{
+			name:             "unspecified option defaults to true",
+			opts:             &MixerServerOptions{},
+			wantExpandTopics: true,
+		},
+		{
+			name: "explicit false option",
+			opts: &MixerServerOptions{
+				AgentDefaultExpandTopics: proto.Bool(false),
+			},
+			wantExpandTopics: false,
+		},
+		{
+			name: "explicit true option",
+			opts: &MixerServerOptions{
+				AgentDefaultExpandTopics: proto.Bool(true),
+			},
+			wantExpandTopics: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := NewMixerServer(nil, nil, nil, nil, tc.opts)
+			if s.AgentService() == nil {
+				t.Fatalf("AgentService() is nil, expected initialized service")
+			}
+			if got := s.AgentService().DefaultExpandTopics(); got != tc.wantExpandTopics {
+				t.Errorf("DefaultExpandTopics() = %v, want %v", got, tc.wantExpandTopics)
 			}
 		})
 	}


### PR DESCRIPTION
Added a CLI flag to control the default topic expansion behavior in the agent `SearchIndicators` API when `expand_topics` is not explicitly provided in the request payload.

### Context & Motivation
Previously, `SearchIndicators` hardcoded topic expansion to `true` when omitted from the request. In custom Data Commons instances with extensive topic ontologies, recursive topic expansion causes response payloads to balloon into multiple megabytes and exhaust client token limits. This change allows instances to configure whether topic expansion occurs by default, while preserving existing behavior for standard deployments.

### Changes
* Added `--agent_default_expand_topics` CLI flag (defaults to `true`) and wired it through `MixerServerOptions` and `agent.Service`.
* Updated `SearchIndicators` to use the configured service default when `expand_topics` is not specified in the request (request-level overrides continue to take precedence).
* Added unit tests for service options and request overrides.

### Verification & Testing
Verified against a test database:

1. **Default (`--agent_default_expand_topics=true` or omitted):**
   * Request without `expand_topics`:
     ```bash
     curl -s -X POST "http://localhost:8081/v2/agent/search_indicators" \
       -H "Content-Type: application/json" \
       -d '{"query": "health", "places": ["World"], "include_topics": true}' | wc -c
     ```
     Returned `4,684,981` bytes.

   * Explicit unexpanded override:
     ```bash
     curl -s -X POST "http://localhost:8081/v2/agent/search_indicators" \
       -H "Content-Type: application/json" \
       -d '{"query": "health", "places": ["World"], "include_topics": true, "expand_topics": false}' | wc -c
     ```
     Returned `3,280` bytes.

2. **Configured (`--agent_default_expand_topics=false`):**
   * Default request without `expand_topics` in body:
     ```bash
     curl -s -X POST "http://localhost:8081/v2/agent/search_indicators" \
       -H "Content-Type: application/json" \
       -d '{"query": "health", "places": ["World"], "include_topics": true}' | wc -c
     ```
     Returned `3,280` bytes.

   * Explicit expanded override:
     ```bash
     curl -s -X POST "http://localhost:8081/v2/agent/search_indicators" \
       -H "Content-Type: application/json" \
       -d '{"query": "health", "places": ["World"], "include_topics": true, "expand_topics": true}' | wc -c
     ```
     Returned `4,684,981` bytes.
