### PR TITLE
Use LinkedEdge table for SDMX requests when UseMaterializedLinkedEdge is enabled

### DIFF
--- a/internal/server/spanner/golden/query_builder/get_sdmx_availability_contained_materialized_entity1.sql
+++ b/internal/server/spanner/golden/query_builder/get_sdmx_availability_contained_materialized_entity1.sql
@@ -1,0 +1,21 @@
+		@{SCAN_METHOD=COLUMNAR, EXECUTION_METHOD=BATCH}
+		WITH contained_places_0 AS (
+			SELECT DISTINCT child AS place_id
+			FROM LinkedEdge
+			WHERE predicate = 'containedInPlace'
+				AND ancestor = 'country/USA'
+				AND child_type = 'County'
+		),
+			series AS (
+			SELECT
+				t.entity1 AS value
+			FROM contained_places_0 anchor
+			JOIN@{JOIN_METHOD=APPLY_JOIN} TimeSeries@{FORCE_INDEX=_BASE_TABLE} t
+				ON t.entity1 = anchor.place_id
+				AND t.variable_measured = 'var1'
+		)
+			SELECT DISTINCT t.value AS value
+			FROM series t
+			WHERE t.value IS NOT NULL
+				AND t.value != ''
+			ORDER BY value

--- a/internal/server/spanner/golden/query_builder/get_sdmx_availability_contained_materialized_entity2_remote.sql
+++ b/internal/server/spanner/golden/query_builder/get_sdmx_availability_contained_materialized_entity2_remote.sql
@@ -1,0 +1,25 @@
+		@{SCAN_METHOD=COLUMNAR, EXECUTION_METHOD=BATCH}
+		WITH contained_places_0 AS (
+			SELECT DISTINCT child AS place_id
+			FROM LinkedEdge
+			WHERE predicate = 'containedInPlace'
+				AND ancestor = 'Earth'
+				AND child_type = 'Country'
+			UNION DISTINCT
+			SELECT place_id
+			FROM UNNEST(['country/USA']) AS place_id
+		),
+			series AS (
+			SELECT
+				t.entity1 AS value
+			FROM contained_places_0 anchor
+			JOIN@{JOIN_METHOD=APPLY_JOIN} TimeSeries@{FORCE_INDEX=TimeSeriesByEntity2} t
+				ON t.entity2 = anchor.place_id
+				AND t.variable_measured = 'var1'
+			WHERE t.entity2 IS NOT NULL
+		)
+			SELECT DISTINCT t.value AS value
+			FROM series t
+			WHERE t.value IS NOT NULL
+				AND t.value != ''
+			ORDER BY value

--- a/internal/server/spanner/golden/query_builder/get_sdmx_obs_contained_materialized_entity1.sql
+++ b/internal/server/spanner/golden/query_builder/get_sdmx_obs_contained_materialized_entity1.sql
@@ -1,0 +1,41 @@
+		@{SCAN_METHOD=COLUMNAR, EXECUTION_METHOD=BATCH}
+		WITH contained_places_0 AS (
+			SELECT DISTINCT child AS place_id
+			FROM LinkedEdge
+			WHERE predicate = 'containedInPlace'
+				AND ancestor = 'country/USA'
+				AND child_type = 'County'
+		),
+		series AS (
+			SELECT
+				t.variable_measured,
+				t.entity1,
+				t.extra_entities_id,
+				t.facet_id,
+				t.provenance,
+				t.facet,
+				t.entities
+			FROM contained_places_0 anchor
+			JOIN@{JOIN_METHOD=APPLY_JOIN} TimeSeries@{FORCE_INDEX=_BASE_TABLE} t
+				ON t.entity1 = anchor.place_id
+				AND t.variable_measured = 'var1'
+		)
+		SELECT
+			t.variable_measured,
+			t.entity1 AS observation_about,
+			t.facet_id,
+			ANY_VALUE(t.provenance) AS provenance,
+			COALESCE(
+				ARRAY_AGG(STRUCT(o.date AS date, o.value AS str_value)),
+				ARRAY(SELECT AS STRUCT CAST(NULL AS STRING) AS date, CAST(NULL AS STRING) AS str_value FROM UNNEST([1]) WHERE FALSE)
+			) AS dates_and_values,
+			ANY_VALUE(t.facet) AS facets,
+			ANY_VALUE(t.entities) AS entities
+		FROM series t
+		JOIN@{JOIN_METHOD=APPLY_JOIN} Observation o
+		USING (variable_measured, entity1, extra_entities_id, facet_id)
+		GROUP BY
+			t.variable_measured,
+			t.entity1,
+			t.extra_entities_id,
+			t.facet_id

