### PR TITLE
fix(v2): preserve node pagination tokens across data sources

### DIFF
--- a/internal/server/handler_v2.go
+++ b/internal/server/handler_v2.go
@@ -247,16 +247,15 @@ func (s *Server) V2Node(ctx context.Context, in *pbv2.NodeRequest) (
 			errGroup.Go(func() error {
 				// Update |next_token| before sending the request to remote.
 				// Peel off one layer of |remote_pagination_info| hierarchy.
-				remoteReqNextToken, err := util.EncodeProto(remotePaginationInfo)
+				remoteReq, err := remoteNodeRequest(in, remotePaginationInfo)
 				if err != nil {
 					return err
 				}
-				in.NextToken = remoteReqNextToken
 
 				// Call remote.
 				remoteResp := &pbv2.NodeResponse{}
 				if err := util.FetchRemote(
-					errCtx, s.metadata, s.httpClient, "/v2/node", in, remoteResp); err != nil {
+					errCtx, s.metadata, s.httpClient, "/v2/node", remoteReq, remoteResp); err != nil {
 					return err
 				}
 				remoteRespChan <- remoteResp
@@ -292,6 +291,21 @@ func (s *Server) V2Node(ctx context.Context, in *pbv2.NodeRequest) (
 	)
 
 	return v2Resp, nil
+}
+
+// remoteNodeRequest returns a private request for the continuation-page remote call.
+// It clones |in| so that the concurrent local call and the V3 mirror still observe
+// the caller's composite |next_token|.
+func remoteNodeRequest(
+	in *pbv2.NodeRequest, remotePaginationInfo *pbv1.PaginationInfo,
+) (*pbv2.NodeRequest, error) {
+	nextToken, err := util.EncodeProto(remotePaginationInfo)
+	if err != nil {
+		return nil, err
+	}
+	remoteReq := proto.Clone(in).(*pbv2.NodeRequest)
+	remoteReq.NextToken = nextToken
+	return remoteReq, nil
 }
 
 // V2Event implements API for mixer.V2Event.

--- a/internal/server/handler_v2_test.go
+++ b/internal/server/handler_v2_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/datacommonsorg/mixer/internal/util"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/testing/protocmp"
 )
 
@@ -85,6 +86,60 @@ func TestUseMetadata(t *testing.T) {
 		if diff := cmp.Diff(toRemote, c.wantToRemote); diff != "" {
 			t.Errorf("%s: unexpected toRemote diff %v", c.desc, diff)
 		}
+	}
+}
+
+// The continuation-page remote call rewrites |next_token| to the remote's nested
+// token. It runs concurrently with the local read, which needs the caller's
+// composite token, so the rewrite must happen on a private copy.
+func TestV2NodeKeepsCallerPaginationToken(t *testing.T) {
+	remotePaginationInfo := &pbv1.PaginationInfo{
+		CursorGroups: []*pbv1.CursorGroup{{
+			Keys:    []string{"remote"},
+			Cursors: []*pbv1.Cursor{{Item: 20}},
+		}},
+	}
+	callerToken, err := util.EncodeProto(&pbv1.PaginationInfo{
+		CursorGroups: []*pbv1.CursorGroup{{
+			Keys:    []string{"local"},
+			Cursors: []*pbv1.Cursor{{Item: 10}},
+		}},
+		RemotePaginationInfo: remotePaginationInfo,
+	})
+	if err != nil {
+		t.Fatalf("EncodeProto() error = %v", err)
+	}
+	wantRemoteToken, err := util.EncodeProto(remotePaginationInfo)
+	if err != nil {
+		t.Fatalf("EncodeProto() error = %v", err)
+	}
+
+	transport := &mockRemoteTransport{}
+	s := &Server{
+		store:    &store.Store{},
+		metadata: &resource.Metadata{RemoteMixerDomain: "http://mock-remote"},
+		flags:    &featureflags.Flags{},
+		httpClient: &http.Client{
+			Transport: transport,
+		},
+	}
+	s.cachedata.Store(&cache.Cache{})
+
+	// An empty |property| lets the local read return without touching the store.
+	in := &pbv2.NodeRequest{Nodes: []string{"geoId/06"}, NextToken: callerToken}
+	if _, err := s.V2Node(context.Background(), in); err != nil {
+		t.Fatalf("V2Node() error = %v", err)
+	}
+
+	if got := in.GetNextToken(); got != callerToken {
+		t.Errorf("caller request next token = %q, want %q", got, callerToken)
+	}
+	sentReq := &pbv2.NodeRequest{}
+	if err := protojson.Unmarshal(transport.lastBody, sentReq); err != nil {
+		t.Fatalf("unmarshaling remote request: %v", err)
+	}
+	if got := sentReq.GetNextToken(); got != wantRemoteToken {
+		t.Errorf("remote received next token = %q, want %q", got, wantRemoteToken)
 	}
 }
 