--- a/internal/server/spanner/golden/query_builder/get_sdmx_obs_contained_materialized_entity1_multiple_sets.sql
+++ b/internal/server/spanner/golden/query_builder/get_sdmx_obs_contained_materialized_entity1_multiple_sets.sql
@@ -1,0 +1,59 @@
+		@{SCAN_METHOD=COLUMNAR, EXECUTION_METHOD=BATCH}
+		WITH contained_places_0 AS (
+			SELECT DISTINCT child AS place_id
+			FROM LinkedEdge
+			WHERE predicate = 'containedInPlace'
+				AND ancestor = 'country/CAN'
+				AND child_type = 'Province'
+		),
+		contained_places_1 AS (
+			SELECT DISTINCT child AS place_id
+			FROM LinkedEdge
+			WHERE predicate = 'containedInPlace'
+				AND ancestor = 'country/USA'
+				AND child_type = 'State'
+		),
+		contained_places_2 AS (
+			SELECT DISTINCT child AS place_id
+			FROM LinkedEdge
+			WHERE predicate = 'containedInPlace'
+				AND ancestor = 'northamerica'
+				AND child_type = 'Country'
+		),
+		series AS (
+			SELECT
+				t.variable_measured,
+				t.entity1,
+				t.extra_entities_id,
+				t.facet_id,
+				t.provenance,
+				t.facet,
+				t.entities
+			FROM contained_places_0 anchor
+			JOIN@{JOIN_METHOD=APPLY_JOIN} TimeSeries@{FORCE_INDEX=_BASE_TABLE} t
+				ON t.entity1 = anchor.place_id
+				AND t.variable_measured = 'var1'
+			WHERE t.entity3 IS NOT NULL
+				AND t.entity3 IN (SELECT place_id FROM contained_places_1)
+				AND t.entity2 IS NOT NULL
+				AND t.entity2 IN (SELECT place_id FROM contained_places_2)
+		)
+		SELECT
+			t.variable_measured,
+			t.entity1 AS observation_about,
+			t.facet_id,
+			ANY_VALUE(t.provenance) AS provenance,
+			COALESCE(
+				ARRAY_AGG(STRUCT(o.date AS date, o.value AS str_value)),
+				ARRAY(SELECT AS STRUCT CAST(NULL AS STRING) AS date, CAST(NULL AS STRING) AS str_value FROM UNNEST([1]) WHERE FALSE)
+			) AS dates_and_values,
+			ANY_VALUE(t.facet) AS facets,
+			ANY_VALUE(t.entities) AS entities
+		FROM series t
+		JOIN@{JOIN_METHOD=APPLY_JOIN} Observation o
+		USING (variable_measured, entity1, extra_entities_id, facet_id)
+		GROUP BY
+			t.variable_measured,
+			t.entity1,
+			t.extra_entities_id,
+			t.facet_id

--- a/internal/server/spanner/golden/query_builder/get_sdmx_obs_contained_materialized_entity3_before_entity2_remote.sql
+++ b/internal/server/spanner/golden/query_builder/get_sdmx_obs_contained_materialized_entity3_before_entity2_remote.sql
@@ -1,0 +1,47 @@
+		@{SCAN_METHOD=COLUMNAR, EXECUTION_METHOD=BATCH}
+		WITH contained_places_0 AS (
+			SELECT DISTINCT child AS place_id
+			FROM LinkedEdge
+			WHERE predicate = 'containedInPlace'
+				AND ancestor = 'country/USA'
+				AND child_type = 'State'
+			UNION DISTINCT
+			SELECT place_id
+			FROM UNNEST(['country/CAN','country/USA']) AS place_id
+		),
+		series AS (
+			SELECT
+				t.variable_measured,
+				t.entity1,
+				t.extra_entities_id,
+				t.facet_id,
+				t.provenance,
+				t.facet,
+				t.entities
+			FROM contained_places_0 anchor
+			JOIN@{JOIN_METHOD=APPLY_JOIN} TimeSeries@{FORCE_INDEX=TimeSeriesByEntity3} t
+				ON t.entity3 = anchor.place_id
+				AND t.variable_measured = 'var1'
+			WHERE t.entity3 IS NOT NULL
+				AND t.entity2 IS NOT NULL
+				AND t.entity2 IN (SELECT place_id FROM contained_places_0)
+		)
+		SELECT
+			t.variable_measured,
+			t.entity1 AS observation_about,
+			t.facet_id,
+			ANY_VALUE(t.provenance) AS provenance,
+			COALESCE(
+				ARRAY_AGG(STRUCT(o.date AS date, o.value AS str_value)),
+				ARRAY(SELECT AS STRUCT CAST(NULL AS STRING) AS date, CAST(NULL AS STRING) AS str_value FROM UNNEST([1]) WHERE FALSE)
+			) AS dates_and_values,
+			ANY_VALUE(t.facet) AS facets,
+			ANY_VALUE(t.entities) AS entities
+		FROM series t
+		JOIN@{JOIN_METHOD=APPLY_JOIN} Observation o
+		USING (variable_measured, entity1, extra_entities_id, facet_id)
+		GROUP BY
+			t.variable_measured,
+			t.entity1,
+			t.extra_entities_id,
+			t.facet_id