@@ -492,10 +547,18 @@ func TestShouldRouteResolveToDispatcher(t *testing.T) {
 
 type mockRemoteTransport struct {
 	lastPath string
+	lastBody []byte
 }
 
 func (m *mockRemoteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	m.lastPath = req.URL.Path
+	if req.Body != nil {
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		m.lastBody = body
+	}
 	return &http.Response{
 		StatusCode: http.StatusOK,
 		Body:       io.NopCloser(strings.NewReader(`{}`)),
@@ -506,9 +569,9 @@ func TestV2RemoteAPIPaths(t *testing.T) {
 	ctx := context.Background()
 	transport := &mockRemoteTransport{}
 	s := &Server{
-		store:      &store.Store{},
-		metadata:   &resource.Metadata{RemoteMixerDomain: "http://mock-remote"},
-		flags:      &featureflags.Flags{},
+		store:    &store.Store{},
+		metadata: &resource.Metadata{RemoteMixerDomain: "http://mock-remote"},
+		flags:    &featureflags.Flags{},
 		httpClient: &http.Client{
 			Transport: transport,
 		},

--- a/internal/server/remote/client.go
+++ b/internal/server/remote/client.go
@@ -29,6 +29,7 @@ import (
 	"github.com/datacommonsorg/mixer/internal/server/resource"
 
 	"github.com/datacommonsorg/mixer/internal/util"
+	"google.golang.org/protobuf/proto"
 )
 
 // RemoteClient encapsulates a client for a Remote Mixer.
@@ -51,6 +52,9 @@ func NewRemoteClient(metadata *resource.Metadata) (*RemoteClient, error) {
 }
 
 func (rc *RemoteClient) Node(ctx context.Context, req *pbv2.NodeRequest) (*pbv2.NodeResponse, error) {
+	// |req| belongs to the caller and is shared across the concurrent data source
+	// fan-out, so peel the per-source |next_token| out of a private copy.
+	req = proto.Clone(req).(*pbv2.NodeRequest)
 	err := updateNodeRequestNextToken(req, rc.id)
 	if err != nil {
 		return nil, err

--- a/internal/server/remote/client_test.go
+++ b/internal/server/remote/client_test.go
@@ -16,6 +16,7 @@ package remote
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -23,7 +24,9 @@ import (
 	sdmxpb "github.com/datacommonsorg/mixer/internal/proto/sdmx"
 	pbv2 "github.com/datacommonsorg/mixer/internal/proto/v2"
 	"github.com/datacommonsorg/mixer/internal/server/resource"
+	"github.com/datacommonsorg/mixer/internal/util"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 func TestRemoteClient_Observation_SurfaceHeader(t *testing.T) {
@@ -115,5 +118,68 @@ func TestRemoteClient_Sdmx_ErrorTolerance(t *testing.T) {
 				t.Errorf("len(client.SdmxData().GetSeries()) = %d, want %d", len(got.GetSeries()), tc.wantSeries)
 			}
 		})
+	}
+}
+
+// Node peels the per-source continuation token out of the composite token it is
+// given. The request belongs to the caller and is shared across the concurrent
+// data source fan-out, so that peel must not be visible to the caller.
+func TestRemoteClientNodeKeepsCallerPaginationToken(t *testing.T) {
+	const remoteToken = "remote-page-two"
+	var sentNextToken string
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("reading remote request body: %v", err)
+			return
+		}
+		sentReq := &pbv2.NodeRequest{}
+		if err := protojson.Unmarshal(body, sentReq); err != nil {
+			t.Errorf("unmarshaling remote request: %v", err)
+			return
+		}
+		sentNextToken = sentReq.GetNextToken()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer ts.Close()
+
+	client, err := NewRemoteClient(&resource.Metadata{
+		RemoteMixerDomain: ts.URL,
+		RemoteMixerAPIKey: "test-api-key",
+	})
+	if err != nil {
+		t.Fatalf("NewRemoteClient() error = %v", err)
+	}
+
+	// The remote data source keys its pagination info by the remote mixer domain.
+	callerToken, err := util.EncodeProto(&pbv2.Pagination{
+		Info: []*pbv2.Pagination_DataSourceInfo{{
+			Id: ts.URL,
+			DataSourceInfo: &pbv2.Pagination_DataSourceInfo_StringInfo{
+				StringInfo: remoteToken,
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("EncodeProto() error = %v", err)
+	}
+
+	req := &pbv2.NodeRequest{
+		Nodes:     []string{"geoId/06"},
+		Property:  "->name",
+		NextToken: callerToken,
+	}
+	if _, err := client.Node(context.Background(), req); err != nil {
+		t.Fatalf("Node() error = %v", err)
+	}
+
+	if got := req.GetNextToken(); got != callerToken {
+		t.Errorf("caller request next token = %q, want %q", got, callerToken)
+	}
+	if sentNextToken != remoteToken {
+		t.Errorf("remote received next token = %q, want %q", sentNextToken, remoteToken)
 	}
 }


### PR DESCRIPTION
`V2Node` sends one request to local and remote data sources in parallel. The request carries a combined continuation token holding a cursor for each source. Before calling the remote Mixer, `RemoteClient.Node` extracted the remote cursor by overwriting `NextToken` on that shared request. Depending on goroutine timing, the local read could then observe the remote cursor or an empty token and restart at page one, so paging through a federated node query could repeat or drop results.

The fix gives the remote call a private clone before replacing `NextToken`. The clone happens inside `RemoteClient.Node`, so every dispatcher caller is covered by one change and the request a caller hands in is never modified. The legacy `V2Node` path calls `FetchRemote` directly rather than going through `RemoteClient`, so `remoteNodeRequest` applies the same ownership rule there. Pagination encoding and response merging are unchanged.

`nodefetcher` advances pages from `resp.NextToken`, not from the request it passed in, so no caller depended on the previous mutation.

Two regression tests cover the two paths, each asserting that the caller keeps its combined token *and* that the remote still receives its correctly extracted token. Both were confirmed to fail against the unfixed code.

Testing: `go build ./...`, `go vet ./internal/server/... ./internal/nodefetcher/...`, and `go test ./internal/server ./internal/server/remote ./internal/server/datasources ./internal/server/dispatcher ./internal/nodefetcher -count=1` pass. `go test -race ./internal/server/remote ./internal/server -run 'TestRemoteClientNodeKeepsCallerPaginationToken|TestV2NodeKeepsCallerPaginationToken' -count=10` also passes.