--- a/internal/server/spanner/golden/query_builder_multientity_test.go
+++ b/internal/server/spanner/golden/query_builder_multientity_test.go
@@ -274,7 +274,7 @@ func TestMultiEntityGetSdmxObservationsQuery(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			goldenFile := c.golden + ".sql"
 			runQueryBuilderGoldenTest(t, goldenFile, func(ctx context.Context) (interface{}, error) {
-				builder, err := spanner.NewMultiEntityQueryBuilder(spanner.DefaultTableConfig(), spanner.QueryConfig{})
+				builder, err := spanner.NewMultiEntityQueryBuilder(spanner.DefaultTableConfig(), spanner.QueryConfig{UseMaterializedLinkedEdge: c.useMaterializedLinkedEdge})
 				if err != nil {
 					return nil, err
 				}
@@ -978,6 +978,7 @@ func TestMultiEntityGetSdmxAvailabilityQueryContainedInPlace(t *testing.T) {
 		constraints                     map[string]*sdmxpb.SdmxComponentConstraint
 		observationPropertyToEntitySlot map[string]string
 		containedInPlaceToRemoteDCIDs   map[datacommons.ContainedInPlaceConstraint][]string
+		useMaterializedLinkedEdge       bool
 		golden                          string
 	}{
 		{
@@ -989,6 +990,17 @@ func TestMultiEntityGetSdmxAvailabilityQueryContainedInPlace(t *testing.T) {
 			},
 			observationPropertyToEntitySlot: map[string]string{"observationAbout": "entity1"},
 			golden:                          "get_sdmx_availability_contained_entity1.sql",
+		},
+		{
+			name:        "entity1 all dates (materialized LinkedEdge)",
+			componentID: "observationAbout",
+			constraints: map[string]*sdmxpb.SdmxComponentConstraint{
+				"variableMeasured": sdmxComponentConstraint("var1"),
+				"observationAbout": sdmxContainedInPlaceConstraint("country/USA", "County"),
+			},
+			observationPropertyToEntitySlot: map[string]string{"observationAbout": "entity1"},
+			useMaterializedLinkedEdge:       true,
+			golden:                          "get_sdmx_availability_contained_materialized_entity1.sql",
 		},
 		{
 			name:        "entity1 explicit time periods",
@@ -1017,11 +1029,28 @@ func TestMultiEntityGetSdmxAvailabilityQueryContainedInPlace(t *testing.T) {
 			},
 			golden: "get_sdmx_availability_contained_entity2_remote.sql",
 		},
+		{
+			name:        "remote entity2 (materialized LinkedEdge)",
+			componentID: "destinationCountry",
+			constraints: map[string]*sdmxpb.SdmxComponentConstraint{
+				"variableMeasured": sdmxComponentConstraint("var1"),
+				"sourceCountry":    sdmxContainedInPlaceConstraint(earthCountries.Ancestor, earthCountries.ChildPlaceType),
+			},
+			observationPropertyToEntitySlot: map[string]string{
+				"destinationCountry": "entity1",
+				"sourceCountry":      "entity2",
+			},
+			containedInPlaceToRemoteDCIDs: map[datacommons.ContainedInPlaceConstraint][]string{
+				earthCountries: {"country/USA"},
+			},
+			useMaterializedLinkedEdge: true,
+			golden:                    "get_sdmx_availability_contained_materialized_entity2_remote.sql",
+		},
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			runQueryBuilderGoldenTest(t, tc.golden, func(ctx context.Context) (interface{}, error) {
-				builder, err := spanner.NewMultiEntityQueryBuilder(spanner.DefaultTableConfig(), spanner.QueryConfig{})
+				builder, err := spanner.NewMultiEntityQueryBuilder(spanner.DefaultTableConfig(), spanner.QueryConfig{UseMaterializedLinkedEdge: tc.useMaterializedLinkedEdge})
 				if err != nil {
 					return nil, err
 				}

--- a/internal/server/spanner/golden/query_multientity_cases_test.go
+++ b/internal/server/spanner/golden/query_multientity_cases_test.go
@@ -416,6 +416,7 @@ var multiEntitySdmxObservationsTestCases = []struct {
 	constraints                     map[string]*sdmxpb.SdmxComponentConstraint
 	observationPropertyToEntitySlot map[string]string
 	containedInPlaceToRemoteDCIDs   map[datacommons.ContainedInPlaceConstraint][]string
+	useMaterializedLinkedEdge       bool
 	golden                          string
 }{
 	{
@@ -523,6 +524,16 @@ var multiEntitySdmxObservationsTestCases = []struct {
 		golden:                          "get_sdmx_obs_contained_entity1",
 	},
 	{
+		name: "contained observation about on entity1 (materialized LinkedEdge)",
+		constraints: map[string]*sdmxpb.SdmxComponentConstraint{
+			"variableMeasured": sdmxComponentConstraint("var1"),
+			"observationAbout": sdmxContainedInPlaceConstraint("country/USA", "County"),
+		},
+		observationPropertyToEntitySlot: map[string]string{"observationAbout": "entity1"},
+		useMaterializedLinkedEdge:       true,
+		golden:                          "get_sdmx_obs_contained_materialized_entity1",
+	},
+	{
 		name: "contained observation about with explicit time periods",
 		constraints: map[string]*sdmxpb.SdmxComponentConstraint{
 			"variableMeasured": sdmxComponentConstraint("var1"),
@@ -591,6 +602,22 @@ var multiEntitySdmxObservationsTestCases = []struct {
 		golden: "get_sdmx_obs_contained_entity3_before_entity2_remote",
 	},
 	{
+		name: "entity3 anchors before entity2 and reuses remote place set (materialized LinkedEdge)",
+		constraints: map[string]*sdmxpb.SdmxComponentConstraint{
+			"variableMeasured": sdmxComponentConstraint("var1"),
+			"middle":           sdmxContainedInPlaceConstraint("country/USA", "State"),
+			"last":             sdmxContainedInPlaceConstraint("country/USA", "State"),
+		},
+		observationPropertyToEntitySlot: map[string]string{
+			"first": "entity1", "middle": "entity2", "last": "entity3",
+		},
+		containedInPlaceToRemoteDCIDs: map[datacommons.ContainedInPlaceConstraint][]string{
+			{Ancestor: "country/USA", ChildPlaceType: "State"}: {"country/CAN", "country/USA"},
+		},
+		useMaterializedLinkedEdge: true,
+		golden:                    "get_sdmx_obs_contained_materialized_entity3_before_entity2_remote",
+	},
+	{
 		name: "entity3 remote place set with latest time period",
 		constraints: map[string]*sdmxpb.SdmxComponentConstraint{
 			"variableMeasured": sdmxComponentConstraint("var1"),
@@ -618,5 +645,19 @@ var multiEntitySdmxObservationsTestCases = []struct {
 			"first": "entity1", "middle": "entity2", "last": "entity3",
 		},
 		golden: "get_sdmx_obs_contained_entity1_multiple_sets",
+	},
+	{
+		name: "entity1 anchors entity2 and entity3 place sets (materialized LinkedEdge)",
+		constraints: map[string]*sdmxpb.SdmxComponentConstraint{
+			"variableMeasured": sdmxComponentConstraint("var1"),
+			"first":            sdmxContainedInPlaceConstraint("country/CAN", "Province"),
+			"middle":           sdmxContainedInPlaceConstraint("northamerica", "Country"),
+			"last":             sdmxContainedInPlaceConstraint("country/USA", "State"),
+		},
+		observationPropertyToEntitySlot: map[string]string{
+			"first": "entity1", "middle": "entity2", "last": "entity3",
+		},
+		useMaterializedLinkedEdge: true,
+		golden:                    "get_sdmx_obs_contained_materialized_entity1_multiple_sets",
 	},
 }

--- a/internal/server/spanner/query_builder_multientity.go
+++ b/internal/server/spanner/query_builder_multientity.go
@@ -644,26 +644,37 @@ func (b *multiEntityQueryBuilder) buildSdmxContainedSeriesPlan(
 			params[ancestorParam] = key.Ancestor
 			params[childPlaceTypeParam] = key.ChildPlaceType
 			remoteDCIDs := containedInPlaceToRemoteDCIDs[key]
+			var containedPlaces string
+			if b.queryConfig.UseMaterializedLinkedEdge {
+				containedPlaces = fmt.Sprintf(
+					b.statements.sdmxContainedPlacesLinkedEdge,
+					datacommons.PropertyContainedInPlace,
+					ancestorParam,
+					childPlaceTypeParam,
+				)
+			} else {
+				containedPlaces = fmt.Sprintf(
+					b.statements.sdmxContainedPlacesEdge,
+					containedRule.GraphPredicate,
+					ancestorParam,
+					typeRule.GraphPredicate,
+					childPlaceTypeParam,
+				)
+			}
 			if len(remoteDCIDs) > 0 {
 				remotePlacesParam := fmt.Sprintf("containment_%d_remote_places", cteIndex)
 				params[remotePlacesParam] = remoteDCIDs
 				cteDefinitions = append(cteDefinitions, fmt.Sprintf(
 					b.statements.sdmxContainedPlacesWithRemoteCTE,
 					cteName,
-					containedRule.GraphPredicate,
-					ancestorParam,
-					typeRule.GraphPredicate,
-					childPlaceTypeParam,
+					containedPlaces,
 					remotePlacesParam,
 				))
 			} else {
 				cteDefinitions = append(cteDefinitions, fmt.Sprintf(
 					b.statements.sdmxContainedPlacesCTE,
 					cteName,
-					containedRule.GraphPredicate,
-					ancestorParam,
-					typeRule.GraphPredicate,
-					childPlaceTypeParam,
+					containedPlaces,
 				))
 			}
 		}

--- a/internal/server/spanner/statements_multientity.go
+++ b/internal/server/spanner/statements_multientity.go
@@ -41,6 +41,8 @@ type MultiEntityStatements struct {
 	getSdmxContainedInPlaceLatest                  string
 	getSdmxContainedAvailability                   string
 	getSdmxContainedAvailabilityWithDates          string
+	sdmxContainedPlacesEdge                        string
+	sdmxContainedPlacesLinkedEdge                  string
 	sdmxContainedPlacesCTE                         string
 	sdmxContainedPlacesWithRemoteCTE               string
 	sdmxContainedSeriesCTE                         string
@@ -372,30 +374,32 @@ func NewMultiEntityStatements(cfg TableConfig) (*MultiEntityStatements, error) {
 			"@{JOIN_METHOD=MERGE_JOIN}",
 		),
 
+		sdmxContainedPlacesEdge: `SELECT DISTINCT contained.subject_id AS place_id
+			FROM Edge typed
+			JOIN@{FORCE_JOIN_ORDER=TRUE} Edge contained ON contained.subject_id = typed.subject_id
+			WHERE contained.predicate = '%[1]s'
+				AND contained.object_id = @%[2]s
+				AND typed.predicate = '%[3]s'
+				AND typed.object_id = @%[4]s`,
+
+		sdmxContainedPlacesLinkedEdge: `SELECT DISTINCT child AS place_id
+			FROM LinkedEdge
+			WHERE predicate = '%[1]s'
+				AND ancestor = @%[2]s
+				AND child_type = @%[3]s`,
+
 		// Force typeOf edges as the left input so Spanner filters by place type
 		// before containment. A broad containment lookup can return every place
 		// under an ancestor and usually produces a larger intermediate result.
 		sdmxContainedPlacesCTE: `%[1]s AS (
-			SELECT DISTINCT contained.subject_id AS place_id
-			FROM Edge typed
-			JOIN@{FORCE_JOIN_ORDER=TRUE} Edge contained ON contained.subject_id = typed.subject_id
-			WHERE contained.predicate = '%[2]s'
-				AND contained.object_id = @%[3]s
-				AND typed.predicate = '%[4]s'
-				AND typed.object_id = @%[5]s
+			%[2]s
 		)`,
 
 		sdmxContainedPlacesWithRemoteCTE: `%[1]s AS (
-			SELECT DISTINCT contained.subject_id AS place_id
-			FROM Edge typed
-			JOIN@{FORCE_JOIN_ORDER=TRUE} Edge contained ON contained.subject_id = typed.subject_id
-			WHERE contained.predicate = '%[2]s'
-				AND contained.object_id = @%[3]s
-				AND typed.predicate = '%[4]s'
-				AND typed.object_id = @%[5]s
+			%[2]s
 			UNION DISTINCT
 			SELECT place_id
-			FROM UNNEST(@%[6]s) AS place_id
+			FROM UNNEST(@%[3]s) AS place_id
 		)`,
 
 		sdmxContainedSeriesCTE: fmt.Sprintf(`series AS (


### PR DESCRIPTION
Follow up to https://github.com/datacommonsorg/mixer/pull/2101 for SDMX 
The change only affects contained places CTEs

### Spanner query comparison (old vs new)
All requests for Count_Person

#### Availability
Entity 1 - counties in USA
* Time elapsed: 1.81s vs 1.48s
* CPU time: 437.27ms vs 333.51ms
* Rows scanned: 36,734 vs 33,190
* Remote calls: 2 vs 1

Remote entity 2 - country in Earth
* Time elapsed: 67.05ms vs 61.77ms
* CPU time: 58.82ms vs 32.67ms
* Rows scanned: 1,014 vs 257
* Remote calls: 1 vs 1

#### Observation
Entity 1 - counties in USA
* Time elapsed: 1.76s vs 1.43s
* CPU time: 1.98s vs 1.6s
* Rows scanned: 577,191 vs 573,647
* Remote calls: 2 vs 1

Entity 1 multiple sets - Province in Canada; State in USA; Country in North America
* Time elapsed: 143.02ms vs 46.68ms
* CPU time: 121.75ms vs 38.2ms
* Rows scanned: 956 vs 93
* Remote calls: 2 vs 0

Remote entity 3 before entity 2 - states in USA 
* Time elapsed: 149.8ms vs 144.88ms 
* CPU time: 109.46ms vs 100.66ms
* Rows scanned: 215 vs 52
* Remote calls: 54 vs 54